### PR TITLE
docs: add n1.5 documentation to README and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ if message.tool_calls:
 
 Live n1 model IDs and parameter docs are maintained at `https://docs.yutori.com/reference/n1`. The SDK forwards standard OpenAI chat-completions parameters through `**kwargs`, including `tools`, `tool_choice`, and `response_format`.
 
+The SDK exports canonical model constants so you don't need to hardcode strings:
+
+```python
+from yutori.n1 import N1_MODEL, N1_5_MODEL
+
+# N1_MODEL   = "n1-latest"
+# N1_5_MODEL = "n1.5-latest"
+```
+
 For Playwright users, the SDK provides a screenshot helper that captures and encodes images optimized for n1:
 
 ```python
@@ -125,6 +134,31 @@ coords = [500, 250]
 x, y = denormalize_coordinates(coords, width=1280, height=800)
 ```
 
+For agent loops that need user context (location, timezone, current date/time), the SDK provides formatting helpers:
+
+```python
+from yutori.n1 import format_task_with_context, format_stop_and_summarize
+
+# Append user context to a task string
+task = format_task_with_context(
+    "Book a table for 2 tonight",
+    user_timezone="America/Los_Angeles",
+    user_location="San Francisco, CA, US",
+)
+# Result:
+#   Book a table for 2 tonight
+#
+#   User's location: San Francisco, CA, US
+#   User's timezone: America/Los_Angeles
+#   Current Date: April 11, 2026
+#   Current Time: 14:05:49 PDT
+#   Today is: Saturday
+
+# When hitting max steps or an error, send a stop-and-summarize message
+# so the model returns a summary instead of nothing
+stop_message = format_stop_and_summarize("Book a table for 2 tonight")
+```
+
 For screenshot-heavy agent loops, the SDK also provides opt-in trimming helpers under `yutori.n1`:
 
 ```python
@@ -149,6 +183,46 @@ history before the next step so old screenshots do not keep accumulating in memo
 deep-copying the full history on every step when trimming is not needed.
 
 If you don't want to manage your own browser infrastructure, use the Browsing API which calls n1 on a cloud browser.
+
+### n1.5
+
+n1.5 extends the n1 API with selectable tool sets, structured JSON output, and a redesigned action space. It uses the same `client.chat.completions.create(...)` call with three additional parameters:
+
+```python
+from yutori.n1 import N1_5_MODEL, TOOL_SET_EXPANDED
+
+response = client.chat.completions.create(
+    model=N1_5_MODEL,
+    messages=messages,
+    tool_set=TOOL_SET_EXPANDED,               # Built-in tool set
+    disable_tools=["hold_key", "drag"],        # Remove specific tools
+    json_schema={                              # Request structured output
+        "type": "object",
+        "properties": {"names": {"type": "array", "items": {"type": "string"}}},
+        "required": ["names"],
+    },
+)
+```
+
+**Parameters:**
+- `tool_set` — Built-in tool set to activate. Use the constants `TOOL_SET_CORE` (`"browser_tools_core-20260403"`) or `TOOL_SET_EXPANDED` (`"browser_tools_expanded-20260403"`), which adds `extract_elements`, `find`, `set_element_value`, and `execute_js`.
+- `disable_tools` — List of tool names to remove from the selected tool set.
+- `json_schema` — JSON Schema dict for structured output. When provided, the model returns a `parsed_json` field on the response.
+
+n1.5 also uses lowercase key names (e.g. `ctrl+c`, `enter`) instead of Playwright names. The SDK provides helpers to convert them:
+
+```python
+from yutori.n1 import map_key_to_playwright, map_keys_individual
+
+# Single key or combo → Playwright format
+map_key_to_playwright("ctrl+c")    # "Control+c"
+map_key_to_playwright("enter")     # "Enter"
+
+# For keyboard.down()/up() which need individual keys
+map_keys_individual("ctrl+shift")  # ["Control", "Shift"]
+```
+
+See [examples/n1_5.py](examples/n1_5.py) for a complete n1.5 browsing agent.
 
 ## Browsing API
 
@@ -505,7 +579,11 @@ Run `yutori --help` or `yutori <command> --help` for full option details.
 
 ## Examples
 
-See [examples/](examples/) for complete working examples, including a browser automation agent using the n1 API.
+See [examples/](examples/) for complete working examples:
+- [`n1.py`](examples/n1.py) — Browser automation agent using the n1 API
+- [`n1_5.py`](examples/n1_5.py) — Browser automation agent using n1.5 with tool sets, structured output, and key mapping
+- [`n1_custom_tools.py`](examples/n1_custom_tools.py) — n1 agent with custom tools for content extraction
+- [`n1_memo.py`](examples/n1_memo.py) — n1 agent with custom tools for memorizing information
 
 ## Contributing
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,25 @@ Options:
 - `--headless` - Run browser in headless mode
 - `--max-steps` - Maximum number of steps (default: 100)
 
+## n1_5.py
+
+A complete browsing agent using the n1.5 API. n1.5 introduces selectable tool sets (`TOOL_SET_CORE`, `TOOL_SET_EXPANDED`), optional structured JSON output via `--json-schema`, and a redesigned action space with lowercase key names. The example uses `format_task_with_context(...)` to append user context, `map_key_to_playwright(...)` / `map_keys_individual(...)` for key mapping, and `format_stop_and_summarize(...)` for graceful termination when hitting max steps.
+
+```bash
+uv run python examples/n1_5.py --task "List the team member names" --start-url "https://www.yutori.com"
+```
+
+Options:
+- `--task` - The task to perform
+- `--start-url` - Starting URL
+- `--headless` - Run browser in headless mode
+- `--max-steps` - Maximum number of steps (default: 100)
+- `--tool-set` - Tool set to use: `core` or `expanded` (default: core)
+- `--disable-tools` - Space-separated list of tools to disable
+- `--json-schema` - JSON schema string for structured output
+- `--timezone` - User timezone (default: America/Los_Angeles)
+- `--location` - User location (default: San Francisco, CA, US)
+
 ## n1_custom_tools.py
 
 Extends the basic agent with a custom tool for extracting content and links from the page. Demonstrates how to define custom tools and pass them to the n1 API.


### PR DESCRIPTION
## Summary

The v0.5.0 release merged several PRs introducing n1.5 model support, but the README and examples/README.md were not updated to reflect these changes. The entire n1.5 feature set — the headline capability of 0.5.0 — was undiscoverable from documentation.

**Commits that introduced the drift:**
- #36 — n1.5 model support with `N1_5_MODEL`, `TOOL_SET_CORE`, `TOOL_SET_EXPANDED`, `tool_set`/`disable_tools`/`json_schema` params, key mapping helpers, `n1_5.py` example
- #40 — `format_task_with_context()` and `format_user_context()` helpers
- #42 — `format_stop_and_summarize()` helper
- #44 — Refactored n1 examples with page ready helpers

**What was out of sync:**
- README mentioned only `n1-latest` with no mention of n1.5
- The three new `create()` parameters (`tool_set`, `disable_tools`, `json_schema`) were undocumented
- New agent-loop helpers (`format_task_with_context`, `format_stop_and_summarize`) were not shown
- Key mapping helpers (`map_key_to_playwright`, `map_keys_individual`) were not mentioned
- The `n1_5.py` example was missing from both READMEs
- The Examples section only had a vague pointer instead of listing available examples

**What this PR updates:**
- Add model constants section with `N1_MODEL` / `N1_5_MODEL`
- Document `format_task_with_context` and `format_stop_and_summarize` helpers
- Add n1.5 subsection covering `tool_set`, `disable_tools`, `json_schema` params
- Document key mapping helpers for n1.5 lowercase key names
- Add `n1_5.py` entry to `examples/README.md` with full CLI options
- List all four examples explicitly in root README

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime code paths or APIs are modified, but incorrect docs could cause user confusion if examples drift from actual SDK behavior.
> 
> **Overview**
> Updates the docs to make `n1.5` discoverable and usable from the README, including model constants (`N1_MODEL`, `N1_5_MODEL`), agent-loop formatting helpers (`format_task_with_context`, `format_stop_and_summarize`), and the n1.5-specific `tool_set`/`disable_tools`/`json_schema` parameters plus key-mapping helpers.
> 
> Improves the Examples sections by explicitly listing available scripts and adding a dedicated `n1_5.py` entry in `examples/README.md` with its CLI flags (tool set selection, disabling tools, JSON schema, timezone/location).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d55c5b8201c96b74bf17eeda534eba0c0db8d90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->