### PR TITLE
refactor(chat): extract apply_chat_extra_body helper for sync/async

### DIFF
--- a/yutori/_async/chat.py
+++ b/yutori/_async/chat.py
@@ -7,6 +7,8 @@ from typing import Any, Iterable
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 
+from .._http import apply_chat_extra_body
+
 
 class AsyncChatCompletions:
     """OpenAI-compatible chat completions for n1 API (async)."""
@@ -42,16 +44,12 @@ class AsyncChatCompletions:
         Returns:
             ChatCompletion object.
         """
-        extra_body = kwargs.pop("extra_body", None) or {}
-        if tool_set is not None:
-            extra_body["tool_set"] = tool_set
-        if disable_tools is not None:
-            extra_body["disable_tools"] = disable_tools
-        if json_schema is not None:
-            extra_body["json_schema"] = json_schema
-
-        if extra_body:
-            kwargs["extra_body"] = extra_body
+        apply_chat_extra_body(
+            kwargs,
+            tool_set=tool_set,
+            disable_tools=disable_tools,
+            json_schema=json_schema,
+        )
 
         return await self._client.chat.completions.create(model=model, messages=messages, **kwargs)
 

--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -67,3 +67,21 @@ def resolve_scout_status_endpoint(status: str) -> str:
     if status not in _SCOUT_STATUS_ENDPOINTS:
         raise ValueError(f"Invalid status: {status}. Must be 'active', 'paused', or 'done'.")
     return _SCOUT_STATUS_ENDPOINTS[status]
+
+
+def apply_chat_extra_body(kwargs: dict[str, Any], **fields: Any) -> None:
+    """Merge non-None ``fields`` into ``kwargs["extra_body"]`` in place.
+
+    Pops any user-provided ``extra_body`` from ``kwargs``, overlays the
+    non-None ``fields`` on top of it, and writes the result back under
+    ``extra_body`` — but only if the merged dict is non-empty. Used by
+    ChatCompletions.create to compose the ``extra_body`` kwarg forwarded
+    to the OpenAI client without letting sync and async implementations
+    drift out of sync.
+    """
+    extra_body = kwargs.pop("extra_body", None) or {}
+    for key, value in fields.items():
+        if value is not None:
+            extra_body[key] = value
+    if extra_body:
+        kwargs["extra_body"] = extra_body

--- a/yutori/_sync/chat.py
+++ b/yutori/_sync/chat.py
@@ -7,6 +7,8 @@ from typing import Any, Iterable
 from openai import OpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 
+from .._http import apply_chat_extra_body
+
 
 class ChatCompletions:
     """OpenAI-compatible chat completions for n1 API."""
@@ -42,16 +44,12 @@ class ChatCompletions:
         Returns:
             ChatCompletion object.
         """
-        extra_body = kwargs.pop("extra_body", None) or {}
-        if tool_set is not None:
-            extra_body["tool_set"] = tool_set
-        if disable_tools is not None:
-            extra_body["disable_tools"] = disable_tools
-        if json_schema is not None:
-            extra_body["json_schema"] = json_schema
-
-        if extra_body:
-            kwargs["extra_body"] = extra_body
+        apply_chat_extra_body(
+            kwargs,
+            tool_set=tool_set,
+            disable_tools=disable_tools,
+            json_schema=json_schema,
+        )
 
         return self._client.chat.completions.create(model=model, messages=messages, **kwargs)
 


### PR DESCRIPTION
## Summary

Both `ChatCompletions.create` (sync) and `AsyncChatCompletions.create` (async) carried an identical 9-line block that composed the OpenAI `extra_body` kwarg from the n1.5-only parameters (`tool_set`, `disable_tools`, `json_schema`) on top of any user-provided `extra_body`:

```python
extra_body = kwargs.pop("extra_body", None) or {}
if tool_set is not None:
    extra_body["tool_set"] = tool_set
if disable_tools is not None:
    extra_body["disable_tools"] = disable_tools
if json_schema is not None:
    extra_body["json_schema"] = json_schema
if extra_body:
    kwargs["extra_body"] = extra_body
```

Extracts the logic into `apply_chat_extra_body()` in `_http.py` so both call sites collapse to a single call:

```python
apply_chat_extra_body(
    kwargs,
    tool_set=tool_set,
    disable_tools=disable_tools,
    json_schema=json_schema,
)
```

## Why this is an improvement

- **Single source of truth.** Adding a new n1.5-only pass-through field (or changing how an existing one is merged) is now a one-line edit in one place. Previously, adding a field required remembering to update both files, and forgetting one would silently diverge sync vs async behavior.
- **Same pattern already used here.** `_http.py` already holds `build_headers`, `build_payload`, `build_query_params`, `handle_response`, and `resolve_scout_status_endpoint` — all helpers extracted for exactly this sync/async consistency reason. `apply_chat_extra_body` fits right in.

## Why this is safe

- **No behavioral change.** The helper preserves the original five-step sequence exactly: (1) pop `extra_body` from kwargs (None → empty dict), (2) overlay each non-None field, (3) re-insert the merged dict only if it's non-empty. Field iteration order matches insertion order, which matches the original three sequential `if` blocks.
- **Edge cases preserved.** Caller passes `extra_body=None` explicitly → still coerces to `{}`. Caller passes non-empty `extra_body` with no n1.5 fields → still re-inserted unchanged. All fields None and no user-provided `extra_body` → `extra_body` key absent from kwargs.
- **Existing tests already cover this.** `test_chat_completions_n1_5_forwards_extra_body_options` in both `tests/test_client.py` and `tests/test_async_client.py` passes `tool_set` + `disable_tools` + `json_schema` + `extra_body={"trace_id": "trace-123"}` and asserts the four-key merge on the forwarded kwargs.

## Stats

3 files changed, ~20 insertions / ~20 deletions.

## Test plan

- [ ] CI: `pytest` passes (the two `forwards_extra_body_options` tests + the plain `test_chat_completions` tests for sync/async).
- [ ] CI: `ruff check` / `ruff format` clean.
- [ ] No new imports or public API surface — `apply_chat_extra_body` is a module-private-ish helper in `_http.py` (underscored module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes `extra_body` merging logic; main risk is unintended changes to how user-provided `extra_body` is merged/omitted, but behavior is intended to remain identical.
> 
> **Overview**
> Consolidates the duplicated logic in `ChatCompletions.create` and `AsyncChatCompletions.create` that merges n1.5-only options (`tool_set`, `disable_tools`, `json_schema`) into any user-supplied `extra_body`.
> 
> Adds `apply_chat_extra_body()` in `_http.py` and updates both sync/async chat implementations to call it, reducing the chance of sync/async behavior drifting when new `extra_body` fields are added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69b8aae8d5ca48adeab5cff63e112cd32041a07d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->