### PR TITLE
Add non-mutating n1 trimming helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ response = await client.chat.completions.create(
 
 This keeps the raw OpenAI-compatible `client.chat.completions.create(...)` call unchanged, while giving Yutori users a safer
 message-preparation helper for large screenshot histories. In long-lived loops, assign the trimmed copy back to your owned
-history before the next step so old screenshots do not keep accumulating in memory.
+history before the next step so old screenshots do not keep accumulating in memory. The size pre-check is there to avoid
+deep-copying the full history on every step when trimming is not needed.
 
 If you don't want to manage your own browser infrastructure, use the Browsing API which calls n1 on a cloud browser.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ if message.tool_calls:
         print(f"Arguments: {tool_call.function.arguments}")
 ```
 
+For screenshot-heavy agent loops, the SDK also provides opt-in trimming helpers under `yutori.n1`:
+
+```python
+from yutori.n1 import acreate_trimmed
+
+response = await acreate_trimmed(
+    client.chat.completions,
+    messages,
+    model="n1-latest",
+    max_bytes=9_500_000,
+    keep_recent=6,
+)
+```
+
+This keeps the raw OpenAI-compatible `client.chat.completions.create(...)` call unchanged, while giving Yutori users a safer
+helper for large screenshot histories that does not mutate the original `messages` list.
+
 If you don't want to manage your own browser infrastructure, use the Browsing API which calls n1 on a cloud browser.
 
 ## Browsing API

--- a/README.md
+++ b/README.md
@@ -96,19 +96,22 @@ if message.tool_calls:
 For screenshot-heavy agent loops, the SDK also provides opt-in trimming helpers under `yutori.n1`:
 
 ```python
-from yutori.n1 import acreate_trimmed
+from yutori.n1 import trimmed_messages_to_fit
 
-response = await acreate_trimmed(
-    client.chat.completions,
+trimmed_messages, size_bytes, removed = trimmed_messages_to_fit(
     messages,
-    model="n1-latest",
     max_bytes=9_500_000,
     keep_recent=6,
+)
+
+response = await client.chat.completions.create(
+    model="n1-latest",
+    messages=trimmed_messages,
 )
 ```
 
 This keeps the raw OpenAI-compatible `client.chat.completions.create(...)` call unchanged, while giving Yutori users a safer
-helper for large screenshot histories that does not mutate the original `messages` list.
+message-preparation helper for large screenshot histories that does not mutate the original `messages` list.
 
 If you don't want to manage your own browser infrastructure, use the Browsing API which calls n1 on a cloud browser.
 

--- a/README.md
+++ b/README.md
@@ -96,22 +96,24 @@ if message.tool_calls:
 For screenshot-heavy agent loops, the SDK also provides opt-in trimming helpers under `yutori.n1`:
 
 ```python
-from yutori.n1 import trimmed_messages_to_fit
+from yutori.n1 import estimate_messages_size_bytes, trimmed_messages_to_fit
 
-trimmed_messages, size_bytes, removed = trimmed_messages_to_fit(
-    messages,
-    max_bytes=9_500_000,
-    keep_recent=6,
-)
+if estimate_messages_size_bytes(messages) > 9_500_000:
+    messages, size_bytes, removed = trimmed_messages_to_fit(
+        messages,
+        max_bytes=9_500_000,
+        keep_recent=6,
+    )
 
 response = await client.chat.completions.create(
     model="n1-latest",
-    messages=trimmed_messages,
+    messages=messages,
 )
 ```
 
 This keeps the raw OpenAI-compatible `client.chat.completions.create(...)` call unchanged, while giving Yutori users a safer
-message-preparation helper for large screenshot histories that does not mutate the original `messages` list.
+message-preparation helper for large screenshot histories. In long-lived loops, assign the trimmed copy back to your owned
+history before the next step so old screenshots do not keep accumulating in memory.
 
 If you don't want to manage your own browser infrastructure, use the Browsing API which calls n1 on a cloud browser.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ uv run playwright install chromium
 
 ## n1.py
 
-A complete browsing agent using the n1 API. Launches a local Playwright browser, takes screenshots, sends them to n1 to get predicted actions, and executes them until the task is complete. The example uses `yutori.n1.trimmed_messages_to_fit(...)` so screenshot trimming stays opt-in, does not mutate the agent's message history in place, and still ends with a standard `client.chat.completions.create(...)` call.
+A complete browsing agent using the n1 API. Launches a local Playwright browser, takes screenshots, sends them to n1 to get predicted actions, and executes them until the task is complete. The example keeps its own long-lived message history bounded with `estimate_messages_size_bytes(...)` plus `trimmed_messages_to_fit(...)`, then still ends with a standard `client.chat.completions.create(...)` call.
 
 ```bash
 uv run python examples/n1.py --task "List the team member names" --start-url "https://www.yutori.com"

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ uv run playwright install chromium
 
 ## n1.py
 
-A complete browsing agent using the n1 API. Launches a local Playwright browser, takes screenshots, sends them to n1 to get predicted actions, and executes them until the task is complete.
+A complete browsing agent using the n1 API. Launches a local Playwright browser, takes screenshots, sends them to n1 to get predicted actions, and executes them until the task is complete. The example uses `yutori.n1.acreate_trimmed(...)` so screenshot trimming stays opt-in and does not mutate the agent's message history in place.
 
 ```bash
 uv run python examples/n1.py --task "List the team member names" --start-url "https://www.yutori.com"

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ uv run playwright install chromium
 
 ## n1.py
 
-A complete browsing agent using the n1 API. Launches a local Playwright browser, takes screenshots, sends them to n1 to get predicted actions, and executes them until the task is complete. The example uses `yutori.n1.acreate_trimmed(...)` so screenshot trimming stays opt-in and does not mutate the agent's message history in place.
+A complete browsing agent using the n1 API. Launches a local Playwright browser, takes screenshots, sends them to n1 to get predicted actions, and executes them until the task is complete. The example uses `yutori.n1.trimmed_messages_to_fit(...)` so screenshot trimming stays opt-in, does not mutate the agent's message history in place, and still ends with a standard `client.chat.completions.create(...)` call.
 
 ```bash
 uv run python examples/n1.py --task "List the team member names" --start-url "https://www.yutori.com"

--- a/examples/n1.py
+++ b/examples/n1.py
@@ -6,8 +6,8 @@ This script takes a user query, launches a local Playwright browser session,
 calls the n1 API to get actions, executes them, and iterates until the task is complete.
 
 Features:
-- Payload trimming: uses the SDK's opt-in non-mutating helper for screenshot-heavy
-  agent loops while keeping the raw chat completions interface unchanged.
+- Payload trimming: uses the SDK's opt-in non-mutating helper to prepare
+  messages before a standard chat completions call.
 
 Usage:
     export YUTORI_API_KEY=...
@@ -32,7 +32,7 @@ from pydantic import BaseModel, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
-from yutori.n1 import acreate_trimmed
+from yutori.n1 import trimmed_messages_to_fit
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
@@ -203,14 +203,19 @@ class Agent:
         reraise=True,
     )
     async def _call_llm_with_retries(self) -> ChatCompletion:
+        trimmed_messages, size_bytes, removed = trimmed_messages_to_fit(
+            self._messages,
+            max_bytes=self.max_request_bytes,
+            keep_recent=self.keep_recent_screenshots,
+        )
+        if removed:
+            logger.info(f"Trimmed {removed} old screenshot(s); payload ~{size_bytes / (1024 * 1024):.2f} MB")
+
         return await asyncio.wait_for(
-            acreate_trimmed(
-                self._client.chat.completions,
-                self._messages,
+            self._client.chat.completions.create(
                 model=self.model,
+                messages=trimmed_messages,
                 temperature=self.temperature,
-                max_bytes=self.max_request_bytes,
-                keep_recent=self.keep_recent_screenshots,
             ),
             timeout=120.0,  # 2 minutes
         )

--- a/examples/n1.py
+++ b/examples/n1.py
@@ -6,8 +6,8 @@ This script takes a user query, launches a local Playwright browser session,
 calls the n1 API to get actions, executes them, and iterates until the task is complete.
 
 Features:
-- Payload trimming: automatically removes old screenshots when the message history grows
-  too large for the API, keeping only the most recent screenshots for context.
+- Payload trimming: uses the SDK's opt-in non-mutating helper for screenshot-heavy
+  agent loops while keeping the raw chat completions interface unchanged.
 
 Usage:
     export YUTORI_API_KEY=...
@@ -32,7 +32,7 @@ from pydantic import BaseModel, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
-from yutori.n1.payload import trim_images_to_fit
+from yutori.n1 import acreate_trimmed
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
@@ -204,8 +204,13 @@ class Agent:
     )
     async def _call_llm_with_retries(self) -> ChatCompletion:
         return await asyncio.wait_for(
-            self._client.chat.completions.create(
-                model=self.model, messages=self._messages, temperature=self.temperature
+            acreate_trimmed(
+                self._client.chat.completions,
+                self._messages,
+                model=self.model,
+                temperature=self.temperature,
+                max_bytes=self.max_request_bytes,
+                keep_recent=self.keep_recent_screenshots,
             ),
             timeout=120.0,  # 2 minutes
         )
@@ -223,15 +228,6 @@ class Agent:
                 "image_url": {"url": f"data:image/webp;base64,{screenshot_b64}", "detail": "high"},
             }
         )
