### PR TITLE
Add yutori auth register and self-healing login

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 import base64
-from datetime import datetime, timezone
 import hashlib
 import io
 import json
-import os
-import stat
-from pathlib import Path
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
@@ -19,30 +16,34 @@ import pytest
 from yutori.auth.constants import (
     CALLBACK_HOST,
     CLERK_CLIENT_ID,
-    CLERK_INSTANCE_URL,
     REDIRECT_PORT,
     REDIRECT_URI,
     build_auth_api_url,
 )
 from yutori.auth.credentials import clear_config, load_config, resolve_api_key, save_config
 from yutori.auth.flow import (
+    _authenticate_browser_user,
+    _build_key_name,
     _CallbackHandler,
     _CallbackResult,
-    _build_key_name,
+    _get_registration_state_for_ux,
     _mask_key,
     build_auth_url,
+    check_registration_status,
     exchange_code_for_token,
     generate_api_key,
     generate_pkce,
     get_auth_status,
+    register_user,
     run_login_flow,
+    run_register_flow,
 )
 from yutori.auth.types import AuthStatus, LoginResult
-
 
 # ---------------------------------------------------------------------------
 # PKCE
 # ---------------------------------------------------------------------------
+
 
 class TestPKCE:
     def test_generate_pkce_returns_pair(self):
@@ -53,9 +54,7 @@ class TestPKCE:
 
     def test_generate_pkce_produces_valid_s256_challenge(self):
         verifier, challenge = generate_pkce()
-        expected = base64.urlsafe_b64encode(
-            hashlib.sha256(verifier.encode()).digest()
-        ).rstrip(b"=").decode()
+        expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
         assert challenge == expected
 
     def test_generate_pkce_unique_each_call(self):
@@ -68,6 +67,7 @@ class TestPKCE:
 # ---------------------------------------------------------------------------
 # build_auth_url
 # ---------------------------------------------------------------------------
+
 
 class TestBuildAuthUrl:
     def test_contains_required_params(self):
@@ -84,6 +84,11 @@ class TestBuildAuthUrl:
         assert params["code_challenge_method"] == ["S256"]
         assert params["state"] == ["test_state"]
         assert params["scope"] == ["openid profile email"]
+
+    def test_includes_screen_hint_when_provided(self):
+        url = build_auth_url("test_challenge", "test_state", screen_hint="sign_up")
+        params = parse_qs(urlparse(url).query)
+        assert params["screen_hint"] == ["sign_up"]
 
 
 class TestBuildKeyName:
@@ -106,6 +111,7 @@ class TestBuildKeyName:
 # ---------------------------------------------------------------------------
 # Credentials: save / load / clear / resolve
 # ---------------------------------------------------------------------------
+
 
 class TestCredentials:
     @pytest.fixture(autouse=True)
@@ -230,6 +236,7 @@ class TestResolveApiKey:
 # Callback handler
 # ---------------------------------------------------------------------------
 
+
 class TestCallbackHandler:
     """Tests for the OAuth callback HTTP handler."""
 
@@ -303,6 +310,7 @@ class TestCallbackHandler:
 # Token exchange and API key generation
 # ---------------------------------------------------------------------------
 
+
 class TestTokenExchange:
     def test_exchange_code_for_token_success(self):
         mock_response = MagicMock(spec=httpx.Response)
@@ -353,16 +361,58 @@ class TestGenerateApiKey:
             assert mock_post.call_args[1]["json"] is None
 
 
