### PR TITLE
Add user initiated stop example / helper

### DIFF
--- a/examples/n1_5.py
+++ b/examples/n1_5.py
@@ -166,7 +166,8 @@ class Agent:
         self._step_count = 0
 
     async def run(self, task: str, start_url: str) -> str:
-        # Append user context (location, timezone, current date/time) to the task
+        # Keep original task for stop-and-summarize; format with context for the model
+        original_task = task
         task = format_task_with_context(
             task,
             user_timezone=self.user_timezone,
@@ -224,14 +225,14 @@ class Agent:
 
                 if self._step_count >= self.max_steps:
                     logger.warning(f"Reached maximum steps ({self.max_steps})")
-                    final_response = await self._stop_and_summarize(task)
+                    final_response = await self._stop_and_summarize(original_task)
 
             except KeyboardInterrupt:
                 logger.info("Interrupted by user")
-                final_response = await self._stop_and_summarize(task)
+                final_response = await self._stop_and_summarize(original_task)
             except Exception as e:
                 logger.error(f"Agent error: {e}")
-                final_response = await self._stop_and_summarize(task)
+                final_response = await self._stop_and_summarize(original_task)
             finally:
                 await self._close_browser()
 

--- a/examples/n1_5.py
+++ b/examples/n1_5.py
@@ -222,8 +222,8 @@ class Agent:
                             result += self._url_suffix()
                         content = [{"type": "text", "text": result}] if result else []
                         self._messages.append({"role": "tool", "tool_call_id": tool_call.id, "content": content})
-
-                if self._step_count >= self.max_steps:
+                else:
+                    # Loop exhausted without break — model was still working when limit hit
                     logger.warning(f"Reached maximum steps ({self.max_steps})")
                     final_response = await self._stop_and_summarize(original_task)
 

--- a/examples/n1_5.py
+++ b/examples/n1_5.py
@@ -351,7 +351,14 @@ class Agent:
             })
 
             logger.info("Requesting final summary from model...")
-            response = await self._call_llm_with_retries()
+            response = await asyncio.wait_for(
+                self._client.chat.completions.create(
+                    model=self.model,
+                    messages=self._messages,
+                    temperature=self.temperature,
+                ),
+                timeout=120.0,
+            )
             message = response.choices[0].message
             return message.content or ""
         except Exception as e:

--- a/examples/n1_5.py
+++ b/examples/n1_5.py
@@ -351,14 +351,7 @@ class Agent:
             })
 
             logger.info("Requesting final summary from model...")
-            response = await asyncio.wait_for(
-                self._client.chat.completions.create(
-                    model=self.model,
-                    messages=self._messages,
-                    temperature=self.temperature,
-                ),
-                timeout=120.0,
-            )
+            response = await self._call_llm_with_retries()
             message = response.choices[0].message
             return message.content or ""
         except Exception as e:

--- a/examples/n1_5.py
+++ b/examples/n1_5.py
@@ -57,6 +57,7 @@ from yutori.n1 import (
     aplaywright_screenshot_to_data_url,
     denormalize_coordinates,
     estimate_messages_size_bytes,
+    format_stop_and_summarize,
     format_task_with_context,
     map_key_to_playwright,
     map_keys_individual,
@@ -223,9 +224,14 @@ class Agent:
 
                 if self._step_count >= self.max_steps:
                     logger.warning(f"Reached maximum steps ({self.max_steps})")
+                    final_response = await self._stop_and_summarize(task)
 
             except KeyboardInterrupt:
                 logger.info("Interrupted by user")
+                final_response = await self._stop_and_summarize(task)
+            except Exception as e:
+                logger.error(f"Agent error: {e}")
+                final_response = await self._stop_and_summarize(task)
             finally:
                 await self._close_browser()
 
@@ -322,6 +328,34 @@ class Agent:
 
         response = await self._call_llm_with_retries()
         return response.choices[0].message
+
+    async def _stop_and_summarize(self, task: str) -> str:
+        """Send a final stop message to get the model to summarize its progress.
+
+        Takes a screenshot, appends a "Stop here. Summarize..." user message,
+        and calls the model one last time to produce a text summary rather
+        than returning nothing on max steps, errors, or interruption.
+        """
+        try:
+            # Take a final screenshot so the model can see the current state
+            screenshot_url = await self._take_screenshot()
+            stop_message = format_stop_and_summarize(task)
+            self._messages.append({
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": stop_message},
+                    {"type": "text", "text": "\n\n"},
+                    {"type": "image_url", "image_url": {"url": screenshot_url, "detail": "high"}},
+                ],
+            })
+
+            logger.info("Requesting final summary from model...")
+            response = await self._call_llm_with_retries()
+            message = response.choices[0].message
+            return message.content or ""
+        except Exception as e:
+            logger.error(f"Failed to get stop summary: {e}")
+            return ""
 
     # ------------------------------------------------------------------
     # Coordinate resolution — supports both normalized coordinates and