-
-        # Trim old screenshots to keep payload within API size limits
-        size_bytes, removed = trim_images_to_fit(
-            self._messages,
-            max_bytes=self.max_request_bytes,
-            keep_recent=self.keep_recent_screenshots,
-        )
-        if removed:
-            logger.info(f"Trimmed {removed} old screenshot(s); payload ~{size_bytes / (1024 * 1024):.2f} MB")
 
         for i in range(self._message_index, len(self._messages)):
             logger.info(f"Message: {self._format_message_for_log(self._messages[i])}")

--- a/examples/n1.py
+++ b/examples/n1.py
@@ -6,8 +6,8 @@ This script takes a user query, launches a local Playwright browser session,
 calls the n1 API to get actions, executes them, and iterates until the task is complete.
 
 Features:
-- Payload trimming: uses the SDK's opt-in non-mutating helper to prepare
-  messages before a standard chat completions call.
+- Payload trimming: keeps the agent's owned message history bounded while still
+  ending in a standard chat completions call.
 
 Usage:
     export YUTORI_API_KEY=...
@@ -32,7 +32,7 @@ from pydantic import BaseModel, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
-from yutori.n1 import trimmed_messages_to_fit
+from yutori.n1 import estimate_messages_size_bytes, trimmed_messages_to_fit
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
@@ -203,18 +203,20 @@ class Agent:
         reraise=True,
     )
     async def _call_llm_with_retries(self) -> ChatCompletion:
