### PR TITLE
Extract shared require_api_key() helper for sync/async clients

### DIFF
--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -14,7 +14,6 @@ from ._async import (
 )
 from ._http import build_headers, build_query_params, handle_response
 from .config import DEFAULT_BASE_URL, DEFAULT_TIMEOUT_SECONDS, sanitize_base_url
-from .exceptions import AuthenticationError
 
 
 class AsyncYutoriClient:
@@ -56,15 +55,9 @@ class AsyncYutoriClient:
         Raises:
             AuthenticationError: If no API key is provided or found in environment.
         """
-        from yutori.auth.credentials import resolve_api_key
+        from yutori.auth.credentials import require_api_key
 
-        api_key = resolve_api_key(api_key)
-        if not api_key:
-            raise AuthenticationError(
-                "No API key provided. Run 'yutori auth login', set YUTORI_API_KEY, or pass api_key."
-            )
-
-        self._api_key = api_key
+        self._api_key = require_api_key(api_key)
         self._base_url = sanitize_base_url(base_url)
         self._client = httpx.AsyncClient(timeout=timeout)
 

--- a/yutori/auth/__init__.py
+++ b/yutori/auth/__init__.py
@@ -5,7 +5,7 @@ Lightweight imports (credentials, types) are eager. Heavyweight imports
 penalizing SDK users who never use the OAuth login flow.
 """
 
-from .credentials import clear_config, load_config, resolve_api_key, save_config
+from .credentials import clear_config, load_config, require_api_key, resolve_api_key, save_config
 from .types import AuthStatus, LoginResult
 
 
@@ -25,6 +25,7 @@ __all__ = [
     "clear_config",
     "get_auth_status",
     "load_config",
+    "require_api_key",
     "resolve_api_key",
     "run_login_flow",
     "save_config",

--- a/yutori/auth/credentials.py
+++ b/yutori/auth/credentials.py
@@ -12,6 +12,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from ..exceptions import AuthenticationError
 from .constants import CONFIG_DIR, CONFIG_FILE
 
 
@@ -98,3 +99,18 @@ def resolve_api_key(api_key: str | None = None) -> str | None:
             return stored_key
 
     return None
+
+
+def require_api_key(api_key: str | None = None) -> str:
+    """Resolve an API key and raise if none can be found.
+
+    Same precedence chain as :func:`resolve_api_key`, but raises
+    :class:`AuthenticationError` with a uniform user-facing message when
+    no real key is available.
+    """
+    resolved = resolve_api_key(api_key)
+    if not resolved:
+        raise AuthenticationError(
+            "No API key provided. Run 'yutori auth login', set YUTORI_API_KEY, or pass api_key."
+        )
+    return resolved

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -9,7 +9,6 @@ import httpx
 from ._http import build_headers, build_query_params, handle_response
 from ._sync import BrowsingNamespace, ChatNamespace, ResearchNamespace, ScoutsNamespace
 from .config import DEFAULT_BASE_URL, DEFAULT_TIMEOUT_SECONDS, sanitize_base_url
-from .exceptions import AuthenticationError
 
 
 class YutoriClient:
@@ -46,15 +45,9 @@ class YutoriClient:
         Raises:
             AuthenticationError: If no API key is provided or found in environment.
         """
-        from yutori.auth.credentials import resolve_api_key
+        from yutori.auth.credentials import require_api_key
 
-        api_key = resolve_api_key(api_key)
-        if not api_key:
-            raise AuthenticationError(
-                "No API key provided. Run 'yutori auth login', set YUTORI_API_KEY, or pass api_key."
-            )
-
-        self._api_key = api_key
+        self._api_key = require_api_key(api_key)
         self._base_url = sanitize_base_url(base_url)
         self._client = httpx.Client(timeout=timeout)
 


### PR DESCRIPTION
## Summary

Both `YutoriClient.__init__` and `AsyncYutoriClient.__init__` had identical blocks that called `resolve_api_key()` and then raised `AuthenticationError` with the same user-facing message if resolution failed:

```python
from yutori.auth.credentials import resolve_api_key

api_key = resolve_api_key(api_key)
if not api_key:
    raise AuthenticationError(
        "No API key provided. Run 'yutori auth login', set YUTORI_API_KEY, or pass api_key."
    )
```

This PR consolidates that into a single `require_api_key()` helper in `yutori/auth/credentials.py` so the precedence chain and the missing-key error stay in lockstep across the sync and async clients.

## Why it's safe

- **Pure extraction.** No behavioral change — error type (`AuthenticationError`), error message, and resolution precedence are all preserved.
- **Tests unchanged and green.** All 300 existing tests pass locally, including the `test_init_without_api_key_raises` / `test_init_with_none_api_key_raises` cases in both `test_client.py` and `test_async_client.py`. No tests asserted on the exact message text.
- **Small blast radius.** 4 files, all changes visible in the diff.

## Test plan

- [x] `pytest` — 300 passed
- [x] Manual smoke: `YutoriClient(api_key='')` still raises `AuthenticationError` with the same message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that consolidates duplicated API-key resolution/validation logic; behavior should remain the same aside from potential edge-case differences in how missing/placeholder keys are detected and the exact exception path.
> 
> **Overview**
> Extracts a shared `require_api_key()` helper in `yutori/auth/credentials.py` that wraps `resolve_api_key()` and raises `AuthenticationError` with a single consistent message when no usable key is found.
> 
> Updates both `YutoriClient` and `AsyncYutoriClient` to use this helper (removing the duplicated inline resolution/raise block), and re-exports `require_api_key` from `yutori/auth/__init__.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e5ea3c20b4fcc754a65172541fc4e0b66193b19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->