### PR TITLE
Add CLI with Clerk OAuth 2.0 + PKCE authentication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.2.0"
+version = "0.3.0"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -34,7 +34,11 @@ Documentation = "https://docs.yutori.com"
 Repository = "https://github.com/yutori-ai/yutori-sdk-python"
 Issues = "https://github.com/yutori-ai/yutori-sdk-python/issues"
 
+[project.scripts]
+yutori = "yutori.cli.main:app"
+
 [project.optional-dependencies]
+cli = ["typer>=0.9.0", "rich>=13.0.0"]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "ruff>=0.1"]
 examples = [
     "loguru>=0.7.0",

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -18,11 +18,13 @@ class TestAsyncYutoriClientInit:
 
     def test_init_without_api_key_raises(self, monkeypatch):
         monkeypatch.delenv("YUTORI_API_KEY", raising=False)
+        monkeypatch.setattr("yutori.auth.credentials.load_config", lambda: None)
         with pytest.raises(AuthenticationError):
             AsyncYutoriClient(api_key="")
 
     def test_init_with_none_api_key_raises(self, monkeypatch):
         monkeypatch.delenv("YUTORI_API_KEY", raising=False)
+        monkeypatch.setattr("yutori.auth.credentials.load_config", lambda: None)
         with pytest.raises(AuthenticationError):
             AsyncYutoriClient(api_key=None)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,522 @@
+"""Tests for the yutori.auth module."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import os
+import stat
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from yutori.auth.constants import (
+    CALLBACK_HOST,
+    CLERK_CLIENT_ID,
+    CLERK_INSTANCE_URL,
+    REDIRECT_PORT,
+    REDIRECT_URI,
+    build_auth_api_url,
+)
+from yutori.auth.credentials import clear_config, load_config, resolve_api_key, save_config
+from yutori.auth.flow import (
+    _CallbackHandler,
+    _CallbackResult,
+    _mask_key,
+    build_auth_url,
+    exchange_code_for_token,
+    generate_api_key,
+    generate_pkce,
+    get_auth_status,
+    run_login_flow,
+)
+from yutori.auth.types import AuthStatus, LoginResult
+
+
+# ---------------------------------------------------------------------------
+# PKCE
+# ---------------------------------------------------------------------------
+
+class TestPKCE:
+    def test_generate_pkce_returns_pair(self):
+        verifier, challenge = generate_pkce()
+        assert isinstance(verifier, str)
+        assert isinstance(challenge, str)
+        assert len(verifier) > 40
+
+    def test_generate_pkce_produces_valid_s256_challenge(self):
+        verifier, challenge = generate_pkce()
+        expected = base64.urlsafe_b64encode(
+            hashlib.sha256(verifier.encode()).digest()
+        ).rstrip(b"=").decode()
+        assert challenge == expected
+
+    def test_generate_pkce_unique_each_call(self):
+        v1, c1 = generate_pkce()
+        v2, c2 = generate_pkce()
+        assert v1 != v2
+        assert c1 != c2
+
+
+# ---------------------------------------------------------------------------
+# build_auth_url
+# ---------------------------------------------------------------------------
+
+class TestBuildAuthUrl:
+    def test_contains_required_params(self):
+        url = build_auth_url("test_challenge", "test_state")
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert parsed.scheme == "https"
+        assert "oauth/authorize" in parsed.path
+        assert params["response_type"] == ["code"]
+        assert params["client_id"] == [CLERK_CLIENT_ID]
+        assert params["redirect_uri"] == [REDIRECT_URI]
+        assert params["code_challenge"] == ["test_challenge"]
+        assert params["code_challenge_method"] == ["S256"]
+        assert params["state"] == ["test_state"]
+        assert params["scope"] == ["openid profile email"]
+
+
+# ---------------------------------------------------------------------------
+# Credentials: save / load / clear / resolve
+# ---------------------------------------------------------------------------
+
+class TestCredentials:
+    @pytest.fixture(autouse=True)
+    def _use_tmp_config(self, tmp_path, monkeypatch):
+        """Redirect config path to a temp directory for all credential tests."""
+        config_path = tmp_path / ".yutori" / "config.json"
+        monkeypatch.setattr("yutori.auth.credentials._get_config_path", lambda: config_path)
+        # Also patch the import in flow.py which imports _get_config_path
+        monkeypatch.setattr("yutori.auth.flow._get_config_path", lambda: config_path)
+        self.config_path = config_path
+        self.config_dir = config_path.parent
+
+    def test_save_and_load_round_trip(self):
+        save_config("yt-test-key-12345")
+        result = load_config()
+        assert result is not None
+        assert result["api_key"] == "yt-test-key-12345"
+
+    def test_save_creates_directory(self):
+        assert not self.config_dir.exists()
+        save_config("yt-key")
+        assert self.config_dir.exists()
+
+    def test_save_sets_file_permissions_0600(self):
+        save_config("yt-key")
+        file_mode = self.config_path.stat().st_mode & 0o777
+        assert file_mode == 0o600
+
+    def test_save_sets_directory_permissions_0700(self):
+        save_config("yt-key")
+        dir_mode = self.config_dir.stat().st_mode & 0o777
+        assert dir_mode == 0o700
+
+    def test_save_overwrites_existing(self):
+        save_config("yt-old-key")
+        save_config("yt-new-key")
+        result = load_config()
+        assert result["api_key"] == "yt-new-key"
+
+    def test_save_atomic_no_temp_files_left(self):
+        save_config("yt-key")
+        files = list(self.config_dir.iterdir())
+        assert len(files) == 1
+        assert files[0].name == "config.json"
+
+    def test_load_returns_none_for_missing_file(self):
+        assert load_config() is None
+
+    def test_load_returns_none_for_corrupt_json(self):
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+        self.config_path.write_text("not valid json{{{")
+        assert load_config() is None
+
+    def test_load_returns_none_for_non_dict(self):
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+        self.config_path.write_text(json.dumps(["not", "a", "dict"]))
+        assert load_config() is None
+
+    def test_clear_removes_file(self):
+        save_config("yt-key")
+        assert self.config_path.exists()
+        clear_config()
+        assert not self.config_path.exists()
+
+    def test_clear_no_error_when_missing(self):
+        clear_config()  # should not raise
+
+
+class TestResolveApiKey:
+    @pytest.fixture(autouse=True)
+    def _use_tmp_config(self, tmp_path, monkeypatch):
+        config_path = tmp_path / ".yutori" / "config.json"
+        monkeypatch.setattr("yutori.auth.credentials._get_config_path", lambda: config_path)
+        self.config_path = config_path
+        monkeypatch.delenv("YUTORI_API_KEY", raising=False)
+
+    def test_explicit_param_wins(self, monkeypatch):
+        monkeypatch.setenv("YUTORI_API_KEY", "yt-env")
+        assert resolve_api_key("yt-explicit") == "yt-explicit"
+
+    def test_env_var_used_when_no_param(self, monkeypatch):
+        monkeypatch.setenv("YUTORI_API_KEY", "yt-env")
+        assert resolve_api_key() == "yt-env"
+        assert resolve_api_key(None) == "yt-env"
+
+    def test_config_file_used_when_no_env(self):
+        save_config("yt-stored")
+        assert resolve_api_key() == "yt-stored"
+
+    def test_returns_none_when_nothing_set(self):
+        assert resolve_api_key() is None
+        assert resolve_api_key(None) is None
+
+    def test_empty_string_param_falls_through(self, monkeypatch):
+        monkeypatch.setenv("YUTORI_API_KEY", "yt-env")
+        assert resolve_api_key("") == "yt-env"
+
+
+# ---------------------------------------------------------------------------
+# Callback handler
+# ---------------------------------------------------------------------------
+
+class TestCallbackHandler:
+    """Tests for the OAuth callback HTTP handler."""
+
+    def _make_handler(self, path: str, callback_result: _CallbackResult) -> _CallbackHandler:
+        """Create a handler with a fake request."""
+        _CallbackHandler.callback_result = callback_result
+
+        handler = _CallbackHandler.__new__(_CallbackHandler)
+        handler.path = path
+        handler.requestline = f"GET {path} HTTP/1.1"
+        handler.request_version = "HTTP/1.1"
+        handler.headers = {}
+        handler.wfile = io.BytesIO()
+        handler.client_address = ("127.0.0.1", 12345)
+
+        # Mock response methods
+        handler._headers_buffer = []
+        handler.send_response = MagicMock()
+        handler.send_header = MagicMock()
+        handler.end_headers = MagicMock()
+        handler.send_error = MagicMock()
+
+        return handler
+
+    def test_success_path(self):
+        result = _CallbackResult()
+        handler = self._make_handler("/callback?code=test_code&state=test_state", result)
+        handler.do_GET()
+
+        assert result.code == "test_code"
+        assert result.state == "test_state"
+        assert result.error is None
+        assert result.received.is_set()
+
+    def test_error_path(self):
+        result = _CallbackResult()
+        handler = self._make_handler("/callback?error=access_denied&error_description=User+denied", result)
+        handler.do_GET()
+
+        assert result.error == "User denied"
+        assert result.code is None
+        assert result.received.is_set()
+
+    def test_missing_code(self):
+        result = _CallbackResult()
+        handler = self._make_handler("/callback?state=test_state", result)
+        handler.do_GET()
+
+        assert result.error == "No authorization code received"
+        assert result.code is None
+        assert result.received.is_set()
+
+    def test_favicon_ignored(self):
+        result = _CallbackResult()
+        handler = self._make_handler("/favicon.ico", result)
+        handler.do_GET()
+
+        assert not result.received.is_set()
+        handler.send_response.assert_called_with(204)
+
+    def test_unknown_path_returns_404(self):
+        result = _CallbackResult()
+        handler = self._make_handler("/unknown", result)
+        handler.do_GET()
+
+        assert not result.received.is_set()
+        handler.send_error.assert_called_with(404)
+
+
+# ---------------------------------------------------------------------------
+# Token exchange and API key generation
+# ---------------------------------------------------------------------------
+
+class TestTokenExchange:
+    def test_exchange_code_for_token_success(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {"access_token": "jwt_token_123"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
+            token = exchange_code_for_token("auth_code", "verifier")
+            assert token == "jwt_token_123"
+            call_kwargs = mock_post.call_args
+            assert "oauth/token" in call_kwargs[0][0]
+            assert call_kwargs[1]["data"]["code"] == "auth_code"
+            assert call_kwargs[1]["data"]["code_verifier"] == "verifier"
+
+    def test_exchange_code_raises_on_error(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "401", request=MagicMock(), response=MagicMock(status_code=401)
+        )
+
+        with patch.object(httpx.Client, "post", return_value=mock_response):
+            with pytest.raises(httpx.HTTPStatusError):
+                exchange_code_for_token("bad_code", "verifier")
+
+
+class TestGenerateApiKey:
+    def test_generate_api_key_success(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {"key": "yt-generated-key"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
+            key = generate_api_key("jwt_token")
+            assert key == "yt-generated-key"
+            call_kwargs = mock_post.call_args
+            assert "Bearer jwt_token" in call_kwargs[1]["headers"]["Authorization"]
+
+    def test_generate_api_key_uses_build_auth_api_url(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {"key": "yt-key"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
+            generate_api_key("jwt")
+            url = mock_post.call_args[0][0]
+            assert url == build_auth_api_url("/client/generate_key")
+
+
+# ---------------------------------------------------------------------------
+# run_login_flow (mocked — no real browser or server)
+# ---------------------------------------------------------------------------
+
+class TestRunLoginFlow:
+    @patch("yutori.auth.flow.webbrowser.open")
+    @patch("yutori.auth.flow.generate_api_key", return_value="yt-new-key")
+    @patch("yutori.auth.flow.exchange_code_for_token", return_value="jwt123")
+    @patch("yutori.auth.flow.save_config")
+    def test_successful_flow(self, mock_save, mock_exchange, mock_gen_key, mock_browser):
+        """Mock the callback result to simulate a successful flow."""
+
+        def fake_server_init(self, addr, handler):
+            pass
+
+        def fake_serve_forever(self):
+            # Simulate the callback happening
+            _CallbackHandler.callback_result.code = "auth_code"
+            _CallbackHandler.callback_result.state = None  # Will be set by run_login_flow
+            _CallbackHandler.callback_result.received.set()
+
+        # We need a more targeted approach: patch the server and thread
+        with patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init), \
+             patch("yutori.auth.flow.socketserver.TCPServer.serve_forever", fake_serve_forever), \
+             patch("yutori.auth.flow.socketserver.TCPServer.shutdown"), \
+             patch("yutori.auth.flow.socketserver.TCPServer.server_close"), \
+             patch("yutori.auth.flow.threading.Thread") as mock_thread_cls:
+
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+
+            # Patch the _CallbackResult so we can control the state
+            original_result = _CallbackResult()
+            with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
+                # We need to make the state match — intercept secrets.token_urlsafe
+                with patch("yutori.auth.flow.secrets.token_urlsafe", return_value="fixed_state"):
+                    # Simulate callback setting the right state before received.wait returns
+                    def side_effect(*args, **kwargs):
+                        original_result.code = "auth_code"
+                        original_result.state = "fixed_state"
+                        original_result.received.set()
+
+                    mock_thread.start.side_effect = side_effect
+
+                    result = run_login_flow()
+                    assert result.success is True
+                    assert result.api_key == "yt-new-key"
+                    mock_save.assert_called_once_with("yt-new-key")
+
+    def test_port_in_use(self):
+        with patch("yutori.auth.flow.socketserver.TCPServer.__init__", side_effect=OSError("Address already in use")):
+            result = run_login_flow()
+            assert result.success is False
+            assert "already in use" in result.error
+
+    def test_timeout(self):
+        def fake_server_init(self, addr, handler):
+            pass
+
+        with patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init), \
+             patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"), \
+             patch("yutori.auth.flow.socketserver.TCPServer.shutdown"), \
+             patch("yutori.auth.flow.socketserver.TCPServer.server_close"), \
+             patch("yutori.auth.flow.webbrowser.open"), \
+             patch("yutori.auth.flow.threading.Thread") as mock_thread_cls:
+
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+
+            original_result = _CallbackResult()
+            with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
+                # Don't set received, so wait() returns False after timeout=0
+                with patch.object(original_result.received, "wait", return_value=False):
+                    result = run_login_flow()
+                    assert result.success is False
+                    assert "timed out" in result.error.lower()
+
+    def test_state_mismatch(self):
+        def fake_server_init(self, addr, handler):
+            pass
+
+        with patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init), \
+             patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"), \
+             patch("yutori.auth.flow.socketserver.TCPServer.shutdown"), \
+             patch("yutori.auth.flow.socketserver.TCPServer.server_close"), \
+             patch("yutori.auth.flow.webbrowser.open"), \
+             patch("yutori.auth.flow.threading.Thread") as mock_thread_cls:
+
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+
+            original_result = _CallbackResult()
+            with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
+                with patch("yutori.auth.flow.secrets.token_urlsafe", return_value="expected_state"):
+                    def side_effect(*args, **kwargs):
+                        original_result.code = "auth_code"
+                        original_result.state = "wrong_state"
+                        original_result.received.set()
+
+                    mock_thread.start.side_effect = side_effect
+
+                    result = run_login_flow()
+                    assert result.success is False
+                    assert "state mismatch" in result.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# get_auth_status
+# ---------------------------------------------------------------------------
+
+class TestGetAuthStatus:
+    @pytest.fixture(autouse=True)
+    def _use_tmp_config(self, tmp_path, monkeypatch):
+        config_path = tmp_path / ".yutori" / "config.json"
+        monkeypatch.setattr("yutori.auth.credentials._get_config_path", lambda: config_path)
+        monkeypatch.setattr("yutori.auth.flow._get_config_path", lambda: config_path)
+        monkeypatch.delenv("YUTORI_API_KEY", raising=False)
+        self.config_path = config_path
+
+    def test_authenticated_from_config_file(self):
+        save_config("yt-test-key-12345")
+        status = get_auth_status()
+        assert status.authenticated is True
+        assert status.source == "config_file"
+        assert "yt-tes" in status.masked_key
+        assert "2345" in status.masked_key
+
+    def test_authenticated_from_env_var(self, monkeypatch):
+        monkeypatch.setenv("YUTORI_API_KEY", "yt-env-key-67890")
+        status = get_auth_status()
+        assert status.authenticated is True
+        assert status.source == "env_var"
+        assert "yt-env" in status.masked_key
+
+    def test_not_authenticated(self):
+        status = get_auth_status()
+        assert status.authenticated is False
+        assert status.masked_key is None
+
+    def test_config_file_takes_precedence_over_env(self, monkeypatch):
+        save_config("yt-config-key-abc")
+        monkeypatch.setenv("YUTORI_API_KEY", "yt-env-key-xyz")
+        status = get_auth_status()
+        assert status.source == "config_file"
+
+
+# ---------------------------------------------------------------------------
+# _mask_key
+# ---------------------------------------------------------------------------
+
+class TestMaskKey:
+    def test_long_key_masked(self):
+        result = _mask_key("yt-abcdefghijk")
+        assert result == "yt-abc...hijk"
+
+    def test_short_key_fully_masked(self):
+        result = _mask_key("short")
+        assert result == "***"
+
+    def test_exactly_11_chars(self):
+        result = _mask_key("12345678901")
+        assert result == "123456...8901"
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+class TestConstants:
+    def test_callback_host_is_ipv4(self):
+        assert CALLBACK_HOST == "127.0.0.1"
+
+    def test_redirect_uri_uses_callback_host(self):
+        assert CALLBACK_HOST in REDIRECT_URI
+        assert str(REDIRECT_PORT) in REDIRECT_URI
+        assert "/callback" in REDIRECT_URI
+
+    def test_build_auth_api_url(self):
+        url = build_auth_api_url("/client/generate_key")
+        assert url.endswith("/client/generate_key")
+        assert "api.yutori.com" in url
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+class TestTypes:
+    def test_login_result_success(self):
+        r = LoginResult(success=True, api_key="yt-key")
+        assert r.success is True
+        assert r.api_key == "yt-key"
+        assert r.error is None
+
+    def test_login_result_failure(self):
+        r = LoginResult(success=False, error="something broke")
+        assert r.success is False
+        assert r.api_key is None
+        assert r.error == "something broke"
+
+    def test_auth_status_authenticated(self):
+        s = AuthStatus(authenticated=True, masked_key="yt-...abc", source="config_file", config_path="/home/.yutori/config.json")
+        assert s.authenticated is True
+        assert s.source == "config_file"
+
+    def test_auth_status_not_authenticated(self):
+        s = AuthStatus(authenticated=False)
+        assert s.authenticated is False
+        assert s.masked_key is None
+        assert s.source is None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -498,8 +498,7 @@ class TestConstants:
 
     def test_build_auth_api_url(self):
         url = build_auth_api_url("/client/generate_key")
-        assert url.endswith("/client/generate_key")
-        assert "api.yutori.com" in url
+        assert url.endswith("/v1/client/generate_key")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -491,8 +491,8 @@ class TestConstants:
     def test_callback_host_is_ipv4(self):
         assert CALLBACK_HOST == "127.0.0.1"
 
-    def test_redirect_uri_uses_callback_host(self):
-        assert CALLBACK_HOST in REDIRECT_URI
+    def test_redirect_uri_uses_localhost(self):
+        assert "localhost" in REDIRECT_URI
         assert str(REDIRECT_PORT) in REDIRECT_URI
         assert "/callback" in REDIRECT_URI
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -437,7 +437,7 @@ class TestGetAuthStatus:
         status = get_auth_status()
         assert status.authenticated is True
         assert status.source == "config_file"
-        assert "yt-tes" in status.masked_key
+        assert "yt-t" in status.masked_key
         assert "2345" in status.masked_key
 
     def test_authenticated_from_env_var(self, monkeypatch):
@@ -445,7 +445,7 @@ class TestGetAuthStatus:
         status = get_auth_status()
         assert status.authenticated is True
         assert status.source == "env_var"
-        assert "yt-env" in status.masked_key
+        assert "yt-e" in status.masked_key
 
     def test_not_authenticated(self):
         status = get_auth_status()
@@ -470,17 +470,29 @@ class TestGetAuthStatus:
 # ---------------------------------------------------------------------------
 
 class TestMaskKey:
-    def test_long_key_masked(self):
-        result = _mask_key("yt-abcdefghijk")
-        assert result == "yt-abc...hijk"
+    def test_long_key_shows_prefix_and_suffix(self):
+        result = _mask_key("yt-abcdefghijklmnop")  # 20 chars
+        assert result == "yt-a...mnop"
+
+    def test_medium_key_shows_prefix_only(self):
+        result = _mask_key("yt-abcdefghijk")  # 14 chars (8-15 range)
+        assert result == "yt-a..."
 
     def test_short_key_fully_masked(self):
-        result = _mask_key("short")
+        result = _mask_key("short")  # 5 chars
         assert result == "***"
 
-    def test_exactly_11_chars(self):
-        result = _mask_key("12345678901")
-        assert result == "123456...8901"
+    def test_exactly_16_chars_shows_prefix_and_suffix(self):
+        result = _mask_key("1234567890abcdef")  # 16 chars
+        assert result == "1234...cdef"
+
+    def test_8_chars_shows_prefix_only(self):
+        result = _mask_key("12345678")  # 8 chars
+        assert result == "1234..."
+
+    def test_7_chars_fully_masked(self):
+        result = _mask_key("1234567")  # 7 chars
+        assert result == "***"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -357,6 +357,7 @@ class TestRunLoginFlow:
                     result = run_login_flow()
                     assert result.success is True
                     assert result.api_key == "yt-new-key"
+                    assert result.auth_url is not None
                     mock_save.assert_called_once_with("yt-new-key")
 
     def test_port_in_use(self):
@@ -386,6 +387,7 @@ class TestRunLoginFlow:
                     result = run_login_flow()
                     assert result.success is False
                     assert "timed out" in result.error.lower()
+                    assert result.auth_url is not None
 
     def test_state_mismatch(self):
         def fake_server_init(self, addr, handler):
@@ -414,6 +416,7 @@ class TestRunLoginFlow:
                     result = run_login_flow()
                     assert result.success is False
                     assert "state mismatch" in result.error.lower()
+                    assert result.auth_url is not None
 
 
 # ---------------------------------------------------------------------------
@@ -515,6 +518,14 @@ class TestTypes:
         assert r.success is False
         assert r.api_key is None
         assert r.error == "something broke"
+
+    def test_login_result_auth_url_default_none(self):
+        r = LoginResult(success=True, api_key="yt-key")
+        assert r.auth_url is None
+
+    def test_login_result_auth_url_preserved(self):
+        r = LoginResult(success=False, error="timeout", auth_url="https://clerk.yutori.com/oauth/authorize?x=1")
+        assert r.auth_url == "https://clerk.yutori.com/oauth/authorize?x=1"
 
     def test_auth_status_authenticated(self):
         s = AuthStatus(authenticated=True, masked_key="yt-...abc", source="config_file", config_path="/home/.yutori/config.json")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -449,11 +449,11 @@ class TestGetAuthStatus:
         assert status.authenticated is False
         assert status.masked_key is None
 
-    def test_config_file_takes_precedence_over_env(self, monkeypatch):
+    def test_env_var_takes_precedence_over_config_file(self, monkeypatch):
         save_config("yt-config-key-abc")
         monkeypatch.setenv("YUTORI_API_KEY", "yt-env-key-xyz")
         status = get_auth_status()
-        assert status.source == "config_file"
+        assert status.source == "env_var"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,11 +17,13 @@ class TestYutoriClientInit:
 
     def test_init_without_api_key_raises(self, monkeypatch):
         monkeypatch.delenv("YUTORI_API_KEY", raising=False)
+        monkeypatch.setattr("yutori.auth.credentials.load_config", lambda: None)
         with pytest.raises(AuthenticationError):
             YutoriClient(api_key="")
 
     def test_init_with_none_api_key_raises(self, monkeypatch):
         monkeypatch.delenv("YUTORI_API_KEY", raising=False)
+        monkeypatch.setattr("yutori.auth.credentials.load_config", lambda: None)
         with pytest.raises(AuthenticationError):
             YutoriClient(api_key=None)
 

--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import Any
 
 import httpx
@@ -57,10 +56,12 @@ class AsyncYutoriClient:
         Raises:
             AuthenticationError: If no API key is provided or found in environment.
         """
-        api_key = api_key or os.environ.get("YUTORI_API_KEY")
+        from yutori.auth.credentials import resolve_api_key
+
+        api_key = resolve_api_key(api_key)
         if not api_key:
             raise AuthenticationError(
-                "No API key provided. Pass api_key or set the YUTORI_API_KEY environment variable."
+                "No API key provided. Run 'yutori auth login', set YUTORI_API_KEY, or pass api_key."
             )
 
         self._api_key = api_key

--- a/yutori/auth/__init__.py
+++ b/yutori/auth/__init__.py
@@ -1,8 +1,25 @@
-"""Authentication utilities for the Yutori SDK."""
+"""Authentication utilities for the Yutori SDK.
+
+Lightweight imports (credentials, types) are eager. Heavyweight imports
+(flow — pulls in http.server, threading, webbrowser) are lazy to avoid
+penalizing SDK users who never use the OAuth login flow.
+"""
 
 from .credentials import clear_config, load_config, resolve_api_key, save_config
-from .flow import get_auth_status, run_login_flow
 from .types import AuthStatus, LoginResult
+
+
+def __getattr__(name: str):
+    if name == "run_login_flow":
+        from .flow import run_login_flow
+
+        return run_login_flow
+    if name == "get_auth_status":
+        from .flow import get_auth_status
+
+        return get_auth_status
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "clear_config",

--- a/yutori/auth/__init__.py
+++ b/yutori/auth/__init__.py
@@ -1,0 +1,16 @@
+"""Authentication utilities for the Yutori SDK."""
+
+from .credentials import clear_config, load_config, resolve_api_key, save_config
+from .flow import get_auth_status, run_login_flow
+from .types import AuthStatus, LoginResult
+
+__all__ = [
+    "clear_config",
+    "get_auth_status",
+    "load_config",
+    "resolve_api_key",
+    "run_login_flow",
+    "save_config",
+    "AuthStatus",
+    "LoginResult",
+]

--- a/yutori/auth/constants.py
+++ b/yutori/auth/constants.py
@@ -15,8 +15,8 @@ REDIRECT_PORT = 54320
 REDIRECT_URI = f"http://localhost:{REDIRECT_PORT}/callback"
 AUTH_TIMEOUT_SECONDS = 300
 
-# Auth API — separate from the SDK data API (api.yutori.com)
-AUTH_API_BASE_URL = os.environ.get("YUTORI_AUTH_API_BASE_URL", "https://api.dev.yutori.com/v1")
+# Auth API for key generation after OAuth (same base as SDK data API)
+AUTH_API_BASE_URL = os.environ.get("YUTORI_AUTH_API_BASE_URL", "https://api.yutori.com/v1")
 
 # Credential storage
 CONFIG_DIR = ".yutori"

--- a/yutori/auth/constants.py
+++ b/yutori/auth/constants.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import os
 
-from yutori.config import DEFAULT_BASE_URL
-
 # Clerk OAuth configuration
 CLERK_INSTANCE_URL = os.environ.get("CLERK_INSTANCE_URL", "https://clerk.yutori.com")
 CLERK_CLIENT_ID = os.environ.get("CLERK_CLIENT_ID", "TGiyfoPbG01Sakpe")
@@ -16,6 +14,9 @@ CALLBACK_HOST = "127.0.0.1"
 REDIRECT_PORT = 54320
 REDIRECT_URI = f"http://localhost:{REDIRECT_PORT}/callback"
 AUTH_TIMEOUT_SECONDS = 300
+
+# Auth API — uses api.yutori.ai (not api.yutori.com which is the SDK data API)
+AUTH_API_BASE_URL = os.environ.get("YUTORI_API_BASE_URL", "https://api.yutori.ai/v1")
 
 # Credential storage
 CONFIG_DIR = ".yutori"
@@ -28,5 +29,5 @@ ERROR_AUTH_FAILED = "Authentication failed"
 
 
 def build_auth_api_url(path: str) -> str:
-    """Build API URL for auth endpoints using the SDK's canonical base URL."""
-    return f"{DEFAULT_BASE_URL}{path}"
+    """Build API URL for auth endpoints (key generation after OAuth)."""
+    return f"{AUTH_API_BASE_URL}{path}"

--- a/yutori/auth/constants.py
+++ b/yutori/auth/constants.py
@@ -21,7 +21,6 @@ CONFIG_DIR = ".yutori"
 CONFIG_FILE = "config.json"
 
 # Error messages
-ERROR_NO_API_KEY = "API key required. Run 'yutori auth login' or set YUTORI_API_KEY."
 ERROR_AUTH_TIMEOUT = "Login timed out. Please try again."
 ERROR_STATE_MISMATCH = "Security validation failed (state mismatch). Please try again."
 ERROR_AUTH_FAILED = "Authentication failed"

--- a/yutori/auth/constants.py
+++ b/yutori/auth/constants.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import os
 
+from yutori.config import DEFAULT_BASE_URL
+
 # Clerk OAuth configuration
 CLERK_INSTANCE_URL = os.environ.get("CLERK_INSTANCE_URL", "https://clerk.yutori.com")
 CLERK_CLIENT_ID = os.environ.get("CLERK_CLIENT_ID", "TGiyfoPbG01Sakpe")
@@ -14,9 +16,6 @@ CALLBACK_HOST = "127.0.0.1"
 REDIRECT_PORT = 54320
 REDIRECT_URI = f"http://localhost:{REDIRECT_PORT}/callback"
 AUTH_TIMEOUT_SECONDS = 300
-
-# Auth API for key generation after OAuth (same base as SDK data API)
-AUTH_API_BASE_URL = os.environ.get("YUTORI_AUTH_API_BASE_URL", "https://api.yutori.com/v1")
 
 # Credential storage
 CONFIG_DIR = ".yutori"
@@ -30,4 +29,4 @@ ERROR_AUTH_FAILED = "Authentication failed"
 
 def build_auth_api_url(path: str) -> str:
     """Build API URL for auth endpoints (key generation after OAuth)."""
-    return f"{AUTH_API_BASE_URL}{path}"
+    return f"{DEFAULT_BASE_URL}{path}"

--- a/yutori/auth/constants.py
+++ b/yutori/auth/constants.py
@@ -10,10 +10,11 @@ from yutori.config import DEFAULT_BASE_URL
 CLERK_INSTANCE_URL = os.environ.get("CLERK_INSTANCE_URL", "https://clerk.yutori.com")
 CLERK_CLIENT_ID = os.environ.get("CLERK_CLIENT_ID", "TGiyfoPbG01Sakpe")
 
-# Callback server — 127.0.0.1 for both bind and redirect URI (no IPv4/IPv6 mismatch)
+# Callback server — bind to 127.0.0.1 (avoids IPv4/IPv6 mismatch),
+# but use localhost in redirect URI (must match Clerk's registered URL).
 CALLBACK_HOST = "127.0.0.1"
 REDIRECT_PORT = 54320
-REDIRECT_URI = f"http://{CALLBACK_HOST}:{REDIRECT_PORT}/callback"
+REDIRECT_URI = f"http://localhost:{REDIRECT_PORT}/callback"
 AUTH_TIMEOUT_SECONDS = 300
 
 # Credential storage

--- a/yutori/auth/constants.py
+++ b/yutori/auth/constants.py
@@ -15,8 +15,8 @@ REDIRECT_PORT = 54320
 REDIRECT_URI = f"http://localhost:{REDIRECT_PORT}/callback"
 AUTH_TIMEOUT_SECONDS = 300
 
-# Auth API — uses api.yutori.ai (not api.yutori.com which is the SDK data API)
-AUTH_API_BASE_URL = os.environ.get("YUTORI_API_BASE_URL", "https://api.yutori.ai/v1")
+# Auth API — separate from the SDK data API (api.yutori.com)
+AUTH_API_BASE_URL = os.environ.get("YUTORI_AUTH_API_BASE_URL", "https://api.dev.yutori.com/v1")
 
 # Credential storage
 CONFIG_DIR = ".yutori"

--- a/yutori/auth/constants.py
+++ b/yutori/auth/constants.py
@@ -1,0 +1,32 @@
+"""Constants for Yutori authentication and configuration."""
+
+from __future__ import annotations
+
+import os
+
+from yutori.config import DEFAULT_BASE_URL
+
+# Clerk OAuth configuration
+CLERK_INSTANCE_URL = os.environ.get("CLERK_INSTANCE_URL", "https://clerk.yutori.com")
+CLERK_CLIENT_ID = os.environ.get("CLERK_CLIENT_ID", "TGiyfoPbG01Sakpe")
+
+# Callback server — 127.0.0.1 for both bind and redirect URI (no IPv4/IPv6 mismatch)
+CALLBACK_HOST = "127.0.0.1"
+REDIRECT_PORT = 54320
+REDIRECT_URI = f"http://{CALLBACK_HOST}:{REDIRECT_PORT}/callback"
+AUTH_TIMEOUT_SECONDS = 300
+
+# Credential storage
+CONFIG_DIR = ".yutori"
+CONFIG_FILE = "config.json"
+
+# Error messages
+ERROR_NO_API_KEY = "API key required. Run 'yutori auth login' or set YUTORI_API_KEY."
+ERROR_AUTH_TIMEOUT = "Login timed out. Please try again."
+ERROR_STATE_MISMATCH = "Security validation failed (state mismatch). Please try again."
+ERROR_AUTH_FAILED = "Authentication failed"
+
+
+def build_auth_api_url(path: str) -> str:
+    """Build API URL for auth endpoints using the SDK's canonical base URL."""
+    return f"{DEFAULT_BASE_URL}{path}"

--- a/yutori/auth/credentials.py
+++ b/yutori/auth/credentials.py
@@ -15,7 +15,7 @@ from typing import Any
 from .constants import CONFIG_DIR, CONFIG_FILE
 
 
-def _get_config_path() -> Path:
+def get_config_path() -> Path:
     return Path.home() / CONFIG_DIR / CONFIG_FILE
 
 
@@ -24,7 +24,7 @@ def load_config() -> dict[str, Any] | None:
 
     Returns None if file doesn't exist, is corrupt, or is not a dict.
     """
-    config_path = _get_config_path()
+    config_path = get_config_path()
     if not config_path.exists():
         return None
     try:
@@ -43,7 +43,7 @@ def save_config(api_key: str) -> None:
     - File: 0600 (owner read/write only)
     - Atomic: writes to temp file in same dir, then os.replace()
     """
-    config_path = _get_config_path()
+    config_path = get_config_path()
     config_dir = config_path.parent
     config_dir.mkdir(parents=True, exist_ok=True)
     os.chmod(config_dir, 0o700)
@@ -65,7 +65,7 @@ def save_config(api_key: str) -> None:
 
 def clear_config() -> None:
     """Delete the config file if it exists."""
-    config_path = _get_config_path()
+    config_path = get_config_path()
     if config_path.exists():
         config_path.unlink()
 

--- a/yutori/auth/credentials.py
+++ b/yutori/auth/credentials.py
@@ -1,0 +1,92 @@
+"""Credential storage for the Yutori SDK.
+
+Stores API keys in ~/.yutori/config.json with restrictive permissions.
+This matches the pattern used by ~/.aws/credentials, ~/.npmrc, etc.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .constants import CONFIG_DIR, CONFIG_FILE
+
+
+def _get_config_path() -> Path:
+    return Path.home() / CONFIG_DIR / CONFIG_FILE
+
+
+def load_config() -> dict[str, Any] | None:
+    """Load config from ~/.yutori/config.json.
+
+    Returns None if file doesn't exist, is corrupt, or is not a dict.
+    """
+    config_path = _get_config_path()
+    if not config_path.exists():
+        return None
+    try:
+        data = json.loads(config_path.read_text())
+        if not isinstance(data, dict):
+            return None
+        return data
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def save_config(api_key: str) -> None:
+    """Save API key to ~/.yutori/config.json with atomic write and restrictive permissions.
+
+    - Directory: 0700 (owner read/write/execute only)
+    - File: 0600 (owner read/write only)
+    - Atomic: writes to temp file in same dir, then os.replace()
+    """
+    config_path = _get_config_path()
+    config_dir = config_path.parent
+    config_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(config_dir, 0o700)
+
+    content = json.dumps({"api_key": api_key}, indent=2)
+
+    # Atomic write: temp file in same directory, then rename
+    fd, tmp_path = tempfile.mkstemp(dir=config_dir, prefix=".config_", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, config_path)
+    except BaseException:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+
+def clear_config() -> None:
+    """Delete the config file if it exists."""
+    config_path = _get_config_path()
+    if config_path.exists():
+        config_path.unlink()
+
+
+def resolve_api_key(api_key: str | None = None) -> str | None:
+    """Resolve an API key using the standard precedence chain.
+
+    Order: explicit parameter > YUTORI_API_KEY env var > config file.
+    Returns None if no key is found (caller decides error behavior).
+    """
+    if api_key:
+        return api_key
+
+    env_key = os.environ.get("YUTORI_API_KEY")
+    if env_key:
+        return env_key
+
+    config = load_config()
+    if config:
+        stored_key = config.get("api_key")
+        if stored_key and isinstance(stored_key, str):
+            return stored_key
+
+    return None

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -91,22 +91,23 @@ class _CallbackHandler(http.server.BaseHTTPRequestHandler):
 
         params = parse_qs(parsed.query)
 
-        if "error" in params:
-            error_text = params.get("error_description", params["error"])[0]
-            self.callback_result.error = error_text
-            self._send_html(f"<h1>Login Failed</h1><p>{html.escape(error_text)}</p>")
-        elif params.get("code"):
-            self.callback_result.code = params["code"][0]
-            self.callback_result.state = params.get("state", [None])[0]
-            self._send_html(
-                "<h1>Login Successful</h1>"
-                "<p>You can close this window and return to the terminal.</p>"
-            )
-        else:
-            self.callback_result.error = "No authorization code received"
-            self._send_html("<h1>Login Failed</h1><p>No authorization code received.</p>")
-
-        self.callback_result.received.set()
+        try:
+            if "error" in params:
+                error_text = params.get("error_description", params["error"])[0]
+                self.callback_result.error = error_text
+                self._send_html(f"<h1>Login Failed</h1><p>{html.escape(error_text)}</p>")
+            elif params.get("code"):
+                self.callback_result.code = params["code"][0]
+                self.callback_result.state = params.get("state", [None])[0]
+                self._send_html(
+                    "<h1>Login Successful</h1>"
+                    "<p>You can close this window and return to the terminal.</p>"
+                )
+            else:
+                self.callback_result.error = "No authorization code received"
+                self._send_html("<h1>Login Failed</h1><p>No authorization code received.</p>")
+        finally:
+            self.callback_result.received.set()
 
     def _send_html(self, body: str) -> None:
         self.send_response(200)

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -1,0 +1,236 @@
+"""OAuth 2.0 + PKCE authentication flow for Yutori.
+
+Implements the Clerk OAuth flow: browser auth -> callback -> code exchange -> API key generation.
+All functions return typed results and never print directly (callers handle presentation).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import html
+import http.server
+import os
+import secrets
+import socketserver
+import threading
+import webbrowser
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import httpx
+
+from .constants import (
+    AUTH_TIMEOUT_SECONDS,
+    CALLBACK_HOST,
+    CLERK_CLIENT_ID,
+    CLERK_INSTANCE_URL,
+    ERROR_AUTH_FAILED,
+    ERROR_AUTH_TIMEOUT,
+    ERROR_STATE_MISMATCH,
+    REDIRECT_PORT,
+    REDIRECT_URI,
+    build_auth_api_url,
+)
+from .credentials import _get_config_path, load_config, save_config
+from .types import AuthStatus, LoginResult
+
+
+def generate_pkce() -> tuple[str, str]:
+    """Generate PKCE code verifier and S256 challenge."""
+    code_verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(code_verifier.encode()).digest()
+    code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return code_verifier, code_challenge
+
+
+def build_auth_url(code_challenge: str, state: str) -> str:
+    """Build Clerk OAuth authorization URL."""
+    params = {
+        "response_type": "code",
+        "client_id": CLERK_CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+        "scope": "openid profile email",
+    }
+    return f"{CLERK_INSTANCE_URL}/oauth/authorize?{urlencode(params)}"
+
+
+class _CallbackResult:
+    """Thread-safe container for OAuth callback data."""
+
+    def __init__(self) -> None:
+        self.code: str | None = None
+        self.state: str | None = None
+        self.error: str | None = None
+        self.received = threading.Event()
+
+
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    """HTTP handler for the OAuth redirect callback."""
+
+    callback_result: _CallbackResult
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass  # Suppress HTTP server logs
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        if parsed.path == "/favicon.ico":
+            self.send_response(204)
+            self.end_headers()
+            return
+        if parsed.path != "/callback":
+            self.send_error(404)
+            return
+
+        params = parse_qs(parsed.query)
+
+        if "error" in params:
+            error_text = params.get("error_description", params["error"])[0]
+            self.callback_result.error = error_text
+            self._send_html(f"<h1>Login Failed</h1><p>{html.escape(error_text)}</p>")
+        elif params.get("code"):
+            self.callback_result.code = params["code"][0]
+            self.callback_result.state = params.get("state", [None])[0]
+            self._send_html(
+                "<h1>Login Successful</h1>"
+                "<p>You can close this window and return to the terminal.</p>"
+            )
+        else:
+            self.callback_result.error = "No authorization code received"
+            self._send_html("<h1>Login Failed</h1><p>No authorization code received.</p>")
+
+        self.callback_result.received.set()
+
+    def _send_html(self, body: str) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(f"<html><body>{body}</body></html>".encode())
+
+
+def exchange_code_for_token(code: str, code_verifier: str) -> str:
+    """Exchange authorization code for JWT via Clerk token endpoint."""
+    with httpx.Client(timeout=30.0) as client:
+        response = client.post(
+            f"{CLERK_INSTANCE_URL}/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": CLERK_CLIENT_ID,
+                "code": code,
+                "redirect_uri": REDIRECT_URI,
+                "code_verifier": code_verifier,
+            },
+        )
+        response.raise_for_status()
+        return response.json()["access_token"]
+
+
+def generate_api_key(jwt: str) -> str:
+    """Generate a Yutori API key using a Clerk JWT."""
+    with httpx.Client(timeout=30.0) as client:
+        response = client.post(
+            build_auth_api_url("/client/generate_key"),
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        response.raise_for_status()
+        return response.json()["key"]
+
+
+def run_login_flow() -> LoginResult:
+    """Run the full OAuth 2.0 + PKCE login flow.
+
+    Opens browser for Clerk authentication, runs a local callback server,
+    exchanges the auth code for a JWT, generates an API key, and saves it.
+
+    Returns a LoginResult — never prints directly.
+    """
+    code_verifier, code_challenge = generate_pkce()
+    state = secrets.token_urlsafe(32)
+    auth_url = build_auth_url(code_challenge, state)
+
+    callback_result = _CallbackResult()
+    _CallbackHandler.callback_result = callback_result
+
+    class _ReusableServer(socketserver.TCPServer):
+        allow_reuse_address = True
+
+    try:
+        server = _ReusableServer((CALLBACK_HOST, REDIRECT_PORT), _CallbackHandler)
+    except OSError as e:
+        if "Address already in use" in str(e):
+            return LoginResult(
+                success=False,
+                error=f"Port {REDIRECT_PORT} is already in use. Close other applications and try again.",
+            )
+        return LoginResult(success=False, error=str(e))
+
+    server.timeout = AUTH_TIMEOUT_SECONDS
+    server_thread = threading.Thread(target=server.serve_forever)
+    server_thread.start()
+
+    webbrowser.open(auth_url)
+
+    callback_result.received.wait(timeout=AUTH_TIMEOUT_SECONDS)
+    server.shutdown()
+    server_thread.join(timeout=1)
+    server.server_close()
+
+    if not callback_result.received.is_set():
+        return LoginResult(success=False, error=ERROR_AUTH_TIMEOUT)
+
+    if callback_result.error:
+        return LoginResult(success=False, error=callback_result.error)
+
+    if callback_result.state != state:
+        return LoginResult(success=False, error=ERROR_STATE_MISMATCH)
+
+    if not callback_result.code:
+        return LoginResult(success=False, error=ERROR_AUTH_FAILED)
+
+    try:
+        jwt = exchange_code_for_token(callback_result.code, code_verifier)
+        api_key = generate_api_key(jwt)
+        save_config(api_key)
+        return LoginResult(success=True, api_key=api_key)
+    except httpx.HTTPStatusError as e:
+        return LoginResult(success=False, error=f"{ERROR_AUTH_FAILED} ({e.response.status_code})")
+    except Exception as e:
+        return LoginResult(success=False, error=str(e))
+
+
+def _mask_key(key: str) -> str:
+    if len(key) > 10:
+        return key[:6] + "..." + key[-4:]
+    return "***"
+
+
+def get_auth_status() -> AuthStatus:
+    """Check current authentication status.
+
+    Returns an AuthStatus — never prints directly.
+    """
+    config_path = str(_get_config_path())
+
+    config = load_config()
+    if config and config.get("api_key"):
+        return AuthStatus(
+            authenticated=True,
+            masked_key=_mask_key(config["api_key"]),
+            source="config_file",
+            config_path=config_path,
+        )
+
+    env_key = os.environ.get("YUTORI_API_KEY")
+    if env_key:
+        return AuthStatus(
+            authenticated=True,
+            masked_key=_mask_key(env_key),
+            source="env_var",
+            config_path=config_path,
+        )
+
+    return AuthStatus(authenticated=False, config_path=config_path)

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -57,7 +57,7 @@ def build_auth_url(code_challenge: str, state: str) -> str:
         "code_challenge_method": "S256",
         "state": state,
         "scope": "openid profile email",
-        "prompt": "consent",
+        "prompt": "login",
     }
     return f"{CLERK_INSTANCE_URL}/oauth/authorize?{urlencode(params)}"
 

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -215,8 +215,10 @@ def run_login_flow() -> LoginResult:
 
 
 def _mask_key(key: str) -> str:
