### PR TITLE
Improve action defaults in example scripts

### DIFF
--- a/examples/n1.py
+++ b/examples/n1.py
@@ -254,14 +254,14 @@ class Agent:
 
             elif action_name == "type":
                 text = arguments.get("text", "")
-                press_enter = arguments.get("press_enter_after", False)
-                clear_first = arguments.get("clear_before_typing", False)
+                press_enter = arguments.get("press_enter_after", True)
+                clear_first = arguments.get("clear_before_typing", True)
 
                 if clear_first:
                     await self._page.keyboard.press("Control+a" if sys.platform != "darwin" else "Meta+a")
                     await self._page.keyboard.press("Backspace")
 
-                await self._page.keyboard.type(text, delay=50)
+                await self._page.keyboard.type(text)
 
                 if press_enter:
                     await self._page.keyboard.press("Enter")
@@ -269,6 +269,7 @@ class Agent:
 
             elif action_name in ("key", "key_press"):
                 key = arguments.get("key") or arguments.get("key_comb", "")
+                key = key.replace("Meta", "ControlOrMeta")
                 await self._page.keyboard.press(key)
                 await asyncio.sleep(0.3)
 
@@ -302,7 +303,7 @@ class Agent:
 
                 await self._page.mouse.move(start_x, start_y)
                 await self._page.mouse.down()
-                await self._page.mouse.move(end_x, end_y, steps=10)
+                await self._page.mouse.move(end_x, end_y)
                 await self._page.mouse.up()
                 await asyncio.sleep(0.5)
 
@@ -323,7 +324,7 @@ class Agent:
                 await asyncio.sleep(1)
 
             elif action_name == "wait":
-                await asyncio.sleep(2)
+                await asyncio.sleep(5)
 
             else:
                 logger.warning(f"Unknown action: {action_name}")

--- a/examples/n1.py
+++ b/examples/n1.py
@@ -269,7 +269,7 @@ class Agent:
 
             elif action_name in ("key", "key_press"):
                 key = arguments.get("key") or arguments.get("key_comb", "")
-                key = key.replace("Meta", "ControlOrMeta")
+                key = "+".join("ControlOrMeta" if k == "Meta" else k for k in key.split("+"))
                 await self._page.keyboard.press(key)
                 await asyncio.sleep(0.3)
 

--- a/examples/n1_custom_tools.py
+++ b/examples/n1_custom_tools.py
@@ -331,14 +331,14 @@ class Agent:
 
             elif action_name == "type":
                 text = arguments.get("text", "")
-                press_enter = arguments.get("press_enter_after", False)
-                clear_first = arguments.get("clear_before_typing", False)
+                press_enter = arguments.get("press_enter_after", True)
+                clear_first = arguments.get("clear_before_typing", True)
 
                 if clear_first:
                     await self._page.keyboard.press("Control+a" if sys.platform != "darwin" else "Meta+a")
                     await self._page.keyboard.press("Backspace")
 
-                await self._page.keyboard.type(text, delay=50)
+                await self._page.keyboard.type(text)
 
                 if press_enter:
                     await self._page.keyboard.press("Enter")
@@ -346,6 +346,7 @@ class Agent:
 
             elif action_name in ("key", "key_press"):
                 key = arguments.get("key") or arguments.get("key_comb", "")
+                key = key.replace("Meta", "ControlOrMeta")
                 await self._page.keyboard.press(key)
                 await asyncio.sleep(0.3)
 
@@ -379,7 +380,7 @@ class Agent:
 
                 await self._page.mouse.move(start_x, start_y)
                 await self._page.mouse.down()
-                await self._page.mouse.move(end_x, end_y, steps=10)
+                await self._page.mouse.move(end_x, end_y)
                 await self._page.mouse.up()
                 await asyncio.sleep(0.5)
 
@@ -400,7 +401,7 @@ class Agent:
                 await asyncio.sleep(1)
 
             elif action_name == "wait":
-                await asyncio.sleep(2)
+                await asyncio.sleep(5)
 
             elif action_name == "extract_content_and_links":
                 result = await self._extract_content_and_links_tool(self._page)