-        trimmed_messages, size_bytes, removed = trimmed_messages_to_fit(
-            self._messages,
-            max_bytes=self.max_request_bytes,
-            keep_recent=self.keep_recent_screenshots,
-        )
-        if removed:
-            logger.info(f"Trimmed {removed} old screenshot(s); payload ~{size_bytes / (1024 * 1024):.2f} MB")
+        size_bytes = estimate_messages_size_bytes(self._messages)
+        if size_bytes > self.max_request_bytes:
+            self._messages, size_bytes, removed = trimmed_messages_to_fit(
+                self._messages,
+                max_bytes=self.max_request_bytes,
+                keep_recent=self.keep_recent_screenshots,
+            )
+            if removed:
+                logger.info(f"Trimmed {removed} old screenshot(s); payload ~{size_bytes / (1024 * 1024):.2f} MB")
 
         return await asyncio.wait_for(
             self._client.chat.completions.create(
                 model=self.model,
-                messages=trimmed_messages,
+                messages=self._messages,
                 temperature=self.temperature,
             ),
             timeout=120.0,  # 2 minutes

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -341,7 +341,7 @@ class TestAsyncChatNamespace:
                 )
                 assert result.choices[0].message.content == "click"
 
-    async def test_n1_helper_acreate_trimmed_uses_trimmed_copy(self):
+    async def test_n1_helper_acreate_trimmed_public_helper_uses_trimmed_copy(self):
         from copy import deepcopy
 
         from openai.types.chat import ChatCompletion, ChatCompletionMessage
