### PR TITLE
Add n1 lifecycle hooks and content normalization helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.4.5"
+version = "0.4.6"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_n1_content.py
+++ b/tests/test_n1_content.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from yutori.n1 import extract_text_content
+
+
+class TestExtractTextContent:
+    def test_none_returns_none(self) -> None:
+        assert extract_text_content(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert extract_text_content("   ") is None
+
+    def test_string_is_stripped(self) -> None:
+        assert extract_text_content("  hello world  ") == "hello world"
+
+    def test_list_of_dict_blocks_joins_text_blocks(self) -> None:
+        content = [
+            {"type": "text", "text": "hello"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            {"type": "text", "text": "world"},
+        ]
+        assert extract_text_content(content) == "hello\nworld"
+
+    def test_list_of_objects_joins_text_blocks(self) -> None:
+        content = [
+            SimpleNamespace(type="text", text="alpha"),
+            SimpleNamespace(type="image_url", text="ignored"),
+            SimpleNamespace(type="text", text="beta"),
+        ]
+        assert extract_text_content(content) == "alpha\nbeta"
+
+    def test_mixed_blocks_are_supported(self) -> None:
+        content = [
+            {"type": "text", "text": "first"},
+            SimpleNamespace(type="text", text="second"),
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            SimpleNamespace(type="text", text="third"),
+        ]
+        assert extract_text_content(content) == "first\nsecond\nthird"
+
+    def test_text_attribute_on_non_list_content_is_supported(self) -> None:
+        content = SimpleNamespace(text="  structured content  ")
+        assert extract_text_content(content) == "structured content"

--- a/tests/test_n1_hooks.py
+++ b/tests/test_n1_hooks.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from yutori.n1 import RunHooksBase
+
+
+class RecordingHooks(RunHooksBase):
+    def __init__(self) -> None:
+        self.events: list[tuple[str, object]] = []
+
+    async def on_agent_end(self, *, output=None):  # type: ignore[override]
+        self.events.append(("agent_end", output))
+        await super().on_agent_end(output=output)
+
+
+@pytest.mark.asyncio
+async def test_base_hooks_are_awaitable_and_no_op() -> None:
+    hooks = RunHooksBase()
+    assert inspect.iscoroutinefunction(hooks.on_agent_start)
+    assert inspect.iscoroutinefunction(hooks.on_llm_start)
+    assert inspect.iscoroutinefunction(hooks.on_llm_end)
+    assert inspect.iscoroutinefunction(hooks.on_tool_start)
+    assert inspect.iscoroutinefunction(hooks.on_tool_end)
+    assert inspect.iscoroutinefunction(hooks.on_agent_end)
+
+    assert await hooks.on_agent_start(messages=[]) is None
+    assert await hooks.on_llm_start(messages=[], tools=None) is None
+    assert await hooks.on_llm_end(response={"message": "ok"}) is None
+    assert await hooks.on_tool_start(name="extract_content", arguments={}) is None
+    assert await hooks.on_tool_end(
+        name="extract_content",
+        arguments={},
+        output="hello",
+        trace="extract_content()",
+    ) is None
+    assert await hooks.on_agent_end(output=None) is None
+
+
+@pytest.mark.asyncio
+async def test_hooks_subclass_cleanly() -> None:
+    hooks = RecordingHooks()
+    await hooks.on_agent_end(output={"status": "done"})
+
+    assert hooks.events == [("agent_end", {"status": "done"})]

--- a/yutori/n1/__init__.py
+++ b/yutori/n1/__init__.py
@@ -7,12 +7,16 @@ Provides reusable helpers for common patterns in n1 agent loops:
 
 from __future__ import annotations
 
+from .content import extract_text_content
+from .hooks import RunHooksBase
 from .loop import acreate_trimmed, create_trimmed
 from .payload import estimate_messages_size_bytes, trim_images_to_fit, trimmed_messages_to_fit
 
 __all__ = [
     "acreate_trimmed",
+    "extract_text_content",
     "create_trimmed",
+    "RunHooksBase",
     "estimate_messages_size_bytes",
     "trim_images_to_fit",
     "trimmed_messages_to_fit",

--- a/yutori/n1/content.py
+++ b/yutori/n1/content.py
@@ -1,0 +1,32 @@
+"""Content normalization helpers for Yutori n1 loops."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def extract_text_content(content: Any) -> str | None:
+    """Extract normalized text from chat-completions style content blocks."""
+
+    if content is None:
+        return None
+    if isinstance(content, str):
+        return content.strip() or None
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    text = block.get("text", "")
+                    if isinstance(text, str):
+                        parts.append(text)
+            elif getattr(block, "type", None) == "text":
+                text = getattr(block, "text", "")
+                parts.append(text if isinstance(text, str) else str(text))
+        normalized = "\n".join(part for part in parts if part).strip()
+        return normalized or None
+
+    text_attr = getattr(content, "text", None)
+    if isinstance(text_attr, str):
+        return text_attr.strip() or None
+    return str(content).strip() or None

--- a/yutori/n1/content.py
+++ b/yutori/n1/content.py
@@ -18,8 +18,7 @@ def extract_text_content(content: Any) -> str | None:
             if isinstance(block, dict):
                 if block.get("type") == "text":
                     text = block.get("text", "")
-                    if isinstance(text, str):
-                        parts.append(text)
+                    parts.append(text if isinstance(text, str) else str(text))
             elif getattr(block, "type", None) == "text":
                 text = getattr(block, "text", "")
                 parts.append(text if isinstance(text, str) else str(text))

--- a/yutori/n1/hooks.py
+++ b/yutori/n1/hooks.py
@@ -1,0 +1,45 @@
+"""Agents-inspired lifecycle hooks for chat-completions-based n1 loops."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openai.types.chat import ChatCompletionMessageParam
+
+
+class RunHooksBase:
+    """Agents-inspired lifecycle hooks for chat-completions-based n1 loops.
+
+    This is intentionally not a drop-in replacement for the OpenAI Agents SDK
+    RunHooksBase. It mirrors the lifecycle phases, not the exact signatures.
+    """
+
+    async def on_agent_start(self, *, messages: list[ChatCompletionMessageParam]) -> None:
+        pass
+
+    async def on_llm_start(
+        self,
+        *,
+        messages: list[ChatCompletionMessageParam],
+        tools: list[dict[str, Any]] | None = None,
+    ) -> None:
+        pass
+
+    async def on_llm_end(self, *, response: Any) -> None:
+        pass
+
+    async def on_tool_start(self, *, name: str, arguments: dict[str, Any]) -> None:
+        pass
+
+    async def on_tool_end(
+        self,
+        *,
+        name: str,
+        arguments: dict[str, Any],
+        output: str | None,
+        trace: str,
+    ) -> None:
+        pass
+
+    async def on_agent_end(self, *, output: Any | None = None) -> None:
+        pass


### PR DESCRIPTION
## Summary
- Add `RunHooksBase` with Agents-inspired lifecycle phases (`on_agent_start`, `on_llm_start/end`, `on_tool_start/end`, `on_agent_end`) for chat-completions-based n1 loops
- Add `extract_text_content()` for normalizing assistant message content across str, list-of-blocks, and object forms
- Export both from `yutori.n1`

These are additive APIs that enable downstream consumers (e.g. `frontend-visualqa`) to build thought cards, read-effect overlays, and rich trace artifacts without modifying the SDK's core loop.

Intentionally **not** a drop-in replacement for the OpenAI Agents SDK `RunHooksBase` — mirrors the lifecycle phases, not the exact signatures.

## Test plan
- [x] `pytest tests/test_n1_content.py tests/test_n1_hooks.py` — 9 tests covering str/None/empty/list-of-dicts/list-of-objects/mixed blocks, hook default no-op, subclassing, awaitability
- [x] `ruff check yutori/n1 tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive utilities and tests with minimal impact on existing behavior; main risk is introducing/committing to new public API surface in `yutori.n1`.
> 
> **Overview**
> Adds two new n1 helper APIs: `RunHooksBase` (async, no-op lifecycle hook methods for agent/LLM/tool phases) and `extract_text_content()` (normalizes chat-completions-style content across strings, block lists, and objects).
> 
> Exports both from `yutori.n1`, adds focused pytest coverage for hook awaitability/subclassing and content extraction behavior, and bumps the package version to `0.4.6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40ac064ce05167df445d93f91f255cefc08c690d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->