### PR TITLE
Extract shared scout status-endpoint helper for sync/async

### DIFF
--- a/yutori/_async/scouts.py
+++ b/yutori/_async/scouts.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from .._http import build_headers, build_payload, build_query_params, handle_response
+from .._http import (
+    build_headers,
+    build_payload,
+    build_query_params,
+    handle_response,
+    resolve_scout_status_endpoint,
+)
 from .._schema import resolve_output_schema
 
 if TYPE_CHECKING:
@@ -165,14 +171,7 @@ class AsyncScoutsNamespace:
 
         # Handle status changes via dedicated endpoints
         if status is not None:
-            status_endpoints = {
-                "paused": "pause",
-                "active": "resume",
-                "done": "done",
-            }
-            if status not in status_endpoints:
-                raise ValueError(f"Invalid status: {status}. Must be 'active', 'paused', or 'done'.")
-            endpoint = status_endpoints[status]
+            endpoint = resolve_scout_status_endpoint(status)
             response = await self._client.post(
                 f"{self._base_url}/scouting/tasks/{scout_id}/{endpoint}",
                 headers=build_headers(self._api_key),

--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -46,3 +46,24 @@ def build_payload(**fields: Any) -> dict[str, Any]:
     together — any field whose value is ``None`` is omitted.
     """
     return {k: v for k, v in fields.items() if v is not None}
+
+
+_SCOUT_STATUS_ENDPOINTS = {
+    "paused": "pause",
+    "active": "resume",
+    "done": "done",
+}
+
+
+def resolve_scout_status_endpoint(status: str) -> str:
+    """Return the scout transition endpoint name for a target status.
+
+    Maps the externally-facing status vocabulary ("paused", "active", "done")
+    onto the API's dedicated transition endpoints ("pause", "resume", "done").
+
+    Raises:
+        ValueError: If ``status`` is not one of the three supported values.
+    """
+    if status not in _SCOUT_STATUS_ENDPOINTS:
+        raise ValueError(f"Invalid status: {status}. Must be 'active', 'paused', or 'done'.")
+    return _SCOUT_STATUS_ENDPOINTS[status]

--- a/yutori/_sync/scouts.py
+++ b/yutori/_sync/scouts.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from .._http import build_headers, build_payload, build_query_params, handle_response
+from .._http import (
+    build_headers,
+    build_payload,
+    build_query_params,
+    handle_response,
+    resolve_scout_status_endpoint,
+)
 from .._schema import resolve_output_schema
 
 if TYPE_CHECKING:
@@ -165,14 +171,7 @@ class ScoutsNamespace:
 
         # Handle status changes via dedicated endpoints
         if status is not None:
-            status_endpoints = {
-                "paused": "pause",
-                "active": "resume",
-                "done": "done",
-            }
-            if status not in status_endpoints:
-                raise ValueError(f"Invalid status: {status}. Must be 'active', 'paused', or 'done'.")
-            endpoint = status_endpoints[status]
+            endpoint = resolve_scout_status_endpoint(status)
             response = self._client.post(
                 f"{self._base_url}/scouting/tasks/{scout_id}/{endpoint}",
                 headers=build_headers(self._api_key),


### PR DESCRIPTION
## Summary

`ScoutsNamespace.update()` and `AsyncScoutsNamespace.update()` each carried an identical block to map the external scout-status vocabulary (`"paused"`, `"active"`, `"done"`) onto the API's dedicated transition endpoints (`"pause"`, `"resume"`, `"done"`), including the validation `ValueError`:

```python
status_endpoints = {
    "paused": "pause",
    "active": "resume",
    "done": "done",
}
if status not in status_endpoints:
    raise ValueError(f"Invalid status: {status}. Must be 'active', 'paused', or 'done'.")
endpoint = status_endpoints[status]
```

This PR moves the mapping + validation into a `resolve_scout_status_endpoint()` helper in `yutori/_http.py` and replaces both copies with a single call — same pattern already used for `build_headers`, `build_payload`, `build_query_params`, and `handle_response`. If the API ever adds a fourth transition state, there's now one place to update instead of two.

## Why this is safe

- **No behavior change.** The helper preserves the exact validation order (`status not in dict` → `ValueError` with the same f-string message → dict lookup) and is called at the same point in `update()` as the inline code was.
- **Exception type and message are byte-for-byte identical.**
- **Existing tests cover the path.** `test_scouts_update_status` in `tests/test_client.py` (and the async counterpart in `tests/test_async_client.py`) asserts `"/pause" in mock_post.call_args[0][0]`, which still holds.
- **CLI untouched.** `yutori/cli/commands/scouts.py` doesn't call `update(status=...)`, so the CLI surface is unaffected.

## Changes

- `yutori/_http.py`: add `_SCOUT_STATUS_ENDPOINTS` constant and `resolve_scout_status_endpoint()` helper.
- `yutori/_sync/scouts.py`: import the helper; replace the inline dict/validation with one call.
- `yutori/_async/scouts.py`: same change on the async side.

Net: 3 files changed, duplicate block removed from two namespaces.

## Test plan

- [ ] `pytest tests/test_client.py::TestScoutsNamespace` passes
- [ ] `pytest tests/test_async_client.py` passes
- [ ] `ruff check` / `ruff format` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that deduplicates status validation/mapping logic without changing request shapes or endpoints, but could affect both sync/async `update(status=...)` if the helper mapping is wrong.
> 
> **Overview**
> Refactors scout status transitions to use a shared `resolve_scout_status_endpoint()` helper in `yutori/_http.py`, centralizing the status validation and mapping (e.g. `"paused"` -> `"pause"`).
> 
> Both sync and async `scouts.update()` now call this helper instead of maintaining duplicate inline dictionaries/validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eaef8ef45c511a1e5f85bde67075a2a5b64244a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->