### PR TITLE
refactor(cli): use context manager for CLI client lifecycle

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,13 +14,18 @@ def _make_client_mock() -> MagicMock:
     """MagicMock that mimics ``YutoriClient`` as a context manager.
 
     The CLI wraps the client in ``with ... as client:``; the real client's
-    ``__exit__`` calls ``close()``. Mirror that here so tests can keep
-    asserting on ``client.close`` and still access the mocked namespaces
-    inside the ``with`` block.
+    ``__exit__`` calls ``close()`` and returns ``None`` so exceptions
+    propagate. Mirror that here — returning the MagicMock from ``close()``
+    would be truthy and would silently swallow exceptions in the ``with``
+    block.
     """
     client = MagicMock()
     client.__enter__.return_value = client
-    client.__exit__.side_effect = lambda *exc_info: client.close()
+
+    def _exit(*exc_info: object) -> None:
+        client.close()
+
+    client.__exit__.side_effect = _exit
     return client
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,20 @@ from yutori.cli.main import app
 runner = CliRunner()
 
 
+def _make_client_mock() -> MagicMock:
+    """MagicMock that mimics ``YutoriClient`` as a context manager.
+
+    The CLI wraps the client in ``with ... as client:``; the real client's
+    ``__exit__`` calls ``close()``. Mirror that here so tests can keep
+    asserting on ``client.close`` and still access the mocked namespaces
+    inside the ``with`` block.
+    """
+    client = MagicMock()
+    client.__enter__.return_value = client
+    client.__exit__.side_effect = lambda *exc_info: client.close()
+    return client
+
+
 def test_root_version_option():
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
@@ -23,7 +37,7 @@ def test_version_subcommand():
 
 
 def test_browse_run_forwards_local_browser_and_auth():
-    client = MagicMock()
+    client = _make_client_mock()
     client.browsing.create.return_value = {"task_id": "task-123", "status": "queued"}
 
     with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
@@ -47,7 +61,7 @@ def test_browse_run_forwards_local_browser_and_auth():
 
 
 def test_research_run_forwards_local_browser():
-    client = MagicMock()
+    client = _make_client_mock()
     client.research.create.return_value = {"task_id": "research-123", "status": "queued"}
 
     with patch("yutori.cli.commands.research.get_authenticated_client", return_value=client):
@@ -69,7 +83,7 @@ def test_research_run_forwards_local_browser():
 
 
 def test_browse_run_handles_failed_create_response():
