### PR TITLE
Add n1 coordinate normalization/denormalization helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ messages = [
 
 Install the optional image dependency with `pip install "yutori[n1]"` if you want to use these screenshot helpers.
 
+n1 tool calls use a normalized `1000x1000` coordinate space. The SDK provides public helpers so agent loops do not need to
+re-implement that math:
+
+```python
+from yutori.n1 import denormalize_coordinates
+
+coords = [500, 250]
+x, y = denormalize_coordinates(coords, width=1280, height=800)
+```
+
 For screenshot-heavy agent loops, the SDK also provides opt-in trimming helpers under `yutori.n1`:
 
 ```python

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ uv run playwright install chromium
 
 ## n1.py
 
-A complete browsing agent using the n1 API. Launches a local Playwright browser, captures screenshots through `yutori.n1.aplaywright_screenshot_to_data_url(...)`, sends them to n1, and executes predicted actions until the task is complete. The example keeps its own long-lived message history bounded with `estimate_messages_size_bytes(...)` plus `trimmed_messages_to_fit(...)`, then still ends with a standard `client.chat.completions.create(...)` call.
+A complete browsing agent using the n1 API. Launches a local Playwright browser, captures screenshots through `yutori.n1.aplaywright_screenshot_to_data_url(...)`, converts tool-call coordinates with `yutori.n1.denormalize_coordinates(...)`, sends them to n1, and executes predicted actions until the task is complete. The example keeps its own long-lived message history bounded with `estimate_messages_size_bytes(...)` plus `trimmed_messages_to_fit(...)`, then still ends with a standard `client.chat.completions.create(...)` call.
 
 ```bash
 uv run python examples/n1.py --task "List the team member names" --start-url "https://www.yutori.com"

--- a/examples/n1.py
+++ b/examples/n1.py
@@ -29,7 +29,12 @@ from pydantic import BaseModel, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
-from yutori.n1 import aplaywright_screenshot_to_data_url, estimate_messages_size_bytes, trimmed_messages_to_fit
+from yutori.n1 import (
+    aplaywright_screenshot_to_data_url,
+    denormalize_coordinates,
+    estimate_messages_size_bytes,
+    trimmed_messages_to_fit,
+)
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
@@ -161,11 +166,6 @@ class Agent:
             resize_to=(self.viewport_width, self.viewport_height),
         )
 
-    def _convert_coordinates(self, rel_x: int, rel_y: int) -> tuple[int, int]:
-        abs_x = int(rel_x / 1000 * self.viewport_width)
-        abs_y = int(rel_y / 1000 * self.viewport_height)
-        return abs_x, abs_y
-
     def _clip_image_url(self, url: str, max_len: int = 50) -> str:
         if url.startswith("data:image"):
             prefix_end = url.find(",") + 1
@@ -249,25 +249,25 @@ class Agent:
         try:
             if action_name == "left_click":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.click(abs_x, abs_y)
                 await asyncio.sleep(0.5)
 
             elif action_name == "double_click":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.dblclick(abs_x, abs_y)
                 await asyncio.sleep(0.5)
 
             elif action_name == "right_click":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.click(abs_x, abs_y, button="right")
                 await asyncio.sleep(0.5)
 
             elif action_name == "triple_click":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.click(abs_x, abs_y, click_count=3)
                 await asyncio.sleep(0.5)
 
@@ -297,7 +297,7 @@ class Agent:
                 direction = arguments.get("direction", "down")
                 amount = arguments.get("amount", 3)
 
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 scroll_delta = amount * (self.viewport_height * 0.1)
 
                 delta_y = scroll_delta if direction == "down" else (-scroll_delta if direction == "up" else 0)
@@ -309,7 +309,7 @@ class Agent:
 
             elif action_name == "hover":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.move(abs_x, abs_y)
                 await asyncio.sleep(0.3)
 
@@ -317,8 +317,8 @@ class Agent:
                 start_coords = arguments.get("start_coordinates") or arguments.get("startCoordinates", [0, 0])
                 end_coords = arguments.get("coordinates") or arguments.get("endCoordinates", [0, 0])
 
