### PR TITLE
Add `yutori auth register` CLI command

### DIFF
--- a/yutori/auth/__init__.py
+++ b/yutori/auth/__init__.py
@@ -14,6 +14,10 @@ def __getattr__(name: str):
         from .flow import run_login_flow
 
         return run_login_flow
+    if name == "run_register_flow":
+        from .flow import run_register_flow
+
+        return run_register_flow
     if name == "get_auth_status":
         from .flow import get_auth_status
 
@@ -27,6 +31,7 @@ __all__ = [
     "load_config",
     "resolve_api_key",
     "run_login_flow",
+    "run_register_flow",
     "save_config",
     "AuthStatus",
     "LoginResult",

--- a/yutori/auth/constants.py
+++ b/yutori/auth/constants.py
@@ -21,10 +21,19 @@ AUTH_TIMEOUT_SECONDS = 300
 CONFIG_DIR = ".yutori"
 CONFIG_FILE = "config.json"
 
+# API endpoints
+GENERATE_KEY_ENDPOINT = "/client/generate_key"
+SIGN_UP_VALIDATE_ENDPOINT = "/client/sign-up/validate-api"
+
+# Clerk sign-up hint
+SCREEN_HINT_SIGN_UP = "sign_up"
+
 # Error messages
 ERROR_AUTH_TIMEOUT = "Login timed out. Please try again."
 ERROR_STATE_MISMATCH = "Security validation failed (state mismatch). Please try again."
 ERROR_AUTH_FAILED = "Authentication failed"
+ERROR_SIGN_UP_FAILED = "Account creation failed"
+ERROR_MAX_KEYS_REACHED = "Maximum number of API keys reached (50). Delete unused keys and try again."
 
 
 def build_auth_api_url(path: str) -> str:

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -9,10 +9,26 @@ from rich.console import Console
 from rich.markup import escape
 
 from yutori.auth.credentials import clear_config, load_config
-from yutori.auth.flow import get_auth_status, run_login_flow
+from yutori.auth.flow import get_auth_status, run_login_flow, run_register_flow
 
 app = typer.Typer(help="Manage authentication")
 console = Console()
+
+
+def _check_existing_credentials(action: str) -> None:
+    if os.environ.get("YUTORI_API_KEY"):
+        console.print(
+            "[yellow]YUTORI_API_KEY environment variable is set — it takes precedence over saved credentials.[/yellow]"
+        )
+        console.print(f"Unset it first if you want to use browser {action}.")
+        raise typer.Exit(1)
+
+    config = load_config()
+    existing_key = config.get("api_key") if config else None
+    if existing_key and isinstance(existing_key, str):
+        console.print("[yellow]You are already authenticated.[/yellow]")
+        console.print(f"Run [bold]yutori auth logout[/bold] first to re-{action}.")
+        raise typer.Exit(1)
 
 
 @app.command()
@@ -21,17 +37,7 @@ def login() -> None:
 
     Opens your browser to log in with Clerk OAuth and saves an API key locally.
     """
-    if os.environ.get("YUTORI_API_KEY"):
-        console.print("[yellow]YUTORI_API_KEY environment variable is set — it takes precedence over saved credentials.[/yellow]")
-        console.print("Unset it first if you want to use browser login.")
-        raise typer.Exit(1)
-
-    config = load_config()
-    existing_key = config.get("api_key") if config else None
-    if existing_key and isinstance(existing_key, str):
-        console.print("[yellow]You are already authenticated.[/yellow]")
-        console.print("Run [bold]yutori auth logout[/bold] first to re-authenticate.")
-        raise typer.Exit(1)
+    _check_existing_credentials("authenticate")
 
     console.print("\n[bold]Opening browser for authentication...[/bold]")
     console.print("[dim]Waiting for authentication...[/dim]\n")
@@ -43,6 +49,30 @@ def login() -> None:
         console.print("You can now use the Yutori CLI and SDK.")
     else:
         console.print(f"\n[red]Authentication failed: {escape(str(result.error))}[/red]")
+        if result.auth_url:
+            console.print(f"\n[dim]If the browser didn't open, visit:[/dim]\n  {result.auth_url}")
+        raise typer.Exit(1)
+
+
+@app.command()
+def register() -> None:
+    """Create a new Yutori account via browser.
+
+    Opens your browser to sign up with Clerk OAuth, creates your account,
+    and saves an API key locally.
+    """
+    _check_existing_credentials("register")
+
+    console.print("\n[bold]Opening browser for sign-up...[/bold]")
+    console.print("[dim]Waiting for authentication...[/dim]\n")
+
+    result = run_register_flow()
+
+    if result.success:
+        console.print("[green]Registration successful! API key saved.[/green]")
+        console.print("You can now use the Yutori CLI and SDK.")
+    else:
+        console.print(f"\n[red]Registration failed: {escape(str(result.error))}[/red]")
         if result.auth_url:
             console.print(f"\n[dim]If the browser didn't open, visit:[/dim]\n  {result.auth_url}")
         raise typer.Exit(1)


### PR DESCRIPTION
## Summary
- Adds `yutori auth register` command that opens Clerk sign-up, creates user account via `/client/sign-up/validate-api`, then generates and saves an API key
- Extracts shared OAuth PKCE flow from `auth login` into reusable helpers (`_run_oauth_flow`, `_generate_and_save_key`, `_format_http_error`)
- Adds constants for new endpoints, error messages, and Clerk `screen_hint`
- Handles 409 (max keys) specifically with a user-friendly message

## Test plan
- [x] All 117 tests pass (70 auth tests, including 12 new for register flow)
- [x] Ruff lint and format clean
- [ ] Manual: `yutori auth register` → complete sign-up → verify user created + API key saved
- [ ] Manual: `yutori auth register` again with same account → succeeds (creates new key)
- [ ] Manual: `yutori auth login` still works for existing users

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new auth path that hits a new sign-up validation endpoint and refactors the shared OAuth flow/error handling; moderate risk due to changes in the authentication flow and user-facing error behavior.
> 
> **Overview**
> Adds `yutori auth register`, which opens Clerk in sign-up mode, calls a new `/client/sign-up/validate-api` step, then generates and saves an API key (mirroring `auth login`).
> 
> Refactors the OAuth PKCE implementation by extracting a shared `_run_oauth_flow` and `_generate_and_save_key`, adds `screen_hint` support to `build_auth_url`, and centralizes HTTP error formatting with special handling for `409` (max API keys reached). New endpoint/error constants are introduced and `run_register_flow` is exported lazily from `yutori.auth`; tests are expanded to cover the new register flow and error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 440aff8ed50792b703a5fed2a77311d63392b54b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->