### PR TITLE
fix: update scouts list() tests to match removed limit param

### DIFF
--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -106,7 +106,7 @@ class TestAsyncScoutsNamespace:
                 assert result == {"scouts": []}
                 params = mock_get.call_args[1]["params"]
                 assert params["page_size"] == 10
-                assert params["limit"] == 10
+                assert "limit" not in params
                 assert params["status"] == "active"
 
     async def test_scouts_get(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -143,7 +143,7 @@ class TestScoutsNamespace:
             mock_get.assert_called_once()
             params = mock_get.call_args[1]["params"]
             assert params["page_size"] == 10
-            assert params["limit"] == 10
+            assert "limit" not in params
             assert params["status"] == "active"
 
     def test_scouts_get(self, client):


### PR DESCRIPTION
## Summary
- The redundant `limit` query param was removed from `scouts.list()` in 5cb83bb, but the sync and async test assertions still expected it, causing 2 test failures
- Updated both `test_client.py` and `test_async_client.py` to assert `limit` is **not** in the query params

## Test plan
- [x] `uv run pytest tests/ -v` — 236 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adjusts test assertions to match existing request behavior and does not change production code paths.
> 
> **Overview**
> Aligns `scouts.list()` unit tests (sync and async) with the recent removal of the redundant `limit` query parameter.
> 
> Both `tests/test_client.py` and `tests/test_async_client.py` now assert that only `page_size` is sent (and that `limit` is absent) when listing scouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fea71363dfc545f3911834d9b911c26a9068cbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->