+class TestRegistrationHelpers:
+    def test_check_registration_status_success(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {"is_registered": True}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
+            status = check_registration_status("jwt-token")
+
+        assert status == {"is_registered": True}
+        assert mock_get.call_args[0][0] == build_auth_api_url("/client/registration-status")
+        assert mock_get.call_args[1]["headers"] == {"Authorization": "Bearer jwt-token"}
+
+    def test_register_user_posts_cli_signup_source(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
+            register_user("jwt-token")
+
+        assert mock_post.call_args[0][0] == build_auth_api_url("/client/register")
+        assert mock_post.call_args[1]["headers"] == {"Authorization": "Bearer jwt-token"}
+        assert mock_post.call_args[1]["json"] == {"signup_source": "cli"}
+
+    def test_get_registration_state_for_ux_handles_non_dict_payload(self):
+        with patch("yutori.auth.flow.check_registration_status", return_value=["unexpected"]):
+            result = _get_registration_state_for_ux("jwt-token")
+
+        assert result is None
+
+
 # ---------------------------------------------------------------------------
 # run_login_flow (mocked — no real browser or server)
 # ---------------------------------------------------------------------------
 
+
 class TestRunLoginFlow:
     @patch("yutori.auth.flow.webbrowser.open")
+    @patch("yutori.auth.flow.register_user")
+    @patch("yutori.auth.flow.check_registration_status", return_value={"is_registered": False})
     @patch("yutori.auth.flow.generate_api_key", return_value="yt-new-key")
     @patch("yutori.auth.flow.exchange_code_for_token", return_value="jwt123")
     @patch("yutori.auth.flow.save_config")
-    def test_successful_flow(self, mock_save, mock_exchange, mock_gen_key, mock_browser):
+    def test_successful_flow(
+        self,
+        mock_save,
+        mock_exchange,
+        mock_gen_key,
+        mock_check_registration,
+        mock_register_user,
+        mock_browser,
+    ):
         """Mock the callback result to simulate a successful flow."""
 
         def fake_server_init(self, addr, handler):
@@ -375,12 +425,13 @@ class TestRunLoginFlow:
             _CallbackHandler.callback_result.received.set()
 
         # We need a more targeted approach: patch the server and thread
-        with patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init), \
-             patch("yutori.auth.flow.socketserver.TCPServer.serve_forever", fake_serve_forever), \
-             patch("yutori.auth.flow.socketserver.TCPServer.shutdown"), \
-             patch("yutori.auth.flow.socketserver.TCPServer.server_close"), \
-             patch("yutori.auth.flow.threading.Thread") as mock_thread_cls:
-
+        with (
+            patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init),
+            patch("yutori.auth.flow.socketserver.TCPServer.serve_forever", fake_serve_forever),
+            patch("yutori.auth.flow.socketserver.TCPServer.shutdown"),
+            patch("yutori.auth.flow.socketserver.TCPServer.server_close"),
+            patch("yutori.auth.flow.threading.Thread") as mock_thread_cls,
+        ):
             mock_thread = MagicMock()
             mock_thread_cls.return_value = mock_thread
 
@@ -400,14 +451,84 @@ class TestRunLoginFlow:
                     result = run_login_flow()
                     assert result.success is True
                     assert result.api_key == "yt-new-key"
+                    assert result.account_created is True
                     assert result.auth_url is not None
                     mock_save.assert_called_once_with("yt-new-key")
+                    mock_check_registration.assert_called_once_with("jwt123")
+                    mock_register_user.assert_called_once_with("jwt123", signup_source="cli")
                     mock_gen_key.assert_called_once()
                     assert mock_gen_key.call_args.args[0] == "jwt123"
                     key_name = mock_gen_key.call_args.kwargs["key_name"]
                     assert key_name.endswith("-yutori-cli")
                     date_part = key_name[:10]
                     datetime.strptime(date_part, "%Y-%m-%d")
+
+    @patch("yutori.auth.flow.register_user")
+    @patch(
+        "yutori.auth.flow.check_registration_status",
+        side_effect=httpx.HTTPStatusError("500", request=MagicMock(), response=MagicMock(status_code=500)),
+    )
+    @patch("yutori.auth.flow.generate_api_key", return_value="yt-existing-key")
+    @patch("yutori.auth.flow.save_config")
+    @patch("yutori.auth.flow._authenticate_browser_user")
+    def test_login_continues_when_registration_status_probe_fails(
+        self,
+        mock_authenticate_browser_user,
+        mock_save,
+        mock_gen_key,
+        mock_check_registration,
+        mock_register_user,
+    ):
+        mock_authenticate_browser_user.return_value = MagicMock(
+            jwt="jwt123",
+            auth_url="https://auth.example",
+            error=None,
+        )
+
+        result = run_login_flow()
+
+        assert result.success is True
+        assert result.api_key == "yt-existing-key"
+        assert result.account_created is None
+        mock_check_registration.assert_called_once_with("jwt123")
+        mock_register_user.assert_called_once_with("jwt123", signup_source="cli")
+        mock_save.assert_called_once_with("yt-existing-key")
+
+    @patch(
+        "yutori.auth.flow.register_user",
+        side_effect=httpx.HTTPStatusError(
+            "500",
+            request=MagicMock(),
+            response=MagicMock(status_code=500, text="backend error"),
+        ),
+    )
+    @patch("yutori.auth.flow.check_registration_status", return_value={"is_registered": True})
+    @patch("yutori.auth.flow.generate_api_key", return_value="yt-existing-key")
+    @patch("yutori.auth.flow.save_config")
+    @patch("yutori.auth.flow._authenticate_browser_user")
+    def test_login_continues_when_register_returns_server_error_for_existing_account(
+        self,
+        mock_authenticate_browser_user,
+        mock_save,
+        mock_gen_key,
+        mock_check_registration,
+        mock_register_user,
+    ):
+        mock_authenticate_browser_user.return_value = MagicMock(
+            jwt="jwt123",
+            auth_url="https://auth.example",
+            error=None,
+        )
+
+        result = run_login_flow()
+
+        assert result.success is True
+        assert result.api_key == "yt-existing-key"
+        assert result.account_created is False
+        mock_check_registration.assert_called_once_with("jwt123")
+        mock_register_user.assert_called_once_with("jwt123", signup_source="cli")
+        mock_gen_key.assert_called_once()
+        mock_save.assert_called_once_with("yt-existing-key")
 
     def test_port_in_use(self):
         with patch("yutori.auth.flow.socketserver.TCPServer.__init__", side_effect=OSError("Address already in use")):