--- a/yutori/n1/__init__.py
+++ b/yutori/n1/__init__.py
@@ -24,6 +24,7 @@ from .keys import map_key_to_playwright, map_keys_individual
 from .loop import acreate_trimmed, create_trimmed
 from .models import N1_5_MODEL, N1_MODEL, TOOL_SET_CORE, TOOL_SET_EXPANDED
 from .payload import estimate_messages_size_bytes, trim_images_to_fit, trimmed_messages_to_fit
+from .stop import format_stop_and_summarize
 
 __all__ = [
     "acreate_trimmed",
@@ -32,6 +33,7 @@ __all__ = [
     "extract_text_content",
     "create_trimmed",
     "format_task_with_context",
+    "format_stop_and_summarize",
     "format_user_context",
     "map_key_to_playwright",
     "map_keys_individual",

--- a/yutori/n1/context.py
+++ b/yutori/n1/context.py
@@ -7,7 +7,7 @@ string, giving the model awareness of the user's environment.
 from __future__ import annotations
 
 import platform
-from datetime import datetime
+from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
 

--- a/yutori/n1/context.py
+++ b/yutori/n1/context.py
@@ -34,7 +34,6 @@ def format_user_context(
             user_timezone = str(tz)
         except Exception:
             # No IANA timezone data available (e.g. Windows without tzdata).
-            # Fall back to UTC via the stdlib.
             tz = timezone.utc
             user_timezone = "UTC"
 

--- a/yutori/n1/context.py
+++ b/yutori/n1/context.py
@@ -7,7 +7,7 @@ string, giving the model awareness of the user's environment.
 from __future__ import annotations
 
 import platform
-from datetime import datetime, timezone
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
 

--- a/yutori/n1/stop.py
+++ b/yutori/n1/stop.py
@@ -1,0 +1,29 @@
+"""Stop-and-summarize message for graceful agent termination.
+
+When an agent loop hits max steps, encounters an error, or is
+interrupted, sending a final "stop" message prompts the model to
+summarize its progress rather than returning nothing.
+"""
+
+from __future__ import annotations
+
+
+def format_stop_and_summarize(task: str) -> str:
+    """Build a stop-and-summarize message for the given task.
+
+    Intended to be sent as a user message after the last tool response
+    (with a screenshot) so the model produces a final text summary.
+
+    Example::
+
+        >>> format_stop_and_summarize("Find the cheapest flight to Tokyo")
+        'Stop here. Summarize your current progress and list in detail ...'
+    """
+    return (
+        f"Stop here. "
+        f"Summarize your current progress and list in detail all the findings "
+        f"relevant to the given task:\n{task}\n"
+        f"Provide URLs for all relevant results you find and return them in your response. "
+        f"If there is no specific URL for a result, "
+        f"cite the page URL that the information was found on."
+    )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a small prompt-formatting helper and updates an example script to request a final summary on max-steps, interrupts, or errors, without changing core library execution paths.
> 
> **Overview**
> Adds a new `format_stop_and_summarize` helper (`yutori/n1/stop.py`) and exports it from `yutori.n1` for generating a final “stop and summarize progress” user message.
> 
> Updates the `examples/n1_5.py` agent loop to preserve the original task and, when max steps are hit (or on `KeyboardInterrupt`/unexpected exceptions), take a final screenshot, send the stop message, and make one last model call to return a best-effort summary instead of ending without a useful response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f1ceb0f6f5c8644468e0e30e080b0dff76965a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->