### PR TITLE
Add CLI with browser-based authentication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,14 @@ examples = [
     "pydantic>=2.0.0",
     "tenacity>=9.0.0",
 ]
+cli = [
+    "typer>=0.9.0",
+    "keyring>=24.0.0",
+    "rich>=13.0.0",
+]
+
+[project.scripts]
+yutori = "yutori.cli.main:app"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/yutori/cli/__init__.py
+++ b/yutori/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Yutori CLI module."""

--- a/yutori/cli/auth/__init__.py
+++ b/yutori/cli/auth/__init__.py
@@ -1,0 +1,5 @@
+"""Authentication utilities for the CLI."""
+
+from .credentials import clear_credentials, get_credentials, save_credentials
+
+__all__ = ["get_credentials", "save_credentials", "clear_credentials"]

--- a/yutori/cli/auth/callback_server.py
+++ b/yutori/cli/auth/callback_server.py
@@ -1,0 +1,164 @@
+"""Local HTTP callback server for browser-based authentication."""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Callable
+from urllib.parse import parse_qs, urlparse
+
+from ..constants import CALLBACK_TIMEOUT_SECONDS, DEFAULT_CALLBACK_PORT
+
+
+@dataclass
+class AuthResult:
+    """Result from the authentication callback."""
+
+    success: bool
+    api_key: str | None = None
+    key_name: str | None = None
+    error: str | None = None
+
+
+class CallbackHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for the auth callback."""
+
+    result: AuthResult | None = None
+    expected_state: str | None = None
+    on_result: Callable[[AuthResult], None] | None = None
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+
+        if parsed.path != "/callback":
+            self._send_response(404, "Not Found")
+            return
+
+        params = parse_qs(parsed.query)
+        state = params.get("state", [None])[0]
+        key = params.get("key", [None])[0]
+        name = params.get("name", [None])[0]
+        error = params.get("error", [None])[0]
+
+        if error:
+            result = AuthResult(success=False, error=error)
+            self._send_success_page("Authentication failed. You can close this window.")
+            self._set_result(result)
+            return
+
+        if not state or state != CallbackHandler.expected_state:
+            result = AuthResult(success=False, error="Invalid state parameter (possible CSRF)")
+            self._send_success_page("Authentication failed: Invalid state. You can close this window.")
+            self._set_result(result)
+            return
+
+        if not key:
+            result = AuthResult(success=False, error="No API key received")
+            self._send_success_page("Authentication failed: No key received. You can close this window.")
+            self._set_result(result)
+            return
+
+        result = AuthResult(success=True, api_key=key, key_name=name)
+        self._send_success_page("Authentication successful! You can close this window and return to your terminal.")
+        self._set_result(result)
+
+    def _send_response(self, code: int, message: str) -> None:
+        self.send_response(code)
+        self.send_header("Content-type", "text/plain")
+        self.end_headers()
+        self.wfile.write(message.encode())
+
+    def _send_success_page(self, message: str) -> None:
+        html = f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>Yutori CLI Authentication</title>
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+            background-color: #f8fafc;
+        }}
+        .container {{
+            text-align: center;
+            padding: 2rem;
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            max-width: 400px;
+        }}
+        h1 {{ color: #1e293b; margin-bottom: 1rem; }}
+        p {{ color: #64748b; }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Yutori CLI</h1>
+        <p>{message}</p>
+    </div>
+</body>
+</html>"""
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write(html.encode())
+
+    def _set_result(self, result: AuthResult) -> None:
+        CallbackHandler.result = result
+        if CallbackHandler.on_result:
+            CallbackHandler.on_result(result)
+
+
+def generate_state() -> str:
+    """Generate a random state string for CSRF protection."""
+    return secrets.token_urlsafe(32)
+
+
+def start_callback_server(
+    state: str,
+    port: int = DEFAULT_CALLBACK_PORT,
+    timeout: int = CALLBACK_TIMEOUT_SECONDS,
+) -> AuthResult:
+    """Start the callback server and wait for authentication.
+
+    Args:
+        state: The state string for CSRF protection.
+        port: The port to listen on.
+        timeout: Maximum seconds to wait for callback.
+
+    Returns:
+        AuthResult with the authentication outcome.
+    """
+    CallbackHandler.result = None
+    CallbackHandler.expected_state = state
+
+    server = HTTPServer(("127.0.0.1", port), CallbackHandler)
+    server.timeout = 1
+
+    result_event = threading.Event()
+
+    def on_result(result: AuthResult) -> None:
+        result_event.set()
+
+    CallbackHandler.on_result = on_result
+
+    start_time = time.time()
+    while not result_event.is_set():
+        if time.time() - start_time > timeout:
+            server.server_close()
+            return AuthResult(success=False, error=f"Timed out waiting for authentication ({timeout}s)")
+
+        server.handle_request()
+
+    server.server_close()
+    return CallbackHandler.result or AuthResult(success=False, error="Unknown error")

--- a/yutori/cli/auth/credentials.py
+++ b/yutori/cli/auth/credentials.py
@@ -1,0 +1,144 @@
+"""Credential storage for the Yutori CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TypedDict
+
+from ..constants import (
+    CREDENTIALS_DIR_NAME,
+    CREDENTIALS_FILE_NAME,
+    KEYRING_SERVICE_NAME,
+    KEYRING_USERNAME,
+)
+
+
+class StoredCredentials(TypedDict):
+    api_key: str
+    created_at: str
+    key_name: str
+
+
+def _get_credentials_file_path() -> Path:
+    """Get the path to the credentials file."""
+    config_dir = Path.home() / ".config" / CREDENTIALS_DIR_NAME
+    return config_dir / CREDENTIALS_FILE_NAME
+
+
+def _try_keyring_get() -> str | None:
+    """Try to get credentials from system keyring."""
+    try:
+        import keyring
+
+        return keyring.get_password(KEYRING_SERVICE_NAME, KEYRING_USERNAME)
+    except Exception:
+        return None
+
+
+def _try_keyring_set(api_key: str) -> bool:
+    """Try to store credentials in system keyring."""
+    try:
+        import keyring
+
+        keyring.set_password(KEYRING_SERVICE_NAME, KEYRING_USERNAME, api_key)
+        return True
+    except Exception:
+        return False
+
+
+def _try_keyring_delete() -> bool:
+    """Try to delete credentials from system keyring."""
+    try:
+        import keyring
+
+        keyring.delete_password(KEYRING_SERVICE_NAME, KEYRING_USERNAME)
+        return True
+    except Exception:
+        return False
+
+
+def get_credentials() -> StoredCredentials | None:
+    """Get stored credentials.
+
+    Tries keyring first, then falls back to file storage.
+
+    Returns:
+        StoredCredentials if found, None otherwise.
+    """
+    api_key = _try_keyring_get()
+    if api_key:
+        return StoredCredentials(
+            api_key=api_key,
+            created_at="",
+            key_name="",
+        )
+
+    credentials_file = _get_credentials_file_path()
+    if credentials_file.exists():
+        try:
+            with open(credentials_file) as f:
+                data = json.load(f)
+                return StoredCredentials(
+                    api_key=data.get("api_key", ""),
+                    created_at=data.get("created_at", ""),
+                    key_name=data.get("key_name", ""),
+                )
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    return None
+
+
+def save_credentials(api_key: str, key_name: str) -> None:
+    """Save credentials.
+
+    Tries keyring first, then falls back to file storage.
+
+    Args:
+        api_key: The API key to store.
+        key_name: The name of the API key.
+    """
+    if _try_keyring_set(api_key):
+        return
+
+    credentials_file = _get_credentials_file_path()
+    credentials_file.parent.mkdir(parents=True, exist_ok=True)
+
+    credentials = StoredCredentials(
+        api_key=api_key,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        key_name=key_name,
+    )
+
+    with open(credentials_file, "w") as f:
+        json.dump(credentials, f, indent=2)
+
+    os.chmod(credentials_file, stat.S_IRUSR | stat.S_IWUSR)
+
+
+def clear_credentials() -> bool:
+    """Clear stored credentials.
+
+    Removes from both keyring and file storage.
+
+    Returns:
+        True if any credentials were cleared, False otherwise.
+    """
+    cleared = False
+
+    if _try_keyring_delete():
+        cleared = True
+
+    credentials_file = _get_credentials_file_path()
+    if credentials_file.exists():
+        try:
+            credentials_file.unlink()
+            cleared = True
+        except OSError:
+            pass
+
+    return cleared

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -1,0 +1,1 @@
+"""CLI command modules."""

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -1,0 +1,97 @@
+"""Authentication commands for the Yutori CLI."""
+
+from __future__ import annotations
+
+import webbrowser
+from urllib.parse import urlencode
+
+import typer
+from rich.console import Console
+
+from ..auth.callback_server import generate_state, start_callback_server
+from ..auth.credentials import clear_credentials, get_credentials, save_credentials
+from ..constants import CLI_AUTH_PATH, DEFAULT_CALLBACK_PORT, WEB_APP_BASE_URL
+
+app = typer.Typer(help="Manage authentication")
+console = Console()
+
+
+@app.command()
+def login(
+    port: int = typer.Option(DEFAULT_CALLBACK_PORT, help="Local callback server port"),
+) -> None:
+    """Authenticate with Yutori via browser.
+
+    Opens your browser to log in and authorize the CLI.
+    """
+    existing = get_credentials()
+    if existing and existing.get("api_key"):
+        console.print("[yellow]You are already authenticated.[/yellow]")
+        console.print("Run [bold]yutori auth logout[/bold] first to re-authenticate.")
+        raise typer.Exit(1)
+
+    state = generate_state()
+
+    params = urlencode({"state": state, "port": str(port)})
+    auth_url = f"{WEB_APP_BASE_URL}{CLI_AUTH_PATH}?{params}"
+
+    console.print("\n[bold]Opening browser for authentication...[/bold]")
+    console.print(f"If it doesn't open, visit: {auth_url}\n")
+
+    webbrowser.open(auth_url)
+
+    console.print("[dim]Waiting for authentication...[/dim]")
+
+    result = start_callback_server(state, port=port)
+
+    if result.success and result.api_key:
+        save_credentials(result.api_key, result.key_name or "CLI Key")
+        console.print("\n[green]Successfully authenticated![/green]")
+        console.print("You can now use the Yutori CLI.")
+    else:
+        console.print(f"\n[red]Authentication failed: {result.error}[/red]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def logout() -> None:
+    """Remove stored credentials."""
+    if clear_credentials():
+        console.print("[green]Successfully logged out.[/green]")
+    else:
+        console.print("[yellow]No credentials found.[/yellow]")
+
+
+@app.command()
+def status() -> None:
+    """Show current authentication status."""
+    creds = get_credentials()
+
+    if not creds or not creds.get("api_key"):
+        console.print("[yellow]Not authenticated.[/yellow]")
+        console.print("Run [bold]yutori auth login[/bold] to authenticate.")
+        raise typer.Exit(1)
+
+    api_key = creds["api_key"]
+    masked_key = f"{api_key[:7]}...{api_key[-4:]}" if len(api_key) > 11 else "***"
+
+    console.print("[green]Authenticated[/green]")
+    console.print(f"  API Key: {masked_key}")
+
+    if creds.get("key_name"):
+        console.print(f"  Key Name: {creds['key_name']}")
+    if creds.get("created_at"):
+        console.print(f"  Created: {creds['created_at']}")
+
+    try:
+        from yutori import YutoriClient
+
+        client = YutoriClient(api_key=api_key)
+        usage = client.get_usage()
+        client.close()
+
+        if usage.get("user_id"):
+            console.print(f"  User ID: {usage['user_id']}")
+        console.print("\n[green]API key is valid.[/green]")
+    except Exception as e:
+        console.print(f"\n[yellow]Warning: Could not verify API key: {e}[/yellow]")

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -1,0 +1,169 @@
+"""Scouts commands for the Yutori CLI."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ..auth.credentials import get_credentials
+
+app = typer.Typer(help="Manage scouts")
+console = Console()
+
+
+def _get_client() -> Any:
+    """Get an authenticated YutoriClient."""
+    from yutori import YutoriClient
+
+    creds = get_credentials()
+    if not creds or not creds.get("api_key"):
+        console.print("[red]Not authenticated. Run 'yutori auth login' first.[/red]")
+        raise typer.Exit(1)
+
+    return YutoriClient(api_key=creds["api_key"])
+
+
+@app.command("list")
+def list_scouts(
+    limit: int = typer.Option(None, help="Maximum number of scouts to return"),
+    status: str = typer.Option(None, help="Filter by status: active, paused, done"),
+) -> None:
+    """List your scouts."""
+    client = _get_client()
+
+    try:
+        result = client.scouts.list(limit=limit, status=status)
+        scouts = result.get("scouts", [])
+
+        if not scouts:
+            console.print("[yellow]No scouts found.[/yellow]")
+            return
+
+        table = Table(title="Your Scouts")
+        table.add_column("ID", style="cyan", no_wrap=True)
+        table.add_column("Query", max_width=50)
+        table.add_column("Status", style="green")
+        table.add_column("Interval")
+
+        for scout in scouts:
+            interval_secs = scout.get("output_interval", 0)
+            if interval_secs >= 86400:
+                interval_str = f"{interval_secs // 86400}d"
+            elif interval_secs >= 3600:
+                interval_str = f"{interval_secs // 3600}h"
+            else:
+                interval_str = f"{interval_secs // 60}m"
+
+            status_val = scout.get("status", "unknown")
+            query = scout.get("query", "")
+            if len(query) > 47:
+                query = query[:47] + "..."
+
+            table.add_row(
+                scout.get("id", ""),
+                query,
+                status_val,
+                interval_str,
+            )
+
+        console.print(table)
+    finally:
+        client.close()
+
+
+@app.command()
+def get(
+    scout_id: str = typer.Argument(help="The scout ID"),
+) -> None:
+    """Get details of a specific scout."""
+    client = _get_client()
+
+    try:
+        scout = client.scouts.get(scout_id)
+
+        console.print(f"\n[bold]Scout: {scout.get('id', scout_id)}[/bold]\n")
+        console.print(f"  Query: {scout.get('query', 'N/A')}")
+        console.print(f"  Status: {scout.get('status', 'N/A')}")
+
+        interval_secs = scout.get("output_interval", 0)
+        if interval_secs >= 86400:
+            interval_str = f"{interval_secs // 86400} day(s)"
+        elif interval_secs >= 3600:
+            interval_str = f"{interval_secs // 3600} hour(s)"
+        else:
+            interval_str = f"{interval_secs // 60} minute(s)"
+        console.print(f"  Interval: {interval_str}")
+
+        if scout.get("user_timezone"):
+            console.print(f"  Timezone: {scout['user_timezone']}")
+        if scout.get("user_location"):
+            console.print(f"  Location: {scout['user_location']}")
+        if scout.get("created_at"):
+            console.print(f"  Created: {scout['created_at']}")
+        if scout.get("last_run_at"):
+            console.print(f"  Last Run: {scout['last_run_at']}")
+        if scout.get("next_run_at"):
+            console.print(f"  Next Run: {scout['next_run_at']}")
+    finally:
+        client.close()
+
+
+@app.command()
+def create(
+    query: str = typer.Option(None, "--query", "-q", help="What to monitor"),
+    interval: str = typer.Option("daily", "--interval", "-i", help="Run interval: hourly, daily, weekly"),
+    timezone: str = typer.Option(None, "--timezone", "-tz", help="e.g., America/Los_Angeles"),
+) -> None:
+    """Create a new scout.
+
+    If --query is not provided, you will be prompted interactively.
+    """
+    if not query:
+        query = typer.prompt("What would you like to monitor?")
+
+    interval_map = {
+        "hourly": 3600,
+        "daily": 86400,
+        "weekly": 604800,
+    }
+    output_interval = interval_map.get(interval.lower(), 86400)
+
+    client = _get_client()
+
+    try:
+        result = client.scouts.create(
+            query=query,
+            output_interval=output_interval,
+            user_timezone=timezone,
+        )
+
+        console.print("\n[green]Scout created successfully![/green]")
+        console.print(f"  ID: {result.get('id', 'N/A')}")
+        console.print(f"  Query: {result.get('query', query)}")
+        console.print(f"  Status: {result.get('status', 'N/A')}")
+    finally:
+        client.close()
+
+
+@app.command()
+def delete(
+    scout_id: str = typer.Argument(help="The scout ID to delete"),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+) -> None:
+    """Delete a scout."""
+    if not force:
+        confirm = typer.confirm(f"Are you sure you want to delete scout {scout_id}?")
+        if not confirm:
+            console.print("[yellow]Cancelled.[/yellow]")
+            raise typer.Exit(0)
+
+    client = _get_client()
+
+    try:
+        client.scouts.delete(scout_id)
+        console.print(f"[green]Scout {scout_id} deleted.[/green]")
+    finally:
+        client.close()

--- a/yutori/cli/commands/usage.py
+++ b/yutori/cli/commands/usage.py
@@ -1,0 +1,76 @@
+"""Usage command for the Yutori CLI."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ..auth.credentials import get_credentials
+
+app = typer.Typer(help="View usage statistics")
+console = Console()
+
+
+def _get_client() -> Any:
+    """Get an authenticated YutoriClient."""
+    from yutori import YutoriClient
+
+    creds = get_credentials()
+    if not creds or not creds.get("api_key"):
+        console.print("[red]Not authenticated. Run 'yutori auth login' first.[/red]")
+        raise typer.Exit(1)
+
+    return YutoriClient(api_key=creds["api_key"])
+
+
+@app.callback(invoke_without_command=True)
+def usage(ctx: typer.Context) -> None:
+    """Show API usage statistics."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    client = _get_client()
+
+    try:
+        data = client.get_usage()
+
+        console.print("\n[bold]Usage Statistics[/bold]\n")
+
+        if data.get("user_id"):
+            console.print(f"  User ID: {data['user_id']}")
+        if data.get("api_key_id"):
+            console.print(f"  API Key ID: {data['api_key_id']}")
+
+        scouts = data.get("scouts", [])
+        if scouts:
+            console.print(f"\n  [bold]Scouts:[/bold] {len(scouts)}")
+
+            table = Table()
+            table.add_column("ID", style="cyan")
+            table.add_column("Query", max_width=40)
+            table.add_column("Status")
+            table.add_column("Runs")
+
+            for scout in scouts[:10]:
+                query = scout.get("query", "")
+                if len(query) > 37:
+                    query = query[:37] + "..."
+
+                table.add_row(
+                    scout.get("id", "")[:8] + "...",
+                    query,
+                    scout.get("status", ""),
+                    str(scout.get("run_count", 0)),
+                )
+
+            console.print(table)
+
+            if len(scouts) > 10:
+                console.print(f"  ... and {len(scouts) - 10} more")
+        else:
+            console.print("\n  No scouts yet.")
+    finally:
+        client.close()

--- a/yutori/cli/constants.py
+++ b/yutori/cli/constants.py
@@ -1,0 +1,13 @@
+"""Constants for the Yutori CLI."""
+
+DEFAULT_CALLBACK_PORT = 29170
+CALLBACK_TIMEOUT_SECONDS = 120
+CLI_KEY_NAME = "CLI Key (auto-generated)"
+
+CREDENTIALS_DIR_NAME = "yutori"
+CREDENTIALS_FILE_NAME = "credentials.json"
+KEYRING_SERVICE_NAME = "yutori-cli"
+KEYRING_USERNAME = "api_key"
+
+WEB_APP_BASE_URL = "https://app.yutori.com"
+CLI_AUTH_PATH = "/cli-auth"

--- a/yutori/cli/main.py
+++ b/yutori/cli/main.py
@@ -1,0 +1,29 @@
+"""Main entry point for the Yutori CLI."""
+
+from __future__ import annotations
+
+import typer
+
+from .commands import auth, scouts, usage
+
+app = typer.Typer(
+    name="yutori",
+    help="Yutori CLI - Manage your scouts and web automation",
+    no_args_is_help=True,
+)
+
+app.add_typer(auth.app, name="auth")
+app.add_typer(scouts.app, name="scouts")
+app.add_typer(usage.app, name="usage")
+
+
+@app.command()
+def version() -> None:
+    """Show the CLI version."""
+    from yutori import __version__
+
+    typer.echo(f"yutori {__version__}")
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary
- Add CLI module with browser-based authentication flow
- Integrate with `/cli-auth` page in Scout frontend (see yutori-ai/yutori#5725)
- Support credential storage via system keyring with file fallback

## CLI Commands

```bash
# Authentication
yutori auth login      # Opens browser, creates and saves API key
yutori auth logout     # Removes stored credentials
yutori auth status     # Shows current auth status and verifies key

# Scouts
yutori scouts list              # List all scouts
yutori scouts create            # Create a new scout (interactive)
yutori scouts get <scout_id>    # Get scout details
yutori scouts delete <scout_id> # Delete a scout

# Usage
yutori usage           # Show API usage statistics
```

## Installation

```bash
pip install yutori[cli]
```

## Test plan
- [ ] Install with `pip install -e ".[cli]"`
- [ ] Run `yutori auth login` and verify browser opens
- [ ] Complete authentication in browser
- [ ] Verify credentials stored (check `yutori auth status`)
- [ ] Test scout commands with authenticated session
- [ ] Test `yutori auth logout` clears credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new authentication/credential-handling code (local callback server, keyring/file storage) which can impact API key security, but is largely isolated from the core SDK.
> 
> **Overview**
> Adds an installable `yutori` CLI entrypoint (via `pyproject.toml` `cli` extras and `project.scripts`) built on Typer/Rich.
> 
> Implements browser-based authentication: `yutori auth login` opens the web app `/cli-auth`, runs a local HTTP callback server with state validation, and persists the returned API key via system keyring with a file fallback (restricted perms); `logout` and `status` manage/verify stored creds.
> 
> Adds initial operational commands: `yutori scouts` for list/get/create/delete and `yutori usage` to display usage/scout stats using `YutoriClient` with stored credentials.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9ae0bfa4b429a43f60e36a7edaf0614cef8d4d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->