### PR TITLE
Add examples/n1.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/README.md
+++ b/README.md
@@ -47,35 +47,48 @@ client = YutoriClient()  # Uses YUTORI_API_KEY env var
 
 The Yutori API provides four main capabilities:
 
-| API | Description | SDK Namespace |
-|-----|-------------|---------------|
-| **n1** | Pixels-to-actions LLM for browser control | `client.chat` |
-| **Browsing** | One-time browser automation tasks | `client.browsing` |
-| **Research** | Deep web research using 100+ tools | `client.research` |
-| **Scouting** | Continuous web monitoring on a schedule | `client.scouts` |
+| API          | Description                               | SDK Namespace     |
+| ------------ | ----------------------------------------- | ----------------- |
+| **n1**       | Pixels-to-actions LLM for browser control | `client.chat`     |
+| **Browsing** | One-time browser automation tasks         | `client.browsing` |
+| **Research** | Deep web research using 100+ tools        | `client.research` |
+| **Scouting** | Continuous web monitoring on a schedule   | `client.scouts`   |
 
 ## n1 API
 
-The n1 API is a pixels-to-actions LLM that processes screenshots and predicts browser actions (click, type, scroll, etc.). It follows the OpenAI Chat Completions interface using the `observation` role for screenshots.
+The n1 API is a pixels-to-actions LLM that processes screenshots and predicts browser actions (click, type, scroll, etc.). It follows the OpenAI Chat Completions interface using the `tool` role for screenshots.
 
 ```python
-response = client.chat.completions(
-    model="n1-preview-2025-11",
+response = client.chat.completions.create(
+    model="n1-latest",
     messages=[
         {
             "role": "user",
-            "content": [{"type": "text", "text": "Search for Yutori"}]
-        },
-        {
-            "role": "observation",
             "content": [
-                {"type": "image_url", "image_url": {"url": "data:image/webp;base64,..."}}
+                {
+                    "type": "text",
+                    "text": "Describe the screenshot and search for Yutori."
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://upload.wikimedia.org/wikipedia/commons/5/53/Google_homepage_%28as_of_January_2024%29.jpg"
+                    }
+                }
             ]
         }
-    ],
+    ]
 )
-print(response)
-# {"thoughts": "I'll click on the search bar...", "actions": [{"action_type": "click", "center_coordinates": [500, 300]}]}
+
+# Get the thoughts
+message = response.choices[0].message
+print(message.content)
+
+# Get the tool calls, such as browser interaction actions
+if message.tool_calls:
+    for tool_call in message.tool_calls:
+        print(f"Action: {tool_call.function.name}")
+        print(f"Arguments: {tool_call.function.arguments}")
 ```
 
 If you don't want to manage your own browser infrastructure, use the Browsing API which calls n1 on a cloud browser.
@@ -269,10 +282,10 @@ except APIError as e:
 
 ### Exception Types
 
-| Exception | Status Code | Description |
-|-----------|-------------|-------------|
-| `AuthenticationError` | 401 | Invalid or missing API key |
-| `APIError` | 4xx, 5xx | General API error with status code |
+| Exception             | Status Code | Description                        |
+| --------------------- | ----------- | ---------------------------------- |
+| `AuthenticationError` | 401         | Invalid or missing API key         |
+| `APIError`            | 4xx, 5xx    | General API error with status code |
 
 ## Configuration
 
