### PR TITLE
Add missing __all__ exports to cli subpackages

### DIFF
--- a/yutori/cli/__init__.py
+++ b/yutori/cli/__init__.py
@@ -1,1 +1,3 @@
 """Yutori CLI module."""
+
+__all__: list[str] = []

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -10,6 +10,12 @@ from rich.markup import escape
 
 from yutori.auth.credentials import resolve_api_key
 
+__all__ = [
+    "get_authenticated_client",
+    "print_rejection_reason",
+    "print_task_submission_result",
+]
+
 _console = Console()
 
 


### PR DESCRIPTION
## Summary

- Adds `__all__` to `yutori/cli/__init__.py` (empty list, as it has no public exports)
- Adds `__all__` to `yutori/cli/commands/__init__.py` listing the three public helper functions

This brings these two `__init__.py` files in line with the rest of the codebase (`auth`, `_sync`, `_async`, `n1`) which all define `__all__`.

All 229 tests pass.

## Test plan
- [x] All 229 existing tests pass
- [x] `ruff check` clean on both files
- [x] Verified imports work correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates module export lists in CLI `__init__.py` files, with no behavior changes beyond what `from ... import *` exposes.
> 
> **Overview**
> Adds explicit `__all__` definitions for the CLI packages to standardize public exports.
> 
> `yutori/cli/__init__.py` now declares an empty `__all__`, and `yutori/cli/commands/__init__.py` now lists the three helper functions it intends to expose (`get_authenticated_client`, `print_rejection_reason`, `print_task_submission_result`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ed00010be3e9a1e701f4f1d882686a33d700a9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->