### PR TITLE
Add browser parameter to browsing.create()

### DIFF
--- a/yutori/_async/browsing.py
+++ b/yutori/_async/browsing.py
@@ -27,6 +27,7 @@ class AsyncBrowsingNamespace:
         max_steps: int | None = None,
         agent: str | None = None,
         require_auth: bool | None = None,
+        browser: str | None = None,
         output_schema: object | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
@@ -40,6 +41,8 @@ class AsyncBrowsingNamespace:
             agent: Agent to use ("navigator-n1-latest" or
                    "claude-sonnet-4-5-computer-use-2025-01-24").
             require_auth: Use auth-optimized browser for login flows.
+            browser: "cloud" (default) or "local" to use the desktop app with
+                     the user's logged-in sessions.
             output_schema: JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance.
             webhook_url: URL for completion notifications.
             webhook_format: "scout" (default), "slack", or "zapier".
@@ -58,6 +61,8 @@ class AsyncBrowsingNamespace:
             payload["agent"] = agent
         if require_auth is not None:
             payload["require_auth"] = require_auth
+        if browser is not None:
+            payload["browser"] = browser
         resolved_schema = resolve_output_schema(output_schema)
         if resolved_schema is not None:
             payload["output_schema"] = resolved_schema

--- a/yutori/_sync/browsing.py
+++ b/yutori/_sync/browsing.py
@@ -27,6 +27,7 @@ class BrowsingNamespace:
         max_steps: int | None = None,
         agent: str | None = None,
         require_auth: bool | None = None,
+        browser: str | None = None,
         output_schema: object | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
@@ -40,6 +41,8 @@ class BrowsingNamespace:
             agent: Agent to use ("navigator-n1-latest" or
                    "claude-sonnet-4-5-computer-use-2025-01-24").
             require_auth: Use auth-optimized browser for login flows.
+            browser: "cloud" (default) or "local" to use the desktop app with
+                     the user's logged-in sessions.
             output_schema: JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance.
             webhook_url: URL for completion notifications.
             webhook_format: "scout" (default), "slack", or "zapier".
@@ -58,6 +61,8 @@ class BrowsingNamespace:
             payload["agent"] = agent
         if require_auth is not None:
             payload["require_auth"] = require_auth
+        if browser is not None:
+            payload["browser"] = browser
         resolved_schema = resolve_output_schema(output_schema)
         if resolved_schema is not None:
             payload["output_schema"] = resolved_schema


### PR DESCRIPTION
## Summary
- Add `browser: str | None = None` parameter to both sync and async `browsing.create()` methods
- Supports `"cloud"` (default) and `"local"` (routes through desktop app with user's logged-in sessions)

## Test plan
- [ ] Call `client.browsing.create(..., browser="local")` — verify `browser` included in request payload
- [ ] Call `client.browsing.create(...)` without browser — verify no `browser` key in payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an optional request field to browsing task creation without altering existing defaults; low risk aside from potential backend validation differences for the new parameter.
> 
> **Overview**
> Adds an optional `browser` parameter to both sync and async `browsing.create()` methods, documenting support for `"cloud"` (default) vs `"local"`.
> 
> When provided, the SDK now includes `browser` in the JSON payload sent to `POST /browsing/tasks`; omitted values keep the prior request shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01c5628a0fd404bd5db73838a65dd09f6dc1af6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->