### PR TITLE
Add browser param to research, rejection_reason to CLI (ENG-4632)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ if message.tool_calls:
         print(f"Arguments: {tool_call.function.arguments}")
 ```
 
+Live n1 model IDs and parameter docs are maintained at `https://docs.yutori.com/reference/n1`. The SDK forwards standard OpenAI chat-completions parameters through `**kwargs`, including `tools`, `tool_choice`, and `response_format`.
+
 For Playwright users, the SDK provides a screenshot helper that captures and encodes images optimized for n1:
 
 ```python
@@ -140,7 +142,7 @@ If you don't want to manage your own browser infrastructure, use the Browsing AP
 
 ## Browsing API
 
-Run one-time browser automation tasks. An AI agent operates a cloud browser to complete your task.
+Run one-time browser automation tasks. An AI agent can operate either Yutori's cloud browser or Yutori Local on the desktop to complete your task.
 
 ```python
 # Create a browsing task
@@ -159,6 +161,19 @@ while True:
 
 print(result)
 ```
+
+For login-heavy flows, you can route the task through Yutori Local and use the auth-optimized browser:
+
+```python
+task = client.browsing.create(
+    task="Log in and export the latest invoice.",
+    start_url="https://example.com/login",
+    browser="local",
+    require_auth=True,
+)
+```
+
+Failed browsing tasks may include a `rejection_reason` field to explain why the task was rejected.
 
 ### Structured Output with Webhooks
 
@@ -224,6 +239,17 @@ while True:
 
 print(result)
 ```
+
+If the research task needs access to a logged-in browser session, use Yutori Local:
+
+```python
+task = client.research.create(
+    query="Review the latest updates in our vendor dashboard and summarize them.",
+    browser="local",
+)
+```
+
+Failed research tasks may include a `rejection_reason` field to explain why the task was rejected.
 
 ### Structured Output
 
@@ -323,6 +349,8 @@ scout = client.scouts.create(
     output_schema=NewsItem,  # auto-converted to JSON schema
 )
 ```
+
+Scout responses may also include `rejection_reason` when a run or configuration is rejected.
 
 <details>
 <summary>Using a JSON schema dict instead</summary>
@@ -432,11 +460,11 @@ yutori scouts delete SCOUT_ID               # Delete a scout
 
 # Browsing
 yutori browse run "extract all prices" https://example.com/products
-yutori browse run "log in and continue" https://example.com/login --require-auth
+yutori browse run "log in and continue" https://example.com/login --browser local --require-auth
 yutori browse get TASK_ID
 
 # Research
-yutori research run "latest developments in quantum computing"
+yutori research run "latest developments in quantum computing" --browser local
 yutori research get TASK_ID
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -162,14 +162,23 @@ while True:
 print(result)
 ```
 
-For login-heavy flows, you can route the task through Yutori Local and use the auth-optimized browser:
+For tasks that involve logging in on a cloud browser, use `require_auth` to pick an auth-optimized provider:
 
 ```python
 task = client.browsing.create(
     task="Log in and export the latest invoice.",
     start_url="https://example.com/login",
-    browser="local",
     require_auth=True,
+)
+```
+
+To use Yutori Local with the user's existing logged-in desktop sessions instead of the cloud:
+
+```python
+task = client.browsing.create(
+    task="Export the latest invoice from my dashboard.",
+    start_url="https://example.com/dashboard",
+    browser="local",
 )
 ```
 
@@ -460,7 +469,8 @@ yutori scouts delete SCOUT_ID               # Delete a scout
 
 # Browsing
 yutori browse run "extract all prices" https://example.com/products
-yutori browse run "log in and continue" https://example.com/login --browser local --require-auth
+yutori browse run "log in and continue" https://example.com/login --require-auth
+yutori browse run "export dashboard data" https://example.com/dashboard --browser local
 yutori browse get TASK_ID
 
 # Research