@@ -419,13 +540,14 @@ class TestRunLoginFlow:
         def fake_server_init(self, addr, handler):
             pass
 
-        with patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init), \
-             patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"), \
-             patch("yutori.auth.flow.socketserver.TCPServer.shutdown"), \
-             patch("yutori.auth.flow.socketserver.TCPServer.server_close"), \
-             patch("yutori.auth.flow.webbrowser.open"), \
-             patch("yutori.auth.flow.threading.Thread") as mock_thread_cls:
-
+        with (
+            patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init),
+            patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"),
+            patch("yutori.auth.flow.socketserver.TCPServer.shutdown"),
+            patch("yutori.auth.flow.socketserver.TCPServer.server_close"),
+            patch("yutori.auth.flow.webbrowser.open"),
+            patch("yutori.auth.flow.threading.Thread") as mock_thread_cls,
+        ):
             mock_thread = MagicMock()
             mock_thread_cls.return_value = mock_thread
 
@@ -442,19 +564,21 @@ class TestRunLoginFlow:
         def fake_server_init(self, addr, handler):
             pass
 
-        with patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init), \
-             patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"), \
-             patch("yutori.auth.flow.socketserver.TCPServer.shutdown"), \
-             patch("yutori.auth.flow.socketserver.TCPServer.server_close"), \
-             patch("yutori.auth.flow.webbrowser.open"), \
-             patch("yutori.auth.flow.threading.Thread") as mock_thread_cls:
-
+        with (
+            patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init),
+            patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"),
+            patch("yutori.auth.flow.socketserver.TCPServer.shutdown"),
+            patch("yutori.auth.flow.socketserver.TCPServer.server_close"),
+            patch("yutori.auth.flow.webbrowser.open"),
+            patch("yutori.auth.flow.threading.Thread") as mock_thread_cls,
+        ):
             mock_thread = MagicMock()
             mock_thread_cls.return_value = mock_thread
 
             original_result = _CallbackResult()
             with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
                 with patch("yutori.auth.flow.secrets.token_urlsafe", return_value="expected_state"):
+
                     def side_effect(*args, **kwargs):
                         original_result.code = "auth_code"
                         original_result.state = "wrong_state"
@@ -467,10 +591,64 @@ class TestRunLoginFlow:
                     assert "state mismatch" in result.error.lower()
                     assert result.auth_url is not None
 
+    def test_browser_open_error_still_cleans_up_callback_server(self):
+        def fake_server_init(self, addr, handler):
+            pass
+
+        with (
+            patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init),
+            patch("yutori.auth.flow.socketserver.TCPServer.shutdown") as mock_shutdown,
+            patch("yutori.auth.flow.socketserver.TCPServer.server_close") as mock_close,
+            patch("yutori.auth.flow.webbrowser.open", side_effect=RuntimeError("boom")),
+            patch("yutori.auth.flow.threading.Thread") as mock_thread_cls,
+        ):
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+
+            original_result = _CallbackResult()
+            with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
+                with patch.object(original_result.received, "wait", return_value=False):
+                    result = _authenticate_browser_user()
+
+        assert result.jwt is None
+        assert result.auth_url is not None
+        assert "timed out" in result.error.lower()
+        mock_shutdown.assert_called_once()
+        mock_thread.start.assert_called_once()
+        mock_thread.join.assert_called_once_with(timeout=2)
+        mock_close.assert_called_once()
+
+
+class TestRunRegisterFlow:
+    @patch("yutori.auth.flow._complete_auth_flow")
+    @patch("yutori.auth.flow._authenticate_browser_user")
+    def test_register_uses_sign_up_screen_hint(self, mock_authenticate_browser_user, mock_complete_auth_flow):
+        mock_authenticate_browser_user.return_value = MagicMock(
+            jwt="jwt123",
+            auth_url="https://auth.example",
+            error=None,
+        )
+        mock_complete_auth_flow.return_value = LoginResult(
+            success=True,
+            api_key="yt-key",
+            account_created=True,
+        )
+
+        result = run_register_flow()
+
+        assert result.success is True
+        mock_authenticate_browser_user.assert_called_once_with(screen_hint="sign_up")
+        mock_complete_auth_flow.assert_called_once_with(
+            "jwt123",
+            "https://auth.example",
+            key_source="yutori-cli",
+        )
+
 
 # ---------------------------------------------------------------------------
 # get_auth_status
 # ---------------------------------------------------------------------------
