### PR TITLE
docs(api): update /v1/usage response to navigator_* field names

### DIFF
--- a/api.md
+++ b/api.md
@@ -80,8 +80,10 @@ usage = client.get_usage(period="7d")
 - `num_active_scouts` (`int`)
 - `active_scout_ids` (`list[str]`)
 - `rate_limits` (`dict`): `requests_today`, `daily_limit`, `remaining_requests`, `reset_at`, `status` (`"available"` | `"unavailable"`)
-- `n1_rate_limits` (`dict`): `requests_today`, `daily_limit`, `remaining_requests`, `reset_at`, `per_second_limit`
-- `activity` (`dict`): `period`, `scout_runs`, `browsing_tasks`, `research_tasks`, `n1_calls`
+- `navigator_rate_limits` (`dict`): `requests_today`, `daily_limit`, `remaining_requests`, `reset_at`, `per_second_limit`
+- `activity` (`dict`): `period`, `scout_runs`, `browsing_tasks`, `research_tasks`, `navigator_calls`
+
+The response also includes `n1_rate_limits` and `activity.n1_calls` as deprecated aliases of `navigator_rate_limits` and `navigator_calls` respectively. They will be removed in a future release — prefer the `navigator_*` names.
 
 ## Model constants and tool sets
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -38,6 +38,15 @@ class TestAsyncYutoriClientInit:
 
 @pytest.mark.asyncio
 class TestAsyncYutoriClientGetUsage:
+    # Mirrors the current server dual-emit: both navigator_* and n1_* keys
+    # are present with equal values. See yutori.codex PR #8174.
+    _NAVIGATOR_LIMITS = {
+        "requests_today": 50,
+        "daily_limit": 50000,
+        "remaining_requests": 49950,
+        "reset_at": "2026-03-04T00:00:00+00:00",
+        "per_second_limit": 20,
+    }
     USAGE_RESPONSE = {
         "num_active_scouts": 2,
         "active_scout_ids": ["id-1", "id-2"],
@@ -48,18 +57,14 @@ class TestAsyncYutoriClientGetUsage:
             "reset_at": "2026-03-04T00:00:00+00:00",
             "status": "available",
         },
-        "n1_rate_limits": {
-            "requests_today": 50,
-            "daily_limit": 50000,
-            "remaining_requests": 49950,
-            "reset_at": "2026-03-04T00:00:00+00:00",
-            "per_second_limit": 20,
-        },
+        "navigator_rate_limits": _NAVIGATOR_LIMITS,
+        "n1_rate_limits": _NAVIGATOR_LIMITS,
         "activity": {
             "period": "24h",
             "scout_runs": 10,
             "browsing_tasks": 3,
             "research_tasks": 2,
+            "navigator_calls": 50,
             "n1_calls": 50,
         },
     }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -44,6 +44,15 @@ class TestYutoriClientInit:
 
 
 class TestYutoriClientGetUsage:
+    # Mirrors the current server dual-emit: both navigator_* and n1_* keys
+    # are present with equal values. See yutori.codex PR #8174.
+    _NAVIGATOR_LIMITS = {
+        "requests_today": 50,
+        "daily_limit": 50000,
+        "remaining_requests": 49950,
+        "reset_at": "2026-03-04T00:00:00+00:00",
+        "per_second_limit": 20,
+    }
     USAGE_RESPONSE = {
         "num_active_scouts": 2,
         "active_scout_ids": ["id-1", "id-2"],
@@ -54,18 +63,14 @@ class TestYutoriClientGetUsage:
             "reset_at": "2026-03-04T00:00:00+00:00",
             "status": "available",
         },
-        "n1_rate_limits": {
-            "requests_today": 50,
-            "daily_limit": 50000,
-            "remaining_requests": 49950,
-            "reset_at": "2026-03-04T00:00:00+00:00",
-            "per_second_limit": 20,
-        },
+        "navigator_rate_limits": _NAVIGATOR_LIMITS,
+        "n1_rate_limits": _NAVIGATOR_LIMITS,
         "activity": {
             "period": "24h",
             "scout_runs": 10,
             "browsing_tasks": 3,
             "research_tasks": 2,
+            "navigator_calls": 50,
             "n1_calls": 50,
         },
     }

--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -83,7 +83,11 @@ class AsyncYutoriClient:
 
         Returns:
             Dictionary with ``num_active_scouts``, ``active_scout_ids``,
