### PR TITLE
test: add tests for resolve_scout_status_endpoint helper

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,24 @@
+"""Tests for shared HTTP helpers in yutori._http."""
+
+import pytest
+
+from yutori._http import resolve_scout_status_endpoint
+
+
+class TestResolveScoutStatusEndpoint:
+    def test_paused_maps_to_pause(self):
+        assert resolve_scout_status_endpoint("paused") == "pause"
+
+    def test_active_maps_to_resume(self):
+        assert resolve_scout_status_endpoint("active") == "resume"
+
+    def test_done_maps_to_done(self):
+        assert resolve_scout_status_endpoint("done") == "done"
+
+    def test_invalid_status_raises(self):
+        with pytest.raises(ValueError, match="Invalid status"):
+            resolve_scout_status_endpoint("deleted")
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="Invalid status"):
+            resolve_scout_status_endpoint("")


### PR DESCRIPTION
## Summary

- Add `tests/test_http.py` with unit tests for the `resolve_scout_status_endpoint` helper extracted in #52
- Covers all three valid transitions (`paused`→`pause`, `active`→`resume`, `done`→`done`) and invalid-status error

The helper was extracted from duplicated inline mappings in the sync/async scouts namespaces but only the `paused` transition had indirect test coverage. The `active` and `done` transitions were untested.

## Test plan

- [ ] Run `pytest tests/test_http.py -v` to verify all 5 tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds unit tests and does not change runtime behavior. The only impact is on CI test coverage and potential test brittleness if error messages change.
> 
> **Overview**
> Adds a new `tests/test_http.py` suite to validate `resolve_scout_status_endpoint` status-to-transition mapping (`paused`→`pause`, `active`→`resume`, `done`→`done`).
> 
> Also asserts that invalid or empty status values raise `ValueError` with an "Invalid status" message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5cb0fbb8114b956521ecf38a372ad07b68a9aac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->