@@ -400,6 +400,63 @@ class TestAsyncChatNamespace:
         sent_messages = call_kwargs["messages"]
         assert sent_messages is not original_messages
         assert sent_messages == trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)[0]
+        assert original_messages == original_snapshot
+
+    async def test_n1_payload_helper_supports_standard_async_create_pattern(self):
+        from copy import deepcopy
+
+        from openai.types.chat import ChatCompletion, ChatCompletionMessage
+        from openai.types.chat.chat_completion import Choice
+
+        from yutori.n1 import trimmed_messages_to_fit
+
+        mock_completion = ChatCompletion(
+            id="chatcmpl-123",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="click"),
+                )
+            ],
+            created=1234567890,
+            model="n1-latest",
+            object="chat.completion",
+        )
+        original_messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Check the page"},
+                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
+                ],
+            },
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "text", "text": "Tool output"},
+                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
+                ],
+            },
+        ]
+        original_snapshot = deepcopy(original_messages)
+        trimmed_messages, _, _ = trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)
+
+        with patch("yutori._async.chat.AsyncOpenAI") as MockAsyncOpenAI:
+            mock_openai_client = MagicMock()
+            mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+            mock_openai_client.close = AsyncMock()
+            MockAsyncOpenAI.return_value = mock_openai_client
+
+            async with AsyncYutoriClient(api_key="yt-test") as client:
+                result = await client.chat.completions.create(
+                    model="n1-latest",
+                    messages=trimmed_messages,
+                )
+                assert result.choices[0].message.content == "click"
+
+        call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+        assert call_kwargs["messages"] == trimmed_messages
         assert original_messages == original_snapshot
 
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -341,6 +341,67 @@ class TestAsyncChatNamespace:
                 )
                 assert result.choices[0].message.content == "click"
 
+    async def test_n1_helper_acreate_trimmed_uses_trimmed_copy(self):
+        from copy import deepcopy
+
+        from openai.types.chat import ChatCompletion, ChatCompletionMessage
+        from openai.types.chat.chat_completion import Choice
+
+        from yutori.n1 import acreate_trimmed
+        from yutori.n1.payload import trimmed_messages_to_fit
+
+        mock_completion = ChatCompletion(
+            id="chatcmpl-123",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="click"),
+                )
+            ],
+            created=1234567890,
+            model="n1-latest",
+            object="chat.completion",
+        )
+        original_messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Check the page"},
+                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
+                ],
+            },
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "text", "text": "Tool output"},
+                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
+                ],
+            },
+        ]
+        original_snapshot = deepcopy(original_messages)
+
+        with patch("yutori._async.chat.AsyncOpenAI") as MockAsyncOpenAI:
+            mock_openai_client = MagicMock()
+            mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+            mock_openai_client.close = AsyncMock()
+            MockAsyncOpenAI.return_value = mock_openai_client
+
+            async with AsyncYutoriClient(api_key="yt-test") as client:
+                result = await acreate_trimmed(
+                    client.chat.completions,
+                    original_messages,
+                    max_bytes=100,
+                    keep_recent=1,
+                )
+                assert result.choices[0].message.content == "click"
+
+        call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+        sent_messages = call_kwargs["messages"]
+        assert sent_messages is not original_messages
+        assert sent_messages == trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)[0]
+        assert original_messages == original_snapshot
+
 
 @pytest.mark.asyncio
 class TestAsyncErrorHandling:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -378,7 +378,7 @@ class TestChatNamespace:
             assert call_kwargs["model"] == "n1-latest"
             client.close()
 
-    def test_n1_helper_create_trimmed_uses_trimmed_copy(self):
+    def test_n1_helper_create_trimmed_public_helper_uses_trimmed_copy(self):
         from copy import deepcopy
 
         from openai.types.chat import ChatCompletion, ChatCompletionMessage
@@ -437,6 +437,63 @@ class TestChatNamespace:
         sent_messages = call_kwargs["messages"]
         assert sent_messages is not original_messages
         assert sent_messages == trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)[0]
