### PR TITLE
test: add n1.5 test coverage

### DIFF
--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -411,6 +411,58 @@ class TestAsyncChatNamespace:
                 )
                 assert result.choices[0].message.content == "click"
 
+    async def test_chat_completions_n1_5_forwards_extra_body_options(self):
+        from openai.types.chat import ChatCompletion, ChatCompletionMessage
+        from openai.types.chat.chat_completion import Choice
+
+        from yutori.n1 import TOOL_SET_CORE
+
+        json_schema = {
+            "type": "object",
+            "properties": {"status": {"type": "string"}},
+            "required": ["status"],
+            "additionalProperties": False,
+        }
+        mock_completion = ChatCompletion(
+            id="chatcmpl-123",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content='{"status":"ok"}'),
+                )
+            ],
+            created=1234567890,
+            model="n1.5-latest",
+            object="chat.completion",
+        )
+
+        with patch("yutori._async.chat.AsyncOpenAI") as MockAsyncOpenAI:
+            mock_openai_client = MagicMock()
+            mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+            mock_openai_client.close = AsyncMock()
+            MockAsyncOpenAI.return_value = mock_openai_client
+
+            async with AsyncYutoriClient(api_key="yt-test") as client:
+                result = await client.chat.completions.create(
+                    messages=[{"role": "user", "content": "Reply with JSON."}],
+                    model="n1.5-latest",
+                    tool_set=TOOL_SET_CORE,
+                    disable_tools=["hold_key"],
+                    json_schema=json_schema,
+                    extra_body={"trace_id": "trace-123"},
+                )
+                assert result.choices[0].message.content == '{"status":"ok"}'
+
+        call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == "n1.5-latest"
+        assert call_kwargs["extra_body"] == {
+            "trace_id": "trace-123",
+            "tool_set": TOOL_SET_CORE,
+            "disable_tools": ["hold_key"],
+            "json_schema": json_schema,
+        }
+
     async def test_n1_helper_acreate_trimmed_public_helper_uses_trimmed_copy(self):
         from copy import deepcopy
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -444,6 +444,57 @@ class TestChatNamespace:
             assert call_kwargs["model"] == "n1-latest"
             client.close()
 
+    def test_chat_completions_n1_5_forwards_extra_body_options(self):
+        from openai.types.chat import ChatCompletion, ChatCompletionMessage
+        from openai.types.chat.chat_completion import Choice
+
+        from yutori.n1 import TOOL_SET_CORE
+
+        json_schema = {
+            "type": "object",
+            "properties": {"status": {"type": "string"}},
+            "required": ["status"],
+            "additionalProperties": False,
+        }
+        mock_completion = ChatCompletion(
+            id="chatcmpl-123",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content='{"status":"ok"}'),
+                )
+            ],
+            created=1234567890,
+            model="n1.5-latest",
+            object="chat.completion",
+        )
+
+        with patch("yutori._sync.chat.OpenAI") as MockOpenAI:
+            mock_openai_client = MagicMock()
+            mock_openai_client.chat.completions.create.return_value = mock_completion
+            MockOpenAI.return_value = mock_openai_client
+
+            client = YutoriClient(api_key="yt-test")
+            result = client.chat.completions.create(
+                messages=[{"role": "user", "content": "Reply with JSON."}],
+                model="n1.5-latest",
+                tool_set=TOOL_SET_CORE,
+                disable_tools=["hold_key"],
+                json_schema=json_schema,
+                extra_body={"trace_id": "trace-123"},
+            )
+            assert result.choices[0].message.content == '{"status":"ok"}'
+            call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+            assert call_kwargs["model"] == "n1.5-latest"
+            assert call_kwargs["extra_body"] == {
+                "trace_id": "trace-123",
+                "tool_set": TOOL_SET_CORE,
+                "disable_tools": ["hold_key"],
+                "json_schema": json_schema,
+            }
+            client.close()
+
     def test_n1_helper_create_trimmed_public_helper_uses_trimmed_copy(self):
         from copy import deepcopy
 