@@ -290,6 +303,7 @@ client = YutoriClient(
 
 - Python 3.9+
 - [httpx](https://www.python-httpx.org/) for HTTP requests
+- [openai](https://github.com/openai/openai-python) for the n1 chat API
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ client = YutoriClient(
 - Python 3.9+
 - [httpx](https://www.python-httpx.org/) for HTTP requests
 
+## Examples
+
+See [examples/](examples/) for complete working examples, including a browser automation agent using the n1 API.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The Yutori API provides four main capabilities:
 
 ## n1 API
 
-The n1 API is a pixels-to-actions LLM that processes screenshots and predicts browser actions (click, type, scroll, etc.). It follows the OpenAI Chat Completions interface using the `tool` role for screenshots.
+The n1 API is a pixels-to-actions LLM that processes screenshots and predicts browser actions (click, type, scroll, etc.). It follows the OpenAI Chat Completions interface:
 
 ```python
 response = client.chat.completions.create(

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,35 @@
+# Yutori SDK Examples
+
+Example scripts demonstrating how to use the Yutori API.
+
+## Setup
+
+Install dependencies using [uv](https://docs.astral.sh/uv/getting-started/installation/):
+
+```bash
+# Install SDK with example dependencies
+uv sync --extra examples
+
+# Install Playwright browsers
+uv run playwright install chromium
+```
+
+Set your API key (see [Authentication](https://docs.yutori.com/authentication)):
+
+```bash
+export YUTORI_API_KEY=<your-api-key>
+```
+
+## Examples
+
+### n1.py - Browser Automation Agent
+
+A complete browser agent that uses the n1 API to autonomously navigate websites and complete tasks.
+
+The script launches a local Playwright browser, takes screenshots, sends them to the n1 API to get predicted actions, executes those actions, and repeats until the task is complete.
+
+**Usage:**
+
+```bash
+uv run python examples/n1.py --task "List the team member names" --start-url "https://www.yutori.com"
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,9 +22,9 @@ export YUTORI_API_KEY=<your-api-key>
 
 ## Examples
 
-### n1.py - Browser Automation Agent
+### n1.py
 
-A complete browser agent that uses the n1 API to autonomously navigate websites and complete tasks.
+Demonstrate how to build a browsing agent with n1 API to navigate the web and complete tasks.
 
 The script launches a local Playwright browser, takes screenshots, sends them to the n1 API to get predicted actions, executes those actions, and repeats until the task is complete.
 

--- a/examples/n1.py
+++ b/examples/n1.py
@@ -125,8 +125,12 @@ class Agent:
         await asyncio.sleep(1)
 
     async def _cleanup(self) -> None:
+        self._messages = []
+        self._step_count = 0
+
         if self._browser:
             await self._browser.close()
+            self._browser = None
 
     async def _take_screenshot(self) -> str:
         screenshot_bytes = await self._page.screenshot(type="jpeg", quality=75)
@@ -208,14 +212,13 @@ class Agent:
         )
         return response
 
-    async def _execute_action(self, tool_call) -> bool:
+    async def _execute_action(self, tool_call) -> None:
         action_name = tool_call.function.name
 
         try:
             arguments = json.loads(tool_call.function.arguments)
         except json.JSONDecodeError:
             logger.error(f"Failed to parse arguments: {tool_call.function.arguments}")
-            return False
 
         try:
             if action_name == "left_click":
@@ -325,11 +328,8 @@ class Agent:
             except Exception:
                 pass
 
-            return True
-
         except Exception as e:
             logger.error(f"Error executing {action_name}: {e}")
-            return False
 
 
 async def main():

--- a/examples/n1.py
+++ b/examples/n1.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python
+"""
+n1 Browser Agent - A web browsing agent using Yutori's n1 API
+
+This script takes a user query, launches a local Playwright browser session,
+calls the n1 API to get actions, executes them, and iterates until the task is complete.
+
+Usage:
+    export YUTORI_API_KEY=...
+    python examples/n1.py --task "List the team member names" --start-url "https://www.yutori.com"
+"""
+
+import argparse
+import asyncio
+import base64
+import io
+import json
+import os
+import sys
+
+from loguru import logger
+from openai import OpenAI
+from PIL import Image
+from playwright.async_api import Browser, Page, async_playwright
+from pydantic import BaseModel, Field
+
+
+class Config(BaseModel):
+    # task
+    task: str = Field(default="List the team member names")
+    start_url: str = "https://www.yutori.com"
+    # model
+    api_key: str = Field(default_factory=lambda: os.getenv("YUTORI_API_KEY"))
+    base_url: str = "https://api.yutori.com/v1"
+    model: str = "n1-latest"
+    temperature: float = 0.3
+    # agent
+    max_steps: int = 30
+    # browser
+    viewport_width: int = 1280
+    viewport_height: int = 800
+    headless: bool = False
+
+
+class Agent:
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://api.yutori.com/v1",
+        model: str = "n1-latest",
+        temperature: float = 0.3,
+        max_steps: int = 30,
+        viewport_width: int = 1280,
+        viewport_height: int = 800,
+        headless: bool = False,
+    ):
+        self.api_key = api_key
+        self.base_url = base_url
+        self.model = model
+        self.temperature = temperature
+        self.max_steps = max_steps
+        self.viewport_width = viewport_width
+        self.viewport_height = viewport_height
+        self.headless = headless
+
+        self._client = OpenAI(base_url=base_url, api_key=api_key)
+        self._browser: Browser | None = None
+        self._page: Page | None = None
+        self._messages: list = []
+        self._step_count = 0
+
+    async def run(self, task: str, start_url: str) -> str:
+        logger.info(f"Task: {task}")
+        logger.info(f"Starting URL: {start_url}")
+
+        final_response = ""
+
+        async with async_playwright() as playwright:
+            try:
+                await self._init_browser(playwright)
+                await self._page.goto(start_url)
+                await self._page.wait_for_load_state("domcontentloaded")
+
+                while self._step_count < self.max_steps:
+                    self._step_count += 1
+                    logger.debug(f"Step {self._step_count}, URL: {self._page.url}")
+
+                    response = await self._get_next_action(task)
+                    message = response.choices[0].message
+
+                    # Log raw model prediction
+                    logger.info(f"Model response: {message}")
+
+                    # Store the assistant's response
+                    self._messages.append(message.model_dump(exclude_none=True))
+
+                    if message.content:
+                        final_response = message.content
+
+                    # Stop when there are no tool calls
+                    if not message.tool_calls:
+                        logger.info("Task completed (no more tool calls)")
+                        break
+
+                    # Execute the action(s)
+                    for tool_call in message.tool_calls:
+                        await self._execute_action(tool_call)
+
+                if self._step_count >= self.max_steps:
+                    logger.warning(f"Reached maximum steps ({self.max_steps})")
+
+            except KeyboardInterrupt:
+                logger.info("Interrupted by user")
+            finally:
+                await self._cleanup()
+
+        return final_response
+
+    async def _init_browser(self, playwright) -> None:
+        self._browser = await playwright.chromium.launch(headless=self.headless)
+        context = await self._browser.new_context(
+            viewport={"width": self.viewport_width, "height": self.viewport_height}
+        )
+        self._page = await context.new_page()
+        await asyncio.sleep(1)
+
+    async def _cleanup(self) -> None:
+        if self._browser:
+            await self._browser.close()
+
+    async def _take_screenshot(self) -> str:
+        screenshot_bytes = await self._page.screenshot(type="jpeg", quality=75)
+        img = Image.open(io.BytesIO(screenshot_bytes))
+        webp_buffer = io.BytesIO()
+        img.save(webp_buffer, format="WEBP", quality=90)
+        webp_bytes = webp_buffer.getvalue()
+        return base64.b64encode(webp_bytes).decode("utf-8")
+
+    def _convert_coordinates(self, rel_x: int, rel_y: int) -> tuple[int, int]:
+        abs_x = int(rel_x / 1000 * self.viewport_width)
+        abs_y = int(rel_y / 1000 * self.viewport_height)
+        return abs_x, abs_y
+
+    def _clip_image_url(self, url: str, max_len: int = 50) -> str:
+        if url.startswith("data:image"):
+            prefix_end = url.find(",") + 1
+            if prefix_end > 0 and len(url) > prefix_end + max_len:
+                return url[: prefix_end + 20] + "...[clipped]"
+        return url if len(url) <= max_len else url[:max_len] + "..."
+
+    def _format_message_for_log(self, message: dict) -> dict:
+        result = {}
+        for key, value in message.items():
+            if key == "content" and isinstance(value, list):
+                clipped_content = []
+                for item in value:
+                    if isinstance(item, dict) and item.get("type") == "image_url":
+                        clipped_item = dict(item)
+                        if "image_url" in clipped_item and "url" in clipped_item["image_url"]:
+                            clipped_item["image_url"] = {"url": self._clip_image_url(clipped_item["image_url"]["url"])}
+                        clipped_content.append(clipped_item)
+                    else:
+                        clipped_content.append(item)
+                result[key] = clipped_content
+            else:
+                result[key] = value
+        return result
+
+    async def _get_next_action(self, task: str) -> dict:
+        screenshot_b64 = await self._take_screenshot()
+        current_url = self._page.url
+
+        if not self._messages:
+            # First message - include the task
+            user_message = {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": task},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/webp;base64,{screenshot_b64}"},
+                    },
+                ],
+            }
+            self._messages.append(user_message)
+            logger.info(f"User message: {self._format_message_for_log(user_message)}")
+        else:
+            # Subsequent messages - add tool result with new screenshot
+            last_assistant_msg = self._messages[-1]
+            if last_assistant_msg.get("role") == "assistant" and last_assistant_msg.get("tool_calls"):
+                tool_call_id = last_assistant_msg["tool_calls"][0]["id"]
+                tool_message = {
+                    "role": "tool",
+                    "tool_call_id": tool_call_id,
+                    "content": [
+                        {"type": "text", "text": f"Current URL: {current_url}"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:image/webp;base64,{screenshot_b64}"},
+                        },
+                    ],
+                }
+                self._messages.append(tool_message)
+                logger.info(f"Tool result: {self._format_message_for_log(tool_message)}")
+
+        response = self._client.chat.completions.create(
+            model=self.model, messages=self._messages, temperature=self.temperature
+        )
+        return response
+
+    async def _execute_action(self, tool_call) -> bool:
+        action_name = tool_call.function.name
+
+        try:
+            arguments = json.loads(tool_call.function.arguments)
+        except json.JSONDecodeError:
+            logger.error(f"Failed to parse arguments: {tool_call.function.arguments}")
+            return False
+
+        try:
+            if action_name == "left_click":
+                coords = arguments.get("coordinates", [0, 0])
+                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                await self._page.mouse.click(abs_x, abs_y)
+                await asyncio.sleep(0.5)
+
+            elif action_name == "double_click":
+                coords = arguments.get("coordinates", [0, 0])
+                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                await self._page.mouse.dblclick(abs_x, abs_y)
+                await asyncio.sleep(0.5)
+
+            elif action_name == "right_click":
+                coords = arguments.get("coordinates", [0, 0])
+                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                await self._page.mouse.click(abs_x, abs_y, button="right")
+                await asyncio.sleep(0.5)
+
+            elif action_name == "triple_click":
+                coords = arguments.get("coordinates", [0, 0])
+                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                await self._page.mouse.click(abs_x, abs_y, click_count=3)
+                await asyncio.sleep(0.5)
+
+            elif action_name == "type":
+                text = arguments.get("text", "")
+                press_enter = arguments.get("press_enter_after", False)
+                clear_first = arguments.get("clear_before_typing", False)
+
+                if clear_first:
+                    await self._page.keyboard.press("Control+a" if sys.platform != "darwin" else "Meta+a")
+                    await self._page.keyboard.press("Backspace")
+
+                await self._page.keyboard.type(text, delay=50)
+
+                if press_enter:
+                    await self._page.keyboard.press("Enter")
+                await asyncio.sleep(0.5)
+
+            elif action_name in ("key", "key_press"):
+                key = arguments.get("key") or arguments.get("key_comb", "")
+                await self._page.keyboard.press(key)
+                await asyncio.sleep(0.3)
+
+            elif action_name == "scroll":
+                coords = arguments.get("coordinates") or arguments.get("coordinate", [500, 500])
+                direction = arguments.get("direction", "down")
+                amount = arguments.get("amount", 3)
+
+                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                scroll_delta = amount * (self.viewport_height * 0.1)
+
+                delta_y = scroll_delta if direction == "down" else (-scroll_delta if direction == "up" else 0)
+                delta_x = scroll_delta if direction == "right" else (-scroll_delta if direction == "left" else 0)
+
+                await self._page.mouse.move(abs_x, abs_y)
+                await self._page.mouse.wheel(delta_x, delta_y)
+                await asyncio.sleep(0.5)
+
+            elif action_name == "hover":
+                coords = arguments.get("coordinates", [0, 0])
+                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                await self._page.mouse.move(abs_x, abs_y)
+                await asyncio.sleep(0.3)
+
+            elif action_name == "drag":
+                start_coords = arguments.get("start_coordinates") or arguments.get("startCoordinates", [0, 0])
+                end_coords = arguments.get("coordinates") or arguments.get("endCoordinates", [0, 0])
+
+                start_x, start_y = self._convert_coordinates(start_coords[0], start_coords[1])
+                end_x, end_y = self._convert_coordinates(end_coords[0], end_coords[1])
+
+                await self._page.mouse.move(start_x, start_y)
+                await self._page.mouse.down()
+                await self._page.mouse.move(end_x, end_y, steps=10)
+                await self._page.mouse.up()
+                await asyncio.sleep(0.5)
+
+            elif action_name in ("goto", "goto_url"):
+                url = arguments.get("url", "")
+                await self._page.goto(url)
+                await self._page.wait_for_load_state("domcontentloaded")
+                await asyncio.sleep(1)
+
+            elif action_name in ("back", "go_back"):
+                await self._page.go_back()
+                await self._page.wait_for_load_state("domcontentloaded")
+                await asyncio.sleep(0.5)
+
+            elif action_name == "refresh":
+                await self._page.reload()
+                await self._page.wait_for_load_state("domcontentloaded")
+                await asyncio.sleep(1)
+
+            elif action_name == "wait":
+                await asyncio.sleep(2)
+
+            else:
+                logger.warning(f"Unknown action: {action_name}")
+                return False
+
+            # Wait for any navigation or dynamic content
+            try:
+                await self._page.wait_for_load_state("domcontentloaded", timeout=3000)
+            except Exception:
+                pass
+
+            return True
+
+        except Exception as e:
+            logger.error(f"Error executing {action_name}: {e}")
+            return False
+
+
+async def main():
+    logger.remove()
+    logger.level("DEBUG", color="<fg #808080>")
+    logger.add(
+        sys.stdout,
+        format=(
+            "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
+            "<level>{level: <8}</level> | "
+            "<cyan>{file}</cyan>:<cyan>{line:>3}</cyan> | "
+            "<level>{message}</level>{exception}"
+        ),
+        colorize=True,
+    )
+
+    default_config = Config()
+    parser = argparse.ArgumentParser(description="Example of using Yutori n1 API to perform a web browsing task")
+    parser.add_argument("--task", default=default_config.task, help="The task to perform")
+    parser.add_argument("--start-url", default=default_config.start_url, help="Starting URL")
+    parser.add_argument(
+        "--api-key",
+        default=default_config.api_key,
+        help="Yutori API key, or set YUTORI_API_KEY in environment variables",
+    )
+    parser.add_argument("--base-url", default=default_config.base_url, help="Yutori n1 base URL")
+    parser.add_argument("--model", default=default_config.model, help="Yutori n1 model")
+    parser.add_argument("--temperature", type=float, default=default_config.temperature, help="Yutori n1 temperature")
+    parser.add_argument("--max-steps", type=int, default=default_config.max_steps, help="Maximum number of steps")
+    parser.add_argument("--viewport-width", type=int, default=default_config.viewport_width, help="Viewport width")
+    parser.add_argument("--viewport-height", type=int, default=default_config.viewport_height, help="Viewport height")
+    parser.add_argument("--headless", action="store_true", help="Run browser in headless mode")
+    args = parser.parse_args()
+    config = Config.model_validate(vars(args))
+
+    agent = Agent(
+        api_key=config.api_key,
+        base_url=config.base_url,
+        model=config.model,
+        temperature=config.temperature,
+        max_steps=config.max_steps,
+        viewport_width=config.viewport_width,
+        viewport_height=config.viewport_height,
+        headless=config.headless,
+    )
+
+    result = await agent.run(config.task, config.start_url)
+    logger.info(f"Final result: {result or '(No final response from model)'}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/n1.py
+++ b/examples/n1.py
@@ -64,7 +64,7 @@ class Agent:
         self.viewport_height = viewport_height
         self.headless = headless
 
-        self._client = AsyncYutoriClient(api_key=api_key, base_url=base_url)
+        self._client = AsyncYutoriClient(api_key=self.api_key, base_url=self.base_url)
         self._browser: Browser | None = None
         self._page: Page | None = None
         self._messages: list = []

--- a/examples/n1.py
+++ b/examples/n1.py
@@ -19,10 +19,11 @@ import os
 import sys
 
 from loguru import logger
-from openai import OpenAI
 from PIL import Image
 from playwright.async_api import Browser, Page, async_playwright
 from pydantic import BaseModel, Field
+
+from yutori import AsyncYutoriClient
 
 
 class Config(BaseModel):
@@ -63,7 +64,7 @@ class Agent:
         self.viewport_height = viewport_height
         self.headless = headless
 
-        self._client = OpenAI(base_url=base_url, api_key=api_key)
+        self._client = AsyncYutoriClient(api_key=api_key, base_url=base_url)
         self._browser: Browser | None = None
         self._page: Page | None = None
         self._messages: list = []
@@ -207,7 +208,7 @@ class Agent:
                 self._messages.append(tool_message)
                 logger.info(f"Tool result: {self._format_message_for_log(tool_message)}")
 
-        response = self._client.chat.completions.create(
+        response = await self._client.chat.completions.create(
             model=self.model, messages=self._messages, temperature=self.temperature
         )
         return response

--- a/examples/n1.py
+++ b/examples/n1.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-n1 Browser Agent - A web browsing agent using Yutori's n1 API
+A web browsing agent using Yutori's n1 API (OpenAI API compatible)
 
 This script takes a user query, launches a local Playwright browser session,
 calls the n1 API to get actions, executes them, and iterates until the task is complete.
@@ -35,7 +35,7 @@ class Config(BaseModel):
     model: str = "n1-latest"
     temperature: float = 0.3
     # agent
-    max_steps: int = 30
+    max_steps: int = 100
     # browser
     viewport_width: int = 1280
     viewport_height: int = 800
@@ -49,7 +49,7 @@ class Agent:
         base_url: str = "https://api.yutori.com/v1",
         model: str = "n1-latest",
         temperature: float = 0.3,
-        max_steps: int = 30,
+        max_steps: int = 100,
         viewport_width: int = 1280,
         viewport_height: int = 800,
         headless: bool = False,
@@ -219,6 +219,7 @@ class Agent:
             arguments = json.loads(tool_call.function.arguments)
         except json.JSONDecodeError:
             logger.error(f"Failed to parse arguments: {tool_call.function.arguments}")
+            return
 
         try:
             if action_name == "left_click":
@@ -320,7 +321,7 @@ class Agent:
 
             else:
                 logger.warning(f"Unknown action: {action_name}")
-                return False
+                return
 
             # Wait for any navigation or dynamic content
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,7 @@ description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"
 
-authors = [
-    { name = "Yutori", email = "support@yutori.com" },
-]
+authors = [{ name = "Yutori", email = "support@yutori.com" }]
 
 license = { text = "Apache License 2.0" }
 keywords = ["yutori", "sdk", "api", "automation", "web-agent", "browser", "ai"]
@@ -28,9 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
-dependencies = [
-    "httpx>=0.26.0,<0.28.0",
-]
+dependencies = ["httpx>=0.26.0,<0.28.0"]
 
 [project.urls]
 Homepage = "https://yutori.com"
@@ -40,6 +36,13 @@ Issues = "https://github.com/yutori-ai/yutori-sdk-python/issues"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "ruff>=0.1"]
+examples = [
+    "loguru>=0.7.0",
+    "openai>=1.0.0",
+    "pillow>=10.0.0",
+    "playwright>=1.40.0",
+    "pydantic>=2.0.0",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -54,4 +57,3 @@ select = ["E", "F", "I", "W"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ examples = [
     "pillow>=10.0.0",
     "playwright>=1.40.0",
     "pydantic>=2.0.0",
+    "tenacity>=9.0.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
-dependencies = ["httpx>=0.26.0,<0.28.0"]
+dependencies = ["httpx>=0.26.0,<0.28.0", "openai>=1.0.0"]
 
 [project.urls]
 Homepage = "https://yutori.com"
@@ -38,7 +38,6 @@ Issues = "https://github.com/yutori-ai/yutori-sdk-python/issues"
 dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "ruff>=0.1"]
 examples = [
     "loguru>=0.7.0",
-    "openai>=1.0.0",
     "pillow>=10.0.0",
     "playwright>=1.40.0",
     "pydantic>=2.0.0",

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -209,6 +209,7 @@ class TestAsyncChatNamespace:
         with patch("yutori._async.chat.AsyncOpenAI") as MockAsyncOpenAI:
             mock_openai_client = MagicMock()
             mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+            mock_openai_client.close = AsyncMock()
             MockAsyncOpenAI.return_value = mock_openai_client
 
             async with AsyncYutoriClient(api_key="yt-test") as client:

--- a/yutori/_async/chat.py
+++ b/yutori/_async/chat.py
@@ -26,7 +26,7 @@ class AsyncChatCompletions:
         Args:
             messages: List of messages following OpenAI Chat format.
             model: Model to use (default: "n1-latest").
-            **kwargs: Additional parameters (e.g., temperature, stream).
+            **kwargs: Additional parameters (e.g., temperature).
 
         Returns:
             ChatCompletion object.

--- a/yutori/_async/chat.py
+++ b/yutori/_async/chat.py
@@ -2,52 +2,41 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any, Iterable
 
-from .._http import build_headers, handle_response
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 
-if TYPE_CHECKING:
-    import httpx
+
+class AsyncChatCompletions:
+    """OpenAI-compatible chat completions for n1 API (async)."""
+
+    def __init__(self, openai_client: AsyncOpenAI) -> None:
+        self._client = openai_client
+
+    async def create(
+        self,
+        messages: Iterable[ChatCompletionMessageParam],
+        *,
+        model: str = "n1-latest",
+        **kwargs: Any,
+    ) -> ChatCompletion:
+        """Create a chat completion using the n1 API.
+
+        Args:
+            messages: List of messages following OpenAI Chat format.
+            model: Model to use (default: "n1-latest").
+            **kwargs: Additional parameters (e.g., temperature, stream).
+
+        Returns:
+            ChatCompletion object.
+        """
+        return await self._client.chat.completions.create(model=model, messages=messages, **kwargs)
 
 
 class AsyncChatNamespace:
     """Async namespace for n1 API operations (pixels-to-actions LLM)."""
 
-    def __init__(self, client: httpx.AsyncClient, base_url: str, api_key: str) -> None:
-        self._client = client
-        self._base_url = base_url
-        self._api_key = api_key
-
-    async def completions(
-        self,
-        messages: list[dict[str, Any]],
-        *,
-        model: str = "n1-preview-2025-11",
-        **kwargs: Any,
-    ) -> dict[str, Any]:
-        """Get next browser action from screenshot using the n1 API.
-
-        The n1 API is a pixels-to-actions LLM that processes screenshots
-        and predicts browser actions (click, type, scroll, etc.).
-
-        Args:
-            messages: List of messages following OpenAI Chat format.
-                      Use "observation" role for screenshots.
-            model: Model to use (default: "n1-preview-2025-11").
-            **kwargs: Additional parameters passed to the API.
-
-        Returns:
-            Dictionary containing the model's response with predicted actions.
-        """
-        payload: dict[str, Any] = {
-            "messages": messages,
-            "model": model,
-            **kwargs,
-        }
-
-        response = await self._client.post(
-            f"{self._base_url}/chat/completions",
-            headers=build_headers(self._api_key, auth_type="bearer"),
-            json=payload,
-        )
-        return handle_response(response)
+    def __init__(self, base_url: str, api_key: str, timeout: float) -> None:
+        self._openai_client = AsyncOpenAI(base_url=base_url, api_key=api_key, timeout=timeout)
+        self.completions = AsyncChatCompletions(self._openai_client)

--- a/yutori/_async/chat.py
+++ b/yutori/_async/chat.py
@@ -40,3 +40,6 @@ class AsyncChatNamespace:
     def __init__(self, base_url: str, api_key: str, timeout: float) -> None:
         self._openai_client = AsyncOpenAI(base_url=base_url, api_key=api_key, timeout=timeout)
         self.completions = AsyncChatCompletions(self._openai_client)
+
+    async def close(self) -> None:
+        await self._openai_client.close()

--- a/yutori/_sync/chat.py
+++ b/yutori/_sync/chat.py
@@ -26,7 +26,7 @@ class ChatCompletions:
         Args:
             messages: List of messages following OpenAI Chat format.
             model: Model to use (default: "n1-latest").
-            **kwargs: Additional parameters (e.g., temperature, stream).
+            **kwargs: Additional parameters (e.g., temperature).
 
         Returns:
             ChatCompletion object.

--- a/yutori/_sync/chat.py
+++ b/yutori/_sync/chat.py
@@ -40,3 +40,6 @@ class ChatNamespace:
     def __init__(self, base_url: str, api_key: str, timeout: float) -> None:
         self._openai_client = OpenAI(base_url=base_url, api_key=api_key, timeout=timeout)
         self.completions = ChatCompletions(self._openai_client)
+
+    def close(self) -> None:
+        self._openai_client.close()

--- a/yutori/_sync/chat.py
+++ b/yutori/_sync/chat.py
@@ -2,52 +2,41 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any, Iterable
 
-from .._http import build_headers, handle_response
+from openai import OpenAI
+from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 
-if TYPE_CHECKING:
-    import httpx
+
+class ChatCompletions:
+    """OpenAI-compatible chat completions for n1 API."""
+
+    def __init__(self, openai_client: OpenAI) -> None:
+        self._client = openai_client
+
+    def create(
+        self,
+        messages: Iterable[ChatCompletionMessageParam],
+        *,
+        model: str = "n1-latest",
+        **kwargs: Any,
+    ) -> ChatCompletion:
+        """Create a chat completion using the n1 API.
+
+        Args:
+            messages: List of messages following OpenAI Chat format.
+            model: Model to use (default: "n1-latest").
+            **kwargs: Additional parameters (e.g., temperature, stream).
+
+        Returns:
+            ChatCompletion object.
+        """
+        return self._client.chat.completions.create(model=model, messages=messages, **kwargs)
 
 
 class ChatNamespace:
     """Namespace for n1 API operations (pixels-to-actions LLM)."""
 
-    def __init__(self, client: httpx.Client, base_url: str, api_key: str) -> None:
-        self._client = client
-        self._base_url = base_url
-        self._api_key = api_key
-
-    def completions(
-        self,
-        messages: list[dict[str, Any]],
-        *,
-        model: str = "n1-preview-2025-11",
-        **kwargs: Any,
-    ) -> dict[str, Any]:
-        """Get next browser action from screenshot using the n1 API.
-
-        The n1 API is a pixels-to-actions LLM that processes screenshots
-        and predicts browser actions (click, type, scroll, etc.).
-
-        Args:
-            messages: List of messages following OpenAI Chat format.
-                      Use "observation" role for screenshots.
-            model: Model to use (default: "n1-preview-2025-11").
-            **kwargs: Additional parameters passed to the API.
-
-        Returns:
-            Dictionary containing the model's response with predicted actions.
-        """
-        payload: dict[str, Any] = {
-            "messages": messages,
-            "model": model,
-            **kwargs,
-        }
-
-        response = self._client.post(
-            f"{self._base_url}/chat/completions",
-            headers=build_headers(self._api_key, auth_type="bearer"),
-            json=payload,
-        )
-        return handle_response(response)
+    def __init__(self, base_url: str, api_key: str, timeout: float) -> None:
+        self._openai_client = OpenAI(base_url=base_url, api_key=api_key, timeout=timeout)
+        self.completions = ChatCompletions(self._openai_client)

--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -71,7 +71,7 @@ class AsyncYutoriClient:
         self.scouts = AsyncScoutsNamespace(self._client, self._base_url, self._api_key)
         self.browsing = AsyncBrowsingNamespace(self._client, self._base_url, self._api_key)
         self.research = AsyncResearchNamespace(self._client, self._base_url, self._api_key)
-        self.chat = AsyncChatNamespace(self._client, self._base_url, self._api_key)
+        self.chat = AsyncChatNamespace(self._base_url, self._api_key, timeout)
 
     async def get_usage(self) -> dict[str, Any]:
         """Get usage statistics for your API key.

--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -91,6 +91,7 @@ class AsyncYutoriClient:
     async def close(self) -> None:
         """Release the underlying HTTP client resources."""
         await self._client.aclose()
+        await self.chat.close()
 
     async def __aenter__(self) -> AsyncYutoriClient:
         return self

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -61,7 +61,7 @@ class YutoriClient:
         self.scouts = ScoutsNamespace(self._client, self._base_url, self._api_key)
         self.browsing = BrowsingNamespace(self._client, self._base_url, self._api_key)
         self.research = ResearchNamespace(self._client, self._base_url, self._api_key)
-        self.chat = ChatNamespace(self._client, self._base_url, self._api_key)
+        self.chat = ChatNamespace(self._base_url, self._api_key, timeout)
 
     def get_usage(self) -> dict[str, Any]:
         """Get usage statistics for your API key.

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -81,6 +81,7 @@ class YutoriClient:
     def close(self) -> None:
         """Release the underlying HTTP client resources."""
         self._client.close()
+        self.chat.close()
 
     def __enter__(self) -> YutoriClient:
         return self


### PR DESCRIPTION
Changes:
- Update SDK's chat namespace to be OpenAI API compatible (now `client.chat.completions.**create**`, returns a pydantic object rather than dict, which is consistent with our doc website)
- Add a self-contained example `examples/n1.py` showing how to build a simple agent with n1 API for web browsing tasks.
- Update README for installation and getting started

Run the script:
```
uv run python examples/n1.py \
  --task "List the team member names" \
  --start-url "https://www.yutori.com"
```
which will open a local chromium browser and navigate to finish the task. Log things like:
<img width="1672" height="1442" alt="image" src="https://github.com/user-attachments/assets/88f322ac-acbe-4787-93a5-b9a0ed30bb99" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public chat API shape (now `client.chat.completions.create` returning `ChatCompletion`) and introduces a new dependency (`openai`), which may affect existing integrations and resource cleanup.
> 
> **Overview**
> Updates the n1 chat interface to be **OpenAI SDK compatible**, moving from raw `httpx` calls returning dicts to `OpenAI`/`AsyncOpenAI` calls via `client.chat.completions.create(...)` that return typed `ChatCompletion` objects, and ensures clients close the underlying OpenAI client on `close()`/context exit.
> 
> Adds a new `examples/` package with a self-contained `examples/n1.py` Playwright browsing agent plus setup docs, updates `README.md` usage snippets to match the new API, and adjusts packaging (`openai` dependency + `examples` extras) and version control to include `uv.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31f2384b8c8595d54c3a344f4240aa25a8286e1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->