+
 
 class TestGetAuthStatus:
     @pytest.fixture(autouse=True)
@@ -518,6 +696,7 @@ class TestGetAuthStatus:
 # _mask_key
 # ---------------------------------------------------------------------------
 
+
 class TestMaskKey:
     def test_long_key_shows_prefix_and_suffix(self):
         result = _mask_key("yt-abcdefghijklmnop")  # 20 chars
@@ -548,6 +727,7 @@ class TestMaskKey:
 # Constants
 # ---------------------------------------------------------------------------
 
+
 class TestConstants:
     def test_callback_host_is_ipv4(self):
         assert CALLBACK_HOST == "127.0.0.1"
@@ -566,6 +746,7 @@ class TestConstants:
 # Types
 # ---------------------------------------------------------------------------
 
+
 class TestTypes:
     def test_login_result_success(self):
         r = LoginResult(success=True, api_key="yt-key")
@@ -582,13 +763,19 @@ class TestTypes:
     def test_login_result_auth_url_default_none(self):
         r = LoginResult(success=True, api_key="yt-key")
         assert r.auth_url is None
+        assert r.account_created is None
 
     def test_login_result_auth_url_preserved(self):
         r = LoginResult(success=False, error="timeout", auth_url="https://clerk.yutori.com/oauth/authorize?x=1")
         assert r.auth_url == "https://clerk.yutori.com/oauth/authorize?x=1"
 
     def test_auth_status_authenticated(self):
-        s = AuthStatus(authenticated=True, masked_key="yt-...abc", source="config_file", config_path="/home/.yutori/config.json")
+        s = AuthStatus(
+            authenticated=True,
+            masked_key="yt-...abc",
+            source="config_file",
+            config_path="/home/.yutori/config.json",
+        )
         assert s.authenticated is True
         assert s.source == "config_file"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,11 @@
 """Tests for CLI entrypoint behavior."""
 
+from unittest.mock import patch
+
 from typer.testing import CliRunner
 
 from yutori import __version__
+from yutori.auth.types import LoginResult
 from yutori.cli.main import app
 
 runner = CliRunner()
@@ -18,3 +21,84 @@ def test_version_subcommand():
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
     assert result.stdout.strip() == f"yutori {__version__}"
+
+
+def test_auth_login_reports_account_creation(monkeypatch):
+    monkeypatch.delenv("YUTORI_API_KEY", raising=False)
+
+    with (
+        patch("yutori.cli.commands.auth.load_config", return_value=None),
+        patch(
+            "yutori.cli.commands.auth.run_login_flow",
+            return_value=LoginResult(success=True, api_key="yt-key", account_created=True),
+        ) as mock_run_login_flow,
+    ):
+        result = runner.invoke(app, ["auth", "login"])
+
+    assert result.exit_code == 0
+    assert "Account created and authenticated!" in result.stdout
+    mock_run_login_flow.assert_called_once_with()
+
+
+def test_auth_register_uses_register_flow(monkeypatch):
+    monkeypatch.delenv("YUTORI_API_KEY", raising=False)
+
+    with (
+        patch("yutori.cli.commands.auth.load_config", return_value=None),
+        patch(
+            "yutori.cli.commands.auth.run_register_flow",
+            return_value=LoginResult(success=True, api_key="yt-key", account_created=True),
+        ) as mock_run_register_flow,
+    ):
+        result = runner.invoke(app, ["auth", "register"])
+
+    assert result.exit_code == 0
+    assert "Successfully registered and authenticated!" in result.stdout
+    mock_run_register_flow.assert_called_once_with()
+
+
+def test_auth_register_without_account_created_signal_reports_authentication(monkeypatch):
+    monkeypatch.delenv("YUTORI_API_KEY", raising=False)
+
+    with (
+        patch("yutori.cli.commands.auth.load_config", return_value=None),
+        patch(
+            "yutori.cli.commands.auth.run_register_flow",
+            return_value=LoginResult(success=True, api_key="yt-key", account_created=None),
+        ),
+    ):
+        result = runner.invoke(app, ["auth", "register"])
+
+    assert result.exit_code == 0
+    assert "Successfully authenticated!" in result.stdout
+    assert "Successfully registered and authenticated!" not in result.stdout
+
+
+def test_auth_register_rejects_when_env_var_is_set(monkeypatch):
+    monkeypatch.setenv("YUTORI_API_KEY", "yt-env-key")
+
+    result = runner.invoke(app, ["auth", "register"])
+
+    assert result.exit_code == 1
+    assert "YUTORI_API_KEY environment variable is set" in result.stdout
+
+
+def test_auth_register_surfaces_failure_with_auth_url(monkeypatch):
+    monkeypatch.delenv("YUTORI_API_KEY", raising=False)
+
+    with (
+        patch("yutori.cli.commands.auth.load_config", return_value=None),
+        patch(
+            "yutori.cli.commands.auth.run_register_flow",
+            return_value=LoginResult(
+                success=False,
+                error="bad things happened",
+                auth_url="https://auth.example/register",
+            ),
+        ),
+    ):
+        result = runner.invoke(app, ["auth", "register"])
+
+    assert result.exit_code == 1
+    assert "Registration failed: bad things happened" in result.stdout
+    assert "https://auth.example/register" in result.stdout

