### PR TITLE
docs: add n1.5 model support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,18 @@ API key resolution order: explicit parameter > `YUTORI_API_KEY` env var > `~/.yu
 
 The Yutori API provides four main capabilities:
 
-| API          | Description                               | SDK Namespace     |
-| ------------ | ----------------------------------------- | ----------------- |
-| **n1**       | Pixels-to-actions LLM for browser control | `client.chat`     |
-| **Browsing** | One-time browser automation tasks         | `client.browsing` |
-| **Research** | Deep web research using 100+ tools        | `client.research` |
-| **Scouting** | Continuous web monitoring on a schedule   | `client.scouts`   |
+| API          | Description                                    | SDK Namespace     |
+| ------------ | ---------------------------------------------- | ----------------- |
+| **n1 / n1.5** | Pixels-to-actions LLMs for browser control    | `client.chat`     |
+| **Browsing** | One-time browser automation tasks              | `client.browsing` |
+| **Research** | Deep web research using 100+ tools             | `client.research` |
+| **Scouting** | Continuous web monitoring on a schedule        | `client.scouts`   |
 
-## n1 API
+## n1 / n1.5 API
 
-The n1 API is a pixels-to-actions LLM that processes screenshots and predicts browser actions (click, type, scroll, etc.). It follows the OpenAI Chat Completions interface:
+The n1 family of APIs are pixels-to-actions LLMs that process screenshots and predict browser actions (click, type, scroll, etc.). They follow the OpenAI Chat Completions interface.
+
+**n1.5** extends n1 with an expanded action space (mouse_move, drag, hold_key, go_forward, etc.), built-in tool sets for DOM interaction, and JSON structured output. Use `model="n1.5-latest"` to access it:
 
 ```python
 response = client.chat.completions.create(
@@ -93,7 +95,23 @@ if message.tool_calls:
         print(f"Arguments: {tool_call.function.arguments}")
 ```
 
-Live n1 model IDs and parameter docs are maintained at `https://docs.yutori.com/reference/n1`. The SDK forwards standard OpenAI chat-completions parameters through `**kwargs`, including `tools`, `tool_choice`, and `response_format`.
+n1.5 adds first-class parameters for tool sets, tool disabling, and structured JSON output:
+
+```python
+from yutori.n1 import N1_5_MODEL, TOOL_SET_EXPANDED
+
+response = client.chat.completions.create(
+    model=N1_5_MODEL,  # "n1.5-latest"
+    messages=messages,
+    tool_set=TOOL_SET_EXPANDED,       # built-in DOM tools (extract_elements, find, etc.)
+    disable_tools=["hold_key"],       # optionally disable specific tools
+    json_schema={"type": "object"},   # structured output
+)
+```
+
+The SDK also provides `map_key_to_playwright` and `map_keys_individual` helpers for converting n1.5's lowercase key names to Playwright-compatible names. See [examples/n1_5.py](examples/n1_5.py) for a complete n1.5 agent loop.
+
+Live model IDs and parameter docs are maintained at [docs.yutori.com/reference/n1](https://docs.yutori.com/reference/n1) and [docs.yutori.com/reference/n1-5](https://docs.yutori.com/reference/n1-5). The SDK forwards standard OpenAI chat-completions parameters through `**kwargs`, including `tools`, `tool_choice`, and `response_format`.
 
 For Playwright users, the SDK provides a screenshot helper that captures and encodes images optimized for n1:
 
@@ -505,7 +523,7 @@ Run `yutori --help` or `yutori <command> --help` for full option details.
 
 ## Examples
 
-See [examples/](examples/) for complete working examples, including a browser automation agent using the n1 API.
+See [examples/](examples/) for complete working examples, including browser automation agents using the n1 and n1.5 APIs.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Update API overview table to list n1.5 alongside n1
- Add n1.5-specific documentation: model constants (`N1_5_MODEL`, `TOOL_SET_EXPANDED`), new chat params (`tool_set`, `disable_tools`, `json_schema`), and key mapping helpers
- Link to the new `n1_5.py` example and `docs.yutori.com/reference/n1-5`
- Update examples section to reference both n1 and n1.5

## Context

Commit 8527afa added full n1.5 support to the SDK (model constants, key mapping, tool sets, new chat completion parameters, and a complete `examples/n1_5.py` agent loop), but the README was not updated. Users reading the README had no way to discover n1.5 capabilities.

## Test plan

- [ ] Verify all links in the updated README resolve correctly
- [ ] Confirm code examples are syntactically valid
- [ ] Check that referenced symbols (`N1_5_MODEL`, `TOOL_SET_EXPANDED`, `map_key_to_playwright`, `map_keys_individual`) match actual exports in `yutori/n1/__init__.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes, but incorrect parameter/symbol names or links could mislead users integrating `n1.5`.
> 
> **Overview**
> Adds `n1.5` to the README’s API overview and reframes the section as **`n1 / n1.5`**.
> 
> Documents `n1.5`-specific usage, including `N1_5_MODEL`/`TOOL_SET_EXPANDED`, new chat params (`tool_set`, `disable_tools`, `json_schema`), key-mapping helpers, and links to `examples/n1_5.py` plus the `n1-5` reference docs. Updates the Examples section to mention both models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cd0b25ac7253a0433976cd2fed11c8484e5fc30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->