### PR TITLE
refactor: extract build_payload() to eliminate repeated None-filtering

### DIFF
--- a/yutori/_async/browsing.py
+++ b/yutori/_async/browsing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from .._http import build_headers, handle_response
+from .._http import build_headers, build_payload, handle_response
 from .._schema import resolve_output_schema
 
 if TYPE_CHECKING:
@@ -50,26 +50,17 @@ class AsyncBrowsingNamespace:
         Returns:
             Dictionary containing task details including task_id.
         """
-        payload: dict[str, Any] = {
-            "task": task,
-            "start_url": start_url,
-        }
-
-        if max_steps is not None:
-            payload["max_steps"] = max_steps
-        if agent is not None:
-            payload["agent"] = agent
-        if require_auth is not None:
-            payload["require_auth"] = require_auth
-        if browser is not None:
-            payload["browser"] = browser
-        resolved_schema = resolve_output_schema(output_schema)
-        if resolved_schema is not None:
-            payload["output_schema"] = resolved_schema
-        if webhook_url is not None:
-            payload["webhook_url"] = webhook_url
-        if webhook_format is not None:
-            payload["webhook_format"] = webhook_format
+        payload = build_payload(
+            task=task,
+            start_url=start_url,
+            max_steps=max_steps,
+            agent=agent,
+            require_auth=require_auth,
+            browser=browser,
+            output_schema=resolve_output_schema(output_schema),
+            webhook_url=webhook_url,
+            webhook_format=webhook_format,
+        )
 
         response = await self._client.post(
             f"{self._base_url}/browsing/tasks",

--- a/yutori/_async/research.py
+++ b/yutori/_async/research.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from .._http import build_headers, handle_response
+from .._http import build_headers, build_payload, handle_response
 from .._schema import resolve_output_schema
 
 if TYPE_CHECKING:
@@ -47,21 +47,15 @@ class AsyncResearchNamespace:
         Returns:
             Dictionary containing task details including task_id.
         """
