### PR TITLE
Add yutori.n1 payload trimming utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.3.5"
+version = "0.4.0"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -203,6 +203,28 @@ class TestResolveApiKey:
         monkeypatch.setenv("YUTORI_API_KEY", "yt-env")
         assert resolve_api_key("") == "yt-env"
 
+    def test_placeholder_param_falls_through(self, monkeypatch):
+        monkeypatch.setenv("YUTORI_API_KEY", "yt-env")
+        assert resolve_api_key("YOUR_API_KEY") == "yt-env"
+
+    def test_placeholder_env_falls_through_to_config(self, monkeypatch):
+        monkeypatch.setenv("YUTORI_API_KEY", "YOUR_API_KEY")
+        save_config("yt-stored")
+        assert resolve_api_key() == "yt-stored"
+
+    def test_placeholder_env_returns_none_without_config(self, monkeypatch):
+        monkeypatch.setenv("YUTORI_API_KEY", "YOUR_API_KEY")
+        assert resolve_api_key() is None
+
+    def test_placeholder_in_config_returns_none(self):
+        save_config("YOUR_API_KEY")
+        assert resolve_api_key() is None
+
+    def test_placeholder_with_whitespace_falls_through(self, monkeypatch):
+        monkeypatch.setenv("YUTORI_API_KEY", "  YOUR_API_KEY  ")
+        save_config("yt-stored")
+        assert resolve_api_key() == "yt-stored"
+
 
 # ---------------------------------------------------------------------------
 # Callback handler

