### PR TITLE
Remove unused `_ = version` assignment in CLI root callback

### DIFF
--- a/yutori/cli/main.py
+++ b/yutori/cli/main.py
@@ -45,7 +45,6 @@ def main(
     ),
 ) -> None:
     """Yutori CLI root callback."""
-    _ = version
 
 
 @app.command()


### PR DESCRIPTION
## Summary

- Remove the no-op `_ = version` assignment in the `main()` Typer callback (`yutori/cli/main.py:48`)
- The `version` parameter must exist for Typer option binding, but the eager `_version_callback` handles the logic — the assignment to `_` was unnecessary
- Ruff (E/F/I/W) passes cleanly without it

From `.claude/CLEANUP.md` in the yutori monorepo.

cc @dhruvbatra

https://claude.ai/code/session_01SELwz5i41LTerMaBSetFFX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a no-op assignment in the CLI entrypoint with no behavior change, as `--version` handling remains in the eager callback.
> 
> **Overview**
> Removes the unused `_ = version` no-op in the Typer root callback (`yutori/cli/main.py`) while keeping the `--version` option binding and eager `_version_callback` behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59914f12efb5ad1aebd018df12fa06ad4e56a2b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->