-    client = MagicMock()
+    client = _make_client_mock()
     client.browsing.create.return_value = {
         "task_id": "task-123",
         "status": "failed",
@@ -89,7 +103,7 @@ def test_browse_run_handles_failed_create_response():
 
 
 def test_research_run_handles_failed_create_response():
-    client = MagicMock()
+    client = _make_client_mock()
     client.research.create.return_value = {
         "task_id": "r-1",
         "status": "failed",
@@ -108,7 +122,7 @@ def test_research_run_handles_failed_create_response():
 
 
 def test_browse_get_shows_rejection_reason():
-    client = MagicMock()
+    client = _make_client_mock()
     client.browsing.get.return_value = {
         "task_id": "task-123",
         "status": "failed",
@@ -124,7 +138,7 @@ def test_browse_get_shows_rejection_reason():
 
 
 def test_research_get_shows_rejection_reason():
-    client = MagicMock()
+    client = _make_client_mock()
     client.research.get.return_value = {
         "task_id": "research-123",
         "status": "failed",
@@ -140,7 +154,7 @@ def test_research_get_shows_rejection_reason():
 
 
 def test_scouts_get_shows_rejection_reason():
-    client = MagicMock()
+    client = _make_client_mock()
     client.scouts.get.return_value = {
         "id": "scout-123",
         "query": "monitor releases",
@@ -157,7 +171,7 @@ def test_scouts_get_shows_rejection_reason():
 
 
 def test_scouts_list_shows_rejection_reason_column():
-    client = MagicMock()
+    client = _make_client_mock()
     client.scouts.list.return_value = {
         "scouts": [
             {

--- a/yutori/cli/commands/browse.py
+++ b/yutori/cli/commands/browse.py
@@ -26,9 +26,7 @@ def run(
     browser: str = typer.Option(None, "--browser", help="Browser backend: cloud or local"),
 ) -> None:
     """Start a new browsing task."""
-    client = get_authenticated_client()
-
-    try:
+    with get_authenticated_client() as client:
         result = client.browsing.create(
             task=task,
             start_url=start_url,
@@ -39,8 +37,6 @@ def run(
         )
 
         print_task_submission_result(console, "Browsing", result)
-    finally:
-        client.close()
 
 
 @app.command()
@@ -48,9 +44,7 @@ def get(
     task_id: str = typer.Argument(help="The browsing task ID"),
 ) -> None:
     """Get the status and result of a browsing task."""
-    client = get_authenticated_client()
-
-    try:
+    with get_authenticated_client() as client:
         result = client.browsing.get(task_id)
 
         print_task_get_header(console, "Browsing", task_id, result)
@@ -63,5 +57,3 @@ def get(
             console.print(f"  Created: {result['created_at']}")
 
         print_task_result_output(console, result)
-    finally:
-        client.close()

--- a/yutori/cli/commands/research.py
+++ b/yutori/cli/commands/research.py
@@ -25,9 +25,7 @@ def run(
     browser: str = typer.Option(None, "--browser", help="Browser backend: cloud or local"),
 ) -> None:
     """Start a new research task."""
-    client = get_authenticated_client()
-
-    try:
+    with get_authenticated_client() as client:
         result = client.research.create(
             query=query,
             user_timezone=timezone,
@@ -36,8 +34,6 @@ def run(
         )
 
         print_task_submission_result(console, "Research", result)
-    finally:
-        client.close()
 
 
 @app.command()
@@ -45,9 +41,7 @@ def get(
     task_id: str = typer.Argument(help="The research task ID"),
 ) -> None:
     """Get the status and result of a research task."""
-    client = get_authenticated_client()
-
-    try:
+    with get_authenticated_client() as client:
         result = client.research.get(task_id)
 
         print_task_get_header(console, "Research", task_id, result)
@@ -58,5 +52,3 @@ def get(
             console.print(f"  Created: {result['created_at']}")
 
         print_task_result_output(console, result)
-    finally:
-        client.close()

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -19,9 +19,7 @@ def list_scouts(
     status: str = typer.Option(None, help="Filter by status: active, paused, done"),
 ) -> None:
     """List your scouts."""
-    client = get_authenticated_client()
-
-    try:
+    with get_authenticated_client() as client:
         result = client.scouts.list(limit=limit, status=status)
         scouts = result.get("scouts", [])
 
@@ -52,8 +50,6 @@ def list_scouts(
             )
 
         console.print(table)
-    finally:
-        client.close()
 
 
 @app.command()
@@ -61,9 +57,7 @@ def get(
     scout_id: str = typer.Argument(help="The scout ID"),
 ) -> None:
     """Get details of a specific scout."""
-    client = get_authenticated_client()
-
-    try:
+    with get_authenticated_client() as client:
         scout = client.scouts.get(scout_id)
 
         console.print(f"\n[bold]Scout: {scout.get('id', scout_id)}[/bold]\n")
@@ -80,8 +74,6 @@ def get(
             console.print(f"  Created: {scout['created_at']}")
         if scout.get("next_run_at"):
             console.print(f"  Next Run: {scout['next_run_at']}")
-    finally:
-        client.close()
 
 
 @app.command()
@@ -100,9 +92,7 @@ def create(
         console.print(f"[red]Invalid interval '{escape(interval)}'. Choose from: hourly, daily, weekly[/red]")
         raise typer.Exit(1)
 
-    client = get_authenticated_client()
-
-    try:
+    with get_authenticated_client() as client:
         result = client.scouts.create(
             query=query,
             output_interval=output_interval,
@@ -118,8 +108,6 @@ def create(
         console.print(f"  Query: {escape(result.get('query', query))}")
         console.print(f"  Status: {status}")
         print_rejection_reason(console, result)
-    finally:
-        client.close()
 
 
 @app.command()
@@ -134,10 +122,6 @@ def delete(
             console.print("[yellow]Cancelled.[/yellow]")
             raise typer.Exit(0)
 
-    client = get_authenticated_client()
-
-    try:
+    with get_authenticated_client() as client:
         client.scouts.delete(scout_id)
         console.print(f"[green]Scout {scout_id} deleted.[/green]")
-    finally:
-        client.close()

--- a/yutori/cli/commands/usage.py
+++ b/yutori/cli/commands/usage.py
@@ -21,9 +21,7 @@ def usage(
     if ctx.invoked_subcommand is not None:
         return
 
-    client = get_authenticated_client()
-
-    try:
+    with get_authenticated_client() as client:
         data = client.get_usage(period=period)
 
         console.print("\n[bold]Usage Statistics[/bold]\n")
@@ -76,5 +74,3 @@ def usage(
             console.print(table)
 
         console.print()
-    finally:
-        client.close()


### PR DESCRIPTION
## Structural issue

All nine CLI subcommand bodies in `yutori/cli/commands/` follow the same lifecycle pattern:

```python
client = get_authenticated_client()

try:
    # ... actual command ...
finally:
    client.close()
```

`YutoriClient` already implements the context-manager protocol — `__exit__` calls `close()` — so the verbose try/finally adds boilerplate without buying anything. It also slightly increases the risk that a future edit either forgets the cleanup or adds a `return` above the `finally` incorrectly.

## Change

Replace the explicit `try/finally` with `with get_authenticated_client() as client:` across:

- `yutori/cli/commands/browse.py` (2 sites)
- `yutori/cli/commands/research.py` (2 sites)
- `yutori/cli/commands/scouts.py` (4 sites)
- `yutori/cli/commands/usage.py` (1 site)

Tests (`tests/test_cli.py`) are updated to use a small `_make_client_mock()` helper that wires the mock's `__enter__`/`__exit__` to return self and invoke `close()`, so all existing `client.close.assert_called_once()` assertions continue to hold.

## Why it's safe

- No behavior change. `YutoriClient.__exit__` already delegates to `close()`, which closes both the httpx client and the chat/n1 sub-client.
- Scope is limited to CLI wiring; the SDK API surface and `get_authenticated_client()` return type are unchanged.
- Verified by the full existing test suite (`pytest -m "not slow"`) — 299 passed, 0 failed.

## Test plan

- [x] `pytest tests/test_cli.py` — all 10 tests pass
- [x] `pytest -m "not slow"` — all 299 tests pass
- [x] `ruff check yutori/cli` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to CLI wiring; behavior should remain the same, but incorrect context-manager behavior could affect resource cleanup or exception propagation in CLI commands.
> 
> **Overview**
> Refactors CLI commands to manage the authenticated `YutoriClient` via `with get_authenticated_client() as client:` instead of explicit `try/finally` + `client.close()` across `browse`, `research`, `scouts`, and `usage` commands.
> 
> Updates `tests/test_cli.py` to use a `_make_client_mock()` helper that correctly mimics the client’s context-manager semantics (ensuring `close()` is called and exceptions aren’t swallowed), keeping existing `client.close.assert_called_once()` assertions valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db5c80365932c6f8257bb7c2dc377c8cf32db6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->