### PR TITLE
Accept Pydantic BaseModel classes/instances for output_schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,26 @@ print(result)
 
 ### Structured Output with Webhooks
 
+You can define the output structure using a JSON schema dict or a Pydantic BaseModel class (Pydantic is optional):
+
+```python
+from pydantic import BaseModel  # optional dependency
+
+class Employee(BaseModel):
+    name: str
+    title: str
+
+task = client.browsing.create(
+    task="Give me a list of all employees (names and titles) of Yutori.",
+    start_url="https://yutori.com",
+    max_steps=75,
+    webhook_url="https://example.com/webhook",
+    output_schema=Employee,  # auto-converted to JSON schema
+)
+```
+
+Or use a raw dict:
+
 ```python
 task = client.browsing.create(
     task="Give me a list of all employees (names and titles) of Yutori.",
@@ -162,21 +182,18 @@ print(result)
 ### Structured Output
 
 ```python
+from pydantic import BaseModel  # optional dependency
+
+class Finding(BaseModel):
+    title: str
+    summary: str
+    source_url: str
+
 task = client.research.create(
     query="What are the latest developments in quantum computing?",
     user_timezone="America/Los_Angeles",
     webhook_url="https://example.com/webhook",
-    output_schema={
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "title": {"type": "string"},
-                "summary": {"type": "string"},
-                "source_url": {"type": "string"}
-            }
-        }
-    }
+    output_schema=Finding,  # or pass a JSON schema dict
 )
 ```
 
@@ -220,23 +237,20 @@ client.scouts.delete("scout_abc123")
 ### Structured Output with Webhooks
 
 ```python
+from pydantic import BaseModel  # optional dependency
+
+class NewsItem(BaseModel):
+    headline: str
+    summary: str
+    source_url: str
+
 scout = client.scouts.create(
     query="Tell me about the latest news and announcements about Yutori",
     output_interval=86400,  # Daily
     user_timezone="America/Los_Angeles",
     skip_email=True,
     webhook_url="https://example.com/webhook",
-    output_schema={
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "headline": {"type": "string"},
-                "summary": {"type": "string"},
-                "source_url": {"type": "string"}
-            }
-        }
-    }
+    output_schema=NewsItem,  # or pass a JSON schema dict
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ task = client.browsing.create(
 )
 ```
 
-Or use a raw dict:
+<details>
+<summary>Using a JSON schema dict instead</summary>
 
 ```python
 task = client.browsing.create(
@@ -157,6 +158,8 @@ task = client.browsing.create(
     }
 )
 ```
+
+</details>
 
 ## Research API
 
@@ -193,9 +196,33 @@ task = client.research.create(
     query="What are the latest developments in quantum computing?",
     user_timezone="America/Los_Angeles",
     webhook_url="https://example.com/webhook",
-    output_schema=Finding,  # or pass a JSON schema dict
+    output_schema=Finding,  # auto-converted to JSON schema
 )
 ```
+
+<details>
+<summary>Using a JSON schema dict instead</summary>
+
+```python
+task = client.research.create(
+    query="What are the latest developments in quantum computing?",
+    user_timezone="America/Los_Angeles",
+    webhook_url="https://example.com/webhook",
+    output_schema={
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "summary": {"type": "string"},
+                "source_url": {"type": "string"}
+            }
+        }
+    }
+)
+```
+
+</details>
 
 ## Scouting API
 
