### PR TITLE
fix: remove redundant `limit` query param in scouts list()

### DIFF
--- a/yutori/_async/scouts.py
+++ b/yutori/_async/scouts.py
@@ -35,7 +35,7 @@ class AsyncScoutsNamespace:
             Dictionary containing list of scouts.
         """
         # API pagination parameter is `page_size`; keep `limit` for SDK ergonomics.
-        params = build_query_params(page_size=limit, limit=limit, status=status)
+        params = build_query_params(page_size=limit, status=status)
         response = await self._client.get(
             f"{self._base_url}/scouting/tasks",
             headers=build_headers(self._api_key),

--- a/yutori/_sync/scouts.py
+++ b/yutori/_sync/scouts.py
@@ -35,7 +35,7 @@ class ScoutsNamespace:
             Dictionary containing list of scouts.
         """
         # API pagination parameter is `page_size`; keep `limit` for SDK ergonomics.
-        params = build_query_params(page_size=limit, limit=limit, status=status)
+        params = build_query_params(page_size=limit, status=status)
         response = self._client.get(
             f"{self._base_url}/scouting/tasks",
             headers=build_headers(self._api_key),


### PR DESCRIPTION
## Summary

The `list()` method in both `yutori/_sync/scouts.py` and `yutori/_async/scouts.py` was incorrectly sending both `page_size` and `limit` as query parameters to the API.

The comment in the code explains the intent: `limit` is the SDK-facing ergonomic parameter that maps to the API's `page_size` pagination parameter. However, the implementation was passing both:

```python
# Before (buggy)
params = build_query_params(page_size=limit, limit=limit, status=status)
```

Since `build_query_params` simply filters out `None` values and passes the rest through, both `page_size` and `limit` were being sent to the API as query parameters. The `limit` parameter is unrecognized by the API.

This PR removes `limit=limit` from both calls so only the correct `page_size` parameter is sent:

```python
# After (fixed)
params = build_query_params(page_size=limit, status=status)
```

## Files Changed

- `yutori/_sync/scouts.py` — removed `limit=limit` from `build_query_params` call in `list()`
- `yutori/_async/scouts.py` — removed `limit=limit` from `build_query_params` call in `list()`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small bugfix to query parameter construction for `scouts.list()` that only affects request URLs and should improve API compatibility.
> 
> **Overview**
> Fixes `scouts.list()` in both the sync and async SDKs to only send the API-supported pagination param (`page_size`) derived from the SDK’s `limit` argument.
> 
> This removes the redundant/unrecognized `limit` query parameter from requests to `GET /scouting/tasks`, avoiding accidental extra query params being forwarded to the API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85e91c836709f79d497df0aa2d969bd2f0a4f87b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->