-                start_x, start_y = self._convert_coordinates(start_coords[0], start_coords[1])
-                end_x, end_y = self._convert_coordinates(end_coords[0], end_coords[1])
+                start_x, start_y = denormalize_coordinates(start_coords, self.viewport_width, self.viewport_height)
+                end_x, end_y = denormalize_coordinates(end_coords, self.viewport_width, self.viewport_height)
 
                 await self._page.mouse.move(start_x, start_y)
                 await self._page.mouse.down()

--- a/examples/n1_custom_tools.py
+++ b/examples/n1_custom_tools.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
-from yutori.n1 import aplaywright_screenshot_to_data_url
+from yutori.n1 import aplaywright_screenshot_to_data_url, denormalize_coordinates
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
@@ -224,11 +224,6 @@ class Agent:
             resize_to=(self.viewport_width, self.viewport_height),
         )
 
-    def _convert_coordinates(self, rel_x: int, rel_y: int) -> tuple[int, int]:
-        abs_x = int(rel_x / 1000 * self.viewport_width)
-        abs_y = int(rel_y / 1000 * self.viewport_height)
-        return abs_x, abs_y
-
     def _clip_image_url(self, url: str, max_len: int = 50) -> str:
         if url.startswith("data:image"):
             prefix_end = url.find(",") + 1
@@ -303,25 +298,25 @@ class Agent:
         try:
             if action_name == "left_click":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.click(abs_x, abs_y)
                 await asyncio.sleep(0.5)
 
             elif action_name == "double_click":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.dblclick(abs_x, abs_y)
                 await asyncio.sleep(0.5)
 
             elif action_name == "right_click":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.click(abs_x, abs_y, button="right")
                 await asyncio.sleep(0.5)
 
             elif action_name == "triple_click":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.click(abs_x, abs_y, click_count=3)
                 await asyncio.sleep(0.5)
 
@@ -351,7 +346,7 @@ class Agent:
                 direction = arguments.get("direction", "down")
                 amount = arguments.get("amount", 3)
 
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 scroll_delta = amount * (self.viewport_height * 0.1)
 
                 delta_y = scroll_delta if direction == "down" else (-scroll_delta if direction == "up" else 0)
@@ -363,7 +358,7 @@ class Agent:
 
             elif action_name == "hover":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.move(abs_x, abs_y)
                 await asyncio.sleep(0.3)
 
@@ -371,8 +366,8 @@ class Agent:
                 start_coords = arguments.get("start_coordinates") or arguments.get("startCoordinates", [0, 0])
                 end_coords = arguments.get("coordinates") or arguments.get("endCoordinates", [0, 0])
 
-                start_x, start_y = self._convert_coordinates(start_coords[0], start_coords[1])
-                end_x, end_y = self._convert_coordinates(end_coords[0], end_coords[1])
+                start_x, start_y = denormalize_coordinates(start_coords, self.viewport_width, self.viewport_height)
+                end_x, end_y = denormalize_coordinates(end_coords, self.viewport_width, self.viewport_height)
 
                 await self._page.mouse.move(start_x, start_y)
                 await self._page.mouse.down()

--- a/examples/n1_memo.py
+++ b/examples/n1_memo.py
@@ -35,7 +35,7 @@ from pydantic import BaseModel, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
-from yutori.n1 import aplaywright_screenshot_to_data_url
+from yutori.n1 import aplaywright_screenshot_to_data_url, denormalize_coordinates
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
@@ -275,11 +275,6 @@ class Agent:
             resize_to=(self.viewport_width, self.viewport_height),
         )
 
-    def _convert_coordinates(self, rel_x: int, rel_y: int) -> tuple[int, int]:
-        abs_x = int(rel_x / 1000 * self.viewport_width)
-        abs_y = int(rel_y / 1000 * self.viewport_height)
-        return abs_x, abs_y
-
     def _clip_image_url(self, url: str, max_len: int = 50) -> str:
         if url.startswith("data:image"):
             prefix_end = url.find(",") + 1
@@ -355,25 +350,25 @@ class Agent:
         try:
             if action_name == "left_click":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.click(abs_x, abs_y)
                 await asyncio.sleep(0.5)
 
             elif action_name == "double_click":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.dblclick(abs_x, abs_y)
                 await asyncio.sleep(0.5)
 
             elif action_name == "right_click":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.click(abs_x, abs_y, button="right")
                 await asyncio.sleep(0.5)
 
             elif action_name == "triple_click":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.click(abs_x, abs_y, click_count=3)
                 await asyncio.sleep(0.5)
 
