### PR TITLE
Bump version to 0.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.4.2"
+version = "0.4.3"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Bump the SDK version from `0.4.2` to `0.4.3` so the merged non-mutating n1 trimming helpers can be published to PyPI.

## Verification

- `uv run pytest -q` -> `168 passed`
- `uvx --from build pyproject-build`