+        assert original_messages == original_snapshot
+
+    def test_n1_payload_helper_supports_standard_create_pattern(self):
+        from copy import deepcopy
+
+        from openai.types.chat import ChatCompletion, ChatCompletionMessage
+        from openai.types.chat.chat_completion import Choice
+
+        from yutori.n1 import trimmed_messages_to_fit
+
+        mock_completion = ChatCompletion(
+            id="chatcmpl-123",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="click"),
+                )
+            ],
+            created=1234567890,
+            model="n1-latest",
+            object="chat.completion",
+        )
+        original_messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Check the page"},
+                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
+                ],
+            },
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "text", "text": "Tool output"},
+                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
+                ],
+            },
+        ]
+        original_snapshot = deepcopy(original_messages)
+        trimmed_messages, _, _ = trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)
+
+        with patch("yutori._sync.chat.OpenAI") as MockOpenAI:
+            mock_openai_client = MagicMock()
+            mock_openai_client.chat.completions.create.return_value = mock_completion
+            MockOpenAI.return_value = mock_openai_client
+
+            client = YutoriClient(api_key="yt-test")
+            result = client.chat.completions.create(
+                model="n1-latest",
+                messages=trimmed_messages,
+            )
+            assert result.choices[0].message.content == "click"
+            client.close()
+
+        call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+        assert call_kwargs["messages"] == trimmed_messages
         assert original_messages == original_snapshot
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -378,6 +378,67 @@ class TestChatNamespace:
             assert call_kwargs["model"] == "n1-latest"
             client.close()
 
+    def test_n1_helper_create_trimmed_uses_trimmed_copy(self):
+        from copy import deepcopy
+
+        from openai.types.chat import ChatCompletion, ChatCompletionMessage
+        from openai.types.chat.chat_completion import Choice
+
+        from yutori.n1 import create_trimmed
+        from yutori.n1.payload import trimmed_messages_to_fit
+
+        mock_completion = ChatCompletion(
+            id="chatcmpl-123",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="click"),
+                )
+            ],
+            created=1234567890,
+            model="n1-latest",
+            object="chat.completion",
+        )
+        original_messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Check the page"},
+                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
+                ],
+            },
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "text", "text": "Tool output"},
+                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
+                ],
+            },
+        ]
+        original_snapshot = deepcopy(original_messages)
+
+        with patch("yutori._sync.chat.OpenAI") as MockOpenAI:
+            mock_openai_client = MagicMock()
+            mock_openai_client.chat.completions.create.return_value = mock_completion
+            MockOpenAI.return_value = mock_openai_client
+
+            client = YutoriClient(api_key="yt-test")
+            result = create_trimmed(
+                client.chat.completions,
+                original_messages,
+                max_bytes=100,
+                keep_recent=1,
+            )
+            assert result.choices[0].message.content == "click"
+            client.close()
+
+        call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+        sent_messages = call_kwargs["messages"]
+        assert sent_messages is not original_messages
+        assert sent_messages == trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)[0]
+        assert original_messages == original_snapshot
+
 
 class TestErrorHandling:
     def test_api_error_on_400(self):

--- a/tests/test_n1_payload.py
+++ b/tests/test_n1_payload.py
@@ -7,6 +7,7 @@ from yutori.n1.payload import (
     estimate_messages_size_bytes,
     message_has_image,
     trim_images_to_fit,
+    trimmed_messages_to_fit,
 )
 
 # ---------------------------------------------------------------------------
@@ -200,3 +201,25 @@ class TestTrimImagesToFit:
         # Only the very last image should survive
         assert message_has_image(msgs[-1])
         assert removed >= 2
+
+
+class TestTrimmedMessagesToFit:
+    def test_returns_trimmed_copy_without_mutating_input(self):
+        big_data = "A" * 5000
+        original_messages = [
+            _image_msg("assistant", url=big_data),
+            _image_msg("assistant", url=big_data),
+            _image_msg("assistant", url=big_data),
+        ]
+
+        trimmed_messages, size, removed = trimmed_messages_to_fit(
+            original_messages,
+            max_bytes=10_000,
+            keep_recent=1,
+        )
+
+        assert removed > 0
+        assert size > 0
+        assert trimmed_messages is not original_messages
+        assert message_has_image(original_messages[0]) is True
+        assert any(not message_has_image(message) for message in trimmed_messages[:-1])

