### PR TITLE
chore: fix stale CLEANUP references after PR #24 merge

### DIFF
--- a/.claude/CLEANUP.md
+++ b/.claude/CLEANUP.md
@@ -4,8 +4,8 @@ Items identified for future cleanup runs. Pick one per run.
 
 ## yutori-sdk-python
 
-- [ ] `cli/main.py:48` — Unused `_ = version` assignment in `main()` callback. Remove or document why the parameter must exist.
-- [ ] `cli/__init__.py`, `cli/commands/__init__.py` — Missing `__all__` exports (other subpackages define them).
+- [ ] `yutori/cli/main.py:48` — Unused `_ = version` assignment in `main()` callback. Remove or document why the parameter must exist.
+- [ ] `yutori/cli/__init__.py`, `yutori/cli/commands/__init__.py` — Missing `__all__` exports (other subpackages define them).
 
 ## yutori-mcp
 

--- a/.claude/CLEANUP_LOG.md
+++ b/.claude/CLEANUP_LOG.md
@@ -4,10 +4,6 @@
 
 **Action taken:** Replaced deprecated `Optional[Any]` with `Any | None` in `yutori/exceptions.py` and removed unused `Optional` import. This was the only file in the codebase still using the old pattern.
 
-**Branch pushed:** `cleanup/modernize-optional-type-hint` (commit `342a2d0`)
-
-**PR status:** Could not create PR — GitHub MCP tools not available in this environment. Branch is pushed and ready for manual PR creation.
-
-**Slack status:** Could not post to #updates-from-code-bots — no Slack tools available.
+**Merged:** PR #24 (commit `a2643dc`)
 
 **Other findings:** Identified 8 additional cleanup items across yutori-sdk-python, yutori-mcp, and halluminate. Added to `.claude/CLEANUP.md`.


### PR DESCRIPTION
## Summary

Daily code cleanup fixing stale documentation references in yutori-sdk-python.

- Fix file paths in CLEANUP.md: add missing `yutori/` prefix to cli module paths
- Update CLEANUP_LOG.md: record actual merged PR #24 (commit `a2643dc`) instead of stale branch/commit references from before MCP tools were available

## Owners

cc @dhruvbatra — fixes references from your recent PRs (#24, #25)

## Test plan

- [ ] CI passes (doc-only changes)

Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LPUmVB7nnRe1UMwkPRspyx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only updates to cleanup tracking files; no runtime code changes, so risk is limited to minor documentation accuracy issues.
> 
> **Overview**
> Updates `.claude/CLEANUP.md` to correct stale `yutori-sdk-python` cleanup item paths (adds the missing `yutori/` prefix).
> 
> Updates `.claude/CLEANUP_LOG.md` to reflect the actual merge of PR #24 (commit `a2643dc`) and removes outdated notes about branch/PR/Slack posting limitations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83f32d4306ceb86fda87f5dbb3dc17c0b63df31f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->