### PR TITLE
Fix n1 API example image URL causing upstream errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ response = client.chat.completions.create(
                 {
                     "type": "image_url",
                     "image_url": {
-                        "url": "https://upload.wikimedia.org/wikipedia/commons/5/53/Google_homepage_%28as_of_January_2024%29.jpg"
+                        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/53/Google_homepage_%28as_of_January_2024%29.jpg/1280px-Google_homepage_%28as_of_January_2024%29.jpg"
                     }
                 }
             ]


### PR DESCRIPTION
## Summary
- The example image URL in the README pointed to a full-resolution 2732x1810 Wikipedia image (298KB) that causes timeout errors
- Replaced with the 1280px Wikipedia thumbnail (33KB) which matches the recommended WXGA resolution

## Test plan
- [x] Verified the new URL returns 200 and is 33KB
- [x] Verified the n1 API returns a valid response with the new URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates an example URL; no runtime code paths are modified.
> 
> **Overview**
> Updates the `README.md` n1 API example to use a smaller Wikipedia **thumbnail** image URL instead of the full-resolution image, avoiding upstream timeouts/errors when sending the screenshot to the API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90f9b12feb8e40e8948600303d91d88d5edf757d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->