@@ -403,7 +398,7 @@ class Agent:
                 direction = arguments.get("direction", "down")
                 amount = arguments.get("amount", 3)
 
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 scroll_delta = amount * (self.viewport_height * 0.1)
 
                 delta_y = scroll_delta if direction == "down" else (-scroll_delta if direction == "up" else 0)
@@ -415,7 +410,7 @@ class Agent:
 
             elif action_name == "hover":
                 coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = self._convert_coordinates(coords[0], coords[1])
+                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
                 await self._page.mouse.move(abs_x, abs_y)
                 await asyncio.sleep(0.3)
 
@@ -423,8 +418,8 @@ class Agent:
                 start_coords = arguments.get("start_coordinates") or arguments.get("startCoordinates", [0, 0])
                 end_coords = arguments.get("coordinates") or arguments.get("endCoordinates", [0, 0])
 
-                start_x, start_y = self._convert_coordinates(start_coords[0], start_coords[1])
-                end_x, end_y = self._convert_coordinates(end_coords[0], end_coords[1])
+                start_x, start_y = denormalize_coordinates(start_coords, self.viewport_width, self.viewport_height)
+                end_x, end_y = denormalize_coordinates(end_coords, self.viewport_width, self.viewport_height)
 
                 await self._page.mouse.move(start_x, start_y)
                 await self._page.mouse.down()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.4.9"
+version = "0.4.10"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_n1_coordinates.py
+++ b/tests/test_n1_coordinates.py
@@ -1,0 +1,99 @@
+"""Tests for yutori.n1.coordinates."""
+
+import pytest
+
+from yutori.n1 import N1_COORDINATE_SCALE, denormalize_coordinates, normalize_coordinates
+
+
+class TestDenormalizeCoordinates:
+    def test_scales_n1_coordinates_to_viewport_pixels(self):
+        assert denormalize_coordinates([500, 250], width=1280, height=800) == (640, 200)
+
+    def test_origin_returns_zero(self):
+        assert denormalize_coordinates([0, 0], width=1280, height=800) == (0, 0)
+
+    def test_clamps_out_of_bounds_values_by_default(self):
+        assert denormalize_coordinates([1000, 1000], width=1280, height=800) == (1279, 799)
+        assert denormalize_coordinates([-100, -50], width=1280, height=800) == (0, 0)
+
+    def test_can_return_unclamped_coordinates(self):
+        assert denormalize_coordinates([1000, 1000], width=1280, height=800, clamp=False) == (1280, 800)
+
+    def test_accepts_float_coordinates(self):
+        x, y = denormalize_coordinates([500.7, 250.3], width=1280, height=800)
+        assert isinstance(x, int) and isinstance(y, int)
+        assert (x, y) == (round(500.7 / 1000 * 1280), round(250.3 / 1000 * 800))
+
+    def test_accepts_tuple_input(self):
+        assert denormalize_coordinates((500, 250), width=1280, height=800) == (640, 200)
+
+    def test_custom_scale(self):
+        assert denormalize_coordinates([250, 250], width=1000, height=1000, scale=500) == (500, 500)
+
+
+class TestNormalizeCoordinates:
+    def test_scales_viewport_pixels_to_n1_coordinates(self):
+        assert normalize_coordinates([640, 200], width=1280, height=800) == (500, 250)
+
+    def test_origin_returns_zero(self):
+        assert normalize_coordinates([0, 0], width=1280, height=800) == (0, 0)
+
+    def test_clamps_out_of_bounds_values_by_default(self):
+        assert normalize_coordinates([1400, 900], width=1280, height=800) == (
+            N1_COORDINATE_SCALE,
+            N1_COORDINATE_SCALE,
+        )
+        assert normalize_coordinates([-1, -5], width=1280, height=800) == (0, 0)
+
+    def test_can_return_unclamped_coordinates(self):
+        assert normalize_coordinates([1400, 900], width=1280, height=800, clamp=False) == (1094, 1125)
+
+    def test_custom_scale(self):
+        assert normalize_coordinates([500, 500], width=1000, height=1000, scale=500) == (250, 250)
+
+
+class TestRoundtrip:
+    @pytest.mark.parametrize(
+        "coords",
+        [[0, 0], [500, 250], [999, 999], [100, 900], [1, 1]],
+    )
+    def test_normalize_denormalize_roundtrip(self, coords):
+        w, h = 1280, 800
+        abs_x, abs_y = denormalize_coordinates(coords, width=w, height=h, clamp=False)
+        norm_x, norm_y = normalize_coordinates([abs_x, abs_y], width=w, height=h, clamp=False)
+        assert abs(norm_x - coords[0]) <= 1
+        assert abs(norm_y - coords[1]) <= 1
+
+
+class TestCoordinateValidation:
+    def test_rejects_wrong_coordinate_length(self):
+        with pytest.raises(ValueError, match="exactly 2 items"):
+            denormalize_coordinates([500], width=1280, height=800)
+
+    def test_rejects_too_many_coordinates(self):
+        with pytest.raises(ValueError, match="exactly 2 items"):
+            normalize_coordinates([500, 500, 500], width=1280, height=800)
+
+    def test_rejects_none_coordinates(self):
+        with pytest.raises(ValueError, match="must not be None"):
+            denormalize_coordinates(None, width=1280, height=800)
+
+    def test_rejects_inf_coordinates(self):
+        with pytest.raises(ValueError, match="finite numbers"):
+            denormalize_coordinates([float("inf"), 500], width=1280, height=800)
+
+    def test_rejects_nan_coordinates(self):
+        with pytest.raises(ValueError, match="finite numbers"):
+            normalize_coordinates([500, float("nan")], width=1280, height=800)
+
+    @pytest.mark.parametrize(
+        "name, kwargs",
+        [("width", {"width": 0, "height": 800}), ("height", {"width": 1280, "height": 0})],
+    )
+    def test_rejects_non_positive_dimensions(self, name, kwargs):
+        with pytest.raises(ValueError, match=rf"{name} must be positive"):
+            denormalize_coordinates([500, 500], **kwargs)
+
+    def test_rejects_non_positive_scale(self):
+        with pytest.raises(ValueError, match="scale must be positive"):
+            normalize_coordinates([500, 500], width=1280, height=800, scale=0)