-    if len(key) > 10:
-        return key[:6] + "..." + key[-4:]
+    if len(key) >= 16:
+        return key[:4] + "..." + key[-4:]
+    if len(key) >= 8:
+        return key[:4] + "..."
     return "***"
 
 

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -57,6 +57,7 @@ def build_auth_url(code_challenge: str, state: str) -> str:
         "code_challenge_method": "S256",
         "state": state,
         "scope": "openid profile email",
+        "prompt": "consent",
     }
     return f"{CLERK_INSTANCE_URL}/oauth/authorize?{urlencode(params)}"
 
@@ -203,7 +204,12 @@ def run_login_flow() -> LoginResult:
         save_config(api_key)
         return LoginResult(success=True, api_key=api_key, auth_url=auth_url)
     except httpx.HTTPStatusError as e:
-        return LoginResult(success=False, error=f"{ERROR_AUTH_FAILED} ({e.response.status_code})", auth_url=auth_url)
+        detail = ""
+        try:
+            detail = f": {e.response.text}"
+        except Exception:
+            pass
+        return LoginResult(success=False, error=f"{ERROR_AUTH_FAILED} ({e.response.status_code}){detail}", auth_url=auth_url)
     except Exception as e:
         return LoginResult(success=False, error=str(e), auth_url=auth_url)
 

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -57,7 +57,6 @@ def build_auth_url(code_challenge: str, state: str) -> str:
         "code_challenge_method": "S256",
         "state": state,
         "scope": "openid profile email",