-        payload: dict[str, Any] = {"query": query}
-
-        if user_timezone is not None:
-            payload["user_timezone"] = user_timezone
-        if user_location is not None:
-            payload["user_location"] = user_location
-        if browser is not None:
-            payload["browser"] = browser
-        resolved_schema = resolve_output_schema(output_schema)
-        if resolved_schema is not None:
-            payload["output_schema"] = resolved_schema
-        if webhook_url is not None:
-            payload["webhook_url"] = webhook_url
-        if webhook_format is not None:
-            payload["webhook_format"] = webhook_format
+        payload = build_payload(
+            query=query,
+            user_timezone=user_timezone,
+            user_location=user_location,
+            browser=browser,
+            output_schema=resolve_output_schema(output_schema),
+            webhook_url=webhook_url,
+            webhook_format=webhook_format,
+        )
 
         response = await self._client.post(
             f"{self._base_url}/research/tasks",

--- a/yutori/_async/scouts.py
+++ b/yutori/_async/scouts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from .._http import build_headers, build_query_params, handle_response
+from .._http import build_headers, build_payload, build_query_params, handle_response
 from .._schema import resolve_output_schema
 
 if TYPE_CHECKING:
@@ -89,28 +89,18 @@ class AsyncScoutsNamespace:
         Returns:
             Dictionary containing created scout details.
         """
-        payload: dict[str, Any] = {
-            "query": query,
-            "output_interval": output_interval,
-        }
-
-        if start_timestamp is not None:
-            payload["start_timestamp"] = start_timestamp
-        if user_timezone is not None:
-            payload["user_timezone"] = user_timezone
-        if user_location is not None:
-            payload["user_location"] = user_location
-        resolved_schema = resolve_output_schema(output_schema)
-        if resolved_schema is not None:
-            payload["output_schema"] = resolved_schema
-        if skip_email is not None:
-            payload["skip_email"] = skip_email
-        if webhook_url is not None:
-            payload["webhook_url"] = webhook_url
-        if webhook_format is not None:
-            payload["webhook_format"] = webhook_format
-        if is_public is not None:
-            payload["is_public"] = is_public
+        payload = build_payload(
+            query=query,
+            output_interval=output_interval,
+            start_timestamp=start_timestamp,
+            user_timezone=user_timezone,
+            user_location=user_location,
+            output_schema=resolve_output_schema(output_schema),
+            skip_email=skip_email,
+            webhook_url=webhook_url,
+            webhook_format=webhook_format,
+            is_public=is_public,
+        )
 
         response = await self._client.post(
             f"{self._base_url}/scouting/tasks",
@@ -155,23 +145,16 @@ class AsyncScoutsNamespace:
         Raises:
             ValueError: If status is provided along with other fields (API limitation).
         """
-        resolved_schema = resolve_output_schema(output_schema)
-
-        # Build payload from non-None field values (single source of truth for field list)
-        payload: dict[str, Any] = {
-            k: v
-            for k, v in {
-                "query": query,
-                "output_interval": output_interval,
-                "user_timezone": user_timezone,
-                "user_location": user_location,
-                "output_schema": resolved_schema,
-                "skip_email": skip_email,
-                "webhook_url": webhook_url,
-                "webhook_format": webhook_format,
-            }.items()
-            if v is not None
-        }
+        payload = build_payload(
+            query=query,
+            output_interval=output_interval,
+            user_timezone=user_timezone,
+            user_location=user_location,
+            output_schema=resolve_output_schema(output_schema),
+            skip_email=skip_email,
+            webhook_url=webhook_url,
+            webhook_format=webhook_format,
+        )
 
         # Check for conflicting parameters - API doesn't support both in one call
         if status is not None and payload:

--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -37,3 +37,12 @@ def handle_response(response: httpx.Response) -> dict[str, Any]:
 def build_query_params(**kwargs: Any) -> dict[str, Any]:
     """Build query parameters, filtering out None values."""
     return {k: v for k, v in kwargs.items() if v is not None}
+
+
+def build_payload(**fields: Any) -> dict[str, Any]:
+    """Build a JSON request payload, filtering out None values.
+
+    Required fields (always non-None) and optional fields can be passed
+    together — any field whose value is ``None`` is omitted.
+    """
+    return {k: v for k, v in fields.items() if v is not None}

--- a/yutori/_sync/browsing.py
+++ b/yutori/_sync/browsing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from .._http import build_headers, handle_response
+from .._http import build_headers, build_payload, handle_response
 from .._schema import resolve_output_schema
 
 if TYPE_CHECKING:
@@ -50,26 +50,17 @@ class BrowsingNamespace:
         Returns:
             Dictionary containing task details including task_id.
         """
-        payload: dict[str, Any] = {
-            "task": task,
-            "start_url": start_url,
-        }
-
-        if max_steps is not None:
-            payload["max_steps"] = max_steps
-        if agent is not None:
-            payload["agent"] = agent
-        if require_auth is not None:
-            payload["require_auth"] = require_auth
-        if browser is not None:
-            payload["browser"] = browser
-        resolved_schema = resolve_output_schema(output_schema)
-        if resolved_schema is not None:
-            payload["output_schema"] = resolved_schema
-        if webhook_url is not None:
-            payload["webhook_url"] = webhook_url
-        if webhook_format is not None:
-            payload["webhook_format"] = webhook_format
+        payload = build_payload(
+            task=task,
+            start_url=start_url,
+            max_steps=max_steps,
+            agent=agent,
+            require_auth=require_auth,
+            browser=browser,
+            output_schema=resolve_output_schema(output_schema),
+            webhook_url=webhook_url,
+            webhook_format=webhook_format,
+        )
 
         response = self._client.post(
             f"{self._base_url}/browsing/tasks",

--- a/yutori/_sync/research.py
+++ b/yutori/_sync/research.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from .._http import build_headers, handle_response
+from .._http import build_headers, build_payload, handle_response
 from .._schema import resolve_output_schema
 
 if TYPE_CHECKING:
@@ -47,21 +47,15 @@ class ResearchNamespace:
         Returns:
             Dictionary containing task details including task_id.
         """
-        payload: dict[str, Any] = {"query": query}
-
-        if user_timezone is not None:
-            payload["user_timezone"] = user_timezone
-        if user_location is not None:
-            payload["user_location"] = user_location
-        if browser is not None:
-            payload["browser"] = browser
-        resolved_schema = resolve_output_schema(output_schema)
-        if resolved_schema is not None:
-            payload["output_schema"] = resolved_schema
-        if webhook_url is not None:
-            payload["webhook_url"] = webhook_url
-        if webhook_format is not None:
-            payload["webhook_format"] = webhook_format
+        payload = build_payload(
+            query=query,
+            user_timezone=user_timezone,
+            user_location=user_location,
+            browser=browser,
+            output_schema=resolve_output_schema(output_schema),
+            webhook_url=webhook_url,
+            webhook_format=webhook_format,
+        )
 
         response = self._client.post(
             f"{self._base_url}/research/tasks",

--- a/yutori/_sync/scouts.py
+++ b/yutori/_sync/scouts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from .._http import build_headers, build_query_params, handle_response
+from .._http import build_headers, build_payload, build_query_params, handle_response
 from .._schema import resolve_output_schema
 
 if TYPE_CHECKING:
@@ -89,28 +89,18 @@ class ScoutsNamespace:
         Returns:
             Dictionary containing created scout details.
         """
-        payload: dict[str, Any] = {
-            "query": query,
-            "output_interval": output_interval,
-        }
-
-        if start_timestamp is not None:
-            payload["start_timestamp"] = start_timestamp
-        if user_timezone is not None:
-            payload["user_timezone"] = user_timezone
-        if user_location is not None:
-            payload["user_location"] = user_location
-        resolved_schema = resolve_output_schema(output_schema)
-        if resolved_schema is not None:
-            payload["output_schema"] = resolved_schema
-        if skip_email is not None:
-            payload["skip_email"] = skip_email
-        if webhook_url is not None:
-            payload["webhook_url"] = webhook_url
-        if webhook_format is not None:
-            payload["webhook_format"] = webhook_format
-        if is_public is not None:
-            payload["is_public"] = is_public
+        payload = build_payload(
+            query=query,
+            output_interval=output_interval,
+            start_timestamp=start_timestamp,
+            user_timezone=user_timezone,
+            user_location=user_location,
+            output_schema=resolve_output_schema(output_schema),
+            skip_email=skip_email,
+            webhook_url=webhook_url,
+            webhook_format=webhook_format,
+            is_public=is_public,
+        )
 
         response = self._client.post(
             f"{self._base_url}/scouting/tasks",
@@ -155,23 +145,16 @@ class ScoutsNamespace:
         Raises:
             ValueError: If status is provided along with other fields (API limitation).
         """
-        resolved_schema = resolve_output_schema(output_schema)
-
-        # Build payload from non-None field values (single source of truth for field list)
-        payload: dict[str, Any] = {
-            k: v
-            for k, v in {
-                "query": query,
-                "output_interval": output_interval,
-                "user_timezone": user_timezone,
-                "user_location": user_location,
-                "output_schema": resolved_schema,
-                "skip_email": skip_email,
-                "webhook_url": webhook_url,
-                "webhook_format": webhook_format,
-            }.items()
-            if v is not None
-        }
+        payload = build_payload(
+            query=query,
+            output_interval=output_interval,
+            user_timezone=user_timezone,
+            user_location=user_location,
+            output_schema=resolve_output_schema(output_schema),
+            skip_email=skip_email,
+            webhook_url=webhook_url,
+            webhook_format=webhook_format,
+        )
 
         # Check for conflicting parameters - API doesn't support both in one call
         if status is not None and payload:


### PR DESCRIPTION
## Summary

- Extracts a `build_payload()` helper into `_http.py` that filters out `None` values from keyword arguments — mirroring the existing `build_query_params()` pattern
- Replaces 40+ instances of manual `if x is not None: payload[k] = v` across sync and async namespace files (browsing, scouts, research)
- Net reduction: **-55 lines** (99 added, 154 removed across 7 files)

## Why this is an improvement

The `if x is not None: payload[k] = v` pattern was the single most repeated boilerplate pattern in the SDK. Every namespace method that builds a JSON request body had 5-8 consecutive conditional blocks doing the same thing. The new `build_payload()` helper:

1. Follows the established pattern — `build_query_params()` already does identical None-filtering for query parameters
2. Makes payload construction declarative — the field list reads like a schema, not imperative code
3. Reduces surface area for bugs — no more risk of copy-paste errors when adding new optional fields

## Why this is safe

- **No behavioral change**: required fields (always non-None from required function params) pass through unchanged; optional `None` fields are filtered identically to before
- **Verified by existing tests**: all payload assertion tests pass (88/90 — the 2 failures are a pre-existing bug in `test_scouts_list` unrelated to this change)
- **`output_schema`** continues to go through `resolve_output_schema()` before being passed to `build_payload()`, preserving the Pydantic model → JSON schema conversion

## Test plan

- [x] All existing sync client tests pass (payload assertions verify correct field inclusion/exclusion)
- [x] All existing async client tests pass
- [x] All Pydantic schema integration tests pass
- [x] `ruff check` clean on all modified files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes request-body construction; main risk is an inadvertent payload shape change if any caller relied on explicitly sending `null` values.
> 
> **Overview**
> Introduces `build_payload()` in `_http.py` to build JSON request bodies by omitting `None` fields (mirroring `build_query_params()`).
> 
> Updates sync and async `browsing`, `research`, and `scouts` create/update methods to use `build_payload()` instead of repeated per-field `None` checks, while still passing `output_schema` through `resolve_output_schema()` before inclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 265109ea43a2414b8ea60b65b5394006e08cec31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->