### PR TITLE
Add period parameter to get_usage

### DIFF
--- a/api.md
+++ b/api.md
@@ -40,10 +40,24 @@ client = YutoriClient(
 
 | Method | HTTP | Endpoint | Returns |
 |--------|------|----------|---------|
-| `client.get_usage()` | GET | `/v1/usage` | `dict` |
+| `client.get_usage(period=None)` | GET | `/v1/usage` | `dict` |
 | `client.close()` | - | - | `None` |
 
-`client.get_usage()` returns an API-defined dictionary. Current responses include summary counters such as `num_scouts` and `active_scout_ids`.
+#### get_usage
+
+```python
+usage = client.get_usage(period="7d")
+```
+
+**Parameters:**
+- `period` (str, optional): Time range for activity counts - `"24h"` (default), `"7d"`, `"30d"`, or `"90d"`.
+
+**Returns:** Dictionary containing:
+- `num_active_scouts` (int): Number of active (non-paused, non-completed) scouts.
+- `active_scout_ids` (list[str]): UUIDs of active scouts.
+- `rate_limits` (dict): API Gateway rate limits with `requests_today`, `daily_limit`, `remaining_requests`, `reset_at`, and `status` (`"available"` or `"unavailable"`).
+- `n1_rate_limits` (dict): n1 API rate limits with `requests_today`, `daily_limit`, `remaining_requests`, `reset_at`, and `per_second_limit`.
+- `activity` (dict): Activity counts for the requested period with `period`, `scout_runs`, `browsing_tasks`, `research_tasks`, and `n1_calls`.
 
 ### AsyncYutoriClient
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -38,16 +38,58 @@ class TestAsyncYutoriClientInit:
 
 @pytest.mark.asyncio
 class TestAsyncYutoriClientGetUsage:
-    async def test_get_usage_success(self):
+    USAGE_RESPONSE = {
+        "num_active_scouts": 2,
+        "active_scout_ids": ["id-1", "id-2"],
+        "rate_limits": {
+            "requests_today": 100,
+            "daily_limit": 10000,
+            "remaining_requests": 9900,
+            "reset_at": "2026-03-04T00:00:00+00:00",
+            "status": "available",
+        },
+        "n1_rate_limits": {
+            "requests_today": 50,
+            "daily_limit": 50000,
+            "remaining_requests": 49950,
+            "reset_at": "2026-03-04T00:00:00+00:00",
+            "per_second_limit": 20,
+        },
+        "activity": {
+            "period": "24h",
+            "scout_runs": 10,
+            "browsing_tasks": 3,
+            "research_tasks": 2,
+            "n1_calls": 50,
+        },
+    }
+
+    def _mock_usage_response(self, period: str = "24h"):
+        import json
+
+        data = {**self.USAGE_RESPONSE, "activity": {**self.USAGE_RESPONSE["activity"], "period": period}}
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
-        mock_response.content = b'{"api_key_id": "key123"}'
-        mock_response.json.return_value = {"api_key_id": "key123"}
+        mock_response.content = json.dumps(data).encode()
+        mock_response.json.return_value = data
+        return mock_response
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
+    async def test_get_usage_success(self):
+        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=self._mock_usage_response()):
             async with AsyncYutoriClient(api_key="yt-test") as client:
                 result = await client.get_usage()