--- a/yutori/n1/__init__.py
+++ b/yutori/n1/__init__.py
@@ -2,13 +2,18 @@
 
 Provides reusable helpers for common patterns in n1 agent loops:
 - Payload management: trim old screenshots to stay within API size limits
+- Loop helpers: create trimmed requests without mutating caller state
 """
 
 from __future__ import annotations
 
-from .payload import estimate_messages_size_bytes, trim_images_to_fit
+from .loop import acreate_trimmed, create_trimmed
+from .payload import estimate_messages_size_bytes, trim_images_to_fit, trimmed_messages_to_fit
 
 __all__ = [
+    "acreate_trimmed",
+    "create_trimmed",
     "estimate_messages_size_bytes",
     "trim_images_to_fit",
+    "trimmed_messages_to_fit",
 ]

--- a/yutori/n1/loop.py
+++ b/yutori/n1/loop.py
@@ -1,0 +1,77 @@
+"""Higher-level helpers for screenshot-heavy n1 agent loops."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Protocol
+
+from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
+
+from .payload import (
+    DEFAULT_KEEP_RECENT_SCREENSHOTS,
+    DEFAULT_MAX_REQUEST_BYTES,
+    trimmed_messages_to_fit,
+)
+
+
+class SupportsSyncChatCompletionsCreate(Protocol):
+    """The subset of the sync chat completions interface needed by loop helpers."""
+
+    def create(
+        self,
+        messages: Iterable[ChatCompletionMessageParam],
+        *,
+        model: str = "n1-latest",
+        **kwargs: Any,
+    ) -> ChatCompletion:
+        """Create a sync n1 chat completion."""
+
+
+class SupportsAsyncChatCompletionsCreate(Protocol):
+    """The subset of the async chat completions interface needed by loop helpers."""
+
+    async def create(
+        self,
+        messages: Iterable[ChatCompletionMessageParam],
+        *,
+        model: str = "n1-latest",
+        **kwargs: Any,
+    ) -> ChatCompletion:
+        """Create an async n1 chat completion."""
+
+
+def create_trimmed(
+    completions: SupportsSyncChatCompletionsCreate,
+    messages: list[dict[str, Any]],
+    *,
+    model: str = "n1-latest",
+    max_bytes: int = DEFAULT_MAX_REQUEST_BYTES,
+    keep_recent: int = DEFAULT_KEEP_RECENT_SCREENSHOTS,
+    **kwargs: Any,
+) -> ChatCompletion:
+    """Create a sync n1 chat completion from a trimmed copy of *messages*."""
+
+    trimmed_messages, _, _ = trimmed_messages_to_fit(
+        messages,
+        max_bytes=max_bytes,
+        keep_recent=keep_recent,
+    )
+    return completions.create(trimmed_messages, model=model, **kwargs)
+
+
+async def acreate_trimmed(
+    completions: SupportsAsyncChatCompletionsCreate,
+    messages: list[dict[str, Any]],
+    *,
+    model: str = "n1-latest",
+    max_bytes: int = DEFAULT_MAX_REQUEST_BYTES,
+    keep_recent: int = DEFAULT_KEEP_RECENT_SCREENSHOTS,
+    **kwargs: Any,
+) -> ChatCompletion:
+    """Create an async n1 chat completion from a trimmed copy of *messages*."""
+
+    trimmed_messages, _, _ = trimmed_messages_to_fit(
+        messages,
+        max_bytes=max_bytes,
+        keep_recent=keep_recent,
+    )
+    return await completions.create(trimmed_messages, model=model, **kwargs)

