### PR TITLE
Mark yutori-mcp cleanup items as done

### DIFF
--- a/.claude/CLEANUP.md
+++ b/.claude/CLEANUP.md
@@ -9,9 +9,9 @@ Items identified for future cleanup runs. Pick one per run.
 
 ## yutori-mcp
 
-- [ ] `formatters.py:7` — Unused constant `DEFAULT_LIMIT = 10` (never referenced anywhere).
-- [ ] `schemas.py` — Duplicate `validate_webhook_url` method copied identically in 4 classes; extract to shared validator.
-- [ ] `schemas.py:119-127` — `output_fields` field defined after a `@field_validator`, breaking conventional Pydantic class ordering.
+- [x] `formatters.py:7` — Unused constant `DEFAULT_LIMIT = 10` (never referenced anywhere).
+- [x] `schemas.py` — Duplicate `validate_webhook_url` method copied identically in 4 classes; extract to shared validator.
+- [x] `schemas.py:119-127` — `output_fields` field defined after a `@field_validator`, breaking conventional Pydantic class ordering.
 
 ## halluminate
 


### PR DESCRIPTION
Marks three yutori-mcp cleanup items as completed in `.claude/CLEANUP.md` — the unused `DEFAULT_LIMIT`, duplicate webhook validator, and misplaced `output_fields` were fixed in yutori-ai/yutori-mcp#39 and prior PRs.

https://claude.ai/code/session_01CAzdS1wA1gChjFQLXhDumv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates checklist status; no code or runtime behavior is modified.
> 
> **Overview**
> Updates `.claude/CLEANUP.md` to mark three `yutori-mcp` cleanup backlog items as completed (unused `DEFAULT_LIMIT`, duplicated `validate_webhook_url` validator, and `output_fields` ordering issue).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b29a11889153fed427e73d8903b8171791043d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->