### PR TITLE
Extract duplicated API key validation into shared helper

### DIFF
--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -48,6 +48,24 @@ def build_payload(**fields: Any) -> dict[str, Any]:
     return {k: v for k, v in fields.items() if v is not None}
 
 
+def resolve_api_key_or_raise(api_key: str | None) -> str:
+    """Resolve an API key via the standard precedence chain, or raise.
+
+    Uses ``auth.credentials.resolve_api_key`` (parameter > env > config)
+    and raises ``AuthenticationError`` with a client-friendly message when
+    no real key is found. Imported lazily to keep the auth package off the
+    import path for code that does not construct a client.
+    """
+    from .auth.credentials import resolve_api_key
+
+    resolved = resolve_api_key(api_key)
+    if not resolved:
+        raise AuthenticationError(
+            "No API key provided. Run 'yutori auth login', set YUTORI_API_KEY, or pass api_key."
+        )
+    return resolved
+
+
 _SCOUT_STATUS_ENDPOINTS = {
     "paused": "pause",
     "active": "resume",

--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -12,9 +12,13 @@ from ._async import (
     AsyncResearchNamespace,
     AsyncScoutsNamespace,
 )
-from ._http import build_headers, build_query_params, handle_response
+from ._http import (
+    build_headers,
+    build_query_params,
+    handle_response,
+    resolve_api_key_or_raise,
+)
 from .config import DEFAULT_BASE_URL, DEFAULT_TIMEOUT_SECONDS, sanitize_base_url
-from .exceptions import AuthenticationError
 
 
 class AsyncYutoriClient:
@@ -56,15 +60,7 @@ class AsyncYutoriClient:
         Raises:
             AuthenticationError: If no API key is provided or found in environment.
         """
-        from yutori.auth.credentials import resolve_api_key
-
-        api_key = resolve_api_key(api_key)
-        if not api_key:
-            raise AuthenticationError(
-                "No API key provided. Run 'yutori auth login', set YUTORI_API_KEY, or pass api_key."
-            )
-
-        self._api_key = api_key
+        self._api_key = resolve_api_key_or_raise(api_key)
         self._base_url = sanitize_base_url(base_url)
         self._client = httpx.AsyncClient(timeout=timeout)
 

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -6,10 +6,14 @@ from typing import Any
 
 import httpx
 
-from ._http import build_headers, build_query_params, handle_response
+from ._http import (
+    build_headers,
+    build_query_params,
+    handle_response,
+    resolve_api_key_or_raise,
+)
 from ._sync import BrowsingNamespace, ChatNamespace, ResearchNamespace, ScoutsNamespace
 from .config import DEFAULT_BASE_URL, DEFAULT_TIMEOUT_SECONDS, sanitize_base_url
-from .exceptions import AuthenticationError
 
 
 class YutoriClient:
@@ -46,15 +50,7 @@ class YutoriClient:
         Raises:
             AuthenticationError: If no API key is provided or found in environment.
         """
-        from yutori.auth.credentials import resolve_api_key
-
-        api_key = resolve_api_key(api_key)
-        if not api_key:
-            raise AuthenticationError(
-                "No API key provided. Run 'yutori auth login', set YUTORI_API_KEY, or pass api_key."
-            )
-
-        self._api_key = api_key
+        self._api_key = resolve_api_key_or_raise(api_key)
         self._base_url = sanitize_base_url(base_url)
         self._client = httpx.Client(timeout=timeout)
 


### PR DESCRIPTION
## Summary

`YutoriClient.__init__` and `AsyncYutoriClient.__init__` both inline the same
`resolve_api_key` + `AuthenticationError` pattern, including a verbatim copy of
the user-facing error string:

```python
api_key = resolve_api_key(api_key)
if not api_key:
    raise AuthenticationError(
        "No API key provided. Run 'yutori auth login', set YUTORI_API_KEY, or pass api_key."
    )
```

Duplicating this leaves the sync and async clients free to drift — if the CLI
hint or env var name ever changes, we have to remember to update both sites.

This PR extracts the check into `resolve_api_key_or_raise()` in `_http.py`
(where `AuthenticationError` is already imported and used by `handle_response`)
and updates both clients to delegate to it.

## Why this is safe

- **No behavioral change.** The error type (`AuthenticationError`) and message
  are unchanged. `_api_key` and `_base_url` are still assigned identically.
- **Import behavior preserved.** `resolve_api_key` is still imported lazily
  from inside the helper, matching the original pattern in both clients.
- **Existing tests assert on type only** (e.g. `pytest.raises(AuthenticationError)`
  in `tests/test_client.py` and `tests/test_async_client.py`), not on the
  message string.

## Test plan

- [x] Existing `TestYutoriClientInit` / `TestAsyncYutoriClientInit` cases still
      exercise both the "missing key raises" and "env var picked up" paths.
- [ ] CI passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes API key resolution and the missing-key `AuthenticationError` message; behavior should remain the same aside from any unintended import/precedence edge cases in the new helper.
> 
> **Overview**
> **Deduplicates client initialization auth handling.**
> 
> Adds `resolve_api_key_or_raise()` in `_http.py` to encapsulate `resolve_api_key` (parameter/env/config) plus the standard missing-key `AuthenticationError` message.
> 
> Updates both `YutoriClient` and `AsyncYutoriClient` initializers to use this helper instead of inlining the same resolution/raise logic, removing the now-unneeded direct `AuthenticationError` import in those modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2c795ab9766436b4cb6f2692321e785aee2b3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->