### PR TITLE
Route CLI auth through platform sign-in

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,8 +14,10 @@ import httpx
 import pytest
 
 from yutori.auth.constants import (
+    AUTH_SIGN_IN_URL,
     CALLBACK_HOST,
     CLERK_CLIENT_ID,
+    CLERK_CONSENT_URL,
     REDIRECT_PORT,
     REDIRECT_URI,
     build_auth_api_url,
@@ -72,16 +74,25 @@ class TestBuildAuthUrl:
         url = build_auth_url("test_challenge", "test_state")
         parsed = urlparse(url)
         params = parse_qs(parsed.query)
+        redirect_url = params["redirect_url"][0]
+        redirect_parsed = urlparse(redirect_url)
+        redirect_params = parse_qs(redirect_parsed.query)
+        sign_in_parsed = urlparse(AUTH_SIGN_IN_URL)
+        consent_parsed = urlparse(CLERK_CONSENT_URL)
 
         assert parsed.scheme == "https"
-        assert "oauth/authorize" in parsed.path
-        assert params["response_type"] == ["code"]
-        assert params["client_id"] == [CLERK_CLIENT_ID]
-        assert params["redirect_uri"] == [REDIRECT_URI]
-        assert params["code_challenge"] == ["test_challenge"]
-        assert params["code_challenge_method"] == ["S256"]
-        assert params["state"] == ["test_state"]
-        assert params["scope"] == ["openid profile email"]
+        assert parsed.netloc == sign_in_parsed.netloc
+        assert parsed.path == sign_in_parsed.path
+        assert redirect_parsed.scheme == "https"
+        assert redirect_parsed.netloc == consent_parsed.netloc
+        assert redirect_parsed.path == consent_parsed.path
+        assert redirect_params["response_type"] == ["code"]
+        assert redirect_params["client_id"] == [CLERK_CLIENT_ID]
+        assert redirect_params["redirect_uri"] == [REDIRECT_URI]
+        assert redirect_params["code_challenge"] == ["test_challenge"]
+        assert redirect_params["code_challenge_method"] == ["S256"]
+        assert redirect_params["state"] == ["test_state"]
+        assert redirect_params["scope"] == ["openid profile email"]
 
 
 class TestBuildKeyName:

--- a/yutori/auth/constants.py
+++ b/yutori/auth/constants.py
@@ -9,6 +9,8 @@ from yutori.config import DEFAULT_BASE_URL
 # Clerk OAuth configuration
 CLERK_INSTANCE_URL = os.environ.get("CLERK_INSTANCE_URL", "https://clerk.yutori.com")
 CLERK_CLIENT_ID = os.environ.get("CLERK_CLIENT_ID", "TGiyfoPbG01Sakpe")
+CLERK_CONSENT_URL = os.environ.get("CLERK_CONSENT_URL", "https://accounts.yutori.com/oauth-consent")
+AUTH_SIGN_IN_URL = os.environ.get("AUTH_SIGN_IN_URL", "https://platform.yutori.com/sign-in")
 
 # Callback server — bind to 127.0.0.1 (avoids IPv4/IPv6 mismatch),
 # but use localhost in redirect URI (must match Clerk's registered URL).

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -23,9 +23,11 @@ from urllib.parse import parse_qs, urlencode, urlparse
 import httpx
 
 from .constants import (
+    AUTH_SIGN_IN_URL,
     AUTH_TIMEOUT_SECONDS,
     CALLBACK_HOST,
     CLERK_CLIENT_ID,
+    CLERK_CONSENT_URL,
     CLERK_INSTANCE_URL,
     ERROR_AUTH_FAILED,
     ERROR_AUTH_TIMEOUT,
@@ -58,7 +60,7 @@ def generate_pkce() -> tuple[str, str]:
 
 
 def build_auth_url(code_challenge: str, state: str) -> str:
-    """Build Clerk OAuth authorization URL."""
+    """Build the platform sign-in URL that leads into Clerk OAuth consent."""
     params = {
         "response_type": "code",
         "client_id": CLERK_CLIENT_ID,
@@ -68,7 +70,8 @@ def build_auth_url(code_challenge: str, state: str) -> str:
         "state": state,
         "scope": "openid profile email",
     }
-    return f"{CLERK_INSTANCE_URL}/oauth/authorize?{urlencode(params)}"
+    consent_url = f"{CLERK_CONSENT_URL}?{urlencode(params)}"
+    return f"{AUTH_SIGN_IN_URL}?{urlencode({'redirect_url': consent_url})}"
 
 
 class _CallbackResult:


### PR DESCRIPTION
## Summary
- send CLI browser login through `https://platform.yutori.com/sign-in`
- preserve the Clerk OAuth consent redirect by nesting `redirect_url` to `https://accounts.yutori.com/oauth-consent`
- cover the new auth URL shape in SDK tests

## Testing
- pytest tests/test_auth.py tests/test_cli_auth.py -q
- ruff check yutori/auth/constants.py yutori/auth/flow.py tests/test_auth.py tests/test_cli_auth.py yutori/cli/commands/auth.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CLI OAuth entrypoint URL shape (platform sign-in -> nested Clerk consent), which can break login if redirect parameters or environment-configured URLs are misconfigured. No token exchange or credential storage logic is modified.
> 
> **Overview**
> CLI browser login is rerouted to start at `AUTH_SIGN_IN_URL` and pass the Clerk consent page (`CLERK_CONSENT_URL`) via a nested `redirect_url`, instead of navigating directly to the Clerk `/oauth/authorize` endpoint.
> 
> Adds new configurable constants for these URLs and updates `build_auth_url` plus its unit test assertions to validate the new two-step URL/parameter structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12b061d454c6c6d96013bbda8d19a2d57dbdb903. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->