--- a/yutori/auth/__init__.py
+++ b/yutori/auth/__init__.py
@@ -14,6 +14,10 @@ def __getattr__(name: str):
         from .flow import run_login_flow
 
         return run_login_flow
+    if name == "run_register_flow":
+        from .flow import run_register_flow
+
+        return run_register_flow
     if name == "get_auth_status":
         from .flow import get_auth_status
 
@@ -27,6 +31,7 @@ __all__ = [
     "load_config",
     "resolve_api_key",
     "run_login_flow",
+    "run_register_flow",
     "save_config",
     "AuthStatus",
     "LoginResult",

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -7,7 +7,6 @@ All functions return typed results and never print directly (callers handle pres
 from __future__ import annotations
 
 import base64
-from datetime import datetime, timezone
 import hashlib
 import html
 import http.server
@@ -17,6 +16,7 @@ import secrets
 import socketserver
 import threading
 import webbrowser
+from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
@@ -40,6 +40,15 @@ from .types import AuthStatus, LoginResult
 logger = logging.getLogger(__name__)
 
 
+class _BrowserAuthResult:
+    """Result of the browser-based OAuth flow before API provisioning."""
+
+    def __init__(self, jwt: str | None, auth_url: str, error: str | None = None) -> None:
+        self.jwt = jwt
+        self.auth_url = auth_url
+        self.error = error
+
+
 def generate_pkce() -> tuple[str, str]:
     """Generate PKCE code verifier and S256 challenge."""
     code_verifier = secrets.token_urlsafe(64)
@@ -48,7 +57,7 @@ def generate_pkce() -> tuple[str, str]:
     return code_verifier, code_challenge
 
 
-def build_auth_url(code_challenge: str, state: str) -> str:
+def build_auth_url(code_challenge: str, state: str, screen_hint: str | None = None) -> str:
     """Build Clerk OAuth authorization URL."""
     params = {
         "response_type": "code",
@@ -59,6 +68,8 @@ def build_auth_url(code_challenge: str, state: str) -> str:
         "state": state,
         "scope": "openid profile email",
     }
+    if screen_hint:
+        params["screen_hint"] = screen_hint
     return f"{CLERK_INSTANCE_URL}/oauth/authorize?{urlencode(params)}"
 
 
@@ -100,10 +111,7 @@ class _CallbackHandler(http.server.BaseHTTPRequestHandler):
             elif params.get("code"):
                 self.callback_result.code = params["code"][0]
                 self.callback_result.state = params.get("state", [None])[0]
-                self._send_html(
-                    "<h1>Login Successful</h1>"
-                    "<p>You can close this window.</p>"
-                )
+                self._send_html("<h1>Login Successful</h1><p>You can close this window.</p>")
             else:
                 self.callback_result.error = "No authorization code received"
                 self._send_html("<h1>Login Failed</h1><p>No authorization code received.</p>")
@@ -153,18 +161,53 @@ def generate_api_key(jwt: str, key_name: str | None = None) -> str:
         return response.json()["key"]
 
 
-def run_login_flow(key_source: str = "yutori-cli") -> LoginResult:
-    """Run the full OAuth 2.0 + PKCE login flow.
+def check_registration_status(jwt: str) -> dict[str, bool]:
+    """Check whether the authenticated Clerk user already has a Yutori account."""
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(
+            build_auth_api_url("/client/registration-status"),
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        response.raise_for_status()
+        return response.json()
 
-    Opens browser for Clerk authentication, runs a local callback server,
-    exchanges the auth code for a JWT, generates an API key, and saves it.
-    Key names are tagged with `key_source` for dashboard visibility.
 
-    Returns a LoginResult — never prints directly.
-    """
+def register_user(jwt: str, signup_source: str = "cli") -> None:
+    """Ensure the authenticated Clerk user is registered and provisioned for API access."""
+    payload = {"signup_source": signup_source}
+    with httpx.Client(timeout=30.0) as client:
+        response = client.post(
+            build_auth_api_url("/client/register"),
+            headers={"Authorization": f"Bearer {jwt}"},
+            json=payload,
+        )
+        response.raise_for_status()
+
+
+def _get_registration_state_for_ux(jwt: str) -> bool | None:
+    """Best-effort registration probe for user messaging only."""
+    try:
+        status = check_registration_status(jwt)
+        if not isinstance(status, dict):
+            logger.warning("Unexpected registration status payload: %s", status)
+            return None
+    except Exception as exc:
+        logger.warning("Could not determine registration status before login: %s", exc)
+        return None
+
+    is_registered = status.get("is_registered")
+    if isinstance(is_registered, bool):
+        return is_registered
+
+    logger.warning("Unexpected registration status payload: %s", status)
+    return None
+
+
+def _authenticate_browser_user(screen_hint: str | None = None) -> _BrowserAuthResult:
+    """Run the Clerk browser flow and exchange the callback for a JWT."""
     code_verifier, code_challenge = generate_pkce()
     state = secrets.token_urlsafe(32)
-    auth_url = build_auth_url(code_challenge, state)
+    auth_url = build_auth_url(code_challenge, state, screen_hint=screen_hint)
 
     callback_result = _CallbackResult()
     _CallbackHandler.callback_result = callback_result
@@ -176,51 +219,156 @@ def run_login_flow(key_source: str = "yutori-cli") -> LoginResult:
         server = _ReusableServer((CALLBACK_HOST, REDIRECT_PORT), _CallbackHandler)
     except OSError as e:
         if "Address already in use" in str(e):
-            return LoginResult(
-                success=False,
+            return _BrowserAuthResult(
+                jwt=None,
+                auth_url=auth_url,
                 error=f"Port {REDIRECT_PORT} is already in use. Close other applications and try again.",
             )
-        return LoginResult(success=False, error=str(e))
+        return _BrowserAuthResult(jwt=None, auth_url=auth_url, error=str(e))
 
     server_thread = threading.Thread(target=server.serve_forever, daemon=True)
-    server_thread.start()
-
-    if not webbrowser.open(auth_url):
-        logger.warning("Could not open browser. Open this URL manually:\n  %s", auth_url)
-
+    thread_started = False
     try:
+        server_thread.start()
+        thread_started = True
+
+        try:
+            browser_opened = webbrowser.open(auth_url)
+        except Exception as e:
+            logger.warning("Could not open browser automatically (%s). Open this URL manually:\n  %s", e, auth_url)
+        else:
+            if not browser_opened:
+                logger.warning("Could not open browser. Open this URL manually:\n  %s", auth_url)
+
         callback_result.received.wait(timeout=AUTH_TIMEOUT_SECONDS)
     finally:
         server.shutdown()
-        server_thread.join(timeout=2)
+        if thread_started:
+            server_thread.join(timeout=2)
         server.server_close()
 
     if not callback_result.received.is_set():
-        return LoginResult(success=False, error=ERROR_AUTH_TIMEOUT, auth_url=auth_url)
+        return _BrowserAuthResult(jwt=None, auth_url=auth_url, error=ERROR_AUTH_TIMEOUT)
 
     if callback_result.error:
-        return LoginResult(success=False, error=callback_result.error, auth_url=auth_url)
+        return _BrowserAuthResult(jwt=None, auth_url=auth_url, error=callback_result.error)
 
     if callback_result.state != state:
-        return LoginResult(success=False, error=ERROR_STATE_MISMATCH, auth_url=auth_url)
+        return _BrowserAuthResult(jwt=None, auth_url=auth_url, error=ERROR_STATE_MISMATCH)
 
     if not callback_result.code:
-        return LoginResult(success=False, error=ERROR_AUTH_FAILED, auth_url=auth_url)
+        return _BrowserAuthResult(jwt=None, auth_url=auth_url, error=ERROR_AUTH_FAILED)
 
     try:
         jwt = exchange_code_for_token(callback_result.code, code_verifier)
-        api_key = generate_api_key(jwt, key_name=_build_key_name(key_source))
-        save_config(api_key)
-        return LoginResult(success=True, api_key=api_key, auth_url=auth_url)
     except httpx.HTTPStatusError as e:
         detail = ""
         try:
             detail = f": {e.response.text}"
         except Exception:
             pass
-        return LoginResult(success=False, error=f"{ERROR_AUTH_FAILED} ({e.response.status_code}){detail}", auth_url=auth_url)
+        return _BrowserAuthResult(
+            jwt=None,
+            auth_url=auth_url,
+            error=f"{ERROR_AUTH_FAILED} ({e.response.status_code}){detail}",
+        )
+    except Exception as e:
+        return _BrowserAuthResult(jwt=None, auth_url=auth_url, error=str(e))
+
+    return _BrowserAuthResult(jwt=jwt, auth_url=auth_url)
+
+
+def _complete_auth_flow(
+    jwt: str,
+    auth_url: str,
+    *,
+    key_source: str,
+    signup_source: str = "cli",
+) -> LoginResult:
+    """Provision the Clerk identity and create a Yutori API key."""
+    was_registered = _get_registration_state_for_ux(jwt)
+
+    try:
+        register_user(jwt, signup_source=signup_source)
+    except httpx.HTTPStatusError as e:
+        should_continue = was_registered is True and e.response.status_code >= 500
+        if not should_continue:
+            detail = ""
+            try:
+                detail = f": {e.response.text}"
+            except Exception:
+                pass
+            return LoginResult(
+                success=False,
+                error=f"{ERROR_AUTH_FAILED} ({e.response.status_code}){detail}",
+                auth_url=auth_url,
+            )
+
+        logger.warning(
+            "Register request failed after confirming the account already exists; continuing with key generation: %s",
+            e,
+        )
+    except httpx.RequestError as e:
+        if was_registered is not True:
+            return LoginResult(success=False, error=str(e), auth_url=auth_url)
+
+        logger.warning(
+            "Register request failed after confirming the account already exists; continuing with key generation: %s",
+            e,
+        )
+
+    try:
+        api_key = generate_api_key(jwt, key_name=_build_key_name(key_source))
+        save_config(api_key)
+        return LoginResult(
+            success=True,
+            api_key=api_key,
+            auth_url=auth_url,
+            account_created=None if was_registered is None else not was_registered,
+        )
+    except httpx.HTTPStatusError as e:
+        detail = ""
+        try:
+            detail = f": {e.response.text}"
+        except Exception:
+            pass
+        return LoginResult(
+            success=False,
+            error=f"{ERROR_AUTH_FAILED} ({e.response.status_code}){detail}",
+            auth_url=auth_url,
+        )
     except Exception as e:
         return LoginResult(success=False, error=str(e), auth_url=auth_url)
+
+
+def run_login_flow(key_source: str = "yutori-cli") -> LoginResult:
+    """Run the full OAuth 2.0 + PKCE login flow.
+
+    Opens browser for Clerk authentication, runs a local callback server,
+    exchanges the auth code for a JWT, ensures the account is registered,
+    generates an API key, and saves it.
+    Key names are tagged with `key_source` for dashboard visibility.
+
+    Returns a LoginResult — never prints directly.
+    """
+    browser_auth = _authenticate_browser_user()
+    if browser_auth.error or not browser_auth.jwt:
+        return LoginResult(success=False, error=browser_auth.error, auth_url=browser_auth.auth_url)
+
+    return _complete_auth_flow(browser_auth.jwt, browser_auth.auth_url, key_source=key_source)
+
+
+def run_register_flow(key_source: str = "yutori-cli") -> LoginResult:
+    """Run the OAuth 2.0 + PKCE registration flow using Clerk's sign-up screen."""
+    browser_auth = _authenticate_browser_user(screen_hint="sign_up")
+    if browser_auth.error or not browser_auth.jwt:
+        return LoginResult(success=False, error=browser_auth.error, auth_url=browser_auth.auth_url)
+
+    return _complete_auth_flow(
+        browser_auth.jwt,
+        browser_auth.auth_url,
+        key_source=key_source,
+    )
 
 
 def _mask_key(key: str) -> str:

--- a/yutori/auth/types.py
+++ b/yutori/auth/types.py
@@ -13,6 +13,7 @@ class LoginResult:
     api_key: str | None = None
     error: str | None = None
     auth_url: str | None = None
+    account_created: bool | None = None
 
 
 @dataclass

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -9,10 +9,15 @@ from rich.console import Console
 from rich.markup import escape
 
 from yutori.auth.credentials import clear_config, load_config
-from yutori.auth.flow import get_auth_status, run_login_flow
+from yutori.auth.flow import get_auth_status, run_login_flow, run_register_flow
 
 app = typer.Typer(help="Manage authentication")
 console = Console()
+
+
+_ENV_VAR_PRECEDENCE_MESSAGE = (
+    "[yellow]YUTORI_API_KEY environment variable is set — it takes precedence over saved credentials.[/yellow]"
+)
 
 
 @app.command()
@@ -22,7 +27,7 @@ def login() -> None:
     Opens your browser to log in with Clerk OAuth and saves an API key locally.
     """
     if os.environ.get("YUTORI_API_KEY"):
-        console.print("[yellow]YUTORI_API_KEY environment variable is set — it takes precedence over saved credentials.[/yellow]")
+        console.print(_ENV_VAR_PRECEDENCE_MESSAGE)
         console.print("Unset it first if you want to use browser login.")
         raise typer.Exit(1)
 
@@ -39,10 +44,46 @@ def login() -> None:
     result = run_login_flow()
 
     if result.success:
-        console.print("[green]Successfully authenticated![/green]")
+        if result.account_created:
+            console.print("[green]Account created and authenticated![/green]")
+        else:
+            console.print("[green]Successfully authenticated![/green]")
         console.print("You can now use the Yutori CLI and SDK.")
     else:
         console.print(f"\n[red]Authentication failed: {escape(str(result.error))}[/red]")
+        if result.auth_url:
+            console.print(f"\n[dim]If the browser didn't open, visit:[/dim]\n  {result.auth_url}")
+        raise typer.Exit(1)
+
+
+@app.command()
+def register() -> None:
+    """Create a Yutori account via browser and save an API key locally."""
+    if os.environ.get("YUTORI_API_KEY"):
+        console.print(_ENV_VAR_PRECEDENCE_MESSAGE)
+        console.print("Unset it first if you want to use browser registration.")
+        raise typer.Exit(1)
+
+    config = load_config()
+    existing_key = config.get("api_key") if config else None
+    if existing_key and isinstance(existing_key, str):
+        console.print("[yellow]You are already authenticated.[/yellow]")
+        console.print("Run [bold]yutori auth logout[/bold] first to register again.")
+        raise typer.Exit(1)
+
+    console.print("\n[bold]Opening browser to create your account...[/bold]")
+    console.print("[dim]Waiting for registration...[/dim]\n")
+
+    result = run_register_flow()
+
+    if result.success:
+        if result.account_created is True:
+            console.print("[green]Successfully registered and authenticated![/green]")
+        else:
+            console.print("[green]Successfully authenticated![/green]")
+        console.print("You can now use the Yutori CLI and SDK.")
+    else:
+        console.print(f"\n[red]Registration failed: {escape(str(result.error))}[/red]")
         if result.auth_url:
             console.print(f"\n[dim]If the browser didn't open, visit:[/dim]\n  {result.auth_url}")
         raise typer.Exit(1)


### PR DESCRIPTION
## Summary

- New `yutori auth register` command — opens browser with Clerk sign-up screen, provisions the account, and saves an API key locally
- `yutori auth login` now auto-registers if the account doesn't exist yet, so new users no longer hit a failure when logging in for the first time
- Login reports whether a new account was created (`account_created` on `LoginResult`) for clearer CLI messaging

## Changes

**`yutori/auth/flow.py`**:
- `build_auth_url` accepts optional `screen_hint` (e.g. `"sign_up"`) for Clerk
- New `check_registration_status()` and `register_user()` helpers
- `_authenticate_browser_user()` extracted from `run_login_flow` — handles the browser OAuth + PKCE flow and returns a JWT. Server cleanup is now guaranteed even if browser launch fails.
- `_complete_auth_flow()` — provisions the account (register + generate key + save). Tolerates transient server errors during registration when the account is confirmed to already exist.
- `run_register_flow()` — uses `screen_hint="sign_up"` then completes the auth flow
- `run_login_flow()` — updated to call register (idempotent) before generating a key

**`yutori/auth/types.py`**:
- `LoginResult.account_created: bool | None` — `True` if a new account was created, `False` if existing, `None` if status couldn't be determined

**`yutori/cli/commands/auth.py`**:
- New `register` command with appropriate messaging
- `login` command shows "Account created and authenticated!" when a new account was created

**Tests**: 75 passed (test_auth.py + test_cli.py)

## Test plan

- [ ] `yutori auth register` → opens sign-up page → creates account → saves key
- [ ] `yutori auth login` (new user) → auto-registers → "Account created and authenticated!"
- [ ] `yutori auth login` (existing user) → register is idempotent → "Successfully authenticated!"
- [ ] `yutori auth register` when already authenticated → blocked with helpful message
- [ ] `yutori auth register` with YUTORI_API_KEY set → blocked with env var warning
- [ ] Transient server error during register for existing user → login continues
- [ ] `pytest tests/test_auth.py tests/test_cli.py -q` → 75 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the OAuth login flow and adds new registration/provisioning API calls, which can impact user authentication and onboarding behavior if the new endpoints or error-handling paths misbehave.
> 
> **Overview**
> Adds a new **browser-based registration flow** (`run_register_flow` + `yutori auth register`) that opens Clerk with a `screen_hint=sign_up`, provisions the user via new `/client/register` + `/client/registration-status` calls, and then generates/saves an API key.
> 
> Refactors login into `_authenticate_browser_user` + `_complete_auth_flow`, so `run_login_flow` now *self-heals* by registering on first login; adds `LoginResult.account_created` to drive CLI messaging and includes more robust callback-server cleanup and error details when token exchange/registration fail.
> 
> Updates exports (`yutori.auth.__init__`), CLI messaging/guardrails (env var precedence), and expands tests to cover register/login flows, account-created reporting, and failure-tolerance paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f810407f5d79f10d29569eeaeae8ff6bff79fd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->