--- a/yutori/n1/__init__.py
+++ b/yutori/n1/__init__.py
@@ -2,6 +2,7 @@
 
 Provides reusable helpers for common patterns in n1 agent loops:
 - Screenshot preparation: capture and encode screenshots as optimized WebP data URLs
+- Coordinate conversion: map n1's 1000x1000 tool-call space to viewport pixels
 - Payload management: trim old screenshots to stay within API size limits
 - Loop helpers: create trimmed requests without mutating caller state
 """
@@ -9,6 +10,7 @@ Provides reusable helpers for common patterns in n1 agent loops:
 from __future__ import annotations
 
 from .content import extract_text_content
+from .coordinates import N1_COORDINATE_SCALE, denormalize_coordinates, normalize_coordinates
 from .hooks import RunHooksBase
 from .images import (
     aplaywright_screenshot_to_data_url,
@@ -21,8 +23,11 @@ from .payload import estimate_messages_size_bytes, trim_images_to_fit, trimmed_m
 __all__ = [
     "acreate_trimmed",
     "aplaywright_screenshot_to_data_url",
+    "denormalize_coordinates",
     "extract_text_content",
     "create_trimmed",
+    "N1_COORDINATE_SCALE",
+    "normalize_coordinates",
     "playwright_screenshot_to_data_url",
     "RunHooksBase",
     "screenshot_to_data_url",

--- a/yutori/n1/coordinates.py
+++ b/yutori/n1/coordinates.py
@@ -1,0 +1,95 @@
+"""Coordinate helpers for n1's 1000x1000 action space."""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+N1_COORDINATE_SCALE = 1000
+
+
+def denormalize_coordinates(
+    coordinates: Sequence[int | float],
+    width: int,
+    height: int,
+    *,
+    scale: int = N1_COORDINATE_SCALE,
+    clamp: bool = True,
+) -> tuple[int, int]:
+    """Convert normalized n1 coordinates into viewport pixels.
+
+    When *clamp* is ``True`` (the default), the result is clamped to
+    ``[0, width - 1]`` and ``[0, height - 1]`` so the returned pixel
+    indices are always valid for a viewport of the given size.
+    """
+
+    x, y = _coerce_coordinates(coordinates)
+    _validate_dimension("width", width)
+    _validate_dimension("height", height)
+    _validate_scale(scale)
+
+    raw_x = round(x / scale * width)
+    raw_y = round(y / scale * height)
+
+    if not clamp:
+        return raw_x, raw_y
+
+    return _clamp_to_dimension(raw_x, width), _clamp_to_dimension(raw_y, height)
+
+
+def normalize_coordinates(
+    coordinates: Sequence[int | float],
+    width: int,
+    height: int,
+    *,
+    scale: int = N1_COORDINATE_SCALE,
+    clamp: bool = True,
+) -> tuple[int, int]:
+    """Convert viewport pixels into normalized n1 coordinates.
+
+    When *clamp* is ``True`` (the default), the result is clamped to
+    ``[0, scale]`` so the returned coordinates stay within n1's
+    normalized action space.
+    """
+
+    x, y = _coerce_coordinates(coordinates)
+    _validate_dimension("width", width)
+    _validate_dimension("height", height)
+    _validate_scale(scale)
+
+    raw_x = round(x / width * scale)
+    raw_y = round(y / height * scale)
+
+    if not clamp:
+        return raw_x, raw_y
+
+    return _clamp(raw_x, 0, scale), _clamp(raw_y, 0, scale)
+
+
+def _coerce_coordinates(coordinates: Sequence[int | float]) -> tuple[float, float]:
+    if coordinates is None:
+        raise ValueError("coordinates must not be None")
+    if len(coordinates) != 2:
+        raise ValueError(f"coordinates must contain exactly 2 items, got {coordinates!r}")
+    x, y = float(coordinates[0]), float(coordinates[1])
+    if not (math.isfinite(x) and math.isfinite(y)):
+        raise ValueError(f"coordinates must be finite numbers, got {coordinates!r}")
+    return x, y
+
+
+def _validate_dimension(name: str, value: int) -> None:
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}")
+
+
+def _validate_scale(scale: int) -> None:
+    if scale <= 0:
+        raise ValueError(f"scale must be positive, got {scale}")
+
+
+def _clamp(value: int, lower: int, upper: int) -> int:
+    return max(lower, min(upper, value))
+
+
+def _clamp_to_dimension(value: int, dimension: int) -> int:
+    return _clamp(value, 0, dimension - 1)