-        "prompt": "login",
     }
     return f"{CLERK_INSTANCE_URL}/oauth/authorize?{urlencode(params)}"
 

--- a/yutori/auth/types.py
+++ b/yutori/auth/types.py
@@ -1,0 +1,24 @@
+"""Typed return values for authentication operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class LoginResult:
+    """Result of a login attempt."""
+
+    success: bool
+    api_key: str | None = None
+    error: str | None = None
+
+
+@dataclass
+class AuthStatus:
+    """Current authentication status."""
+
+    authenticated: bool
+    masked_key: str | None = None
+    source: str | None = None  # "config_file", "env_var", or None
+    config_path: str | None = None

--- a/yutori/auth/types.py
+++ b/yutori/auth/types.py
@@ -12,6 +12,7 @@ class LoginResult:
     success: bool
     api_key: str | None = None
     error: str | None = None
+    auth_url: str | None = None
 
 
 @dataclass

--- a/yutori/cli/__init__.py
+++ b/yutori/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Yutori CLI module."""

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -1,0 +1,1 @@
+"""CLI command modules."""

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -1,1 +1,24 @@
 """CLI command modules."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+from rich.console import Console
+
+from yutori.auth.credentials import resolve_api_key
+
+_console = Console()
+
+
+def get_authenticated_client() -> Any:
+    """Get an authenticated YutoriClient, or exit with an error message."""
+    from yutori.client import YutoriClient
+
+    api_key = resolve_api_key()
+    if not api_key:
+        _console.print("[red]Not authenticated. Run 'yutori auth login' first.[/red]")
+        raise typer.Exit(1)
+
+    return YutoriClient(api_key=api_key)

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -19,7 +19,8 @@ def login() -> None:
     Opens your browser to log in with Clerk OAuth and saves an API key locally.
     """
     config = load_config()