--- a/tests/test_n1_keys.py
+++ b/tests/test_n1_keys.py
@@ -1,0 +1,111 @@
+"""Tests for n1.5 key mapping helpers."""
+
+import pytest
+
+from yutori.n1.keys import map_key_to_playwright, map_keys_individual
+
+
+class TestMapKeyToPlaywright:
+    """map_key_to_playwright converts n1.5 key expressions to Playwright press() strings."""
+
+    def test_single_modifier_combo(self):
+        assert map_key_to_playwright("ctrl+c") == ["Control+c"]
+
+    def test_multi_modifier_combo(self):
+        assert map_key_to_playwright("ctrl+shift+t") == ["Control+Shift+t"]
+
+    def test_sequential_presses(self):
+        assert map_key_to_playwright("down down enter") == ["ArrowDown", "ArrowDown", "Enter"]
+
+    def test_single_key(self):
+        assert map_key_to_playwright("enter") == ["Enter"]
+
+    def test_arrow_keys(self):
+        assert map_key_to_playwright("left") == ["ArrowLeft"]
+        assert map_key_to_playwright("right") == ["ArrowRight"]
+        assert map_key_to_playwright("up") == ["ArrowUp"]
+        assert map_key_to_playwright("down") == ["ArrowDown"]
+
+    def test_escape_aliases(self):
+        assert map_key_to_playwright("escape") == ["Escape"]
+        assert map_key_to_playwright("esc") == ["Escape"]
+
+    def test_enter_aliases(self):
+        assert map_key_to_playwright("enter") == ["Enter"]
+        assert map_key_to_playwright("return") == ["Enter"]
+
+    def test_modifier_aliases(self):
+        assert map_key_to_playwright("cmd+a") == ["Meta+a"]
+        assert map_key_to_playwright("command+a") == ["Meta+a"]
+        assert map_key_to_playwright("option+tab") == ["Alt+Tab"]
+        assert map_key_to_playwright("alt+tab") == ["Alt+Tab"]
+
+    def test_function_keys(self):
+        assert map_key_to_playwright("f1") == ["F1"]
+        assert map_key_to_playwright("f12") == ["F12"]
+
+    def test_space_key(self):
+        assert map_key_to_playwright("space") == [" "]
+
+    def test_tab_key(self):
+        assert map_key_to_playwright("tab") == ["Tab"]
+
+    def test_backspace_and_delete(self):
+        assert map_key_to_playwright("backspace") == ["Backspace"]
+        assert map_key_to_playwright("delete") == ["Delete"]
+
+    def test_page_navigation(self):
+        assert map_key_to_playwright("home") == ["Home"]
+        assert map_key_to_playwright("end") == ["End"]
+        assert map_key_to_playwright("pageup") == ["PageUp"]
+        assert map_key_to_playwright("pagedown") == ["PageDown"]
+
+    def test_unknown_key_passes_through(self):
+        assert map_key_to_playwright("x") == ["x"]
+        assert map_key_to_playwright("a") == ["a"]
+
+    def test_preserves_literal_characters(self):
+        assert map_key_to_playwright("/") == ["/"]
+        assert map_key_to_playwright(".") == ["."]
+
+    def test_word_form_punctuation(self):
+        assert map_key_to_playwright("plus") == ["+"]
+        assert map_key_to_playwright("minus") == ["-"]
+        assert map_key_to_playwright("slash") == ["/"]
+
+    def test_strips_whitespace(self):
+        assert map_key_to_playwright("  enter  ") == ["Enter"]
+
+    def test_empty_string_returns_empty_list(self):
+        assert map_key_to_playwright("") == []
+        assert map_key_to_playwright("   ") == []
+
+    def test_mixed_sequential_and_combo(self):
+        # tab then ctrl+a is two separate presses
+        assert map_key_to_playwright("tab ctrl+a") == ["Tab", "Control+a"]
+
+
+class TestMapKeysIndividual:
+    """map_keys_individual flattens combos into individual Playwright keys."""
+
+    def test_combo_is_split(self):
+        assert map_keys_individual("ctrl+c") == ["Control", "c"]
+
+    def test_multi_modifier_combo_is_split(self):
+        assert map_keys_individual("ctrl+shift+t") == ["Control", "Shift", "t"]
+
+    def test_sequential_presses(self):
+        assert map_keys_individual("down down enter") == ["ArrowDown", "ArrowDown", "Enter"]
+
+    def test_single_key(self):
+        assert map_keys_individual("enter") == ["Enter"]
+
+    def test_ctrl_plus_maps_correctly(self):
+        # "ctrl+plus" → ["Control", "+"]
+        assert map_keys_individual("ctrl+plus") == ["Control", "+"]
+
+    def test_empty_string(self):
+        assert map_keys_individual("") == []
+
+    def test_whitespace_only(self):
+        assert map_keys_individual("   ") == []

--- a/tests/test_n1_models.py
+++ b/tests/test_n1_models.py
@@ -1,0 +1,24 @@
+"""Tests for n1/n1.5 model constants and tool set identifiers."""
+
+from yutori.n1 import N1_5_MODEL, N1_MODEL, TOOL_SET_CORE, TOOL_SET_EXPANDED
+
+
+class TestModelConstants:
+    def test_n1_model_identifier(self):
+        assert N1_MODEL == "n1-latest"
+
+    def test_n1_5_model_identifier(self):
+        assert N1_5_MODEL == "n1.5-latest"
+
+
+class TestToolSetConstants:
+    def test_core_tool_set(self):
+        assert "core" in TOOL_SET_CORE
+        assert TOOL_SET_CORE == "browser_tools_core-20260403"
+
+    def test_expanded_tool_set(self):
+        assert "expanded" in TOOL_SET_EXPANDED
+        assert TOOL_SET_EXPANDED == "browser_tools_expanded-20260403"
+
+    def test_tool_sets_are_distinct(self):
+        assert TOOL_SET_CORE != TOOL_SET_EXPANDED


### PR DESCRIPTION
## Summary
- Adds `extra_body` wiring tests for `tool_set`, `disable_tools`, and `json_schema` on both sync and async `ChatCompletions.create` — verifies n1.5 params merge correctly with caller-provided `extra_body`
- Adds `test_n1_keys.py` with 26 tests covering `map_key_to_playwright` and `map_keys_individual` (modifier aliases, arrow keys, sequential presses, combos, edge cases)
- Adds `test_n1_models.py` with 5 tests for `N1_5_MODEL`, `TOOL_SET_CORE`, and `TOOL_SET_EXPANDED` constants

## Test plan
- [x] `uv run pytest tests/ -v` — 269 passed, 0 failed (up from 236)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add coverage around request payload shaping and key/model helpers; low risk aside from potential brittleness due to asserting exact `extra_body` shapes and constant values.
> 
> **Overview**
> Adds new sync+async tests ensuring n1.5 `ChatCompletions.create` merges `tool_set`, `disable_tools`, and `json_schema` into caller-provided `extra_body` when forwarding to the underlying OpenAI client.
> 
> Introduces dedicated test suites for n1.5 key mapping helpers (`map_key_to_playwright`, `map_keys_individual`) across combos, aliases, sequential presses, and edge cases, plus simple assertions for `N1_MODEL`/`N1_5_MODEL` and `TOOL_SET_*` constant identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da1fb95037a3c68a7a879d3a2f691aec53a99ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->