--- a/api.md
+++ b/api.md
@@ -108,9 +108,11 @@ if message.tool_calls:
 **Parameters:**
 - `messages` (Iterable[ChatCompletionMessageParam]): Chat messages following OpenAI format. Include screenshots as `image_url` content blocks.
 - `model` (str): Model ID. Default: `"n1-latest"`.
-- `**kwargs`: Additional parameters (e.g., `temperature`).
+- `**kwargs`: Additional OpenAI-compatible parameters (e.g., `temperature`, `tools`, `tool_choice`, `response_format`).
 
 **Returns:** `ChatCompletion` object from the OpenAI SDK with `choices[0].message` containing the model's response and optional `tool_calls` for browser actions.
+
+Live n1 model IDs and parameter docs are maintained at `https://docs.yutori.com/reference/n1`.
 
 ---
 
@@ -155,6 +157,7 @@ task = client.browsing.create(
     max_steps=75,                  # Optional (1-100)
     agent=None,                    # Optional
     require_auth=False,            # Optional, for login flows
+    browser=None,                  # Optional: "cloud" or "local"
     output_schema=None,            # Optional, JSON schema
     webhook_url=None,              # Optional
     webhook_format=None,           # Optional: "scout", "slack", "zapier"
@@ -167,11 +170,12 @@ task = client.browsing.create(
 - `max_steps` (int, optional): Maximum agent steps (1-100).
 - `agent` (str, optional): Agent to use. Options: `"navigator-n1-latest"`, `"claude-sonnet-4-5-computer-use-2025-01-24"`.
 - `require_auth` (bool, optional): Use auth-optimized browser for login flows.
+- `browser` (str, optional): Browser backend - `"cloud"` (default) or `"local"` for Yutori Local with the user's logged-in desktop sessions.
 - `output_schema` (dict | BaseModel, optional): JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance (auto-converted via `model_json_schema()` for v2 or `schema()` for v1).
 - `webhook_url` (str, optional): URL for completion notifications.
 - `webhook_format` (str, optional): Webhook format - `"scout"` (default), `"slack"`, or `"zapier"`.
 
-**Returns:** Dictionary containing `task_id` and task metadata.
+**Returns:** Dictionary containing `task_id` and task metadata. Failed tasks may include `rejection_reason`.
 
 #### browsing.get
 
@@ -202,6 +206,7 @@ task = client.research.create(
     query="What are the latest developments in quantum computing?",
     user_timezone="America/Los_Angeles",  # Optional
     user_location="San Francisco, CA",    # Optional
+    browser=None,                         # Optional: "cloud" or "local"
     output_schema=None,                   # Optional, JSON schema
     webhook_url=None,                     # Optional
     webhook_format=None,                  # Optional: "scout", "slack", "zapier"
@@ -212,11 +217,12 @@ task = client.research.create(
 - `query` (str): Natural language research query.
 - `user_timezone` (str, optional): Timezone, e.g., `"America/Los_Angeles"`.
 - `user_location` (str, optional): Location, e.g., `"San Francisco, CA, US"`.
+- `browser` (str, optional): Browser backend - `"cloud"` (default) or `"local"` for Yutori Local with the user's logged-in desktop sessions.
 - `output_schema` (dict | BaseModel, optional): JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance (auto-converted via `model_json_schema()` for v2 or `schema()` for v1).
 - `webhook_url` (str, optional): URL for completion notifications.
 - `webhook_format` (str, optional): Webhook format - `"scout"` (default), `"slack"`, or `"zapier"`.
 
-**Returns:** Dictionary containing `task_id` and task metadata.
+**Returns:** Dictionary containing `task_id` and task metadata. Failed tasks may include `rejection_reason`.
 
 #### research.get
 
@@ -268,7 +274,7 @@ scout = client.scouts.get("scout_id")
 **Parameters:**
 - `scout_id` (str): The unique identifier of the scout.
 
-**Returns:** Dictionary with scout details including `id`, `query`, `status`, `next_run_timestamp`.
+**Returns:** Dictionary with scout details including `id`, `query`, `status`, `next_run_timestamp`, and optional `rejection_reason`.
 
 #### scouts.create
 
@@ -299,7 +305,7 @@ scout = client.scouts.create(
 - `webhook_format` (str, optional): Webhook format - `"scout"` (default), `"slack"`, or `"zapier"`.
 - `is_public` (bool, optional): Whether the scout is publicly visible.
 
-**Returns:** Dictionary containing created scout details.
+**Returns:** Dictionary containing created scout details and optional `rejection_reason`.
 
 #### scouts.update
 
@@ -407,9 +413,9 @@ API keys start with `yt-` and can be created at [platform.yutori.com](https://pl
 
 | Command | Description |
 |---------|-------------|
-| `yutori browse run TASK URL [OPTIONS]` | Start a browsing task (`--max-steps`, `--agent`, `--require-auth` flag) |
+| `yutori browse run TASK URL [OPTIONS]` | Start a browsing task (`--max-steps`, `--agent`, `--require-auth`, `--browser`) |
 | `yutori browse get TASK_ID` | Get browsing task status and result |
-| `yutori research run QUERY [OPTIONS]` | Start a research task (`--timezone`, `--location`) |
+| `yutori research run QUERY [OPTIONS]` | Start a research task (`--timezone`, `--location`, `--browser`) |
 | `yutori research get TASK_ID` | Get research task status and result |
 | `yutori scouts list` | List scouts (`--limit`, `--status`) |
 | `yutori scouts get SCOUT_ID` | Get scout details |

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -197,6 +197,27 @@ class TestAsyncBrowsingNamespace:
                 )
                 assert result["task_id"] == "task-123"
 
+    async def test_browsing_create_with_local_browser_and_auth(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"task_id": "task-456"}'
+        mock_response.json.return_value = {"task_id": "task-456"}
+
+        with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
+            async with AsyncYutoriClient(api_key="yt-test") as client:
+                result = await client.browsing.create(
+                    task="Log in and export data",
+                    start_url="https://example.com/login",
+                    require_auth=True,
+                    browser="local",
+                    webhook_format="zapier",
+                )
+                assert result["task_id"] == "task-456"
+                payload = mock_post.call_args[1]["json"]
+                assert payload["require_auth"] is True
+                assert payload["browser"] == "local"
+                assert payload["webhook_format"] == "zapier"
+
     async def test_browsing_get(self):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
@@ -207,6 +228,22 @@ class TestAsyncBrowsingNamespace:
             async with AsyncYutoriClient(api_key="yt-test") as client:
                 result = await client.browsing.get("task-123")
                 assert result["status"] == "succeeded"
+
+    async def test_browsing_get_with_rejection_reason(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"task_id": "task-123", "status": "failed", "rejection_reason": "billing_limit_reached"}'
+        mock_response.json.return_value = {
+            "task_id": "task-123",
+            "status": "failed",
+            "rejection_reason": "billing_limit_reached",
+        }
+
+        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
+            async with AsyncYutoriClient(api_key="yt-test") as client:
+                result = await client.browsing.get("task-123")
+                assert result["status"] == "failed"
+                assert result["rejection_reason"] == "billing_limit_reached"
 
 
 @pytest.mark.asyncio
@@ -222,6 +259,23 @@ class TestAsyncResearchNamespace:
                 result = await client.research.create(query="Find AI funding")
                 assert result["task_id"] == "research-123"
 
+    async def test_research_create_with_local_browser(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"task_id": "research-456"}'
+        mock_response.json.return_value = {"task_id": "research-456"}
+
+        with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
+            async with AsyncYutoriClient(api_key="yt-test") as client:
+                result = await client.research.create(
+                    query="Research a vendor portal behind login",
+                    browser="local",
+                )
+                assert result["task_id"] == "research-456"
+                payload = mock_post.call_args[1]["json"]
+                assert payload["query"] == "Research a vendor portal behind login"
+                assert payload["browser"] == "local"
+
     async def test_research_get(self):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
@@ -232,6 +286,22 @@ class TestAsyncResearchNamespace:
             async with AsyncYutoriClient(api_key="yt-test") as client:
                 result = await client.research.get("research-123")
                 assert result["status"] == "succeeded"
+
+    async def test_research_get_with_rejection_reason(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"task_id": "research-123", "status": "failed", "rejection_reason": "rate_limit_exceeded"}'
+        mock_response.json.return_value = {
+            "task_id": "research-123",
+            "status": "failed",
+            "rejection_reason": "rate_limit_exceeded",
+        }
+
+        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
+            async with AsyncYutoriClient(api_key="yt-test") as client:
+                result = await client.research.get("research-123")
+                assert result["status"] == "failed"
+                assert result["rejection_reason"] == "rate_limit_exceeded"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 """Tests for CLI entrypoint behavior."""
 
+from unittest.mock import MagicMock, patch
+
 from typer.testing import CliRunner
 
 from yutori import __version__
@@ -18,3 +20,159 @@ def test_version_subcommand():
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
     assert result.stdout.strip() == f"yutori {__version__}"
+
+
+def test_browse_run_forwards_local_browser_and_auth():
+    client = MagicMock()
+    client.browsing.create.return_value = {"task_id": "task-123", "status": "queued"}
+
+    with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
+        result = runner.invoke(
+            app,
+            ["browse", "run", "log in and continue", "https://example.com/login", "--browser", "local", "--require-auth"],
+        )
+
+    assert result.exit_code == 0
+    client.browsing.create.assert_called_once_with(
+        task="log in and continue",
+        start_url="https://example.com/login",
+        max_steps=None,
+        agent=None,
+        require_auth=True,
+        browser="local",
+    )
+    client.close.assert_called_once()
+    assert "Browsing task submitted" in result.stdout
+    assert "Rejection Reason" not in result.stdout
+
+
+def test_research_run_forwards_local_browser():
+    client = MagicMock()
+    client.research.create.return_value = {"task_id": "research-123", "status": "queued"}
+
+    with patch("yutori.cli.commands.research.get_authenticated_client", return_value=client):
+        result = runner.invoke(
+            app,
+            ["research", "run", "latest AI announcements", "--browser", "local", "--timezone", "America/Los_Angeles"],
+        )
+
+    assert result.exit_code == 0
+    client.research.create.assert_called_once_with(
+        query="latest AI announcements",
+        user_timezone="America/Los_Angeles",
+        user_location=None,
+        browser="local",
+    )
+    client.close.assert_called_once()
+    assert "Research task submitted" in result.stdout
+    assert "Rejection Reason" not in result.stdout
+
+
+def test_browse_run_handles_failed_create_response():
+    client = MagicMock()
+    client.browsing.create.return_value = {
+        "task_id": "task-123",
+        "status": "failed",
+        "rejection_reason": "billing_limit_reached",
+    }
+
+    with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
+        result = runner.invoke(
+            app,
+            ["browse", "run", "click the button", "https://example.com"],
+        )
+
+    assert result.exit_code == 0
+    assert "Browsing task failed to start" in result.stdout
+    assert "Rejection Reason: billing_limit_reached" in result.stdout
+    client.close.assert_called_once()
+
+
+def test_research_run_handles_failed_create_response():
+    client = MagicMock()
+    client.research.create.return_value = {
+        "task_id": "r-1",
+        "status": "failed",
+    }
+
+    with patch("yutori.cli.commands.research.get_authenticated_client", return_value=client):
+        result = runner.invoke(
+            app,
+            ["research", "run", "latest AI announcements"],
+        )
+
+    assert result.exit_code == 0
+    assert "Research task failed to start" in result.stdout
+    assert "Rejection Reason" not in result.stdout
+    client.close.assert_called_once()
+
+
+def test_browse_get_shows_rejection_reason():
+    client = MagicMock()
+    client.browsing.get.return_value = {
+        "task_id": "task-123",
+        "status": "failed",
+        "rejection_reason": "billing_limit_reached",
+    }
+
+    with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["browse", "get", "task-123"])
+
+    assert result.exit_code == 0
+    assert "Rejection Reason: billing_limit_reached" in result.stdout
+    client.close.assert_called_once()
+
+
+def test_research_get_shows_rejection_reason():
+    client = MagicMock()
+    client.research.get.return_value = {
+        "task_id": "research-123",
+        "status": "failed",
+        "rejection_reason": "rate_limit_exceeded",
+    }
+
+    with patch("yutori.cli.commands.research.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["research", "get", "research-123"])
+
+    assert result.exit_code == 0
+    assert "Rejection Reason: rate_limit_exceeded" in result.stdout
+    client.close.assert_called_once()
+
+
+def test_scouts_get_shows_rejection_reason():
+    client = MagicMock()
+    client.scouts.get.return_value = {
+        "id": "scout-123",
+        "query": "monitor releases",
+        "status": "paused",
+        "rejection_reason": "invalid_query",
+    }
+
+    with patch("yutori.cli.commands.scouts.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["scouts", "get", "scout-123"])
+
+    assert result.exit_code == 0
+    assert "Rejection Reason: invalid_query" in result.stdout
+    client.close.assert_called_once()
+
+
+def test_scouts_list_shows_rejection_reason_column():
+    client = MagicMock()
+    client.scouts.list.return_value = {
+        "scouts": [
+            {
+                "id": "scout-123",
+                "query": "monitor releases",
+                "status": "paused",
+                "output_interval": 3600,
+                "rejection_reason": "invalid_query",
+            }
+        ]
+    }
+
+    with patch("yutori.cli.commands.scouts.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["scouts", "list"])
+
+    assert result.exit_code == 0
+    assert "invalid_query" in result.stdout
+    client.close.assert_called_once()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -244,6 +244,26 @@ class TestBrowsingNamespace:
             assert payload["start_url"] == "https://example.com"
             assert payload["max_steps"] == 10
 
+    def test_browsing_create_with_local_browser_and_auth(self, client):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"task_id": "task-456", "status": "queued"}'
+        mock_response.json.return_value = {"task_id": "task-456", "status": "queued"}
+
+        with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
+            result = client.browsing.create(
+                task="Log in and download the invoice",
+                start_url="https://example.com/login",
+                require_auth=True,
+                browser="local",
+                webhook_format="zapier",
+            )
+            assert result["task_id"] == "task-456"
+            payload = mock_post.call_args[1]["json"]
+            assert payload["require_auth"] is True
+            assert payload["browser"] == "local"
+            assert payload["webhook_format"] == "zapier"
+
     def test_browsing_get(self, client):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
@@ -253,6 +273,21 @@ class TestBrowsingNamespace:
         with patch.object(httpx.Client, "get", return_value=mock_response):
             result = client.browsing.get("task-123")
             assert result["status"] == "succeeded"
+
+    def test_browsing_get_with_rejection_reason(self, client):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"task_id": "task-123", "status": "failed", "rejection_reason": "billing_limit_reached"}'
+        mock_response.json.return_value = {
+            "task_id": "task-123",
+            "status": "failed",
+            "rejection_reason": "billing_limit_reached",
+        }
+
+        with patch.object(httpx.Client, "get", return_value=mock_response):
+            result = client.browsing.get("task-123")
+            assert result["status"] == "failed"
+            assert result["rejection_reason"] == "billing_limit_reached"
 
 
 class TestResearchNamespace:
@@ -271,6 +306,22 @@ class TestResearchNamespace:
             payload = mock_post.call_args[1]["json"]
             assert payload["query"] == "Find AI startup funding"
 
+    def test_research_create_with_local_browser(self, client):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"task_id": "research-456", "status": "queued"}'
+        mock_response.json.return_value = {"task_id": "research-456", "status": "queued"}
+
+        with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
+            result = client.research.create(
+                query="Research competitors with logged-in dashboards",
+                browser="local",
+            )
+            assert result["task_id"] == "research-456"
+            payload = mock_post.call_args[1]["json"]
+            assert payload["query"] == "Research competitors with logged-in dashboards"
+            assert payload["browser"] == "local"
+
     def test_research_get(self, client):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
@@ -280,6 +331,21 @@ class TestResearchNamespace:
         with patch.object(httpx.Client, "get", return_value=mock_response):
             result = client.research.get("research-123")
             assert result["status"] == "succeeded"
+
+    def test_research_get_with_rejection_reason(self, client):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"task_id": "research-123", "status": "failed", "rejection_reason": "rate_limit_exceeded"}'
+        mock_response.json.return_value = {
+            "task_id": "research-123",
+            "status": "failed",
+            "rejection_reason": "rate_limit_exceeded",
+        }
+
+        with patch.object(httpx.Client, "get", return_value=mock_response):
+            result = client.research.get("research-123")
+            assert result["status"] == "failed"
+            assert result["rejection_reason"] == "rate_limit_exceeded"
 
 
 class TestPydanticSchemaIntegration:

--- a/yutori/_async/research.py
+++ b/yutori/_async/research.py
@@ -25,6 +25,7 @@ class AsyncResearchNamespace:
         *,
         user_timezone: str | None = None,
         user_location: str | None = None,
+        browser: str | None = None,
         output_schema: object | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
@@ -37,6 +38,8 @@ class AsyncResearchNamespace:
             query: Natural language research query.
             user_timezone: e.g., "America/Los_Angeles".
             user_location: e.g., "San Francisco, CA, US".
+            browser: "cloud" (default) or "local" to use the desktop app with
+                     the user's logged-in sessions.
             output_schema: JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance.
             webhook_url: URL for completion notifications.
             webhook_format: "scout" (default), "slack", or "zapier".
@@ -50,6 +53,8 @@ class AsyncResearchNamespace:
             payload["user_timezone"] = user_timezone
         if user_location is not None:
             payload["user_location"] = user_location
+        if browser is not None:
+            payload["browser"] = browser
         resolved_schema = resolve_output_schema(output_schema)
         if resolved_schema is not None:
             payload["output_schema"] = resolved_schema

--- a/yutori/_sync/research.py
+++ b/yutori/_sync/research.py
@@ -25,6 +25,7 @@ class ResearchNamespace:
         *,
         user_timezone: str | None = None,
         user_location: str | None = None,
+        browser: str | None = None,
         output_schema: object | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
@@ -37,6 +38,8 @@ class ResearchNamespace:
             query: Natural language research query.
             user_timezone: e.g., "America/Los_Angeles".
             user_location: e.g., "San Francisco, CA, US".
+            browser: "cloud" (default) or "local" to use the desktop app with
+                     the user's logged-in sessions.
             output_schema: JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance.
             webhook_url: URL for completion notifications.
             webhook_format: "scout" (default), "slack", or "zapier".
@@ -50,6 +53,8 @@ class ResearchNamespace:
             payload["user_timezone"] = user_timezone
         if user_location is not None:
             payload["user_location"] = user_location
+        if browser is not None:
+            payload["browser"] = browser
         resolved_schema = resolve_output_schema(output_schema)
         if resolved_schema is not None:
             payload["output_schema"] = resolved_schema

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 
 from yutori.auth.credentials import resolve_api_key
 
@@ -22,3 +23,23 @@ def get_authenticated_client() -> Any:
         raise typer.Exit(1)
 
     return YutoriClient(api_key=api_key)
+
+
+def print_rejection_reason(console: Console, result: dict[str, Any]) -> None:
+    """Print rejection_reason from an API response if present."""
+    reason = result.get("rejection_reason")
+    if reason:
+        console.print(f"  Rejection Reason: {escape(str(reason))}")
+
+
+def print_task_submission_result(console: Console, task_type: str, result: dict[str, Any]) -> None:
+    """Print a task creation response without implying success on failed creates."""
+    status = result.get("status", "N/A")
+    if status == "failed":
+        console.print(f"\n[red]{task_type} task failed to start.[/red]")
+    else:
+        console.print(f"\n[green]{task_type} task submitted.[/green]")
+
+    console.print(f"  Task ID: {result.get('task_id', 'N/A')}")
+    console.print(f"  Status: {status}")
+    print_rejection_reason(console, result)

--- a/yutori/cli/commands/browse.py
+++ b/yutori/cli/commands/browse.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import typer
 from rich.console import Console
 
-from yutori.cli.commands import get_authenticated_client
+from yutori.cli.commands import (
+    get_authenticated_client,
+    print_rejection_reason,
+    print_task_submission_result,
+)
 
 app = typer.Typer(help="Run and manage browsing tasks")
 console = Console()
@@ -18,6 +22,7 @@ def run(
     max_steps: int = typer.Option(None, "--max-steps", help="Maximum number of agent steps"),
     agent: str = typer.Option(None, "--agent", help="Agent to use"),
     require_auth: bool = typer.Option(None, "--require-auth", help="Use auth-optimized browser for login flows"),
+    browser: str = typer.Option(None, "--browser", help="Browser backend: cloud or local"),
 ) -> None:
     """Start a new browsing task."""
     client = get_authenticated_client()
@@ -29,11 +34,10 @@ def run(
             max_steps=max_steps,
             agent=agent,
             require_auth=require_auth,
+            browser=browser,
         )
 
-        console.print("\n[green]Browsing task created![/green]")
-        console.print(f"  Task ID: {result.get('task_id', 'N/A')}")
-        console.print(f"  Status: {result.get('status', 'N/A')}")
+        print_task_submission_result(console, "Browsing", result)
     finally:
         client.close()
 
@@ -50,6 +54,7 @@ def get(
 
         console.print(f"\n[bold]Browsing Task: {result.get('task_id', task_id)}[/bold]\n")
         console.print(f"  Status: {result.get('status', 'N/A')}")
+        print_rejection_reason(console, result)
 
         if result.get("start_url"):
             console.print(f"  Start URL: {result['start_url']}")

--- a/yutori/cli/commands/research.py
+++ b/yutori/cli/commands/research.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 
 from yutori.cli.commands import (
     get_authenticated_client,

--- a/yutori/cli/commands/research.py
+++ b/yutori/cli/commands/research.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import typer
 from rich.console import Console
-from rich.markup import escape
 
-from yutori.cli.commands import get_authenticated_client
+from yutori.cli.commands import (
+    get_authenticated_client,
+    print_rejection_reason,
+    print_task_submission_result,
+)
 
 app = typer.Typer(help="Run and manage research tasks")
 console = Console()
@@ -17,6 +20,7 @@ def run(
     query: str = typer.Argument(help="Natural language research query"),
     timezone: str = typer.Option(None, "--timezone", "-tz", help="e.g., America/Los_Angeles"),
     location: str = typer.Option(None, "--location", help="e.g., San Francisco, CA, US"),
+    browser: str = typer.Option(None, "--browser", help="Browser backend: cloud or local"),
 ) -> None:
     """Start a new research task."""
     client = get_authenticated_client()
@@ -26,11 +30,10 @@ def run(
             query=query,
             user_timezone=timezone,
             user_location=location,
+            browser=browser,
         )
 
-        console.print("\n[green]Research task created![/green]")
-        console.print(f"  Task ID: {result.get('task_id', 'N/A')}")
-        console.print(f"  Status: {result.get('status', 'N/A')}")
+        print_task_submission_result(console, "Research", result)
     finally:
         client.close()
 
@@ -47,6 +50,7 @@ def get(
 
         console.print(f"\n[bold]Research Task: {result.get('task_id', task_id)}[/bold]\n")
         console.print(f"  Status: {result.get('status', 'N/A')}")
+        print_rejection_reason(console, result)
 
         if result.get("query"):
             console.print(f"  Query: {escape(result['query'])}")

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -54,7 +54,7 @@ def list_scouts(
                 query,
                 scout.get("status", "unknown"),
                 interval_str,
-                escape(scout.get("rejection_reason", "")),
+                escape(scout.get("rejection_reason") or ""),
             )
 
         console.print(table)
@@ -121,10 +121,14 @@ def create(
             user_timezone=timezone,
         )
 
-        console.print("\n[green]Scout created successfully![/green]")
+        status = result.get("status", "N/A")
+        if status == "failed":
+            console.print("\n[red]Scout creation failed.[/red]")
+        else:
+            console.print("\n[green]Scout created successfully![/green]")
         console.print(f"  ID: {result.get('id', 'N/A')}")
         console.print(f"  Query: {escape(result.get('query', query))}")
-        console.print(f"  Status: {result.get('status', 'N/A')}")
+        console.print(f"  Status: {status}")
         print_rejection_reason(console, result)
     finally:
         client.close()

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from rich.markup import escape
 from rich.table import Table
 
-from yutori.cli.commands import get_authenticated_client
+from yutori.cli.commands import get_authenticated_client, print_rejection_reason
 
 app = typer.Typer(help="Manage scouts")
 console = Console()
@@ -34,6 +34,7 @@ def list_scouts(
         table.add_column("Query", max_width=50)
         table.add_column("Status", style="green")
         table.add_column("Interval")
+        table.add_column("Reason", max_width=32)
 
         for scout in scouts:
             interval_secs = scout.get("output_interval") or 0
@@ -53,6 +54,7 @@ def list_scouts(
                 query,
                 scout.get("status", "unknown"),
                 interval_str,
+                escape(scout.get("rejection_reason", "")),
             )
 
         console.print(table)
@@ -73,6 +75,7 @@ def get(
         console.print(f"\n[bold]Scout: {scout.get('id', scout_id)}[/bold]\n")
         console.print(f"  Query: {escape(scout.get('query', 'N/A'))}")
         console.print(f"  Status: {scout.get('status', 'N/A')}")
+        print_rejection_reason(console, scout)
 
         interval_secs = scout.get("output_interval") or 0
         if interval_secs >= 86400:
@@ -122,6 +125,7 @@ def create(
         console.print(f"  ID: {result.get('id', 'N/A')}")
         console.print(f"  Query: {escape(result.get('query', query))}")
         console.print(f"  Status: {result.get('status', 'N/A')}")
+        print_rejection_reason(console, result)
     finally:
         client.close()
 


### PR DESCRIPTION
## Summary
- Add `browser` parameter to `research.create()` (sync + async) for Yutori Local support
- Add `--browser` flag to `yutori browse run` and `yutori research run` CLI commands
- Surface `rejection_reason` in all CLI commands with proper Rich markup escaping
- Extract shared `print_rejection_reason` and `print_task_submission_result` CLI helpers
- Document n1 experimental models, `tools`/`tool_choice`/`response_format` params, and `browser`

## Test plan
- [x] `pytest tests/` — 204 passed
- [x] Manual: `yutori research run "test" --browser local` — task queued successfully
- [x] Manual: `yutori browse run "test" https://example.com --browser local` — task queued successfully
- [x] Manual: `yutori browse run "test" https://example.com --require-auth` — task queued successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive (new optional `browser` param/flag) and mostly affect request payload shaping and CLI output formatting, with extensive test coverage.
> 
> **Overview**
> Adds optional `browser="local"` support to `research.create()` (sync + async) and exposes `--browser` on the `yutori research run` and `yutori browse run` CLI commands to route tasks through Yutori Local when desired.
> 
> Updates CLI output to consistently surface API `rejection_reason` (with Rich markup escaping) and to avoid printing success messaging when task creation returns `status="failed"`; `scouts` listing now includes a *Reason* column and `scouts create/get` also display rejection details. Docs are updated to mention n1 parameter passthrough (`tools`, `tool_choice`, `response_format`), live model docs, and the new `browser`/`rejection_reason` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecf6766693658d7a5882f7f5db87c8abcb8aebf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->