### PR TITLE
Remove completed cleanup item (halluminate typo)

### DIFF
--- a/.claude/CLEANUP.md
+++ b/.claude/CLEANUP.md
@@ -15,6 +15,5 @@ Items identified for future cleanup runs. Pick one per run.
 
 ## halluminate
 
-- [ ] `navi_bench/demo.py:70` — Typo: "generat the task config" should be "generate the task config".
 - [ ] `navi_bench/demo.py:19` — Deprecated `Dict[str, Any]` import; use `dict[str, Any]` (already has `from __future__ import annotations`).
 - [ ] `metrics/opentable/opentable_refresh_dates.py:11` — Deprecated `List, Tuple` imports from `typing`.


### PR DESCRIPTION
## Summary
- Remove the halluminate typo item from `.claude/CLEANUP.md` — fixed in yutori-ai/halluminate#61

https://claude.ai/code/session_01RoZmpH7MrTfQSYd18D6kLi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the cleanup backlog list.
> 
> **Overview**
> Updates `.claude/CLEANUP.md` to **remove** the completed `halluminate` cleanup item about the `navi_bench/demo.py:70` typo, leaving the remaining cleanup backlog entries unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5871292182f0fa0f705404a2a72c8b979d823d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->