### PR TITLE
Resize screenshots to viewport before WebP conversion

### DIFF
--- a/examples/n1.py
+++ b/examples/n1.py
@@ -161,6 +161,9 @@ class Agent:
     async def _take_screenshot(self) -> str:
         screenshot_bytes = await self._page.screenshot(type="jpeg", quality=75)
         img = Image.open(io.BytesIO(screenshot_bytes))
+        viewport = (self.viewport_width, self.viewport_height)
+        if img.size != viewport:
+            img = img.resize(viewport, Image.LANCZOS)
         webp_buffer = io.BytesIO()
         img.save(webp_buffer, format="WEBP", quality=90)
         webp_bytes = webp_buffer.getvalue()

--- a/examples/n1_custom_tools.py
+++ b/examples/n1_custom_tools.py
@@ -223,6 +223,9 @@ class Agent:
     async def _take_screenshot(self) -> str:
         screenshot_bytes = await self._page.screenshot(type="jpeg", quality=75)
         img = Image.open(io.BytesIO(screenshot_bytes))
+        viewport = (self.viewport_width, self.viewport_height)
+        if img.size != viewport:
+            img = img.resize(viewport, Image.LANCZOS)
         webp_buffer = io.BytesIO()
         img.save(webp_buffer, format="WEBP", quality=90)
         webp_bytes = webp_buffer.getvalue()

--- a/examples/n1_memo.py
+++ b/examples/n1_memo.py
@@ -274,6 +274,9 @@ class Agent:
     async def _take_screenshot(self) -> str:
         screenshot_bytes = await self._page.screenshot(type="jpeg", quality=75)
         img = Image.open(io.BytesIO(screenshot_bytes))
+        viewport = (self.viewport_width, self.viewport_height)
+        if img.size != viewport:
+            img = img.resize(viewport, Image.LANCZOS)
         webp_buffer = io.BytesIO()
         img.save(webp_buffer, format="WEBP", quality=90)
         webp_bytes = webp_buffer.getvalue()


### PR DESCRIPTION
Add Lanczos resize to handle DPR mismatches where Playwright returns screenshots larger than the configured viewport dimensions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk example-only change; it slightly alters screenshot fidelity and adds a resize step that could impact performance but doesn’t affect core API or security logic.
> 
> **Overview**
> Ensures screenshots embedded into n1 agent requests are always the configured viewport size by **resizing Playwright captures to `(viewport_width, viewport_height)` with `Image.LANCZOS`** before WebP conversion.
> 
> This change is applied consistently across the three example agents (`n1.py`, `n1_custom_tools.py`, `n1_memo.py`) to avoid DPR/viewport-size mismatches producing oversized images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f15c61e61e05147762dcfa2bc7275aa08f30a575. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->