### PR TITLE
refactor: extract shared task-get helpers in CLI

### DIFF
--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -14,6 +14,8 @@ __all__ = [
     "format_interval",
     "get_authenticated_client",
     "print_rejection_reason",
+    "print_task_get_header",
+    "print_task_result_output",
     "print_task_submission_result",
 ]
 
@@ -50,6 +52,27 @@ def print_task_submission_result(console: Console, task_type: str, result: dict[
     console.print(f"  Task ID: {result.get('task_id', 'N/A')}")
     console.print(f"  Status: {status}")
     print_rejection_reason(console, result)
+
+
+def print_task_get_header(console: Console, task_type: str, task_id: str, result: dict[str, Any]) -> None:
+    """Print the common header for a task-get response: title, status, and rejection reason."""
+    console.print(f"\n[bold]{task_type} Task: {result.get('task_id', task_id)}[/bold]\n")
+    console.print(f"  Status: {result.get('status', 'N/A')}")
+    print_rejection_reason(console, result)
+
+
+def print_task_result_output(
+    console: Console, result: dict[str, Any], *, max_length: int = 2000
+) -> None:
+    """Print the ``result``/``output`` body of a task, truncated to ``max_length`` chars."""
+    output = result.get("result") or result.get("output")
+    if not output:
+        return
+    console.print("\n[bold]Result:[/bold]")
+    text = str(output)
+    if len(text) > max_length:
+        text = text[:max_length] + "\n... (truncated)"
+    console.print(text, markup=False)
 
 
 def format_interval(seconds: int, *, short: bool = False) -> str:

--- a/yutori/cli/commands/browse.py
+++ b/yutori/cli/commands/browse.py
@@ -7,7 +7,8 @@ from rich.console import Console
 
 from yutori.cli.commands import (
     get_authenticated_client,
-    print_rejection_reason,
+    print_task_get_header,
+    print_task_result_output,
     print_task_submission_result,
 )
 
@@ -52,9 +53,7 @@ def get(
     try:
         result = client.browsing.get(task_id)
 
-        console.print(f"\n[bold]Browsing Task: {result.get('task_id', task_id)}[/bold]\n")
-        console.print(f"  Status: {result.get('status', 'N/A')}")
-        print_rejection_reason(console, result)
+        print_task_get_header(console, "Browsing", task_id, result)
 
         if result.get("start_url"):
             console.print(f"  Start URL: {result['start_url']}")
@@ -63,12 +62,6 @@ def get(
         if result.get("created_at"):
             console.print(f"  Created: {result['created_at']}")
 
-        output = result.get("result") or result.get("output")
-        if output:
-            console.print("\n[bold]Result:[/bold]")
-            text = str(output)
-            if len(text) > 2000:
-                text = text[:2000] + "\n... (truncated)"
-            console.print(text, markup=False)
+        print_task_result_output(console, result)
     finally:
         client.close()

--- a/yutori/cli/commands/research.py
+++ b/yutori/cli/commands/research.py
@@ -8,7 +8,8 @@ from rich.markup import escape
 
 from yutori.cli.commands import (
     get_authenticated_client,
-    print_rejection_reason,
+    print_task_get_header,
+    print_task_result_output,
     print_task_submission_result,
 )
 
@@ -49,21 +50,13 @@ def get(
     try:
         result = client.research.get(task_id)
 
-        console.print(f"\n[bold]Research Task: {result.get('task_id', task_id)}[/bold]\n")
-        console.print(f"  Status: {result.get('status', 'N/A')}")
-        print_rejection_reason(console, result)
+        print_task_get_header(console, "Research", task_id, result)
 
         if result.get("query"):
             console.print(f"  Query: {escape(result['query'])}")
         if result.get("created_at"):
             console.print(f"  Created: {result['created_at']}")
 
-        output = result.get("result") or result.get("output")
-        if output:
-            console.print("\n[bold]Result:[/bold]")
-            text = str(output)
-            if len(text) > 2000:
-                text = text[:2000] + "\n... (truncated)"
-            console.print(text, markup=False)
+        print_task_result_output(console, result)
     finally:
         client.close()


### PR DESCRIPTION
## Summary

The `browse get` and `research get` CLI commands had two identical, hand-inlined blocks:

1. The "task-get" header — printing `{Type} Task: {id}`, status, and rejection reason.
2. The result/output printing block with a 2000-char truncation — an **exact 7-line duplicate** between `browse.py` and `research.py`.

This PR extracts both into shared helpers alongside the existing `print_task_submission_result` / `print_rejection_reason` / `format_interval` helpers in `yutori/cli/commands/__init__.py`:

- `print_task_get_header(console, task_type, task_id, result)`
- `print_task_result_output(console, result, *, max_length=2000)`

## Why this is an improvement

- Removes an exact copy-paste pair — keeps the truncation logic and header formatting in a single place, so any future tweak (e.g. bumping the truncation length or tweaking output styling) is a one-line change.
- Sits next to existing shared CLI helpers; consistent with the pattern that was already established in this file.
- Each `get` command becomes easier to scan: its type-specific fields (start_url/agent vs. query) stand out, no longer surrounded by boilerplate.

## Why this is safe

- No behavioral change — the output is byte-for-byte identical to before.
- All existing CLI tests pass unchanged (`tests/test_cli.py`, 10 tests). The test suite continues to exercise both `Rejection Reason: ...` output and the unmodified happy-path responses.
- Touches 3 files; no API surface, no public behavior, and no production callers are affected.

## Test plan

- [x] `pytest tests/test_cli.py` — 10 passed locally.
- [x] `ruff check yutori/cli/` — clean.
- [x] Full test suite: same 45 pre-existing failures on `main` and on this branch (all unrelated — navigator_hooks / async_client / packaging / etc.), same 255 passing.

https://claude.ai/code/session_01Mf3c3KmdzD6CTFJFpPtKyZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to CLI output formatting; behavior should be unchanged aside from any subtle differences in shared truncation/header handling.
> 
> **Overview**
> Refactors the CLI `browse get` and `research get` commands to reuse new shared helpers for printing the task header (task id/status/rejection reason) and the task `result`/`output` body with truncation.
> 
> Adds `print_task_get_header` and `print_task_result_output` to `yutori/cli/commands/__init__.py` and updates both commands to call them instead of maintaining duplicated inline printing logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e562851e86138ef4c48b87bcaa3d537d064b0cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->