### PR TITLE
Bump version to 0.4.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.4.3"
+version = "0.4.4"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- Bumps SDK version from 0.4.3 to 0.4.4
- Includes the `browser` parameter addition to `browsing.create()` from #18, plus auth improvements from recent merges

## Release steps
After merging, create a GitHub release tagged `v0.4.4` to trigger the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metadata-only version bump with no runtime/code changes.
> 
> **Overview**
> Updates `pyproject.toml` to bump the `yutori` package version from **0.4.3** to **0.4.4** for the next release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6402adee3166d9864355b8ade7513b2d455ae69c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->