### PR TITLE
Add "detail": "high" to screenshot image URLs in examples

### DIFF
--- a/examples/n1.py
+++ b/examples/n1.py
@@ -208,7 +208,7 @@ class Agent:
         last_content.append(
             {
                 "type": "image_url",
-                "image_url": {"url": f"data:image/webp;base64,{screenshot_b64}"},
+                "image_url": {"url": f"data:image/webp;base64,{screenshot_b64}", "detail": "high"},
             }
         )
 

--- a/examples/n1_custom_tools.py
+++ b/examples/n1_custom_tools.py
@@ -285,7 +285,7 @@ class Agent:
         last_content.append(
             {
                 "type": "image_url",
-                "image_url": {"url": f"data:image/webp;base64,{screenshot_b64}"},
+                "image_url": {"url": f"data:image/webp;base64,{screenshot_b64}", "detail": "high"},
             }
         )
 

--- a/examples/n1_memo.py
+++ b/examples/n1_memo.py
@@ -336,7 +336,7 @@ class Agent:
         last_content.append(
             {
                 "type": "image_url",
-                "image_url": {"url": f"data:image/webp;base64,{screenshot_b64}"},
+                "image_url": {"url": f"data:image/webp;base64,{screenshot_b64}", "detail": "high"},
             }
         )
 


### PR DESCRIPTION
## Summary
- Adds `"detail": "high"` to the `image_url` content blocks in all three n1 example scripts (`n1.py`, `n1_custom_tools.py`, `n1_memo.py`)

## Test plan
- [x] Verify examples still run correctly with the updated image URL format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, example-only payload tweak to the chat message format; main risk is incompatibility if a downstream API/client doesn’t accept the `detail` field.
> 
> **Overview**
> Updates the three n1 browsing example scripts to include `"detail": "high"` alongside the base64 screenshot URL in each `image_url` message content block.
> 
> This changes how screenshots are requested/encoded for the model in examples (`n1.py`, `n1_custom_tools.py`, `n1_memo.py`) without altering the tool execution flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 273d57aceb9f31a65b31cecfa9d3b75d29dbee2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->