### PR TITLE
chore: document missing CLI flags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,16 +465,19 @@ yutori auth logout      # Remove saved credentials
 yutori scouts list                          # List your scouts
 yutori scouts get SCOUT_ID                  # Get scout details
 yutori scouts create -q "monitor for news"  # Create a scout
+yutori scouts create -q "monitor for news" -i daily -tz America/New_York
 yutori scouts delete SCOUT_ID               # Delete a scout
 
 # Browsing
 yutori browse run "extract all prices" https://example.com/products
 yutori browse run "log in and continue" https://example.com/login --require-auth
 yutori browse run "export dashboard data" https://example.com/dashboard --browser local
+yutori browse run "fill out the form" https://example.com --agent n1 --max-steps 50
 yutori browse get TASK_ID
 
 # Research
 yutori research run "latest developments in quantum computing" --browser local
+yutori research run "local events this weekend" -tz America/Los_Angeles --location "San Francisco, CA, US"
 yutori research get TASK_ID
 
 # Usage


### PR DESCRIPTION
## Summary

- Document `--timezone` / `-tz` and `--location` flags for `research run`
- Document `--agent` and `--max-steps` flags for `browse run`
- Document `--interval` / `-i` and `--timezone` / `-tz` flags for `scouts create`

## Context

Daily doc/test drift check found that the README CLI section was missing several flags that exist in the actual CLI code. All flags were verified against the source before documenting.

## Test plan

- [ ] Verify README renders correctly
- [ ] Verify documented flags match actual CLI behavior

https://claude.ai/code/session_01RMZSFSG1VoJBh4Fs3uhVom

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior or APIs are modified.
> 
> **Overview**
> Updates the `README.md` CLI quickstart examples to document additional supported flags.
> 
> Adds examples for `yutori scouts create` with `--interval/-i` and `--timezone/-tz`, `yutori browse run` with `--agent` and `--max-steps`, and `yutori research run` with `--timezone/-tz` and `--location`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87b7b70d2b32af6bdecfc404166691104023bd7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->