### PR TITLE
Adding task formatting and content separator for message construction parity

### DIFF
--- a/examples/n1_5.py
+++ b/examples/n1_5.py
@@ -57,6 +57,7 @@ from yutori.n1 import (
     aplaywright_screenshot_to_data_url,
     denormalize_coordinates,
     estimate_messages_size_bytes,
+    format_task_with_context,
     map_key_to_playwright,
     map_keys_individual,
     trimmed_messages_to_fit,
@@ -108,6 +109,9 @@ class Config(BaseModel):
     tool_set: str = TOOL_SET_CORE
     disable_tools: list[str] = Field(default_factory=list)
     json_schema: dict | None = None
+    # user context
+    user_timezone: str = "America/Los_Angeles"
+    user_location: str = "San Francisco, CA, US"
     # agent
     max_steps: int = 100
     # browser
@@ -129,6 +133,8 @@ class Agent:
         tool_set: str = TOOL_SET_CORE,
         disable_tools: list[str] | None = None,
         json_schema: dict | None = None,
+        user_timezone: str = "America/Los_Angeles",
+        user_location: str = "San Francisco, CA, US",
         max_steps: int = 100,
         viewport_width: int = 1280,
         viewport_height: int = 800,
@@ -143,6 +149,8 @@ class Agent:
         self.tool_set = tool_set
         self.disable_tools = disable_tools or []
         self.json_schema = json_schema
+        self.user_timezone = user_timezone
+        self.user_location = user_location
         self.max_steps = max_steps
         self.viewport_width = viewport_width
         self.viewport_height = viewport_height
@@ -157,6 +165,13 @@ class Agent:
         self._step_count = 0
 
     async def run(self, task: str, start_url: str) -> str:
+        # Append user context (location, timezone, current date/time) to the task
+        task = format_task_with_context(
+            task,
+            user_timezone=self.user_timezone,
+            user_location=self.user_location,
+        )
+
         logger.info(f"Task: {task}")
         logger.info(f"Starting URL: {start_url}")
 
@@ -655,6 +670,8 @@ async def main():
         "--json-schema", type=json.loads, default=None,
         help='JSON Schema for structured output, e.g. \'{"type":"object","properties":{"names":{"type":"array","items":{"type":"string"}}},"required":["names"]}\'',
     )
+    parser.add_argument("--timezone", default=default_config.user_timezone, help="User timezone (e.g. America/New_York)")
+    parser.add_argument("--location", default=default_config.user_location, help="User location (e.g. New York, NY, US)")
     parser.add_argument("--max-steps", type=int, default=default_config.max_steps, help="Maximum number of steps")
     parser.add_argument("--viewport-width", type=int, default=default_config.viewport_width, help="Viewport width")
     parser.add_argument("--viewport-height", type=int, default=default_config.viewport_height, help="Viewport height")
@@ -669,6 +686,9 @@ async def main():
     )
     args = parser.parse_args()
     args.tool_set = _TOOL_SET_ALIASES.get(args.tool_set, args.tool_set)
+    args.user_timezone = args.timezone
+    args.user_location = args.location
+    del args.timezone, args.location
     config = Config.model_validate(vars(args))
 
     agent = Agent(
@@ -679,6 +699,8 @@ async def main():
         tool_set=config.tool_set,
         disable_tools=config.disable_tools,
         json_schema=config.json_schema,
+        user_timezone=config.user_timezone,
+        user_location=config.user_location,
         max_steps=config.max_steps,
         viewport_width=config.viewport_width,
         viewport_height=config.viewport_height,

--- a/examples/n1_5.py
+++ b/examples/n1_5.py
@@ -9,7 +9,7 @@ Key differences from n1:
 - model: "n1.5-latest" (instead of "n1-latest")
 - tool_set / disable_tools: select which built-in tools the model can use
 - json_schema: request structured output (returned as parsed_json on the response)
-- Renamed actions: hover → mouse_move, key_comb → key_press (param: key)
+- Renamed actions: hover → mouse_move; key_press param renamed from key_comb → key
 - New actions: middle_click, mouse_down, mouse_up, go_forward, hold_key
 - type no longer has press_enter_after / clear_before_typing
 - Key names are lowercase (e.g. ctrl+c, enter, left) instead of Playwright names

--- a/examples/n1_5.py
+++ b/examples/n1_5.py
@@ -669,8 +669,8 @@ async def main():
         "--json-schema", type=json.loads, default=None,
         help='JSON Schema for structured output, e.g. \'{"type":"object","properties":{"names":{"type":"array","items":{"type":"string"}}},"required":["names"]}\'',
     )