--- a/examples/n1_custom_tools.py
+++ b/examples/n1_custom_tools.py
@@ -346,7 +346,7 @@ class Agent:
 
             elif action_name in ("key", "key_press"):
                 key = arguments.get("key") or arguments.get("key_comb", "")
-                key = key.replace("Meta", "ControlOrMeta")
+                key = "+".join("ControlOrMeta" if k == "Meta" else k for k in key.split("+"))
                 await self._page.keyboard.press(key)
                 await asyncio.sleep(0.3)
 

--- a/examples/n1_memo.py
+++ b/examples/n1_memo.py
@@ -383,14 +383,14 @@ class Agent:
 
             elif action_name == "type":
                 text = arguments.get("text", "")
-                press_enter = arguments.get("press_enter_after", False)
-                clear_first = arguments.get("clear_before_typing", False)
+                press_enter = arguments.get("press_enter_after", True)
+                clear_first = arguments.get("clear_before_typing", True)
 
                 if clear_first:
                     await self._page.keyboard.press("Control+a" if sys.platform != "darwin" else "Meta+a")
                     await self._page.keyboard.press("Backspace")
 
-                await self._page.keyboard.type(text, delay=50)
+                await self._page.keyboard.type(text)
 
                 if press_enter:
                     await self._page.keyboard.press("Enter")
@@ -398,6 +398,7 @@ class Agent:
 
             elif action_name in ("key", "key_press"):
                 key = arguments.get("key") or arguments.get("key_comb", "")
+                key = key.replace("Meta", "ControlOrMeta")
                 await self._page.keyboard.press(key)
                 await asyncio.sleep(0.3)
 
@@ -431,7 +432,7 @@ class Agent:
 
                 await self._page.mouse.move(start_x, start_y)
                 await self._page.mouse.down()
-                await self._page.mouse.move(end_x, end_y, steps=10)
+                await self._page.mouse.move(end_x, end_y)
                 await self._page.mouse.up()
                 await asyncio.sleep(0.5)
 
@@ -452,7 +453,7 @@ class Agent:
                 await asyncio.sleep(1)
 
             elif action_name == "wait":
-                await asyncio.sleep(2)
+                await asyncio.sleep(5)
 
             elif action_name == "add_question":
                 result = await self._memo_tool_suite.add_question(**arguments)

--- a/examples/n1_memo.py
+++ b/examples/n1_memo.py
@@ -398,7 +398,7 @@ class Agent:
 
             elif action_name in ("key", "key_press"):
                 key = arguments.get("key") or arguments.get("key_comb", "")
-                key = key.replace("Meta", "ControlOrMeta")
+                key = "+".join("ControlOrMeta" if k == "Meta" else k for k in key.split("+"))
                 await self._page.keyboard.press(key)
                 await asyncio.sleep(0.3)
 


### PR DESCRIPTION
## Summary
- **type**: default `press_enter_after` and `clear_before_typing` to `True`, remove 50ms typing delay
- **keypress**: map `Meta` to `ControlOrMeta` before pressing for cross-platform compatibility
- **wait**: increase sleep from 2s to 5s
- **drag**: remove 10-step interpolation from mouse move

## Test plan
- [x] Verify type action clears field and presses enter by default
- [x] Verify keypress with Meta key works on both macOS and Linux
- [x] Verify wait action sleeps for 5 seconds
- [x] Verify drag action completes without step interpolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to example automation scripts, but can alter how existing tasks run by default (auto-clearing, auto-submitting, longer waits).
> 
> **Overview**
> Updates the Playwright action executor in the `examples/n1*.py` scripts to behave more aggressively by default: `type` now clears the field and presses Enter unless explicitly disabled, and typing no longer uses a per-character delay.
> 
> Improves cross-platform key handling by translating `Meta` to `ControlOrMeta`, simplifies `drag` by removing stepped mouse interpolation, and increases the built-in `wait` action delay from 2s to 5s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 159e622c229fce60438ed385bafe2c6841dad51c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->