### PR TITLE
Update docs for PR #2 and clean up dead code

### DIFF
--- a/api.md
+++ b/api.md
@@ -56,31 +56,45 @@ async with AsyncYutoriClient(api_key="yt-...") as client:
 
 ### client.chat
 
-n1 API - Pixels-to-actions LLM for browser control.
+n1 API - Pixels-to-actions LLM for browser control. OpenAI SDK compatible.
 
 | Method | HTTP | Endpoint | Returns |
 |--------|------|----------|---------|
-| `client.chat.completions(messages, model="n1-preview-2025-11", **kwargs)` | POST | `/v1/chat/completions` | `dict` |
+| `client.chat.completions.create(messages, model="n1-latest", **kwargs)` | POST | `/v1/chat/completions` | `ChatCompletion` |
 
-#### chat.completions
+#### chat.completions.create
 
 ```python
-response = client.chat.completions(
+response = client.chat.completions.create(
+    model="n1-latest",
     messages=[
-        {"role": "user", "content": [{"type": "text", "text": "Search for Yutori"}]},
-        {"role": "observation", "content": [{"type": "image_url", "image_url": {"url": "..."}}]}
-    ],
-    model="n1-preview-2025-11",  # Optional, this is the default
-    temperature=0.3,             # Optional
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe the screenshot and search for Yutori."},
+                {"type": "image_url", "image_url": {"url": "https://example.com/screenshot.jpg"}}
+            ]
+        }
+    ]
 )
+
+# Access the response
+message = response.choices[0].message
+print(message.content)  # Model's thoughts
+
+# Get tool calls (browser actions)
+if message.tool_calls:
+    for tool_call in message.tool_calls:
+        print(f"Action: {tool_call.function.name}")
+        print(f"Arguments: {tool_call.function.arguments}")
 ```
 
 **Parameters:**
-- `messages` (list[dict]): Chat messages. Use `"observation"` role for screenshots.
-- `model` (str): Model ID. Default: `"n1-preview-2025-11"`.
-- `**kwargs`: Additional parameters passed to the API.
+- `messages` (Iterable[ChatCompletionMessageParam]): Chat messages following OpenAI format. Include screenshots as `image_url` content blocks.
+- `model` (str): Model ID. Default: `"n1-latest"`.
+- `**kwargs`: Additional parameters (e.g., `temperature`).
 
-**Returns:** Dictionary with `thoughts` and `actions` fields.
+**Returns:** `ChatCompletion` object from the OpenAI SDK with `choices[0].message` containing the model's response and optional `tool_calls` for browser actions.
 
 ---
 
@@ -329,6 +343,11 @@ The SDK supports two authentication methods:
    ```
 
 API keys start with `yt-` and can be created at [platform.yutori.com](https://platform.yutori.com).
+
+## Dependencies
+
+- `httpx>=0.26.0,<0.28.0` - HTTP client for browsing, research, and scouting APIs
+- `openai>=1.0.0` - OpenAI SDK for the n1 chat API (provides `ChatCompletion` types)
 
 ## Error Handling
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,10 +1,6 @@
-# Yutori SDK Examples
-
-Example scripts demonstrating how to use the Yutori API.
+# Examples
 
 ## Setup
-
-Install dependencies using [uv](https://docs.astral.sh/uv/getting-started/installation/):
 
 ```bash
 # Install SDK with example dependencies
@@ -14,22 +10,16 @@ uv sync --extra examples
 uv run playwright install chromium
 ```
 
-Set your API key (see [Authentication](https://docs.yutori.com/authentication)):
+## n1.py
 
-```bash
-export YUTORI_API_KEY=<your-api-key>
-```
-
-## Examples
-
-### n1.py
-
-Demonstrate how to build a browsing agent with n1 API to navigate the web and complete tasks.
-
-The script launches a local Playwright browser, takes screenshots, sends them to the n1 API to get predicted actions, executes those actions, and repeats until the task is complete.
-
-**Usage:**
+A complete browsing agent using the n1 API. Launches a local Playwright browser, takes screenshots, sends them to n1 to get predicted actions, and executes them until the task is complete.
 
 ```bash
 uv run python examples/n1.py --task "List the team member names" --start-url "https://www.yutori.com"
 ```
+
+Options:
+- `--task` - The task to perform
+- `--start-url` - Starting URL
+- `--headless` - Run browser in headless mode
+- `--max-steps` - Maximum number of steps (default: 100)

--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -9,18 +9,12 @@ import httpx
 from .exceptions import APIError, AuthenticationError
 
 
-def build_headers(api_key: str, auth_type: str = "api_key") -> dict[str, str]:
-    """Build request headers with appropriate authentication."""
-    headers = {"Content-Type": "application/json"}
-
-    if auth_type == "api_key":
-        headers["x-api-key"] = api_key
-    elif auth_type == "bearer":
-        headers["Authorization"] = f"Bearer {api_key}"
-    else:
-        raise ValueError(f"Unsupported auth type: {auth_type}")
-
-    return headers
+def build_headers(api_key: str) -> dict[str, str]:
+    """Build request headers with API key authentication."""
+    return {
+        "Content-Type": "application/json",
+        "x-api-key": api_key,
+    }
 
 
 def handle_response(response: httpx.Response) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- Update `api.md` for the new n1 chat API interface from PR #2:
  - Method: `client.chat.completions.create()` (was `client.chat.completions()`)
  - Model: `n1-latest` (was `n1-preview-2025-11`)
  - Format: Standard OpenAI message format (no more `observation` role)
  - Returns: `ChatCompletion` object (was `dict`)
  - Added Dependencies section documenting `openai>=1.0.0`
- Simplify `examples/README.md` to remove redundant onboarding info already in main README
- Remove unused `auth_type` parameter from `build_headers()` in `_http.py`

## Test plan

- [x] All 43 unit tests pass
- [x] Verified against live API with test key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily documentation updates plus a small internal cleanup to always use `x-api-key` headers, with no new runtime behavior beyond removing an unused option.
> 
> **Overview**
> Updates the n1 chat API documentation to the new OpenAI-SDK-compatible interface: `client.chat.completions.create(...)` with model default `n1-latest`, standard OpenAI `messages` format (including `image_url` blocks), and a typed `ChatCompletion` return that exposes `choices[0].message` and optional `tool_calls`.
> 
> Adds a `Dependencies` section documenting the `openai` requirement, streamlines `examples/README.md`, and simplifies `_http.build_headers()` by removing the unused `auth_type` branch and always emitting `x-api-key` auth headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dff9cb303576733a353086f514a6c536d451947. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->