### PR TITLE
Add n1 screenshot preparation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ if message.tool_calls:
         print(f"Arguments: {tool_call.function.arguments}")
 ```
 
+For Playwright users, the SDK provides a screenshot helper that captures and encodes images optimized for n1:
+
+```python
+from yutori.n1 import aplaywright_screenshot_to_data_url
+
+image_url = await aplaywright_screenshot_to_data_url(page)
+
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe the screenshot and search for Yutori."},
+            {"type": "image_url", "image_url": {"url": image_url}},
+        ],
+    }
+]
+```
+
+Install the optional image dependency with `pip install "yutori[n1]"` if you want to use these screenshot helpers.
+
 For screenshot-heavy agent loops, the SDK also provides opt-in trimming helpers under `yutori.n1`:
 
 ```python

--- a/api.md
+++ b/api.md
@@ -125,10 +125,15 @@ Opt-in helper utilities for custom n1 agent loops. These do not change the raw `
 | `trimmed_messages_to_fit(messages, max_bytes=..., keep_recent=...)` | Return a trimmed copy of the messages list without mutating caller state. |
 | `create_trimmed(completions, messages, ...)` | Trim a copy of the messages list, then call sync chat completions. |
 | `acreate_trimmed(completions, messages, ...)` | Async version of `create_trimmed(...)`. |
+| `screenshot_to_data_url(image_bytes, ...)` | Convert screenshot bytes into a `data:image/webp;base64,...` URL optimized for n1. |
+| `playwright_screenshot_to_data_url(page, ...)` | Capture and convert a sync Playwright screenshot optimized for n1. |
+| `aplaywright_screenshot_to_data_url(page, ...)` | Async version of `playwright_screenshot_to_data_url(...)`. |
 | `extract_text_content(content)` | Normalize assistant content across strings, text blocks, and object-backed forms, returning joined text or `None`. |
 | `RunHooksBase` | Async no-op lifecycle hook base class with `on_agent_start`, `on_llm_start`, `on_llm_end`, `on_tool_start`, `on_tool_end`, and `on_agent_end`. |
 
 `RunHooksBase` mirrors the lifecycle phases of higher-level agent loops, but it is not wired into `client.chat` automatically. It is intended for consumers building their own orchestration, tracing, or UI layers around n1.
+
+Install the optional image dependency with `pip install "yutori[n1]"` to use the screenshot conversion helpers.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ uv run playwright install chromium
 
 ## n1.py
 
-A complete browsing agent using the n1 API. Launches a local Playwright browser, takes screenshots, sends them to n1 to get predicted actions, and executes them until the task is complete. The example keeps its own long-lived message history bounded with `estimate_messages_size_bytes(...)` plus `trimmed_messages_to_fit(...)`, then still ends with a standard `client.chat.completions.create(...)` call.
+A complete browsing agent using the n1 API. Launches a local Playwright browser, captures screenshots through `yutori.n1.aplaywright_screenshot_to_data_url(...)`, sends them to n1, and executes predicted actions until the task is complete. The example keeps its own long-lived message history bounded with `estimate_messages_size_bytes(...)` plus `trimmed_messages_to_fit(...)`, then still ends with a standard `client.chat.completions.create(...)` call.
 
 ```bash
 uv run python examples/n1.py --task "List the team member names" --start-url "https://www.yutori.com"

--- a/examples/n1.py
+++ b/examples/n1.py
@@ -16,8 +16,6 @@ Usage:
 
 import argparse
 import asyncio
-import base64
-import io
 import json
 import os
 import sys
@@ -26,13 +24,12 @@ from loguru import logger
 from openai import APIConnectionError, APITimeoutError, InternalServerError, RateLimitError
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from PIL import Image
 from playwright.async_api import Browser, Page, async_playwright
 from pydantic import BaseModel, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
-from yutori.n1 import estimate_messages_size_bytes, trimmed_messages_to_fit
+from yutori.n1 import aplaywright_screenshot_to_data_url, estimate_messages_size_bytes, trimmed_messages_to_fit
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
@@ -159,15 +156,10 @@ class Agent:
             self._browser = None
 
     async def _take_screenshot(self) -> str:
-        screenshot_bytes = await self._page.screenshot(type="jpeg", quality=75)
-        img = Image.open(io.BytesIO(screenshot_bytes))
-        viewport = (self.viewport_width, self.viewport_height)
-        if img.size != viewport:
-            img = img.resize(viewport, Image.LANCZOS)
-        webp_buffer = io.BytesIO()
-        img.save(webp_buffer, format="WEBP", quality=90)
-        webp_bytes = webp_buffer.getvalue()
-        return base64.b64encode(webp_bytes).decode("utf-8")
+        return await aplaywright_screenshot_to_data_url(
+            self._page,
+            resize_to=(self.viewport_width, self.viewport_height),
+        )
 
     def _convert_coordinates(self, rel_x: int, rel_y: int) -> tuple[int, int]:
         abs_x = int(rel_x / 1000 * self.viewport_width)
@@ -226,7 +218,7 @@ class Agent:
         )
 
     async def _predict(self) -> ChatCompletion:
-        screenshot_b64 = await self._take_screenshot()
+        screenshot_url = await self._take_screenshot()
         current_url = self._page.url
 
         last_content = self._messages[-1]["content"]
@@ -235,7 +227,7 @@ class Agent:
         last_content.append(
             {
                 "type": "image_url",
-                "image_url": {"url": f"data:image/webp;base64,{screenshot_b64}", "detail": "high"},
+                "image_url": {"url": screenshot_url, "detail": "high"},
             }
         )
 

--- a/examples/n1_custom_tools.py
+++ b/examples/n1_custom_tools.py
@@ -14,8 +14,6 @@ Usage:
 
 import argparse
 import asyncio
-import base64
-import io
 import json
 import os
 import re
@@ -26,12 +24,12 @@ from loguru import logger
 from openai import APIConnectionError, APITimeoutError, InternalServerError, RateLimitError
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from PIL import Image
 from playwright.async_api import Browser, Page, async_playwright
 from pydantic import BaseModel, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
+from yutori.n1 import aplaywright_screenshot_to_data_url
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
@@ -221,15 +219,10 @@ class Agent:
             self._browser = None
 
     async def _take_screenshot(self) -> str:
-        screenshot_bytes = await self._page.screenshot(type="jpeg", quality=75)
-        img = Image.open(io.BytesIO(screenshot_bytes))
-        viewport = (self.viewport_width, self.viewport_height)
-        if img.size != viewport:
-            img = img.resize(viewport, Image.LANCZOS)
-        webp_buffer = io.BytesIO()
-        img.save(webp_buffer, format="WEBP", quality=90)
-        webp_bytes = webp_buffer.getvalue()
-        return base64.b64encode(webp_bytes).decode("utf-8")
+        return await aplaywright_screenshot_to_data_url(
+            self._page,
+            resize_to=(self.viewport_width, self.viewport_height),
+        )
 
     def _convert_coordinates(self, rel_x: int, rel_y: int) -> tuple[int, int]:
         abs_x = int(rel_x / 1000 * self.viewport_width)
@@ -279,7 +272,7 @@ class Agent:
         )
 
     async def _predict(self) -> ChatCompletion:
-        screenshot_b64 = await self._take_screenshot()
+        screenshot_url = await self._take_screenshot()
         current_url = self._page.url
 
         last_content = self._messages[-1]["content"]
@@ -288,7 +281,7 @@ class Agent:
         last_content.append(
             {
                 "type": "image_url",
-                "image_url": {"url": f"data:image/webp;base64,{screenshot_b64}", "detail": "high"},
+                "image_url": {"url": screenshot_url, "detail": "high"},
             }
         )
 

--- a/examples/n1_memo.py
+++ b/examples/n1_memo.py
@@ -20,8 +20,6 @@ Usage:
 
 import argparse
 import asyncio
-import base64
-import io
 import json
 import os
 import sys
@@ -32,12 +30,12 @@ from loguru import logger
 from openai import APIConnectionError, APITimeoutError, InternalServerError, RateLimitError
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from PIL import Image
 from playwright.async_api import Browser, Page, async_playwright
 from pydantic import BaseModel, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
+from yutori.n1 import aplaywright_screenshot_to_data_url
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
@@ -272,15 +270,10 @@ class Agent:
             self._browser = None
 
     async def _take_screenshot(self) -> str:
-        screenshot_bytes = await self._page.screenshot(type="jpeg", quality=75)
-        img = Image.open(io.BytesIO(screenshot_bytes))
-        viewport = (self.viewport_width, self.viewport_height)
-        if img.size != viewport:
-            img = img.resize(viewport, Image.LANCZOS)
-        webp_buffer = io.BytesIO()
-        img.save(webp_buffer, format="WEBP", quality=90)
-        webp_bytes = webp_buffer.getvalue()
-        return base64.b64encode(webp_bytes).decode("utf-8")
+        return await aplaywright_screenshot_to_data_url(
+            self._page,
+            resize_to=(self.viewport_width, self.viewport_height),
+        )
 
     def _convert_coordinates(self, rel_x: int, rel_y: int) -> tuple[int, int]:
         abs_x = int(rel_x / 1000 * self.viewport_width)
@@ -330,7 +323,7 @@ class Agent:
         )
 
     async def _predict(self) -> ChatCompletion:
-        screenshot_b64 = await self._take_screenshot()
+        screenshot_url = await self._take_screenshot()
         current_url = self._page.url
 
         last_content = self._messages[-1]["content"]
@@ -339,7 +332,7 @@ class Agent:
         last_content.append(
             {
                 "type": "image_url",
-                "image_url": {"url": f"data:image/webp;base64,{screenshot_b64}", "detail": "high"},
+                "image_url": {"url": screenshot_url, "detail": "high"},
             }
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.4.7"
+version = "0.4.8"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ yutori = "yutori.cli.main:app"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "ruff>=0.1"]
+n1 = ["pillow>=10.0.0"]
 examples = [
     "loguru>=0.7.0",
     "pillow>=10.0.0",

--- a/tests/test_n1_images.py
+++ b/tests/test_n1_images.py
@@ -1,0 +1,110 @@
+"""Tests for yutori.n1.images."""
+
+import base64
+import io
+
+import pytest
+from PIL import Image
+
+from yutori.n1.images import (
+    DEFAULT_PLAYWRIGHT_SCREENSHOT_QUALITY,
+    DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
+    _default_webp_quality,
+    aplaywright_screenshot_to_data_url,
+    playwright_screenshot_to_data_url,
+    screenshot_to_data_url,
+)
+
+
+def _image_bytes(fmt: str, size: tuple[int, int] = (32, 20), color=(10, 20, 30)) -> bytes:
+    image = Image.new("RGB", size, color=color)
+    buffer = io.BytesIO()
+    save_kwargs = {"format": fmt}
+    if fmt.upper() in {"JPEG", "JPG"}:
+        save_kwargs["quality"] = DEFAULT_PLAYWRIGHT_SCREENSHOT_QUALITY
+    image.save(buffer, **save_kwargs)
+    return buffer.getvalue()
+
+
+class TestDefaultWebpQuality:
+    def test_prefers_lower_quality_for_png_sources(self):
+        assert _default_webp_quality("PNG") == 30
+
+    def test_prefers_default_quality_for_jpeg_sources(self):
+        assert _default_webp_quality("JPEG") == 90
+
+
+class TestScreenshotToDataUrl:
+    def test_converts_png_bytes_to_webp_data_url(self):
+        image_url = screenshot_to_data_url(_image_bytes("PNG"), resize_to=(64, 40))
+
+        assert image_url.startswith("data:image/webp;base64,")
+
+        encoded = image_url.removeprefix("data:image/webp;base64,")
+        with Image.open(io.BytesIO(base64.b64decode(encoded))) as converted:
+            assert converted.format == "WEBP"
+            assert converted.size == (64, 40)
+
+    def test_skips_resize_when_image_matches_target(self):
+        target = (64, 40)
+        image_url = screenshot_to_data_url(_image_bytes("PNG", size=target), resize_to=target)
+
+        encoded = image_url.removeprefix("data:image/webp;base64,")
+        with Image.open(io.BytesIO(base64.b64decode(encoded))) as converted:
+            assert converted.size == target
+
+    def test_raises_when_pillow_missing(self, monkeypatch):
+        import yutori.n1.images as images_mod
+
+        original = images_mod._require_pillow
+
+        def mock_require_pillow():
+            raise ImportError("n1 screenshot helpers require Pillow. Install with: pip install 'yutori[n1]'")
+
+        monkeypatch.setattr(images_mod, "_require_pillow", mock_require_pillow)
+        with pytest.raises(ImportError, match="yutori\\[n1\\]"):
+            screenshot_to_data_url(b"fake")
+        monkeypatch.setattr(images_mod, "_require_pillow", original)
+
+
+class TestPlaywrightScreenshotHelpers:
+    def test_sync_helper_uses_sdk_capture_policy(self):
+        class FakePage:
+            def __init__(self):
+                self.calls: list[dict[str, int | str | None]] = []
+
+            def screenshot(self, *, type=None, quality=None) -> bytes:
+                self.calls.append({"type": type, "quality": quality})
+                return _image_bytes("JPEG")
+
+        page = FakePage()
+        image_url = playwright_screenshot_to_data_url(page, resize_to=(1280, 800))
+
+        assert page.calls == [
+            {
+                "type": DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
+                "quality": DEFAULT_PLAYWRIGHT_SCREENSHOT_QUALITY,
+            }
+        ]
+        assert image_url.startswith("data:image/webp;base64,")
+
+    @pytest.mark.asyncio
+    async def test_async_helper_uses_sdk_capture_policy(self):
+        class FakeAsyncPage:
+            def __init__(self):
+                self.calls: list[dict[str, int | str | None]] = []
+
+            async def screenshot(self, *, type=None, quality=None) -> bytes:
+                self.calls.append({"type": type, "quality": quality})
+                return _image_bytes("JPEG")
+
+        page = FakeAsyncPage()
+        image_url = await aplaywright_screenshot_to_data_url(page, resize_to=(1280, 800))
+
+        assert page.calls == [
+            {
+                "type": DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
+                "quality": DEFAULT_PLAYWRIGHT_SCREENSHOT_QUALITY,
+            }
+        ]
+        assert image_url.startswith("data:image/webp;base64,")

--- a/yutori/n1/__init__.py
+++ b/yutori/n1/__init__.py
@@ -1,6 +1,7 @@
 """Utilities for building agents with the Yutori n1 API.
 
 Provides reusable helpers for common patterns in n1 agent loops:
+- Screenshot preparation: capture and encode screenshots as optimized WebP data URLs
 - Payload management: trim old screenshots to stay within API size limits
 - Loop helpers: create trimmed requests without mutating caller state
 """
@@ -9,14 +10,22 @@ from __future__ import annotations
 
 from .content import extract_text_content
 from .hooks import RunHooksBase
+from .images import (
+    aplaywright_screenshot_to_data_url,
+    playwright_screenshot_to_data_url,
+    screenshot_to_data_url,
+)
 from .loop import acreate_trimmed, create_trimmed
 from .payload import estimate_messages_size_bytes, trim_images_to_fit, trimmed_messages_to_fit
 
 __all__ = [
     "acreate_trimmed",
+    "aplaywright_screenshot_to_data_url",
     "extract_text_content",
     "create_trimmed",
+    "playwright_screenshot_to_data_url",
     "RunHooksBase",
+    "screenshot_to_data_url",
     "estimate_messages_size_bytes",
     "trim_images_to_fit",
     "trimmed_messages_to_fit",

--- a/yutori/n1/images.py
+++ b/yutori/n1/images.py
@@ -1,0 +1,108 @@
+"""Screenshot preparation helpers for n1 image inputs."""
+
+from __future__ import annotations
+
+import base64
+import io
+from typing import Protocol
+
+DEFAULT_SCREENSHOT_SIZE = (1280, 800)
+DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE = "jpeg"
+DEFAULT_PLAYWRIGHT_SCREENSHOT_QUALITY = 75
+DEFAULT_WEBP_QUALITY = 90
+DEFAULT_WEBP_QUALITY_FOR_PNG = 30
+
+
+class SupportsSyncScreenshot(Protocol):
+    """A sync screenshot producer such as a Playwright sync page."""
+
+    def screenshot(self, *, type: str | None = None, quality: int | None = None) -> bytes:
+        """Capture a screenshot and return image bytes."""
+
+
+class SupportsAsyncScreenshot(Protocol):
+    """An async screenshot producer such as a Playwright async page."""
+
+    async def screenshot(self, *, type: str | None = None, quality: int | None = None) -> bytes:
+        """Capture a screenshot and return image bytes."""
+
+
+def _default_webp_quality(source_format: str | None) -> int:
+    normalized = (source_format or "").upper()
+    if normalized == "PNG":
+        return DEFAULT_WEBP_QUALITY_FOR_PNG
+    return DEFAULT_WEBP_QUALITY
+
+
+def _require_pillow():
+    try:
+        from PIL import Image
+    except ImportError as exc:
+        raise ImportError("n1 screenshot helpers require Pillow. Install with: pip install 'yutori[n1]'") from exc
+    return Image
+
+
+def screenshot_to_data_url(
+    image_bytes: bytes,
+    *,
+    resize_to: tuple[int, int] = DEFAULT_SCREENSHOT_SIZE,
+    source_format: str | None = None,
+    webp_quality: int | None = None,
+) -> str:
+    """Convert screenshot bytes into a WebP data URL optimized for n1."""
+
+    Image = _require_pillow()
+
+    with Image.open(io.BytesIO(image_bytes)) as img:
+        detected_format = (source_format or img.format or "").upper()
+        if img.size != resize_to:
+            img = img.resize(resize_to, Image.LANCZOS)
+        buffer = io.BytesIO()
+        img.save(
+            buffer,
+            format="WEBP",
+            quality=webp_quality if webp_quality is not None else _default_webp_quality(detected_format),
+        )
+
+    encoded = base64.b64encode(buffer.getvalue()).decode("utf-8")
+    return f"data:image/webp;base64,{encoded}"
+
+
+def playwright_screenshot_to_data_url(
+    page: SupportsSyncScreenshot,
+    *,
+    resize_to: tuple[int, int] = DEFAULT_SCREENSHOT_SIZE,
+    webp_quality: int | None = None,
+) -> str:
+    """Capture and convert a sync Playwright-style screenshot for n1."""
+
+    screenshot_bytes = page.screenshot(
+        type=DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
+        quality=DEFAULT_PLAYWRIGHT_SCREENSHOT_QUALITY,
+    )
+    return screenshot_to_data_url(
+        screenshot_bytes,
+        resize_to=resize_to,
+        source_format=DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
+        webp_quality=webp_quality,
+    )
+
+
+async def aplaywright_screenshot_to_data_url(
+    page: SupportsAsyncScreenshot,
+    *,
+    resize_to: tuple[int, int] = DEFAULT_SCREENSHOT_SIZE,
+    webp_quality: int | None = None,
+) -> str:
+    """Capture and convert an async Playwright-style screenshot for n1."""
+
+    screenshot_bytes = await page.screenshot(
+        type=DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
+        quality=DEFAULT_PLAYWRIGHT_SCREENSHOT_QUALITY,
+    )
+    return screenshot_to_data_url(
+        screenshot_bytes,
+        resize_to=resize_to,
+        source_format=DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
+        webp_quality=webp_quality,
+    )


### PR DESCRIPTION
## Summary
- Adds `screenshot_to_data_url`, `playwright_screenshot_to_data_url`, and `aplaywright_screenshot_to_data_url` to `yutori.n1`
- Captures and encodes screenshots optimized for n1 (auto-detects source format, applies recommended WebP compression, returns a ready-to-use data URI)
- Replaces duplicated 8-line screenshot conversion pipeline across all 3 examples with a single SDK call
- Pillow exposed as optional dependency via `pip install "yutori[n1]"`

Closes ENG-4637

## Test plan
- [x] `pytest tests/test_n1_images.py` — 7 tests covering PNG/JPEG conversion, no-resize path, Pillow ImportError, sync/async Playwright helpers
- [x] Full suite: 195 tests pass
- [x] `ruff check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive utilities plus docs/example refactors; main behavior impact is only for users opting into the new `yutori[n1]` Pillow-based helpers.
> 
> **Overview**
> Adds new `yutori.n1` screenshot preparation helpers (`screenshot_to_data_url`, `playwright_screenshot_to_data_url`, `aplaywright_screenshot_to_data_url`) that convert screenshots into n1-optimized WebP `data:` URLs, with Pillow gated behind a new optional extra `yutori[n1]`.
> 
> Refactors the Playwright-based n1 examples to call the new helper instead of duplicating manual JPEG→Pillow resize→WebP→base64 logic, and updates `README.md`/`api.md` to document the helpers and install instructions. Includes new unit tests covering conversion/resizing behavior, default quality selection, missing-Pillow error messaging, and Playwright capture defaults, plus a version bump to `0.4.8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecd579fa0b8da6c4783cf07e0e617cec21868023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->