-    if config and config.get("api_key"):
+    existing_key = config.get("api_key") if config else None
+    if existing_key and isinstance(existing_key, str):
         console.print("[yellow]You are already authenticated.[/yellow]")
         console.print("Run [bold]yutori auth logout[/bold] first to re-authenticate.")
         raise typer.Exit(1)

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import typer
 from rich.console import Console
 
@@ -18,6 +20,11 @@ def login() -> None:
 
     Opens your browser to log in with Clerk OAuth and saves an API key locally.
     """
+    if os.environ.get("YUTORI_API_KEY"):
+        console.print("[yellow]YUTORI_API_KEY environment variable is set — it takes precedence over saved credentials.[/yellow]")
+        console.print("Unset it first if you want to use browser login.")
+        raise typer.Exit(1)
+
     config = load_config()
     existing_key = config.get("api_key") if config else None
     if existing_key and isinstance(existing_key, str):

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -6,6 +6,7 @@ import os
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 
 from yutori.auth import clear_config, get_auth_status, run_login_flow
 from yutori.auth.credentials import load_config
@@ -41,7 +42,7 @@ def login() -> None:
         console.print("[green]Successfully authenticated![/green]")
         console.print("You can now use the Yutori CLI and SDK.")
     else:
-        console.print(f"\n[red]Authentication failed: {result.error}[/red]")
+        console.print(f"\n[red]Authentication failed: {escape(str(result.error))}[/red]")
         if result.auth_url:
             console.print(f"\n[dim]If the browser didn't open, visit:[/dim]\n  {result.auth_url}")
         raise typer.Exit(1)

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -8,8 +8,8 @@ import typer
 from rich.console import Console
 from rich.markup import escape
 
-from yutori.auth import clear_config, get_auth_status, run_login_flow
-from yutori.auth.credentials import load_config
+from yutori.auth.credentials import clear_config, load_config
+from yutori.auth.flow import get_auth_status, run_login_flow
 
 app = typer.Typer(help="Manage authentication")
 console = Console()

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -1,0 +1,67 @@
+"""Authentication commands for the Yutori CLI."""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+
+from yutori.auth import clear_config, get_auth_status, run_login_flow
+from yutori.auth.credentials import load_config
+
+app = typer.Typer(help="Manage authentication")
+console = Console()
+
+
+@app.command()
+def login() -> None:
+    """Authenticate with Yutori via browser.
+
+    Opens your browser to log in with Clerk OAuth and saves an API key locally.
+    """
+    config = load_config()
+    if config and config.get("api_key"):
+        console.print("[yellow]You are already authenticated.[/yellow]")
+        console.print("Run [bold]yutori auth logout[/bold] first to re-authenticate.")
+        raise typer.Exit(1)
+
+    console.print("\n[bold]Opening browser for authentication...[/bold]")
+    console.print("[dim]Waiting for authentication...[/dim]\n")
+
+    result = run_login_flow()
+
+    if result.success:
+        console.print("[green]Successfully authenticated![/green]")
+        console.print("You can now use the Yutori CLI and SDK.")
+    else:
+        console.print(f"\n[red]Authentication failed: {result.error}[/red]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def logout() -> None:
+    """Remove stored credentials."""
+    config = load_config()
+    if config and config.get("api_key"):
+        clear_config()
+        console.print("[green]Successfully logged out.[/green]")
+    else:
+        console.print("[yellow]No credentials found.[/yellow]")
+
+
+@app.command()
+def status() -> None:
+    """Show current authentication status."""
+    auth_status = get_auth_status()
+
+    if not auth_status.authenticated:
+        console.print("[yellow]Not authenticated.[/yellow]")
+        console.print("Run [bold]yutori auth login[/bold] to authenticate.")
+        raise typer.Exit(1)
+
+    console.print("[green]Authenticated[/green]")
+    console.print(f"  API Key: {auth_status.masked_key}")
+
+    if auth_status.source == "config_file":
+        console.print(f"  Source: {auth_status.config_path}")
+    elif auth_status.source == "env_var":
+        console.print("  Source: YUTORI_API_KEY environment variable")

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -35,6 +35,8 @@ def login() -> None:
         console.print("You can now use the Yutori CLI and SDK.")
     else:
         console.print(f"\n[red]Authentication failed: {result.error}[/red]")
+        if result.auth_url:
+            console.print(f"\n[dim]If the browser didn't open, visit:[/dim]\n  {result.auth_url}")
         raise typer.Exit(1)
 
 

--- a/yutori/cli/commands/browse.py
+++ b/yutori/cli/commands/browse.py
@@ -64,6 +64,6 @@ def get(
             text = str(output)
             if len(text) > 2000:
                 text = text[:2000] + "\n... (truncated)"
-            console.print(text)
+            console.print(text, markup=False)
     finally:
         client.close()

--- a/yutori/cli/commands/browse.py
+++ b/yutori/cli/commands/browse.py
@@ -1,0 +1,69 @@
+"""Browse commands for the Yutori CLI."""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+
+from yutori.cli.commands import get_authenticated_client
+
+app = typer.Typer(help="Run and manage browsing tasks")
+console = Console()
+
+
+@app.command()
+def run(
+    task: str = typer.Argument(help="Natural language description of the browsing task"),
+    start_url: str = typer.Argument(help="URL to start browsing from"),
+    max_steps: int | None = typer.Option(None, "--max-steps", help="Maximum agent steps (1-100)"),
+    agent: str | None = typer.Option(None, "--agent", help="Agent to use"),
+    require_auth: bool | None = typer.Option(None, "--require-auth", help="Use auth-optimized browser for login flows"),
+) -> None:
+    """Start a new browsing task."""
+    client = get_authenticated_client()
+
+    try:
+        result = client.browsing.create(
+            task=task,
+            start_url=start_url,
+            max_steps=max_steps,
+            agent=agent,
+            require_auth=require_auth,
+        )
+
+        console.print("\n[green]Browsing task created![/green]")
+        console.print(f"  Task ID: {result.get('task_id', 'N/A')}")
+        console.print(f"  Status: {result.get('status', 'N/A')}")
+    finally:
+        client.close()
+
+
+@app.command()
+def get(
+    task_id: str = typer.Argument(help="The browsing task ID"),
+) -> None:
+    """Get the status and result of a browsing task."""
+    client = get_authenticated_client()
+
+    try:
+        result = client.browsing.get(task_id)
+
+        console.print(f"\n[bold]Browsing Task: {result.get('task_id', task_id)}[/bold]\n")
+        console.print(f"  Status: {result.get('status', 'N/A')}")
+
+        if result.get("start_url"):
+            console.print(f"  Start URL: {result['start_url']}")
+        if result.get("agent"):
+            console.print(f"  Agent: {result['agent']}")
+        if result.get("created_at"):
+            console.print(f"  Created: {result['created_at']}")
+
+        output = result.get("result") or result.get("output")
+        if output:
+            console.print("\n[bold]Result:[/bold]")
+            text = str(output)
+            if len(text) > 2000:
+                text = text[:2000] + "\n... (truncated)"
+            console.print(text)
+    finally:
+        client.close()

--- a/yutori/cli/commands/browse.py
+++ b/yutori/cli/commands/browse.py
@@ -15,9 +15,9 @@ console = Console()
 def run(
     task: str = typer.Argument(help="Natural language description of the browsing task"),
     start_url: str = typer.Argument(help="URL to start browsing from"),
-    max_steps: int | None = typer.Option(None, "--max-steps", help="Maximum number of agent steps"),
-    agent: str | None = typer.Option(None, "--agent", help="Agent to use"),
-    require_auth: bool | None = typer.Option(None, "--require-auth", help="Use auth-optimized browser for login flows"),
+    max_steps: int = typer.Option(None, "--max-steps", help="Maximum number of agent steps"),
+    agent: str = typer.Option(None, "--agent", help="Agent to use"),
+    require_auth: bool = typer.Option(None, "--require-auth", help="Use auth-optimized browser for login flows"),
 ) -> None:
     """Start a new browsing task."""
     client = get_authenticated_client()

--- a/yutori/cli/commands/browse.py
+++ b/yutori/cli/commands/browse.py
@@ -15,7 +15,7 @@ console = Console()
 def run(
     task: str = typer.Argument(help="Natural language description of the browsing task"),
     start_url: str = typer.Argument(help="URL to start browsing from"),
-    max_steps: int | None = typer.Option(None, "--max-steps", help="Maximum agent steps (1-100)"),
+    max_steps: int | None = typer.Option(None, "--max-steps", help="Maximum number of agent steps"),
     agent: str | None = typer.Option(None, "--agent", help="Agent to use"),
     require_auth: bool | None = typer.Option(None, "--require-auth", help="Use auth-optimized browser for login flows"),
 ) -> None:

--- a/yutori/cli/commands/research.py
+++ b/yutori/cli/commands/research.py
@@ -14,8 +14,8 @@ console = Console()
 @app.command()
 def run(
     query: str = typer.Argument(help="Natural language research query"),
-    timezone: str | None = typer.Option(None, "--timezone", "-tz", help="e.g., America/Los_Angeles"),
-    location: str | None = typer.Option(None, "--location", help="e.g., San Francisco, CA, US"),
+    timezone: str = typer.Option(None, "--timezone", "-tz", help="e.g., America/Los_Angeles"),
+    location: str = typer.Option(None, "--location", help="e.g., San Francisco, CA, US"),
 ) -> None:
     """Start a new research task."""
     client = get_authenticated_client()

--- a/yutori/cli/commands/research.py
+++ b/yutori/cli/commands/research.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 
 from yutori.cli.commands import get_authenticated_client
 
@@ -48,7 +49,7 @@ def get(
         console.print(f"  Status: {result.get('status', 'N/A')}")
 
         if result.get("query"):
-            console.print(f"  Query: {result['query']}")
+            console.print(f"  Query: {escape(result['query'])}")
         if result.get("created_at"):
             console.print(f"  Created: {result['created_at']}")
 
@@ -58,6 +59,6 @@ def get(
             text = str(output)
             if len(text) > 2000:
                 text = text[:2000] + "\n... (truncated)"
-            console.print(text)
+            console.print(text, markup=False)
     finally:
         client.close()

--- a/yutori/cli/commands/research.py
+++ b/yutori/cli/commands/research.py
@@ -1,0 +1,63 @@
+"""Research commands for the Yutori CLI."""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+
+from yutori.cli.commands import get_authenticated_client
+
+app = typer.Typer(help="Run and manage research tasks")
+console = Console()
+
+
+@app.command()
+def run(
+    query: str = typer.Argument(help="Natural language research query"),
+    timezone: str | None = typer.Option(None, "--timezone", "-tz", help="e.g., America/Los_Angeles"),
+    location: str | None = typer.Option(None, "--location", help="e.g., San Francisco, CA, US"),
+) -> None:
+    """Start a new research task."""
+    client = get_authenticated_client()
+
+    try:
+        result = client.research.create(
+            query=query,
+            user_timezone=timezone,
+            user_location=location,
+        )
+
+        console.print("\n[green]Research task created![/green]")
+        console.print(f"  Task ID: {result.get('task_id', 'N/A')}")
+        console.print(f"  Status: {result.get('status', 'N/A')}")
+    finally:
+        client.close()
+
+
+@app.command()
+def get(
+    task_id: str = typer.Argument(help="The research task ID"),
+) -> None:
+    """Get the status and result of a research task."""
+    client = get_authenticated_client()
+
+    try:
+        result = client.research.get(task_id)
+
+        console.print(f"\n[bold]Research Task: {result.get('task_id', task_id)}[/bold]\n")
+        console.print(f"  Status: {result.get('status', 'N/A')}")
+
+        if result.get("query"):
+            console.print(f"  Query: {result['query']}")
+        if result.get("created_at"):
+            console.print(f"  Created: {result['created_at']}")
+
+        output = result.get("result") or result.get("output")
+        if output:
+            console.print("\n[bold]Result:[/bold]")
+            text = str(output)
+            if len(text) > 2000:
+                text = text[:2000] + "\n... (truncated)"
+            console.print(text)
+    finally:
+        client.close()

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -36,7 +36,7 @@ def list_scouts(
         table.add_column("Interval")
 
         for scout in scouts:
-            interval_secs = scout.get("output_interval", 0)
+            interval_secs = scout.get("output_interval") or 0
             if interval_secs >= 86400:
                 interval_str = f"{interval_secs // 86400}d"
             elif interval_secs >= 3600:
@@ -74,7 +74,7 @@ def get(
         console.print(f"  Query: {escape(scout.get('query', 'N/A'))}")
         console.print(f"  Status: {scout.get('status', 'N/A')}")
 
-        interval_secs = scout.get("output_interval", 0)
+        interval_secs = scout.get("output_interval") or 0
         if interval_secs >= 86400:
             interval_str = f"{interval_secs // 86400} day(s)"
         elif interval_secs >= 3600:

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -103,7 +103,10 @@ def create(
         query = typer.prompt("What would you like to monitor?")
 
     interval_map = {"hourly": 3600, "daily": 86400, "weekly": 604800}
-    output_interval = interval_map.get(interval.lower(), 86400)
+    output_interval = interval_map.get(interval.lower())
+    if output_interval is None:
+        console.print(f"[red]Invalid interval '{interval}'. Choose from: hourly, daily, weekly[/red]")
+        raise typer.Exit(1)
 
     client = get_authenticated_client()
 

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -2,28 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import typer
 from rich.console import Console
 from rich.table import Table
 
-from yutori.auth.credentials import resolve_api_key
+from yutori.cli.commands import get_authenticated_client
 
 app = typer.Typer(help="Manage scouts")
 console = Console()
-
-
-def _get_client() -> Any:
-    """Get an authenticated YutoriClient."""
-    from yutori.client import YutoriClient
-
-    api_key = resolve_api_key()
-    if not api_key:
-        console.print("[red]Not authenticated. Run 'yutori auth login' first.[/red]")
-        raise typer.Exit(1)
-
-    return YutoriClient(api_key=api_key)
 
 
 @app.command("list")
@@ -32,7 +18,7 @@ def list_scouts(
     status: str = typer.Option(None, help="Filter by status: active, paused, done"),
 ) -> None:
     """List your scouts."""
-    client = _get_client()
+    client = get_authenticated_client()
 
     try:
         result = client.scouts.list(limit=limit, status=status)
@@ -78,7 +64,7 @@ def get(
     scout_id: str = typer.Argument(help="The scout ID"),
 ) -> None:
     """Get details of a specific scout."""
-    client = _get_client()
+    client = get_authenticated_client()
 
     try:
         scout = client.scouts.get(scout_id)
@@ -119,7 +105,7 @@ def create(
     interval_map = {"hourly": 3600, "daily": 86400, "weekly": 604800}
     output_interval = interval_map.get(interval.lower(), 86400)
 
-    client = _get_client()
+    client = get_authenticated_client()
 
     try:
         result = client.scouts.create(
@@ -148,7 +134,7 @@ def delete(
             console.print("[yellow]Cancelled.[/yellow]")
             raise typer.Exit(0)
 
-    client = _get_client()
+    client = get_authenticated_client()
 
     try:
         client.scouts.delete(scout_id)

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -1,0 +1,157 @@
+"""Scouts commands for the Yutori CLI."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from yutori.auth.credentials import resolve_api_key
+
+app = typer.Typer(help="Manage scouts")
+console = Console()
+
+
+def _get_client() -> Any:
+    """Get an authenticated YutoriClient."""
+    from yutori.client import YutoriClient
+
+    api_key = resolve_api_key()
+    if not api_key:
+        console.print("[red]Not authenticated. Run 'yutori auth login' first.[/red]")
+        raise typer.Exit(1)
+
+    return YutoriClient(api_key=api_key)
+
+
+@app.command("list")
+def list_scouts(
+    limit: int = typer.Option(None, help="Maximum number of scouts to return"),
+    status: str = typer.Option(None, help="Filter by status: active, paused, done"),
+) -> None:
+    """List your scouts."""
+    client = _get_client()
+
+    try:
+        result = client.scouts.list(limit=limit, status=status)
+        scouts = result.get("scouts", [])
+
+        if not scouts:
+            console.print("[yellow]No scouts found.[/yellow]")
+            return
+
+        table = Table(title="Your Scouts")
+        table.add_column("ID", style="cyan", no_wrap=True)
+        table.add_column("Query", max_width=50)
+        table.add_column("Status", style="green")
+        table.add_column("Interval")
+
+        for scout in scouts:
+            interval_secs = scout.get("output_interval", 0)
+            if interval_secs >= 86400:
+                interval_str = f"{interval_secs // 86400}d"
+            elif interval_secs >= 3600:
+                interval_str = f"{interval_secs // 3600}h"
+            else:
+                interval_str = f"{interval_secs // 60}m"
+
+            query = scout.get("query", "")
+            if len(query) > 47:
+                query = query[:47] + "..."
+
+            table.add_row(
+                scout.get("id", ""),
+                query,
+                scout.get("status", "unknown"),
+                interval_str,
+            )
+
+        console.print(table)
+    finally:
+        client.close()
+
+
+@app.command()
+def get(
+    scout_id: str = typer.Argument(help="The scout ID"),
+) -> None:
+    """Get details of a specific scout."""
+    client = _get_client()
+
+    try:
+        scout = client.scouts.get(scout_id)
+
+        console.print(f"\n[bold]Scout: {scout.get('id', scout_id)}[/bold]\n")
+        console.print(f"  Query: {scout.get('query', 'N/A')}")
+        console.print(f"  Status: {scout.get('status', 'N/A')}")
+
+        interval_secs = scout.get("output_interval", 0)
+        if interval_secs >= 86400:
+            interval_str = f"{interval_secs // 86400} day(s)"
+        elif interval_secs >= 3600:
+            interval_str = f"{interval_secs // 3600} hour(s)"
+        else:
+            interval_str = f"{interval_secs // 60} minute(s)"
+        console.print(f"  Interval: {interval_str}")
+
+        if scout.get("user_timezone"):
+            console.print(f"  Timezone: {scout['user_timezone']}")
+        if scout.get("created_at"):
+            console.print(f"  Created: {scout['created_at']}")
+        if scout.get("next_run_at"):
+            console.print(f"  Next Run: {scout['next_run_at']}")
+    finally:
+        client.close()
+
+
+@app.command()
+def create(
+    query: str = typer.Option(None, "--query", "-q", help="What to monitor"),
+    interval: str = typer.Option("daily", "--interval", "-i", help="Run interval: hourly, daily, weekly"),
+    timezone: str = typer.Option(None, "--timezone", "-tz", help="e.g., America/Los_Angeles"),
+) -> None:
+    """Create a new scout."""
+    if not query:
+        query = typer.prompt("What would you like to monitor?")
+
+    interval_map = {"hourly": 3600, "daily": 86400, "weekly": 604800}
+    output_interval = interval_map.get(interval.lower(), 86400)
+
+    client = _get_client()
+
+    try:
+        result = client.scouts.create(
+            query=query,
+            output_interval=output_interval,
+            user_timezone=timezone,
+        )
+
+        console.print("\n[green]Scout created successfully![/green]")
+        console.print(f"  ID: {result.get('id', 'N/A')}")
+        console.print(f"  Query: {result.get('query', query)}")
+        console.print(f"  Status: {result.get('status', 'N/A')}")
+    finally:
+        client.close()
+
+
+@app.command()
+def delete(
+    scout_id: str = typer.Argument(help="The scout ID to delete"),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+) -> None:
+    """Delete a scout."""
+    if not force:
+        confirm = typer.confirm(f"Are you sure you want to delete scout {scout_id}?")
+        if not confirm:
+            console.print("[yellow]Cancelled.[/yellow]")
+            raise typer.Exit(0)
+
+    client = _get_client()
+
+    try:
+        client.scouts.delete(scout_id)
+        console.print(f"[green]Scout {scout_id} deleted.[/green]")
+    finally:
+        client.close()

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 from yutori.cli.commands import get_authenticated_client
@@ -70,7 +71,7 @@ def get(
         scout = client.scouts.get(scout_id)
 
         console.print(f"\n[bold]Scout: {scout.get('id', scout_id)}[/bold]\n")
-        console.print(f"  Query: {scout.get('query', 'N/A')}")
+        console.print(f"  Query: {escape(scout.get('query', 'N/A'))}")
         console.print(f"  Status: {scout.get('status', 'N/A')}")
 
         interval_secs = scout.get("output_interval", 0)
@@ -105,7 +106,7 @@ def create(
     interval_map = {"hourly": 3600, "daily": 86400, "weekly": 604800}
     output_interval = interval_map.get(interval.lower())
     if output_interval is None:
-        console.print(f"[red]Invalid interval '{interval}'. Choose from: hourly, daily, weekly[/red]")
+        console.print(f"[red]Invalid interval '{escape(interval)}'. Choose from: hourly, daily, weekly[/red]")
         raise typer.Exit(1)
 
     client = get_authenticated_client()
@@ -119,7 +120,7 @@ def create(
 
         console.print("\n[green]Scout created successfully![/green]")
         console.print(f"  ID: {result.get('id', 'N/A')}")
-        console.print(f"  Query: {result.get('query', query)}")
+        console.print(f"  Query: {escape(result.get('query', query))}")
         console.print(f"  Status: {result.get('status', 'N/A')}")
     finally:
         client.close()

--- a/yutori/cli/commands/usage.py
+++ b/yutori/cli/commands/usage.py
@@ -1,0 +1,77 @@
+"""Usage command for the Yutori CLI."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from yutori.auth.credentials import resolve_api_key
+
+app = typer.Typer(help="View usage statistics")
+console = Console()
+
+
+def _get_client() -> Any:
+    """Get an authenticated YutoriClient."""
+    from yutori.client import YutoriClient
+
+    api_key = resolve_api_key()
+    if not api_key:
+        console.print("[red]Not authenticated. Run 'yutori auth login' first.[/red]")
+        raise typer.Exit(1)
+
+    return YutoriClient(api_key=api_key)
+
+
+@app.callback(invoke_without_command=True)
+def usage(ctx: typer.Context) -> None:
+    """Show API usage statistics."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    client = _get_client()
+
+    try:
+        data = client.get_usage()
+
+        console.print("\n[bold]Usage Statistics[/bold]\n")
+
+        if data.get("user_id"):
+            console.print(f"  User ID: {data['user_id']}")
+        if data.get("api_key_id"):
+            console.print(f"  API Key ID: {data['api_key_id']}")
+
+        scouts = data.get("scouts", [])
+        if scouts:
+            console.print(f"\n  [bold]Scouts:[/bold] {len(scouts)}")
+
+            table = Table()
+            table.add_column("ID", style="cyan")
+            table.add_column("Query", max_width=40)
+            table.add_column("Status")
+            table.add_column("Runs")
+
+            for scout in scouts[:10]:
+                query = scout.get("query", "")
+                if len(query) > 37:
+                    query = query[:37] + "..."
+
+                scout_id = scout.get("id", "")
+                table.add_row(
+                    scout_id,
+                    query,
+                    scout.get("status", ""),
+                    str(scout.get("run_count", 0)),
+                )
+
+            console.print(table)
+
+            if len(scouts) > 10:
+                console.print(f"  ... and {len(scouts) - 10} more")
+        else:
+            console.print("\n  No scouts yet.")
+    finally:
+        client.close()

--- a/yutori/cli/commands/usage.py
+++ b/yutori/cli/commands/usage.py
@@ -2,28 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import typer
 from rich.console import Console
 from rich.table import Table
 
-from yutori.auth.credentials import resolve_api_key
+from yutori.cli.commands import get_authenticated_client
 
 app = typer.Typer(help="View usage statistics")
 console = Console()
-
-
-def _get_client() -> Any:
-    """Get an authenticated YutoriClient."""
-    from yutori.client import YutoriClient
-
-    api_key = resolve_api_key()
-    if not api_key:
-        console.print("[red]Not authenticated. Run 'yutori auth login' first.[/red]")
-        raise typer.Exit(1)
-
-    return YutoriClient(api_key=api_key)
 
 
 @app.callback(invoke_without_command=True)
@@ -32,7 +18,7 @@ def usage(ctx: typer.Context) -> None:
     if ctx.invoked_subcommand is not None:
         return
 
-    client = _get_client()
+    client = get_authenticated_client()
 
     try:
         data = client.get_usage()

--- a/yutori/cli/main.py
+++ b/yutori/cli/main.py
@@ -10,7 +10,7 @@ except ImportError:
     print("Yutori CLI requires extras: pip install yutori[cli]")
     sys.exit(1)
 
-from .commands import auth, scouts, usage
+from .commands import auth, browse, research, scouts, usage
 
 app = typer.Typer(
     name="yutori",
@@ -19,6 +19,8 @@ app = typer.Typer(
 )
 
 app.add_typer(auth.app, name="auth")
+app.add_typer(browse.app, name="browse")
+app.add_typer(research.app, name="research")
 app.add_typer(scouts.app, name="scouts")
 app.add_typer(usage.app, name="usage")
 

--- a/yutori/cli/main.py
+++ b/yutori/cli/main.py
@@ -1,0 +1,35 @@
+"""Main entry point for the Yutori CLI."""
+
+from __future__ import annotations
+
+try:
+    import typer
+except ImportError:
+    import sys
+
+    print("Yutori CLI requires extras: pip install yutori[cli]")
+    sys.exit(1)
+
+from .commands import auth, scouts, usage
+
+app = typer.Typer(
+    name="yutori",
+    help="Yutori CLI - Manage your scouts and web automation",
+    no_args_is_help=True,
+)
+
+app.add_typer(auth.app, name="auth")
+app.add_typer(scouts.app, name="scouts")
+app.add_typer(usage.app, name="usage")
+
+
+@app.command()
+def version() -> None:
+    """Show the CLI version."""
+    from yutori import __version__
+
+    typer.echo(f"yutori {__version__}")
+
+
+if __name__ == "__main__":
+    app()

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import Any
 
 import httpx
@@ -47,10 +46,12 @@ class YutoriClient:
         Raises:
             AuthenticationError: If no API key is provided or found in environment.
         """
-        api_key = api_key or os.environ.get("YUTORI_API_KEY")
+        from yutori.auth.credentials import resolve_api_key
+
+        api_key = resolve_api_key(api_key)
         if not api_key:
             raise AuthenticationError(
-                "No API key provided. Pass api_key or set the YUTORI_API_KEY environment variable."
+                "No API key provided. Run 'yutori auth login', set YUTORI_API_KEY, or pass api_key."
             )
 
         self._api_key = api_key


### PR DESCRIPTION
## Summary

- Adds `yutori auth login` using Clerk OAuth 2.0 + PKCE flow, with credentials saved to `~/.yutori/config.json` (0600 perms, atomic writes)
- Introduces `resolve_api_key()` — single-function precedence chain: explicit param → `YUTORI_API_KEY` env var → config file
- Adds Typer-based CLI (`pip install yutori[cli]`) with `auth`, `scouts`, `usage`, `browse`, and `research` commands
- Bumps version to 0.3.0

## Details

### Auth module (`yutori/auth/`)
- **flow.py**: Full PKCE OAuth flow — generates code verifier/challenge, opens browser, runs localhost callback server, exchanges code for JWT, generates API key. Returns typed `LoginResult` (never prints directly). HTML-escapes error text in callback page to prevent XSS.
- **credentials.py**: `load_config`, `save_config` (atomic write via tempfile + `os.replace`), `clear_config`, `resolve_api_key`
- **constants.py**: Clerk OAuth config. `build_auth_api_url()` uses the SDK's canonical `DEFAULT_BASE_URL` (`api.yutori.com/v1`). Earlier iterations had a `YUTORI_AUTH_API_BASE_URL` env var override for dev testing (when `/client/generate_key` only existed on `api.dev.yutori.com`); this was removed in 14897d5 since the endpoint has been deployed to prod and the override is no longer needed.
- **types.py**: `LoginResult` and `AuthStatus` dataclasses

### CLI (`yutori/cli/`)
- `auth login/logout/status` — thin wrappers over `yutori.auth` with Rich output
- `scouts list/get/create/delete` — manage scouts via SDK client
- `usage` — show API usage statistics
- `browse run/get` — start and poll browsing tasks (`client.browsing.create/get`)
- `research run/get` — start and poll research tasks (`client.research.create/get`)

### Browse & Research commands
Thin CLI wrappers that bring feature parity with the SDK namespaces already exposed by the MCP server:

- **`yutori browse run TASK URL [--max-steps N] [--agent STR] [--require-auth]`** — starts a browsing task
- **`yutori browse get TASK_ID`** — retrieves status and result
- **`yutori research run QUERY [--timezone TZ] [--location LOC]`** — starts a research task
- **`yutori research get TASK_ID`** — retrieves status and result

JSON-heavy options (`output_schema`, `webhook_*`) are intentionally omitted — they're better suited for programmatic SDK use.

### Client changes
- Both `YutoriClient` and `AsyncYutoriClient` now use `resolve_api_key()` instead of direct `os.environ.get`

## Test plan

- [x] 96 tests passing (including auth module, credentials, callback handler, token exchange, login flow, auth status, types, constants)
- [x] `yutori browse --help` / `yutori research --help` show correct subcommands and arguments
- [x] Manual e2e validated against dev environment (using Clerk dev instance + `YUTORI_AUTH_API_BASE_URL` override, which existed at the time but has since been removed — see constants.py note above):
  ```
  CLERK_INSTANCE_URL=https://modest-sturgeon-11.clerk.accounts.dev \
  CLERK_CLIENT_ID=G54yibBWDqF2MVc1 \
  yutori auth login
  ```
  `login` → browser opens → callback → key saved → `status` shows masked key → `logout` clears config
- [x] Prod e2e validated — `/client/generate_key` deployed to `api.yutori.com`, defaults work with no env var overrides:
  ```
  yutori auth login
  ```
  `login` → browser opens Clerk prod (`clerk.yutori.com`) → consent screen → callback → key saved. Required middleware fix in monorepo ([#5923](https://github.com/yutori-ai/yutori/pull/5923)) to allowlist Clerk OAuth consent redirects for users with existing browser sessions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authentication flow, local credential storage, and a CLI entrypoint, which increases surface area and could impact login reliability and key-handling behavior. Core API request logic is largely unchanged, but API key resolution and auth persistence paths are new.
> 
> **Overview**
> Adds a new `yutori` CLI (Typer + Rich) exposed via `pyproject.toml` `project.scripts`, including commands for auth (`login` via browser OAuth, `status`, `logout`) and thin wrappers to run/manage `scouts`, `usage`, `browse`, and `research` operations.
> 
> Introduces a new `yutori.auth` package implementing Clerk OAuth2 + PKCE, local callback handling, token exchange + API key generation, and secure credential persistence to `~/.yutori/config.json` (atomic write, restrictive perms), plus a shared `resolve_api_key()` precedence chain now used by both `YutoriClient` and `AsyncYutoriClient` (with updated error messaging). Also bumps package version to `0.3.0` and adds comprehensive auth-focused tests; client init tests are updated to account for config-based key resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25c4fd577c978addae1fc388a96279a286f2e1c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->