--- a/yutori/n1/payload.py
+++ b/yutori/n1/payload.py
@@ -11,6 +11,7 @@ Adapted from the n1-brightdata project (https://github.com/meirk-brd/n1-brightda
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from typing import Any
 
 DEFAULT_MAX_REQUEST_BYTES = 9_500_000
@@ -115,3 +116,32 @@ def trim_images_to_fit(
                 size_bytes = estimate_messages_size_bytes(messages)
 
     return size_bytes, removed
+
+
+def trimmed_messages_to_fit(
+    messages: list[dict[str, Any]],
+    *,
+    max_bytes: int = DEFAULT_MAX_REQUEST_BYTES,
+    keep_recent: int = DEFAULT_KEEP_RECENT_SCREENSHOTS,
+) -> tuple[list[dict[str, Any]], int, int]:
+    """Return a trimmed copy of *messages* without mutating the caller's list.
+
+    This is the safer helper for higher-level SDK utilities that should not
+    modify agent-loop state in place.
+
+    Args:
+        messages: The original messages list.
+        max_bytes: Target maximum payload size in bytes.
+        keep_recent: Number of recent screenshots to protect from removal.
+
+    Returns:
+        A ``(trimmed_messages, current_size_bytes, images_removed)`` tuple.
+    """
+
+    trimmed_messages = deepcopy(messages)
+    size_bytes, removed = trim_images_to_fit(
+        trimmed_messages,
+        max_bytes=max_bytes,
+        keep_recent=keep_recent,
+    )
+    return trimmed_messages, size_bytes, removed


### PR DESCRIPTION
## Summary

Add non-mutating n1 trimming helpers under `yutori.n1`, while keeping the OpenAI-compatible `client.chat.completions.create(...)` surface unchanged.

## Before

Developers building screenshot-heavy n1 loops had two options:
- Call `client.chat.completions.create(...)` directly and manage payload growth themselves.
- Call `trim_images_to_fit(...)`, which trims in place and mutates the original `messages` list.

That kept the low-level path stable, but it left a gap for callers who wanted a safer SDK helper for large screenshot histories.

## After

This PR adds:
- `yutori.n1.trimmed_messages_to_fit(...)`
- `yutori.n1.create_trimmed(...)` / `yutori.n1.acreate_trimmed(...)`

The recommended usage pattern is now:
1. If you own a long-lived message history, measure it with `estimate_messages_size_bytes(...)`
2. When it exceeds your budget, replace your owned history with the trimmed copy from `trimmed_messages_to_fit(...)`
3. Call `client.chat.completions.create(...)` as usual with that history

Example:

```python
from yutori.n1 import estimate_messages_size_bytes, trimmed_messages_to_fit

if estimate_messages_size_bytes(messages) > 9_500_000:
    messages, size_bytes, removed = trimmed_messages_to_fit(
        messages,
        max_bytes=9_500_000,
        keep_recent=6,
    )

response = await client.chat.completions.create(
    model="n1-latest",
    messages=messages,
)
```

That keeps the actual API call fully standard while also avoiding unbounded growth in long-lived agent loops.

## What Stays Constant For Developers

These behaviors do not change:
- `client.chat.completions.create(...)` is still the raw, OpenAI-compatible call
- existing callers do not need to change anything if they do not want SDK-managed trimming
- `trim_images_to_fit(...)` still exists for callers that intentionally want in-place trimming

So this is additive: safer message-preparation helpers are available, while the low-level contract stays the same.

## Verification

- `uv run pytest -q` -> `166 passed`
- `uv run ruff check README.md examples/README.md examples/n1.py yutori/n1/__init__.py yutori/n1/loop.py yutori/n1/payload.py tests/test_async_client.py tests/test_client.py tests/test_n1_payload.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, opt-in utilities and example/doc updates; primary risk is inadvertent performance/memory overhead from deep-copying large message histories when used incorrectly.
> 
> **Overview**
> Adds opt-in `yutori.n1` helpers to manage screenshot-heavy chat histories without mutating caller state: `trimmed_messages_to_fit(...)` (returns a deep-copied, trimmed messages list) plus `create_trimmed(...)`/`acreate_trimmed(...)` wrappers that call chat completions with a trimmed copy.
> 
> Updates the `examples/n1.py` agent and top-level docs to recommend a *size pre-check* via `estimate_messages_size_bytes(...)` and only then replacing the owned history with the trimmed copy, keeping the underlying `client.chat.completions.create(...)` call unchanged.
> 
> Expands test coverage to assert the new helpers do not mutate the original `messages` and that both sync/async wrappers send the trimmed copy to OpenAI client calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65397221a4d7efbd15d25a9a4f3ad383ebabf622. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->