-                assert result == {"api_key_id": "key123"}
+                assert result["num_active_scouts"] == 2
+                assert result["activity"]["period"] == "24h"
+
+    async def test_get_usage_with_period(self):
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=self._mock_usage_response("30d")
+        ) as mock_get:
+            async with AsyncYutoriClient(api_key="yt-test") as client:
+                result = await client.get_usage(period="30d")
+                assert result["activity"]["period"] == "30d"
+                call_kwargs = mock_get.call_args[1]
+                assert call_kwargs["params"] == {"period": "30d"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -44,16 +44,67 @@ class TestYutoriClientInit:
 
 
 class TestYutoriClientGetUsage:
-    def test_get_usage_success(self):
+    USAGE_RESPONSE = {
+        "num_active_scouts": 2,
+        "active_scout_ids": ["id-1", "id-2"],
+        "rate_limits": {
+            "requests_today": 100,
+            "daily_limit": 10000,
+            "remaining_requests": 9900,
+            "reset_at": "2026-03-04T00:00:00+00:00",
+            "status": "available",
+        },
+        "n1_rate_limits": {
+            "requests_today": 50,
+            "daily_limit": 50000,
+            "remaining_requests": 49950,
+            "reset_at": "2026-03-04T00:00:00+00:00",
+            "per_second_limit": 20,
+        },
+        "activity": {
+            "period": "24h",
+            "scout_runs": 10,
+            "browsing_tasks": 3,
+            "research_tasks": 2,
+            "n1_calls": 50,
+        },
+    }
+
+    def _mock_usage_response(self, period: str = "24h"):
+        import json
+
+        data = {**self.USAGE_RESPONSE, "activity": {**self.USAGE_RESPONSE["activity"], "period": period}}
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
-        mock_response.content = b'{"api_key_id": "key123", "user_id": "user456"}'
-        mock_response.json.return_value = {"api_key_id": "key123", "user_id": "user456"}
+        mock_response.content = json.dumps(data).encode()
+        mock_response.json.return_value = data
+        return mock_response
 
-        with patch.object(httpx.Client, "get", return_value=mock_response):
+    def test_get_usage_success(self):
+        with patch.object(httpx.Client, "get", return_value=self._mock_usage_response()):
             client = YutoriClient(api_key="yt-test")
             result = client.get_usage()
-            assert result == {"api_key_id": "key123", "user_id": "user456"}
+            assert result["num_active_scouts"] == 2
+            assert result["activity"]["period"] == "24h"
+            assert result["rate_limits"]["status"] == "available"
+            client.close()
+
+    def test_get_usage_with_period(self):
+        with patch.object(httpx.Client, "get", return_value=self._mock_usage_response("7d")) as mock_get:
+            client = YutoriClient(api_key="yt-test")
+            result = client.get_usage(period="7d")
+            assert result["activity"]["period"] == "7d"
+            # Verify period is passed as query param
+            call_kwargs = mock_get.call_args[1]
+            assert call_kwargs["params"] == {"period": "7d"}
+            client.close()
+
+    def test_get_usage_no_period_sends_no_params(self):
+        with patch.object(httpx.Client, "get", return_value=self._mock_usage_response()) as mock_get:
+            client = YutoriClient(api_key="yt-test")
+            client.get_usage()
+            call_kwargs = mock_get.call_args[1]
+            assert call_kwargs["params"] == {}
             client.close()
 
     def test_get_usage_auth_error(self):

--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -12,7 +12,7 @@ from ._async import (
     AsyncResearchNamespace,
     AsyncScoutsNamespace,
 )
-from ._http import build_headers, handle_response
+from ._http import build_headers, build_query_params, handle_response
 from .config import DEFAULT_BASE_URL, DEFAULT_TIMEOUT_SECONDS, sanitize_base_url
 from .exceptions import AuthenticationError
 
@@ -85,13 +85,10 @@ class AsyncYutoriClient:
             Dictionary with ``num_active_scouts``, ``active_scout_ids``,
             ``rate_limits``, ``n1_rate_limits``, and ``activity`` counts.
         """
-        params = {}
-        if period is not None:
-            params["period"] = period
         response = await self._client.get(
             f"{self._base_url}/usage",
             headers=build_headers(self._api_key),
-            params=params,
+            params=build_query_params(period=period),
         )
         return handle_response(response)
 

--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -74,16 +74,24 @@ class AsyncYutoriClient:
         self.research = AsyncResearchNamespace(self._client, self._base_url, self._api_key)
         self.chat = AsyncChatNamespace(self._base_url, self._api_key, timeout)
 
-    async def get_usage(self) -> dict[str, Any]:
+    async def get_usage(self, *, period: str | None = None) -> dict[str, Any]:
         """Get usage statistics for your API key.
 
+        Args:
+            period: Time range for activity counts. One of "24h", "7d", "30d", "90d".
+                Defaults to "24h" on the server.
+
         Returns:
-            Dictionary containing usage information. Keys are API-defined and
-            may include counters such as `num_scouts` and `active_scout_ids`.
+            Dictionary with ``num_active_scouts``, ``active_scout_ids``,
+            ``rate_limits``, ``n1_rate_limits``, and ``activity`` counts.
         """
+        params = {}
+        if period is not None:
+            params["period"] = period
         response = await self._client.get(
             f"{self._base_url}/usage",
             headers=build_headers(self._api_key),
+            params=params,
         )
         return handle_response(response)
 

--- a/yutori/cli/commands/usage.py
+++ b/yutori/cli/commands/usage.py
@@ -13,7 +13,10 @@ console = Console()
 
 
 @app.callback(invoke_without_command=True)
-def usage(ctx: typer.Context) -> None:
+def usage(
+    ctx: typer.Context,
+    period: str = typer.Option("24h", help="Activity period: 24h, 7d, 30d, or 90d"),
+) -> None:
     """Show API usage statistics."""
     if ctx.invoked_subcommand is not None:
         return
@@ -21,52 +24,55 @@ def usage(ctx: typer.Context) -> None:
     client = get_authenticated_client()
 
     try:
-        data = client.get_usage()
+        data = client.get_usage(period=period)
 
         console.print("\n[bold]Usage Statistics[/bold]\n")
 
-        if data.get("user_id"):
-            console.print(f"  User ID: {data['user_id']}")
-        if data.get("api_key_id"):
-            console.print(f"  API Key ID: {data['api_key_id']}")
+        # Active scouts
+        num_active = data.get("num_active_scouts", 0)
+        console.print(f"  Active Scouts: {num_active}")
+        active_ids = data.get("active_scout_ids", [])
+        if active_ids:
+            for sid in active_ids[:5]:
+                console.print(f"    - {sid}")
+            if len(active_ids) > 5:
+                console.print(f"    ... and {len(active_ids) - 5} more")
 
-        scouts = data.get("scouts", [])
-        if scouts:
-            console.print(f"\n  [bold]Scouts:[/bold] {len(scouts)}")
+        # Rate limits
+        rate_limits = data.get("rate_limits", {})
+        if rate_limits:
+            console.print(f"\n  [bold]API Rate Limits[/bold] ({rate_limits.get('status', 'unknown')})")
+            if rate_limits.get("status") == "available":
+                console.print(f"    Requests today: {rate_limits.get('requests_today', 'N/A')}")
+                console.print(f"    Daily limit:    {rate_limits.get('daily_limit', 'N/A')}")
+                console.print(f"    Remaining:      {rate_limits.get('remaining_requests', 'N/A')}")
+            console.print(f"    Resets at:      {rate_limits.get('reset_at', 'N/A')}")
 
-            table = Table()
-            table.add_column("ID", style="cyan")
-            table.add_column("Query", max_width=40)
-            table.add_column("Status")
-            table.add_column("Runs")
+        # n1 rate limits
+        n1_limits = data.get("n1_rate_limits", {})
+        if n1_limits:
+            console.print("\n  [bold]n1 API Rate Limits[/bold]")
+            console.print(f"    Requests today: {n1_limits.get('requests_today', 'N/A')}")
+            console.print(f"    Daily limit:    {n1_limits.get('daily_limit', 'N/A')}")
+            console.print(f"    Remaining:      {n1_limits.get('remaining_requests', 'N/A')}")
+            console.print(f"    Per-second:     {n1_limits.get('per_second_limit', 'N/A')}")
+            console.print(f"    Resets at:      {n1_limits.get('reset_at', 'N/A')}")
 
-            for scout in scouts[:10]:
-                query = scout.get("query", "")
-                if len(query) > 37:
-                    query = query[:37] + "..."
+        # Activity counts
+        activity = data.get("activity", {})
+        if activity:
+            p = activity.get("period", period)
+            console.print(f"\n  [bold]Activity ({p})[/bold]")
 
-                scout_id = scout.get("id", "")
-                table.add_row(
-                    scout_id,
-                    query,
-                    scout.get("status", ""),
-                    str(scout.get("run_count", 0)),
-                )
-
+            table = Table(show_header=True, padding=(0, 2))
+            table.add_column("Metric")
+            table.add_column("Count", justify="right")
+            table.add_row("Scout runs", str(activity.get("scout_runs", 0)))
+            table.add_row("Browsing tasks", str(activity.get("browsing_tasks", 0)))
+            table.add_row("Research tasks", str(activity.get("research_tasks", 0)))
+            table.add_row("n1 API calls", str(activity.get("n1_calls", 0)))
             console.print(table)
 
-            if len(scouts) > 10:
-                console.print(f"  ... and {len(scouts) - 10} more")
-            return
-
-        # Newer usage responses may return summary counters instead of scout records.
-        num_scouts = data.get("num_scouts")
-        active_scout_ids = data.get("active_scout_ids")
-        if isinstance(num_scouts, int):
-            console.print(f"\n  [bold]Scouts:[/bold] {num_scouts}")
-            if isinstance(active_scout_ids, list):
-                console.print(f"  Active Scouts: {len(active_scout_ids)}")
-        else:
-            console.print("\n  No scouts yet.")
+        console.print()
     finally:
         client.close()

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import httpx
 
-from ._http import build_headers, handle_response
+from ._http import build_headers, build_query_params, handle_response
 from ._sync import BrowsingNamespace, ChatNamespace, ResearchNamespace, ScoutsNamespace
 from .config import DEFAULT_BASE_URL, DEFAULT_TIMEOUT_SECONDS, sanitize_base_url
 from .exceptions import AuthenticationError
@@ -75,13 +75,10 @@ class YutoriClient:
             Dictionary with ``num_active_scouts``, ``active_scout_ids``,
             ``rate_limits``, ``n1_rate_limits``, and ``activity`` counts.
         """
-        params = {}
-        if period is not None:
-            params["period"] = period
         response = self._client.get(
             f"{self._base_url}/usage",
             headers=build_headers(self._api_key),
-            params=params,
+            params=build_query_params(period=period),
         )
         return handle_response(response)
 

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -64,16 +64,24 @@ class YutoriClient:
         self.research = ResearchNamespace(self._client, self._base_url, self._api_key)
         self.chat = ChatNamespace(self._base_url, self._api_key, timeout)
 
-    def get_usage(self) -> dict[str, Any]:
+    def get_usage(self, *, period: str | None = None) -> dict[str, Any]:
         """Get usage statistics for your API key.
 
+        Args:
+            period: Time range for activity counts. One of "24h", "7d", "30d", "90d".
+                Defaults to "24h" on the server.
+
         Returns:
-            Dictionary containing usage information. Keys are API-defined and
-            may include counters such as `num_scouts` and `active_scout_ids`.
+            Dictionary with ``num_active_scouts``, ``active_scout_ids``,
+            ``rate_limits``, ``n1_rate_limits``, and ``activity`` counts.
         """
+        params = {}
+        if period is not None:
+            params["period"] = period
         response = self._client.get(
             f"{self._base_url}/usage",
             headers=build_headers(self._api_key),
+            params=params,
         )
         return handle_response(response)
 


### PR DESCRIPTION
## Summary
- Add optional `period` keyword argument (`"24h"`, `"7d"`, `"30d"`, `"90d"`) to `get_usage()` in both sync and async clients
- Rewrite CLI `yutori usage` command to display the new response structure: active scouts, API rate limits, n1 rate limits, and activity counts table, with a `--period` flag
- Update `api.md` with parameter docs and return value field descriptions
- Update tests with realistic response fixtures and period parameter verification

## Test plan
- [x] `pytest tests/ -v` — 163 tests pass
- [ ] Verify `yutori usage` and `yutori usage --period 7d` render correctly against the live API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new query-parameterized code path for `get_usage` and rewrites the `yutori usage` CLI output to assume the newer usage response shape, which could surface compatibility issues if the API response differs.
> 
> **Overview**
> `YutoriClient.get_usage` and `AsyncYutoriClient.get_usage` now accept an optional keyword-only `period` and pass it as a query parameter via `build_query_params`.
> 
> The `yutori usage` command gains a `--period` option and is rewritten to display active scout IDs, API + n1 rate-limit info, and a period-scoped activity table instead of the prior scout-centric output. Docs (`api.md`) and tests update accordingly with the new parameter and response fixture/assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc61c512a3368a924be325a59705c202e7807e9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->