### PR TITLE
Replace deprecated Optional[Any] with modern Any | None syntax

### DIFF
--- a/yutori/exceptions.py
+++ b/yutori/exceptions.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 
 class YutoriSDKError(Exception):
@@ -16,7 +16,7 @@ class AuthenticationError(YutoriSDKError):
 class APIError(YutoriSDKError):
     """Raised when the Yutori API returns a non-successful response."""
 
-    def __init__(self, message: str, status_code: int, response: Optional[Any] = None):
+    def __init__(self, message: str, status_code: int, response: Any | None = None):
         super().__init__(message)
         self.message = message
         self.status_code = status_code


### PR DESCRIPTION
## Summary
- Replace `Optional[Any]` with `Any | None` in `exceptions.py` for consistency with the rest of the codebase
- Remove unused `Optional` import from `typing`

This was the only file still using the deprecated `typing.Optional` pattern. Every other module already uses the modern `T | None` syntax (enabled by `from __future__ import annotations`).

## Test plan
- [x] Verified syntax is valid Python
- [x] Confirmed no other usages of `Optional` exist in the codebase
- [x] `from __future__ import annotations` is present, so `Any | None` works at all supported Python versions

https://claude.ai/code/session_01EbStynQuap4TNEdDw9Rjkd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-hint-only change in an exception signature; no runtime behavior or control flow is altered.
> 
> **Overview**
> Updates `APIError.__init__` to use the modern union syntax (`Any | None`) for the optional `response` parameter and removes the now-unused `Optional` import from `typing`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342a2d06e2fe110c9c3d520e12aab4089fc48be6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->