--- a/tests/test_n1_payload.py
+++ b/tests/test_n1_payload.py
@@ -1,0 +1,202 @@
+"""Tests for yutori.n1.payload – payload management utilities."""
+
+from yutori.n1.payload import (
+    DEFAULT_KEEP_RECENT_SCREENSHOTS,
+    DEFAULT_MAX_REQUEST_BYTES,
+    _strip_one_image,
+    estimate_messages_size_bytes,
+    message_has_image,
+    trim_images_to_fit,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+IMG_URL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg"
+
+
+def _text_msg(role: str, text: str) -> dict:
+    return {"role": role, "content": text}
+
+
+def _image_msg(role: str, url: str = IMG_URL, text: str | None = None) -> dict:
+    content: list[dict] = [{"type": "image_url", "image_url": {"url": url}}]
+    if text:
+        content.insert(0, {"type": "text", "text": text})
+    return {"role": role, "content": content}
+
+
+# ---------------------------------------------------------------------------
+# estimate_messages_size_bytes
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateMessagesSizeBytes:
+    def test_empty_list(self):
+        assert estimate_messages_size_bytes([]) == 2  # "[]"
+
+    def test_single_text_message(self):
+        msgs = [_text_msg("user", "hello")]
+        size = estimate_messages_size_bytes(msgs)
+        assert size > 0
+        assert isinstance(size, int)
+
+    def test_size_grows_with_content(self):
+        small = [_text_msg("user", "a")]
+        large = [_text_msg("user", "a" * 1000)]
+        assert estimate_messages_size_bytes(large) > estimate_messages_size_bytes(small)
+
+
+# ---------------------------------------------------------------------------
+# message_has_image
+# ---------------------------------------------------------------------------
+
+
+class TestMessageHasImage:
+    def test_text_message_no_image(self):
+        assert message_has_image(_text_msg("user", "hi")) is False
+
+    def test_string_content_no_image(self):
+        assert message_has_image({"role": "user", "content": "just text"}) is False
+
+    def test_image_message(self):
+        assert message_has_image(_image_msg("user")) is True
+
+    def test_image_with_text(self):
+        assert message_has_image(_image_msg("user", text="caption")) is True
+
+    def test_empty_content_list(self):
+        assert message_has_image({"role": "user", "content": []}) is False
+
+    def test_no_content_key(self):
+        assert message_has_image({"role": "user"}) is False
+
+
+# ---------------------------------------------------------------------------
+# _strip_one_image
+# ---------------------------------------------------------------------------
+
+
+class TestStripOneImage:
+    def test_strips_image(self):
+        msg = _image_msg("user", text="caption")
+        assert _strip_one_image(msg) is True
+        # image should be gone, text should remain
+        assert not any(p.get("type") == "image_url" for p in msg["content"])
+        assert any(p.get("type") == "text" and p["text"] == "caption" for p in msg["content"])
+
+    def test_adds_placeholder_when_no_text(self):
+        msg = _image_msg("user")
+        assert _strip_one_image(msg) is True
+        assert any("omitted" in p.get("text", "").lower() for p in msg["content"])
+
+    def test_no_image_returns_false(self):
+        msg = _text_msg("user", "no image here")
+        assert _strip_one_image(msg) is False
+
+    def test_string_content_returns_false(self):
+        msg = {"role": "user", "content": "plain string"}
+        assert _strip_one_image(msg) is False
+
+    def test_only_removes_first_image(self):
+        msg = {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "img1"}},
+                {"type": "image_url", "image_url": {"url": "img2"}},
+            ],
+        }
+        _strip_one_image(msg)
+        images = [p for p in msg["content"] if p.get("type") == "image_url"]
+        assert len(images) == 1
+        assert images[0]["image_url"]["url"] == "img2"
+
+
+# ---------------------------------------------------------------------------
+# trim_images_to_fit
+# ---------------------------------------------------------------------------
+
+
+class TestTrimImagesToFit:
+    def test_already_under_limit(self):
+        msgs = [_text_msg("user", "hi")]
+        size, removed = trim_images_to_fit(msgs, max_bytes=10_000)
+        assert removed == 0
+
+    def test_no_images_over_limit(self):
+        msgs = [_text_msg("user", "x" * 1000)]
+        size, removed = trim_images_to_fit(msgs, max_bytes=10)
+        assert removed == 0
+
+    def test_removes_old_images_first(self):
+        big_data = "A" * 5000
+        msgs = [
+            _image_msg("assistant", url=big_data),
+            _image_msg("assistant", url=big_data),
+            _image_msg("assistant", url=big_data),
+            _image_msg("assistant", url=big_data),
+        ]
+        size, removed = trim_images_to_fit(msgs, max_bytes=15_000, keep_recent=2)
+        assert removed > 0
+        # The last 2 messages should still have images (protected)
+        assert message_has_image(msgs[-1])
+        assert message_has_image(msgs[-2])
+
+    def test_last_image_always_kept(self):
+        big_data = "A" * 5000
+        msgs = [
+            _image_msg("assistant", url=big_data),
+            _image_msg("assistant", url=big_data),
+        ]
+        # Set max_bytes very low so it would want to remove everything
+        size, removed = trim_images_to_fit(msgs, max_bytes=100, keep_recent=1)
+        # The very last image must be kept
+        assert message_has_image(msgs[-1])
+
+    def test_keep_recent_minimum_is_1(self):
+        big_data = "A" * 5000
+        msgs = [
+            _image_msg("assistant", url=big_data),
+            _image_msg("assistant", url=big_data),
+        ]
+        # keep_recent=0 should be clamped to 1
+        size, removed = trim_images_to_fit(msgs, max_bytes=100, keep_recent=0)
+        assert message_has_image(msgs[-1])
+
+    def test_returns_tuple(self):
+        msgs = [_text_msg("user", "hello")]
+        result = trim_images_to_fit(msgs)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        size, removed = result
+        assert isinstance(size, int)
+        assert isinstance(removed, int)
+
+    def test_defaults(self):
+        assert DEFAULT_MAX_REQUEST_BYTES == 9_500_000
+        assert DEFAULT_KEEP_RECENT_SCREENSHOTS == 6
+
+    def test_messages_mutated_in_place(self):
+        big_data = "A" * 5000
+        msgs = [
+            _image_msg("assistant", url=big_data),
+            _image_msg("assistant", url=big_data),
+            _image_msg("assistant", url=big_data),
+        ]
+        original_id = id(msgs)
+        trim_images_to_fit(msgs, max_bytes=10_000, keep_recent=1)
+        assert id(msgs) == original_id  # same list object
+
+    def test_phase2_removes_protected_except_latest(self):
+        big_data = "A" * 5000
+        msgs = [
+            _image_msg("assistant", url=big_data),
+            _image_msg("assistant", url=big_data),
+            _image_msg("assistant", url=big_data),
+        ]
+        # Very low limit forces phase 2
+        size, removed = trim_images_to_fit(msgs, max_bytes=100, keep_recent=3)
+        # Only the very last image should survive
+        assert message_has_image(msgs[-1])
+        assert removed >= 2

