### PR TITLE
refactor(cli): extract shared format_interval helper for scouts

### DIFF
--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -11,6 +11,7 @@ from rich.markup import escape
 from yutori.auth.credentials import resolve_api_key
 
 __all__ = [
+    "format_interval",
     "get_authenticated_client",
     "print_rejection_reason",
     "print_task_submission_result",
@@ -49,3 +50,22 @@ def print_task_submission_result(console: Console, task_type: str, result: dict[
     console.print(f"  Task ID: {result.get('task_id', 'N/A')}")
     console.print(f"  Status: {status}")
     print_rejection_reason(console, result)
+
+
+def format_interval(seconds: int, *, short: bool = False) -> str:
+    """Format an interval in seconds as a human-readable string.
+
+    Picks the coarsest unit (days/hours/minutes) that fits and truncates.
+
+    Args:
+        seconds: Interval length in seconds.
+        short: If True, use compact form (e.g. ``"1d"``). Otherwise use the
+            verbose form (e.g. ``"1 day(s)"``).
+    """
+    if seconds >= 86400:
+        value, unit_short, unit_long = seconds // 86400, "d", "day(s)"
+    elif seconds >= 3600:
+        value, unit_short, unit_long = seconds // 3600, "h", "hour(s)"
+    else:
+        value, unit_short, unit_long = seconds // 60, "m", "minute(s)"
+    return f"{value}{unit_short}" if short else f"{value} {unit_long}"

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from rich.markup import escape
 from rich.table import Table
 
-from yutori.cli.commands import get_authenticated_client, print_rejection_reason
+from yutori.cli.commands import format_interval, get_authenticated_client, print_rejection_reason
 
 app = typer.Typer(help="Manage scouts")
 console = Console()
@@ -37,13 +37,7 @@ def list_scouts(
         table.add_column("Reason", max_width=32)
 
         for scout in scouts:
-            interval_secs = scout.get("output_interval") or 0
-            if interval_secs >= 86400:
-                interval_str = f"{interval_secs // 86400}d"
-            elif interval_secs >= 3600:
-                interval_str = f"{interval_secs // 3600}h"
-            else:
-                interval_str = f"{interval_secs // 60}m"
+            interval_str = format_interval(scout.get("output_interval") or 0, short=True)
 
             query = scout.get("query", "")
             if len(query) > 47:
@@ -77,13 +71,7 @@ def get(
         console.print(f"  Status: {scout.get('status', 'N/A')}")
         print_rejection_reason(console, scout)
 
-        interval_secs = scout.get("output_interval") or 0
-        if interval_secs >= 86400:
-            interval_str = f"{interval_secs // 86400} day(s)"
-        elif interval_secs >= 3600:
-            interval_str = f"{interval_secs // 3600} hour(s)"
-        else:
-            interval_str = f"{interval_secs // 60} minute(s)"
+        interval_str = format_interval(scout.get("output_interval") or 0)
         console.print(f"  Interval: {interval_str}")
 
         if scout.get("user_timezone"):


### PR DESCRIPTION
## Summary

- `scouts list` and `scouts get` each hand-rolled identical seconds→days/hours/minutes arithmetic, with two different output formats (`"1d"` vs `"1 day(s)"`).
- Extract a single `format_interval()` helper in `yutori/cli/commands/__init__.py` that supports both short and verbose forms via a keyword-only `short` flag.
- The threshold logic (≥86400 / ≥3600 / else) now lives in one place, so a future tweak (e.g. adding a "weeks" bucket) touches one function instead of two.

## Why it's safe

- Pure refactor — no behavioral change. `list` still prints `"1d"`, `get` still prints `"1 day(s)"`, for all the same inputs.
- Blast radius is two call sites, both in `yutori/cli/commands/scouts.py`. No other module formats intervals this way.
- Existing CLI tests in `tests/test_cli.py` (including `test_scouts_list_shows_rejection_reason_column` and `test_scouts_get_shows_rejection_reason`) still exercise both code paths.

## Test plan

- [ ] `uv run pytest tests/test_cli.py` passes
- [ ] `yutori scouts list` and `yutori scouts get <id>` render intervals identically to `main`

Refactor item from https://github.com/yutori-ai/yutori/blob/main/.claude/REFACTOR.md ("Consolidate CLI interval formatting"); companion PR removes it from the list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only consolidates duplicated interval-string formatting logic; behavior should remain the same aside from potential edge-case formatting differences if callers relied on the old inline math.
> 
> **Overview**
> Extracts a shared `format_interval()` helper into `yutori/cli/commands/__init__.py` to convert seconds into day/hour/minute strings with either *short* (e.g. `"1d"`) or verbose (e.g. `"1 day(s)"`) output.
> 
> Updates `scouts list` and `scouts get` to call this helper instead of duplicating threshold/formatting logic inline, keeping interval rendering consistent across both commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a924a232150b1d2758dda9b73b378fde95a0f9da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->