@@ -250,9 +277,35 @@ scout = client.scouts.create(
     user_timezone="America/Los_Angeles",
     skip_email=True,
     webhook_url="https://example.com/webhook",
-    output_schema=NewsItem,  # or pass a JSON schema dict
+    output_schema=NewsItem,  # auto-converted to JSON schema
 )
 ```
+
+<details>
+<summary>Using a JSON schema dict instead</summary>
+
+```python
+scout = client.scouts.create(
+    query="Tell me about the latest news and announcements about Yutori",
+    output_interval=86400,  # Daily
+    user_timezone="America/Los_Angeles",
+    skip_email=True,
+    webhook_url="https://example.com/webhook",
+    output_schema={
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "headline": {"type": "string"},
+                "summary": {"type": "string"},
+                "source_url": {"type": "string"}
+            }
+        }
+    }
+)
+```
+
+</details>
 
 ## Async Usage
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ client = YutoriClient(api_key="yt-...")
 
 # Create a scout that monitors for updates
 scout = client.scouts.create(
-    query="Tell me about the latest news, product updates, and announcements about Yutori",
+    query="Tell me about the latest news, product updates, and announcements about Yutori AI",
 )
 print(f"Created scout: {scout['id']}")
 
@@ -272,7 +272,7 @@ class NewsItem(BaseModel):
     source_url: str
 
 scout = client.scouts.create(
-    query="Tell me about the latest news and announcements about Yutori",
+    query="Tell me about the latest news, product updates, and announcements about Yutori AI",
     output_interval=86400,  # Daily
     user_timezone="America/Los_Angeles",
     skip_email=True,
@@ -286,7 +286,7 @@ scout = client.scouts.create(
 
 ```python
 scout = client.scouts.create(
-    query="Tell me about the latest news and announcements about Yutori",
+    query="Tell me about the latest news, product updates, and announcements about Yutori AI",
     output_interval=86400,  # Daily
     user_timezone="America/Los_Angeles",
     skip_email=True,

--- a/api.md
+++ b/api.md
@@ -130,7 +130,7 @@ task = client.browsing.create(
 - `max_steps` (int, optional): Maximum agent steps (1-100).
 - `agent` (str, optional): Agent to use. Options: `"navigator-n1-latest"`, `"claude-sonnet-4-5-computer-use-2025-01-24"`.
 - `require_auth` (bool, optional): Use auth-optimized browser for login flows.
-- `output_schema` (dict, optional): JSON schema for structured output.
+- `output_schema` (dict | BaseModel, optional): JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance (auto-converted via `model_json_schema()` for v2 or `schema()` for v1).
 - `webhook_url` (str, optional): URL for completion notifications.
 - `webhook_format` (str, optional): Webhook format - `"scout"` (default), `"slack"`, or `"zapier"`.
 
@@ -175,7 +175,7 @@ task = client.research.create(
 - `query` (str): Natural language research query.
 - `user_timezone` (str, optional): Timezone, e.g., `"America/Los_Angeles"`.
 - `user_location` (str, optional): Location, e.g., `"San Francisco, CA, US"`.
-- `output_schema` (dict, optional): JSON schema for structured output.
+- `output_schema` (dict | BaseModel, optional): JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance (auto-converted via `model_json_schema()` for v2 or `schema()` for v1).
 - `webhook_url` (str, optional): URL for completion notifications.
 - `webhook_format` (str, optional): Webhook format - `"scout"` (default), `"slack"`, or `"zapier"`.
 
@@ -256,7 +256,7 @@ scout = client.scouts.create(
 - `start_timestamp` (int, optional): Unix timestamp to start. 0 = immediately.
 - `user_timezone` (str, optional): Timezone, e.g., `"America/Los_Angeles"`.
 - `user_location` (str, optional): Location, e.g., `"San Francisco, CA, US"`.
-- `output_schema` (dict, optional): JSON schema for structured output.
+- `output_schema` (dict | BaseModel, optional): JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance (auto-converted via `model_json_schema()` for v2 or `schema()` for v1).
 - `skip_email` (bool, optional): Disable email notifications.
 - `webhook_url` (str, optional): URL for completion notifications.
 - `webhook_format` (str, optional): Webhook format - `"scout"` (default), `"slack"`, or `"zapier"`.
@@ -292,7 +292,7 @@ client.scouts.update(
 - `output_interval` (int, optional): Updated interval between runs.
 - `user_timezone` (str, optional): Updated timezone.
 - `user_location` (str, optional): Updated location.
-- `output_schema` (dict, optional): Updated JSON schema.
+- `output_schema` (dict | BaseModel, optional): JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance (auto-converted via `model_json_schema()` for v2 or `schema()` for v1).
 - `skip_email` (bool, optional): Updated email notification setting.
 - `webhook_url` (str, optional): Updated webhook URL.
 - `webhook_format` (str, optional): Updated webhook format.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,159 @@
+"""Tests for resolve_output_schema utility."""
+
+import pytest
+
+from yutori._schema import resolve_output_schema
+
+# -- Fake classes to avoid a hard pydantic dependency --
+
+
+class FakeV2Model:
+    """Simulates a Pydantic v2 BaseModel with model_json_schema."""
+
+    @classmethod
+    def model_json_schema(cls) -> dict:
+        return {"type": "object", "properties": {"name": {"type": "string"}}}
+
+
+class FakeV1Model:
+    """Simulates a Pydantic v1 BaseModel with schema."""
+
+    @classmethod
+    def schema(cls) -> dict:
+        return {"type": "object", "properties": {"age": {"type": "integer"}}}
+
+
+class FakeV2AndV1Model:
+    """Has both v2 and v1 methods — v2 should be preferred."""
+
+    @classmethod
+    def model_json_schema(cls) -> dict:
+        return {"source": "v2"}
+
+    @classmethod
+    def schema(cls) -> dict:
+        return {"source": "v1"}
+
+
+class FakeBadReturnModel:
+    """model_json_schema returns a non-dict."""
+
+    @classmethod
+    def model_json_schema(cls) -> str:
+        return "not a dict"
+
+
+class FakeBadV1ReturnModel:
+    """schema returns a non-dict."""
+
+    @classmethod
+    def schema(cls) -> list:
+        return [1, 2, 3]
+
+
+class FakeInstanceMethodSchema:
+    """Has schema as an instance method (not classmethod) — calling on cls raises TypeError."""
+
+    def model_json_schema(self) -> dict:
+        return {"type": "object"}
+
+
+class FakeNonCallableAttr:
+    """Has model_json_schema and schema as non-callable attributes."""
+
+    model_json_schema = "not callable"
+    schema = 42
+
+
+# -- Tests --
+
+
+class TestResolveOutputSchema:
+    def test_none_returns_none(self):
+        assert resolve_output_schema(None) is None
+
+    def test_dict_passthrough(self):
+        schema = {"type": "object", "properties": {"x": {"type": "number"}}}
+        assert resolve_output_schema(schema) is schema
+
+    def test_v2_class(self):
+        result = resolve_output_schema(FakeV2Model)
+        assert result == {"type": "object", "properties": {"name": {"type": "string"}}}
+
+    def test_v2_instance(self):
+        result = resolve_output_schema(FakeV2Model())
+        assert result == {"type": "object", "properties": {"name": {"type": "string"}}}
+
+    def test_v1_class(self):
+        result = resolve_output_schema(FakeV1Model)
+        assert result == {"type": "object", "properties": {"age": {"type": "integer"}}}
+
+    def test_v1_instance(self):
+        result = resolve_output_schema(FakeV1Model())
+        assert result == {"type": "object", "properties": {"age": {"type": "integer"}}}
+
+    def test_v2_preferred_over_v1(self):
+        result = resolve_output_schema(FakeV2AndV1Model)
+        assert result == {"source": "v2"}
+
+    def test_v2_preferred_over_v1_instance(self):
+        result = resolve_output_schema(FakeV2AndV1Model())
+        assert result == {"source": "v2"}
+
+    def test_invalid_string_raises(self):
+        with pytest.raises(TypeError, match="output_schema must be"):
+            resolve_output_schema("bad")
+
+    def test_invalid_int_raises(self):
+        with pytest.raises(TypeError, match="output_schema must be"):
+            resolve_output_schema(42)
+
+    def test_invalid_list_raises(self):
+        with pytest.raises(TypeError, match="output_schema must be"):
+            resolve_output_schema([1, 2])
+
+    def test_bad_return_from_v2(self):
+        with pytest.raises(TypeError, match="model_json_schema.*returned str"):
+            resolve_output_schema(FakeBadReturnModel)
+
+    def test_bad_return_from_v1(self):
+        with pytest.raises(TypeError, match="schema.*returned list"):
+            resolve_output_schema(FakeBadV1ReturnModel)
+
+    def test_instance_method_on_class_raises_canonical_error(self):
+        with pytest.raises(TypeError, match="output_schema must be"):
+            resolve_output_schema(FakeInstanceMethodSchema)
+
+    def test_non_callable_attributes_ignored(self):
+        with pytest.raises(TypeError, match="output_schema must be"):
+            resolve_output_schema(FakeNonCallableAttr)
+
+    def test_non_callable_attributes_ignored_instance(self):
+        with pytest.raises(TypeError, match="output_schema must be"):
+            resolve_output_schema(FakeNonCallableAttr())
+
+
+class TestRealPydantic:
+    def test_pydantic_v2_basemodel(self):
+        pydantic = pytest.importorskip("pydantic")
+
+        class Employee(pydantic.BaseModel):
+            name: str
+            title: str
+
+        result = resolve_output_schema(Employee)
+        assert isinstance(result, dict)
+        assert "properties" in result
+        assert "name" in result["properties"]
+        assert "title" in result["properties"]
+
+    def test_pydantic_v2_basemodel_instance(self):
+        pydantic = pytest.importorskip("pydantic")
+
+        class Employee(pydantic.BaseModel):
+            name: str
+            title: str
+
+        result = resolve_output_schema(Employee(name="Alice", title="Engineer"))
+        assert isinstance(result, dict)
+        assert "name" in result["properties"]

--- a/yutori/_async/browsing.py
+++ b/yutori/_async/browsing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from .._http import build_headers, handle_response
+from .._schema import resolve_output_schema
 
 if TYPE_CHECKING:
     import httpx
@@ -26,7 +27,7 @@ class AsyncBrowsingNamespace:
         max_steps: int | None = None,
         agent: str | None = None,
         require_auth: bool | None = None,
-        output_schema: dict[str, Any] | None = None,
+        output_schema: object | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
     ) -> dict[str, Any]:
@@ -39,7 +40,7 @@ class AsyncBrowsingNamespace:
             agent: Agent to use ("navigator-n1-latest" or
                    "claude-sonnet-4-5-computer-use-2025-01-24").
             require_auth: Use auth-optimized browser for login flows.
-            output_schema: JSON schema for structured output.
+            output_schema: JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance.
             webhook_url: URL for completion notifications.
             webhook_format: "scout" (default), "slack", or "zapier".
 
@@ -57,8 +58,9 @@ class AsyncBrowsingNamespace:
             payload["agent"] = agent
         if require_auth is not None:
             payload["require_auth"] = require_auth
-        if output_schema is not None:
-            payload["output_schema"] = output_schema
+        resolved_schema = resolve_output_schema(output_schema)
+        if resolved_schema is not None:
+            payload["output_schema"] = resolved_schema
         if webhook_url is not None:
             payload["webhook_url"] = webhook_url
         if webhook_format is not None:

--- a/yutori/_async/research.py
+++ b/yutori/_async/research.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from .._http import build_headers, handle_response
+from .._schema import resolve_output_schema
 
 if TYPE_CHECKING:
     import httpx
@@ -24,7 +25,7 @@ class AsyncResearchNamespace:
         *,
         user_timezone: str | None = None,
         user_location: str | None = None,
-        output_schema: dict[str, Any] | None = None,
+        output_schema: object | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
     ) -> dict[str, Any]:
@@ -36,7 +37,7 @@ class AsyncResearchNamespace:
             query: Natural language research query.
             user_timezone: e.g., "America/Los_Angeles".
             user_location: e.g., "San Francisco, CA, US".
-            output_schema: JSON schema for structured output.
+            output_schema: JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance.
             webhook_url: URL for completion notifications.
             webhook_format: "scout" (default), "slack", or "zapier".
 
@@ -49,8 +50,9 @@ class AsyncResearchNamespace:
             payload["user_timezone"] = user_timezone
         if user_location is not None:
             payload["user_location"] = user_location
-        if output_schema is not None:
-            payload["output_schema"] = output_schema
+        resolved_schema = resolve_output_schema(output_schema)
+        if resolved_schema is not None:
+            payload["output_schema"] = resolved_schema
         if webhook_url is not None:
             payload["webhook_url"] = webhook_url
         if webhook_format is not None:

--- a/yutori/_async/scouts.py
+++ b/yutori/_async/scouts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from .._http import build_headers, build_query_params, handle_response
+from .._schema import resolve_output_schema
 
 if TYPE_CHECKING:
     import httpx
@@ -65,7 +66,7 @@ class AsyncScoutsNamespace:
         start_timestamp: int | None = None,
         user_timezone: str | None = None,
         user_location: str | None = None,
-        output_schema: dict[str, Any] | None = None,
+        output_schema: object | None = None,
         skip_email: bool | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
@@ -79,7 +80,7 @@ class AsyncScoutsNamespace:
             start_timestamp: Unix timestamp to start (0 = immediately).
             user_timezone: e.g., "America/Los_Angeles".
             user_location: e.g., "San Francisco, CA, US".
-            output_schema: JSON schema for structured output.
+            output_schema: JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance.
             skip_email: Disable email notifications.
             webhook_url: URL for completion notifications.
             webhook_format: "scout" (default), "slack", or "zapier".
@@ -99,8 +100,9 @@ class AsyncScoutsNamespace:
             payload["user_timezone"] = user_timezone
         if user_location is not None:
             payload["user_location"] = user_location
-        if output_schema is not None:
-            payload["output_schema"] = output_schema
+        resolved_schema = resolve_output_schema(output_schema)
+        if resolved_schema is not None:
+            payload["output_schema"] = resolved_schema
         if skip_email is not None:
             payload["skip_email"] = skip_email
         if webhook_url is not None:
@@ -126,7 +128,7 @@ class AsyncScoutsNamespace:
         output_interval: int | None = None,
         user_timezone: str | None = None,
         user_location: str | None = None,
-        output_schema: dict[str, Any] | None = None,
+        output_schema: object | None = None,
         skip_email: bool | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
@@ -142,7 +144,7 @@ class AsyncScoutsNamespace:
             output_interval: Updated interval between runs.
             user_timezone: Updated timezone.
             user_location: Updated location.
-            output_schema: Updated JSON schema for structured output.
+            output_schema: JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance.
             skip_email: Updated email notification setting.
             webhook_url: Updated webhook URL.
             webhook_format: Updated webhook format.
@@ -153,6 +155,8 @@ class AsyncScoutsNamespace:
         Raises:
             ValueError: If status is provided along with other fields (API limitation).
         """
+        resolved_schema = resolve_output_schema(output_schema)
+
         # Build payload from non-None field values (single source of truth for field list)
         payload: dict[str, Any] = {
             k: v
@@ -161,7 +165,7 @@ class AsyncScoutsNamespace:
                 "output_interval": output_interval,
                 "user_timezone": user_timezone,
                 "user_location": user_location,
-                "output_schema": output_schema,
+                "output_schema": resolved_schema,
                 "skip_email": skip_email,
                 "webhook_url": webhook_url,
                 "webhook_format": webhook_format,

--- a/yutori/_schema.py
+++ b/yutori/_schema.py
@@ -1,0 +1,55 @@
+"""Pydantic BaseModel to JSON schema conversion utility."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_ERROR_MSG = "output_schema must be a dict, a Pydantic BaseModel class, or a BaseModel instance"
+
+
+def resolve_output_schema(output_schema: object | None) -> dict[str, Any] | None:
+    """Convert an output_schema value to a JSON schema dict.
+
+    Accepts:
+        - None -> returns None
+        - dict -> returns as-is
+        - Pydantic v2 BaseModel class or instance (has callable model_json_schema)
+        - Pydantic v1 BaseModel class or instance (has callable schema)
+
+    Raises:
+        TypeError: If the value is not a supported type or the schema method
+            returns a non-dict.
+    """
+    if output_schema is None:
+        return None
+
+    if isinstance(output_schema, dict):
+        return output_schema
+
+    # Resolve instances to their class
+    cls = output_schema if isinstance(output_schema, type) else type(output_schema)
+
+    # Pydantic v2: model_json_schema (check before v1 to avoid deprecation warnings)
+    v2_method = getattr(cls, "model_json_schema", None)
+    if v2_method is not None and callable(v2_method):
+        try:
+            result = v2_method()
+        except TypeError:
+            raise TypeError(_ERROR_MSG) from None
+        if not isinstance(result, dict):
+            raise TypeError(f"model_json_schema() returned {type(result).__name__}, expected dict")
+        return result
+
+    # Pydantic v1: schema
+    v1_method = getattr(cls, "schema", None)
+    if v1_method is not None and callable(v1_method):
+        try:
+            result = v1_method()
+        except TypeError:
+            raise TypeError(_ERROR_MSG) from None
+        if not isinstance(result, dict):
+            raise TypeError(f"schema() returned {type(result).__name__}, expected dict")
+        return result
+
+    raise TypeError(_ERROR_MSG)

--- a/yutori/_sync/browsing.py
+++ b/yutori/_sync/browsing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from .._http import build_headers, handle_response
+from .._schema import resolve_output_schema
 
 if TYPE_CHECKING:
     import httpx
@@ -26,7 +27,7 @@ class BrowsingNamespace:
         max_steps: int | None = None,
         agent: str | None = None,
         require_auth: bool | None = None,
-        output_schema: dict[str, Any] | None = None,
+        output_schema: object | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
     ) -> dict[str, Any]:
@@ -39,7 +40,7 @@ class BrowsingNamespace:
             agent: Agent to use ("navigator-n1-latest" or
                    "claude-sonnet-4-5-computer-use-2025-01-24").
             require_auth: Use auth-optimized browser for login flows.
-            output_schema: JSON schema for structured output.
+            output_schema: JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance.
             webhook_url: URL for completion notifications.
             webhook_format: "scout" (default), "slack", or "zapier".
 
@@ -57,8 +58,9 @@ class BrowsingNamespace:
             payload["agent"] = agent
         if require_auth is not None:
             payload["require_auth"] = require_auth
-        if output_schema is not None:
-            payload["output_schema"] = output_schema
+        resolved_schema = resolve_output_schema(output_schema)
+        if resolved_schema is not None:
+            payload["output_schema"] = resolved_schema
         if webhook_url is not None:
             payload["webhook_url"] = webhook_url
         if webhook_format is not None:

--- a/yutori/_sync/research.py
+++ b/yutori/_sync/research.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from .._http import build_headers, handle_response
+from .._schema import resolve_output_schema
 
 if TYPE_CHECKING:
     import httpx
@@ -24,7 +25,7 @@ class ResearchNamespace:
         *,
         user_timezone: str | None = None,
         user_location: str | None = None,
-        output_schema: dict[str, Any] | None = None,
+        output_schema: object | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
     ) -> dict[str, Any]:
@@ -36,7 +37,7 @@ class ResearchNamespace:
             query: Natural language research query.
             user_timezone: e.g., "America/Los_Angeles".
             user_location: e.g., "San Francisco, CA, US".
-            output_schema: JSON schema for structured output.
+            output_schema: JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance.
             webhook_url: URL for completion notifications.
             webhook_format: "scout" (default), "slack", or "zapier".
 
@@ -49,8 +50,9 @@ class ResearchNamespace:
             payload["user_timezone"] = user_timezone
         if user_location is not None:
             payload["user_location"] = user_location
-        if output_schema is not None:
-            payload["output_schema"] = output_schema
+        resolved_schema = resolve_output_schema(output_schema)
+        if resolved_schema is not None:
+            payload["output_schema"] = resolved_schema
         if webhook_url is not None:
             payload["webhook_url"] = webhook_url
         if webhook_format is not None:


### PR DESCRIPTION
## Motivation

Every `output_schema` parameter in the SDK currently requires a raw `dict[str, Any]` JSON schema. Users who already model their data with Pydantic have to manually call `Model.model_json_schema()` and pass the result — boilerplate that the SDK can handle automatically.

## What changed

The SDK now accepts **Pydantic BaseModel classes or instances** in addition to plain dicts for all `output_schema` parameters. The conversion is duck-typed (checks for `model_json_schema` / `schema` methods) so **Pydantic remains an optional dependency**.

### Before

```python
task = client.browsing.create(
    task="List all employees",
    start_url="https://example.com",
    output_schema={
        "type": "object",
        "properties": {
            "name": {"type": "string"},
            "title": {"type": "string"}
        }
    }
)
```

### After

```python
from pydantic import BaseModel  # optional

class Employee(BaseModel):
    name: str
    title: str

task = client.browsing.create(
    task="List all employees",
    start_url="https://example.com",
    output_schema=Employee,  # auto-converted to JSON schema dict
)
```

Raw dicts still work exactly as before — this is purely additive.

## Details

- **New `yutori/_schema.py`** — `resolve_output_schema()` converts `None` / `dict` / Pydantic v2 class or instance (`model_json_schema()`) / Pydantic v1 class or instance (`schema()`) to a JSON schema dict. Invalid inputs raise `TypeError` with a clear message.
- **Updated 6 namespace files** (`_sync/{browsing,research,scouts}.py`, `_async/{browsing,research,scouts}.py`) — import the helper, widen type hint to `object | None`, call `resolve_output_schema()` before building the request payload.
- **New `tests/test_schema.py`** (18 tests) — covers None, dict passthrough, v2/v1 class and instance, v2-over-v1 preference, TypeError on invalid inputs, non-dict returns, non-callable attributes, instance-method-on-class edge case, and real Pydantic integration via `pytest.importorskip`.
- **Extended `tests/test_client.py`** and **`tests/test_async_client.py`** (6 + 6 tests) — verify resolved schemas land in the HTTP payload for browsing/research/scouts create and scouts update.
- **Updated `README.md`** and **`api.md`** — Pydantic examples alongside existing dict examples; parameter descriptions updated.

## Test plan

- [x] `pytest tests/test_schema.py tests/test_client.py tests/test_async_client.py -v` — 80 passed
- [x] `pytest` (full suite) — 160 passed
- [x] `ruff check` — no new lint errors


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, well-tested input-handling change that only affects how `output_schema` is serialized into request payloads; minimal blast radius outside schema resolution.
> 
> **Overview**
> **Adds first-class Pydantic support for structured output schemas.** All `output_schema` parameters across browsing/research/scouts (sync + async) now accept a JSON schema `dict` *or* a Pydantic `BaseModel` class/instance, which is auto-converted before being sent in the HTTP payload.
> 
> Introduces `resolve_output_schema()` (duck-typed for Pydantic v1/v2, keeping Pydantic optional) plus expanded unit coverage and docs updates (`README.md`, `api.md`) to show the new usage alongside raw dict schemas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b3a690d02b0c34695769a7ece68312ca8d17a73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->