--- a/yutori/n1/__init__.py
+++ b/yutori/n1/__init__.py
@@ -1,0 +1,14 @@
+"""Utilities for building agents with the Yutori n1 API.
+
+Provides reusable helpers for common patterns in n1 agent loops:
+- Payload management: trim old screenshots to stay within API size limits
+"""
+
+from __future__ import annotations
+
+from .payload import estimate_messages_size_bytes, trim_images_to_fit
+
+__all__ = [
+    "estimate_messages_size_bytes",
+    "trim_images_to_fit",
+]

--- a/yutori/n1/payload.py
+++ b/yutori/n1/payload.py
@@ -1,0 +1,117 @@
+"""Payload management utilities for n1 agent loops.
+
+When using the n1 API in an agentic loop, the message history grows with each
+step because every tool response includes a new screenshot. These utilities
+help keep the total payload under the API's size limit by selectively removing
+old screenshots while preserving recent context.
+
+Adapted from the n1-brightdata project (https://github.com/meirk-brd/n1-brightdata).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+DEFAULT_MAX_REQUEST_BYTES = 9_500_000
+DEFAULT_KEEP_RECENT_SCREENSHOTS = 6
+
+
+def estimate_messages_size_bytes(messages: list[dict[str, Any]]) -> int:
+    """Estimate the JSON-serialized byte size of a messages list."""
+    return len(json.dumps(messages, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+
+
+def message_has_image(message: dict[str, Any]) -> bool:
+    """Return True if *message* contains at least one ``image_url`` content block."""
+    content = message.get("content")
+    if not isinstance(content, list):
+        return False
+    return any(isinstance(part, dict) and part.get("type") == "image_url" for part in content)
+
+
+def _strip_one_image(message: dict[str, Any]) -> bool:
+    """Remove the first ``image_url`` block from *message* in place.
+
+    If removing the image leaves the message with no text content, a
+    placeholder text block is inserted so the message remains valid.
+
+    Returns True if an image was removed.
+    """
+    content = message.get("content")
+    if not isinstance(content, list):
+        return False
+
+    removed = False
+    new_content: list[dict[str, Any]] = []
+    for part in content:
+        if not removed and isinstance(part, dict) and part.get("type") == "image_url":
+            removed = True
+            continue
+        new_content.append(part)
+
+    if not removed:
+        return False
+
+    has_text = any(isinstance(p, dict) and p.get("type") == "text" for p in new_content)
+    if not has_text:
+        new_content.append({"type": "text", "text": "Screenshot omitted to stay under request size limit."})
+
+    message["content"] = new_content
+    return True
+
+
+def trim_images_to_fit(
+    messages: list[dict[str, Any]],
+    *,
+    max_bytes: int = DEFAULT_MAX_REQUEST_BYTES,
+    keep_recent: int = DEFAULT_KEEP_RECENT_SCREENSHOTS,
+) -> tuple[int, int]:
+    """Remove old screenshots from *messages* until the payload fits within *max_bytes*.
+
+    The most recent *keep_recent* screenshots are protected from removal (the
+    very last screenshot is always kept). If the payload is already within
+    limits, no changes are made.
+
+    Args:
+        messages: The mutable messages list (modified in place).
+        max_bytes: Target maximum payload size in bytes.
+        keep_recent: Number of recent screenshots to protect from removal.
+
+    Returns:
+        A ``(current_size_bytes, images_removed)`` tuple.
+    """
+    size_bytes = estimate_messages_size_bytes(messages)
+    if size_bytes <= max_bytes:
+        return size_bytes, 0
+
+    image_indices = [i for i, msg in enumerate(messages) if message_has_image(msg)]
+    if not image_indices:
+        return size_bytes, 0
+
+    keep_recent = max(1, keep_recent)
+    protected = set(image_indices[-keep_recent:])
+    removed = 0
+
+    # Phase 1: remove old images outside the protected window
+    for idx in image_indices:
+        if size_bytes <= max_bytes:
+            break
+        if idx in protected:
+            continue
+        if _strip_one_image(messages[idx]):
+            removed += 1
+            size_bytes = estimate_messages_size_bytes(messages)
+
+    # Phase 2: if still over limit, remove from protected set (except the latest)
+    if size_bytes > max_bytes:
+        for idx in image_indices:
+            if size_bytes <= max_bytes:
+                break
+            if idx == image_indices[-1]:
+                continue
+            if _strip_one_image(messages[idx]):
+                removed += 1
+                size_bytes = estimate_messages_size_bytes(messages)
+
+    return size_bytes, removed


### PR DESCRIPTION
## Summary

- Adds a new `yutori.n1` subpackage with reusable payload management utilities for n1 agent loops
- Bumps version `0.3.5` → `0.4.0` for the new public API surface

## Motivation

When using the n1 API in an agentic loop, the message history grows with each step because every tool response includes a base64-encoded screenshot. Without management, the payload eventually exceeds the API's ~10MB request size limit, causing failures.

These utilities were originally developed in the [n1-brightdata](https://github.com/meirk-brd/n1-brightdata) project. We're extracting them into the SDK so that all n1 integrations (n1-brightdata, navi-bench, and customer implementations) can share a single, tested implementation.

## What's included

**`yutori.n1.payload`** provides:
- `trim_images_to_fit(messages, *, max_bytes, keep_recent)` — removes old screenshots from a messages list until the payload fits within `max_bytes`. Protects the most recent `keep_recent` screenshots, and always preserves the very latest. Two-phase approach: first removes unprotected images, then protected ones (except latest) if still over limit.
- `estimate_messages_size_bytes(messages)` — estimates JSON-serialized size of a messages list.
- Constants: `DEFAULT_MAX_REQUEST_BYTES` (9.5MB), `DEFAULT_KEEP_RECENT_SCREENSHOTS` (6).

**`examples/n1.py`** updated to use `trim_images_to_fit` before each API call, with `--max-request-bytes` and `--keep-recent-screenshots` CLI args.

## Test plan

- [x] 23 unit tests in `tests/test_n1_payload.py` covering all functions and edge cases
- [x] Full test suite passes (125/125)
- [x] All imports verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new public `yutori.n1` utilities that mutate message payloads in place and changes API key resolution semantics to treat placeholder values as missing, which could alter authentication behavior in edge cases.
> 
> **Overview**
> Adds a new public `yutori.n1` subpackage with payload-size management helpers (`estimate_messages_size_bytes`, `trim_images_to_fit`) that prune older `image_url` blocks from chat message history (while always keeping the latest screenshot) to stay under request size limits.
> 
> Updates `examples/n1.py` to automatically trim screenshots before each n1 API call and exposes new CLI/config knobs (`--max-request-bytes`, `--keep-recent-screenshots`) to control trimming behavior.
> 
> Adjusts `resolve_api_key` to treat placeholder values like `"YOUR_API_KEY"` (including whitespace variants) as unset across parameter/env/config sources, adds tests for these cases, and bumps package version to `0.4.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05976e99219cec1827abf6392b51aaa817238734. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->