### PR DESCRIPTION
## Summary
- Adds `denormalize_coordinates()`, `normalize_coordinates()`, and `N1_COORDINATE_SCALE` to `yutori.n1`
- Centralizes the 1000×1000 ↔ viewport-pixel conversion that every n1 agent loop needs — downstream projects (frontend-visualqa, navi-bench) were each rolling their own
- Migrates all three SDK examples (`n1.py`, `n1_custom_tools.py`, `n1_memo.py`) to use the new helpers, removing duplicated `_convert_coordinates` methods
- Bumps version to 0.4.10

Key design decisions:
- `round()` instead of `int()` truncation for better accuracy
- Clamping enabled by default (`[0, dim-1]` for denormalize, `[0, scale]` for normalize)
- Input validation for `None`, `inf`/`nan`, wrong-length sequences, non-positive dimensions
- `clamp=False` escape hatch for benchmarks that need prior edge behavior

## Test plan
- [x] 25 new tests in `tests/test_n1_coordinates.py` covering happy paths, edge cases, roundtrip, validation
- [x] Full suite passes (236 tests)
- [x] ruff clean

Companion PRs: yutori-ai/navi-bench and yutori-ai/frontend-visualqa consume these helpers (merge this first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small, well-tested utility API and updates docs/examples without touching auth, networking, or request/response handling.
> 
> **Overview**
> Adds first-class n1 coordinate conversion utilities (`denormalize_coordinates`, `normalize_coordinates`, `N1_COORDINATE_SCALE`) to centralize the 1000x1000 tool-call space ↔ viewport-pixel math, including default clamping and input validation.
> 
> Updates all n1 Playwright examples to use the shared helper (removing duplicated `_convert_coordinates` logic), documents the new API in `README.md`, adds a dedicated test suite for edge cases/roundtrips, and bumps the package version to `0.4.10`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cd345723a647038396751113760d5e6a6af4013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->