-    parser.add_argument("--timezone", default=default_config.user_timezone, help="User timezone (e.g. America/New_York)")
-    parser.add_argument("--location", default=default_config.user_location, help="User location (e.g. New York, NY, US)")
+    parser.add_argument("--timezone", dest="user_timezone", default=default_config.user_timezone, help="User timezone (e.g. America/New_York)")
+    parser.add_argument("--location", dest="user_location", default=default_config.user_location, help="User location (e.g. New York, NY, US)")
     parser.add_argument("--max-steps", type=int, default=default_config.max_steps, help="Maximum number of steps")
     parser.add_argument("--viewport-width", type=int, default=default_config.viewport_width, help="Viewport width")
     parser.add_argument("--viewport-height", type=int, default=default_config.viewport_height, help="Viewport height")
@@ -685,9 +685,6 @@ async def main():
     )
     args = parser.parse_args()
     args.tool_set = _TOOL_SET_ALIASES.get(args.tool_set, args.tool_set)
-    args.user_timezone = args.timezone
-    args.user_location = args.location
-    del args.timezone, args.location
     config = Config.model_validate(vars(args))
 
     agent = Agent(

--- a/examples/n1_5.py
+++ b/examples/n1_5.py
@@ -306,11 +306,8 @@ class Agent:
 
     async def _predict(self) -> ChatCompletion:
         screenshot_url = await self._take_screenshot()
-        current_url = self._page.url
 
         last_content = self._messages[-1]["content"]
-        if len(last_content) == 0:
-            last_content.append({"type": "text", "text": f"Current URL: {current_url}"})
         # Content separator between text and image, matching Praxis prompt builder
         if last_content:
             last_content.append({"type": "text", "text": "\n\n"})

--- a/examples/n1_5.py
+++ b/examples/n1_5.py
@@ -308,9 +308,8 @@ class Agent:
         screenshot_url = await self._take_screenshot()
 
         last_content = self._messages[-1]["content"]
-        # Content separator between text and image, matching Praxis prompt builder
-        if last_content:
-            last_content.append({"type": "text", "text": "\n\n"})
+        # Content separator between text and image
+        last_content.append({"type": "text", "text": "\n\n"})
         last_content.append(
             {
                 "type": "image_url",

--- a/examples/n1_5.py
+++ b/examples/n1_5.py
@@ -311,6 +311,9 @@ class Agent:
         last_content = self._messages[-1]["content"]
         if len(last_content) == 0:
             last_content.append({"type": "text", "text": f"Current URL: {current_url}"})
+        # Content separator between text and image, matching Praxis prompt builder
+        if last_content:
+            last_content.append({"type": "text", "text": "\n\n"})
         last_content.append(
             {
                 "type": "image_url",

--- a/yutori/n1/__init__.py
+++ b/yutori/n1/__init__.py
@@ -12,6 +12,7 @@ Provides reusable helpers for common patterns in n1/n1.5 agent loops:
 from __future__ import annotations
 
 from .content import extract_text_content
+from .context import format_task_with_context, format_user_context
 from .coordinates import N1_COORDINATE_SCALE, denormalize_coordinates, normalize_coordinates
 from .hooks import RunHooksBase
 from .images import (
@@ -30,6 +31,8 @@ __all__ = [
     "denormalize_coordinates",
     "extract_text_content",
     "create_trimmed",
+    "format_task_with_context",
+    "format_user_context",
     "map_key_to_playwright",
     "map_keys_individual",
     "N1_5_MODEL",

--- a/yutori/n1/context.py
+++ b/yutori/n1/context.py
@@ -1,0 +1,66 @@
+"""User context formatting for n1/n1.5 task messages.
+
+Appends location, timezone, and current date/time information to a task
+string, giving the model awareness of the user's environment.
+"""
+
+from __future__ import annotations
+
+import platform
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+
+def format_user_context(
+    *,
+    user_timezone: str = "America/Los_Angeles",
+    user_location: str = "San Francisco, CA, US",
+) -> str:
+    """Build a user context block with location, timezone, and current time.
+
+    Returns a multi-line string like::
+
+        User's location: San Francisco, CA, US
+        User's timezone: America/Los_Angeles
+        Current Date: April 7, 2026
+        Current Time: 10:05:49 PDT
+        Today is: Tuesday
+    """
+    try:
+        tz = ZoneInfo(user_timezone)
+    except (KeyError, Exception):
+        tz = ZoneInfo("America/Los_Angeles")
+
+    now = datetime.now(tz)
+
+    # macOS/Linux use %-d for non-padded day; Windows uses %#d.
+    day_fmt = "%#d" if platform.system() == "Windows" else "%-d"
+
+    lines = [
+        f"User's location: {user_location}",
+        f"User's timezone: {user_timezone}",
+        f"Current Date: {now.strftime(f'%B {day_fmt}, %Y')}",
+        f"Current Time: {now.strftime('%H:%M:%S %Z')}",
+        f"Today is: {now.strftime('%A')}",
+    ]
+    return "\n".join(lines)
+
+
+def format_task_with_context(
+    task: str,
+    *,
+    user_timezone: str = "America/Los_Angeles",
+    user_location: str = "San Francisco, CA, US",
+) -> str:
+    """Append user context to a task string.
+
+    Example::
+
+        >>> format_task_with_context("Book a table for 2 tonight")
+        'Book a table for 2 tonight\\n\\nUser\\'s location: San Francisco, CA, US\\n...'
+    """
+    context = format_user_context(
+        user_timezone=user_timezone,
+        user_location=user_location,
+    )
+    return f"{task}\n\n{context}"

--- a/yutori/n1/context.py
+++ b/yutori/n1/context.py
@@ -7,7 +7,7 @@ string, giving the model awareness of the user's environment.
 from __future__ import annotations
 
 import platform
-from datetime import datetime
+from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
 
@@ -35,7 +35,7 @@ def format_user_context(
         except Exception:
             # No IANA timezone data available (e.g. Windows without tzdata).
             # Fall back to UTC via the stdlib.
-            tz = None
+            tz = timezone.utc
             user_timezone = "UTC"
 
     now = datetime.now(tz)

--- a/yutori/n1/context.py
+++ b/yutori/n1/context.py
@@ -30,6 +30,7 @@ def format_user_context(
         tz = ZoneInfo(user_timezone)
     except (KeyError, Exception):
         tz = ZoneInfo("America/Los_Angeles")
+        user_timezone = str(tz)
 
     now = datetime.now(tz)
 

--- a/yutori/n1/context.py
+++ b/yutori/n1/context.py
@@ -28,9 +28,15 @@ def format_user_context(
     """
     try:
         tz = ZoneInfo(user_timezone)
-    except (KeyError, Exception):
-        tz = ZoneInfo("America/Los_Angeles")
-        user_timezone = str(tz)
+    except Exception:
+        try:
+            tz = ZoneInfo("America/Los_Angeles")
+            user_timezone = str(tz)
+        except Exception:
+            # No IANA timezone data available (e.g. Windows without tzdata).
+            # Fall back to UTC via the stdlib.
+            tz = None
+            user_timezone = "UTC"
 
     now = datetime.now(tz)
 

--- a/yutori/n1/context.py
+++ b/yutori/n1/context.py
@@ -7,7 +7,7 @@ string, giving the model awareness of the user's environment.
 from __future__ import annotations
 
 import platform
-from datetime import datetime, timezone
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
 


### PR DESCRIPTION
Adding some minor changes to message construction in the example for better parity with how model expects message format to be.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to an example script and new prompt-formatting utilities, with primary impact on model prompting/response behavior rather than core runtime logic.
> 
> **Overview**
> **Adds user-context prompt formatting.** Introduces `yutori/n1/context.py` with `format_user_context` and `format_task_with_context`, and exports them from `yutori/n1/__init__.py`.
> 
> **Updates the `examples/n1_5.py` agent loop for message parity.** The example now appends timezone/location/current date-time context to the user task (configurable via new `--timezone`/`--location` flags) and always inserts a `\n\n` text separator before attaching the screenshot image to the last message content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68fddf94939dc27aef377565e0a0e42f4ca79f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->