-            ``rate_limits``, ``n1_rate_limits``, and ``activity`` counts.
+            ``rate_limits``, ``navigator_rate_limits``, and ``activity``
+            counts. The response also includes ``n1_rate_limits`` and
+            ``activity.n1_calls`` as deprecated aliases of
+            ``navigator_rate_limits`` / ``navigator_calls`` for one
+            release; prefer the ``navigator_*`` names.
         """
         response = await self._client.get(
             f"{self._base_url}/usage",

--- a/yutori/cli/commands/usage.py
+++ b/yutori/cli/commands/usage.py
@@ -48,15 +48,15 @@ def usage(
                 console.print(f"    Remaining:      {rate_limits.get('remaining_requests', 'N/A')}")
             console.print(f"    Resets at:      {rate_limits.get('reset_at', 'N/A')}")
 
-        # n1 rate limits
-        n1_limits = data.get("n1_rate_limits", {})
-        if n1_limits:
-            console.print("\n  [bold]n1 API Rate Limits[/bold]")
-            console.print(f"    Requests today: {n1_limits.get('requests_today', 'N/A')}")
-            console.print(f"    Daily limit:    {n1_limits.get('daily_limit', 'N/A')}")
-            console.print(f"    Remaining:      {n1_limits.get('remaining_requests', 'N/A')}")
-            console.print(f"    Per-second:     {n1_limits.get('per_second_limit', 'N/A')}")
-            console.print(f"    Resets at:      {n1_limits.get('reset_at', 'N/A')}")
+        # Navigator rate limits (falls back to the deprecated n1_rate_limits key on older servers)
+        navigator_limits = data.get("navigator_rate_limits") or data.get("n1_rate_limits") or {}
+        if navigator_limits:
+            console.print("\n  [bold]Navigator API Rate Limits[/bold]")
+            console.print(f"    Requests today: {navigator_limits.get('requests_today', 'N/A')}")
+            console.print(f"    Daily limit:    {navigator_limits.get('daily_limit', 'N/A')}")
+            console.print(f"    Remaining:      {navigator_limits.get('remaining_requests', 'N/A')}")
+            console.print(f"    Per-second:     {navigator_limits.get('per_second_limit', 'N/A')}")
+            console.print(f"    Resets at:      {navigator_limits.get('reset_at', 'N/A')}")
 
         # Activity counts
         activity = data.get("activity", {})
@@ -64,13 +64,15 @@ def usage(
             p = activity.get("period", period)
             console.print(f"\n  [bold]Activity ({p})[/bold]")
 
+            # `navigator_calls` is the canonical key; `n1_calls` is the deprecated alias.
+            navigator_calls = activity.get("navigator_calls", activity.get("n1_calls", 0))
             table = Table(show_header=True, padding=(0, 2))
             table.add_column("Metric")
             table.add_column("Count", justify="right")
             table.add_row("Scout runs", str(activity.get("scout_runs", 0)))
             table.add_row("Browsing tasks", str(activity.get("browsing_tasks", 0)))
             table.add_row("Research tasks", str(activity.get("research_tasks", 0)))
-            table.add_row("n1 API calls", str(activity.get("n1_calls", 0)))
+            table.add_row("Navigator API calls", str(navigator_calls))
             console.print(table)
 
         console.print()

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -73,7 +73,11 @@ class YutoriClient:
 
         Returns:
             Dictionary with ``num_active_scouts``, ``active_scout_ids``,
-            ``rate_limits``, ``n1_rate_limits``, and ``activity`` counts.
+            ``rate_limits``, ``navigator_rate_limits``, and ``activity``
+            counts. The response also includes ``n1_rate_limits`` and
+            ``activity.n1_calls`` as deprecated aliases of
+            ``navigator_rate_limits`` / ``navigator_calls`` for one
+            release; prefer the ``navigator_*`` names.
         """
         response = self._client.get(
             f"{self._base_url}/usage",


### PR DESCRIPTION
## Summary

Follow-up to yutori-ai/yutori-sdk-python#49. The n1 → Navigator rollout now includes renaming the developer API response fields from `n1_rate_limits` / `activity.n1_calls` to `navigator_rate_limits` / `activity.navigator_calls`.

The server-side rename (yutori-ai/yutori#8174) dual-emits both keys with the same payload for one release, so older clients keep working. This PR keeps `api.md` consistent:

- `get_usage` Returns docs now list `navigator_rate_limits` and `activity.navigator_calls` as canonical.
- A short note below the list flags `n1_rate_limits` / `activity.n1_calls` as deprecated aliases that will be removed in a future release.

## Companion PRs
- yutori-ai/yutori#8174 — server-side dual-emit + holistic API-dashboard rename.
- yutori-ai/yutori-mcp — bump to 0.2.9, drop the `<0.5.0` SDK pin ceiling, switch formatters to `navigator_*` (fallback to `n1_*`).

## Test plan
- [x] Re-read the `get_usage` section; links and field names match the updated server response shape.
- [ ] No SDK code change required (the `get_usage` method is pass-through — it returns whatever the server emits). Nothing to run beyond the existing 299-test suite which is unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation, CLI display logic, and test fixtures to accommodate a server-side field rename, with backward-compatible fallbacks for older responses.
> 
> **Overview**
> Updates the documented `/v1/usage` response shape to use **canonical** `navigator_rate_limits` and `activity.navigator_calls`, and explicitly marks `n1_rate_limits`/`activity.n1_calls` as deprecated aliases.
> 
> Adjusts the `yutori usage` CLI command to display Navigator rate limits and call counts, **preferring** `navigator_*` keys while falling back to `n1_*` for older servers. Tests/fixtures and `get_usage` docstrings are updated to reflect the server’s temporary dual-emission of both key sets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ebd5ef7ee0c10ddbcf03a27b8b838e91fe99a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->