### PR TITLE
refactor(sdk): extract _BaseNamespace to share namespace init and headers

### DIFF
--- a/yutori/_async/browsing.py
+++ b/yutori/_async/browsing.py
@@ -2,22 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from .._http import build_headers, build_payload, handle_response
+from .._http import _BaseNamespace, build_payload, handle_response
 from .._schema import resolve_output_schema
 
-if TYPE_CHECKING:
-    import httpx
 
-
-class AsyncBrowsingNamespace:
+class AsyncBrowsingNamespace(_BaseNamespace):
     """Async namespace for browsing operations (one-time browser automation)."""
-
-    def __init__(self, client: httpx.AsyncClient, base_url: str, api_key: str) -> None:
-        self._client = client
-        self._base_url = base_url
-        self._api_key = api_key
 
     async def create(
         self,
@@ -64,7 +56,7 @@ class AsyncBrowsingNamespace:
 
         response = await self._client.post(
             f"{self._base_url}/browsing/tasks",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
             json=payload,
         )
         return handle_response(response)
@@ -80,6 +72,6 @@ class AsyncBrowsingNamespace:
         """
         response = await self._client.get(
             f"{self._base_url}/browsing/tasks/{task_id}",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
         )
         return handle_response(response)

--- a/yutori/_async/research.py
+++ b/yutori/_async/research.py
@@ -2,22 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from .._http import build_headers, build_payload, handle_response
+from .._http import _BaseNamespace, build_payload, handle_response
 from .._schema import resolve_output_schema
 
-if TYPE_CHECKING:
-    import httpx
 
-
-class AsyncResearchNamespace:
+class AsyncResearchNamespace(_BaseNamespace):
     """Async namespace for research operations (one-time deep web research)."""
-
-    def __init__(self, client: httpx.AsyncClient, base_url: str, api_key: str) -> None:
-        self._client = client
-        self._base_url = base_url
-        self._api_key = api_key
 
     async def create(
         self,
@@ -59,7 +51,7 @@ class AsyncResearchNamespace:
 
         response = await self._client.post(
             f"{self._base_url}/research/tasks",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
             json=payload,
         )
         return handle_response(response)
@@ -75,6 +67,6 @@ class AsyncResearchNamespace:
         """
         response = await self._client.get(
             f"{self._base_url}/research/tasks/{task_id}",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
         )
         return handle_response(response)

--- a/yutori/_async/scouts.py
+++ b/yutori/_async/scouts.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from .._http import (
-    build_headers,
+    _BaseNamespace,
     build_payload,
     build_query_params,
     handle_response,
@@ -13,17 +13,9 @@ from .._http import (
 )
 from .._schema import resolve_output_schema
 
-if TYPE_CHECKING:
-    import httpx
 
-
-class AsyncScoutsNamespace:
+class AsyncScoutsNamespace(_BaseNamespace):
     """Async namespace for scout-related operations (continuous web monitoring)."""
-
-    def __init__(self, client: httpx.AsyncClient, base_url: str, api_key: str) -> None:
-        self._client = client
-        self._base_url = base_url
-        self._api_key = api_key
 
     async def list(
         self,
@@ -44,7 +36,7 @@ class AsyncScoutsNamespace:
         params = build_query_params(page_size=limit, status=status)
         response = await self._client.get(
             f"{self._base_url}/scouting/tasks",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
             params=params,
         )
         return handle_response(response)
@@ -60,7 +52,7 @@ class AsyncScoutsNamespace:
         """
         response = await self._client.get(
             f"{self._base_url}/scouting/tasks/{scout_id}",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
         )
         return handle_response(response)
 
@@ -110,7 +102,7 @@ class AsyncScoutsNamespace:
 
         response = await self._client.post(
             f"{self._base_url}/scouting/tasks",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
             json=payload,
         )
         return handle_response(response)
@@ -174,7 +166,7 @@ class AsyncScoutsNamespace:
             endpoint = resolve_scout_status_endpoint(status)
             response = await self._client.post(
                 f"{self._base_url}/scouting/tasks/{scout_id}/{endpoint}",
-                headers=build_headers(self._api_key),
+                headers=self._headers,
             )
             return handle_response(response)
 
@@ -184,7 +176,7 @@ class AsyncScoutsNamespace:
 
         response = await self._client.patch(
             f"{self._base_url}/scouting/tasks/{scout_id}",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
             json=payload,
         )
         return handle_response(response)
@@ -200,7 +192,7 @@ class AsyncScoutsNamespace:
         """
         response = await self._client.delete(
             f"{self._base_url}/scouting/tasks/{scout_id}",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
         )
         return handle_response(response)
 
@@ -224,7 +216,7 @@ class AsyncScoutsNamespace:
         params = build_query_params(limit=limit, cursor=cursor)
         response = await self._client.get(
             f"{self._base_url}/scouting/tasks/{scout_id}/updates",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
             params=params,
         )
         return handle_response(response)

--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -85,3 +85,17 @@ def apply_chat_extra_body(kwargs: dict[str, Any], **fields: Any) -> None:
             extra_body[key] = value
     if extra_body:
         kwargs["extra_body"] = extra_body
+
+
+class _BaseNamespace:
+    """Shared base for SDK namespace classes (sync and async).
+
+    Stores the HTTP client, base URL, and a precomputed auth header dict
+    so namespace methods can reference ``self._headers`` directly instead
+    of rebuilding headers on every request.
+    """
+
+    def __init__(self, client: Any, base_url: str, api_key: str) -> None:
+        self._client = client
+        self._base_url = base_url
+        self._headers = build_headers(api_key)

--- a/yutori/_sync/browsing.py
+++ b/yutori/_sync/browsing.py
@@ -2,22 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from .._http import build_headers, build_payload, handle_response
+from .._http import _BaseNamespace, build_payload, handle_response
 from .._schema import resolve_output_schema
 
-if TYPE_CHECKING:
-    import httpx
 
-
-class BrowsingNamespace:
+class BrowsingNamespace(_BaseNamespace):
     """Namespace for browsing operations (one-time browser automation)."""
-
-    def __init__(self, client: httpx.Client, base_url: str, api_key: str) -> None:
-        self._client = client
-        self._base_url = base_url
-        self._api_key = api_key
 
     def create(
         self,
@@ -64,7 +56,7 @@ class BrowsingNamespace:
 
         response = self._client.post(
             f"{self._base_url}/browsing/tasks",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
             json=payload,
         )
         return handle_response(response)
@@ -80,6 +72,6 @@ class BrowsingNamespace:
         """
         response = self._client.get(
             f"{self._base_url}/browsing/tasks/{task_id}",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
         )
         return handle_response(response)

--- a/yutori/_sync/research.py
+++ b/yutori/_sync/research.py
@@ -2,22 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from .._http import build_headers, build_payload, handle_response
+from .._http import _BaseNamespace, build_payload, handle_response
 from .._schema import resolve_output_schema
 
-if TYPE_CHECKING:
-    import httpx
 
-
-class ResearchNamespace:
+class ResearchNamespace(_BaseNamespace):
     """Namespace for research operations (one-time deep web research)."""
-
-    def __init__(self, client: httpx.Client, base_url: str, api_key: str) -> None:
-        self._client = client
-        self._base_url = base_url
-        self._api_key = api_key
 
     def create(
         self,
@@ -59,7 +51,7 @@ class ResearchNamespace:
 
         response = self._client.post(
             f"{self._base_url}/research/tasks",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
             json=payload,
         )
         return handle_response(response)
@@ -75,6 +67,6 @@ class ResearchNamespace:
         """
         response = self._client.get(
             f"{self._base_url}/research/tasks/{task_id}",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
         )
         return handle_response(response)

--- a/yutori/_sync/scouts.py
+++ b/yutori/_sync/scouts.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from .._http import (
-    build_headers,
+    _BaseNamespace,
     build_payload,
     build_query_params,
     handle_response,
@@ -13,17 +13,9 @@ from .._http import (
 )
 from .._schema import resolve_output_schema
 
-if TYPE_CHECKING:
-    import httpx
 
-
-class ScoutsNamespace:
+class ScoutsNamespace(_BaseNamespace):
     """Namespace for scout-related operations (continuous web monitoring)."""
-
-    def __init__(self, client: httpx.Client, base_url: str, api_key: str) -> None:
-        self._client = client
-        self._base_url = base_url
-        self._api_key = api_key
 
     def list(
         self,
@@ -44,7 +36,7 @@ class ScoutsNamespace:
         params = build_query_params(page_size=limit, status=status)
         response = self._client.get(
             f"{self._base_url}/scouting/tasks",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
             params=params,
         )
         return handle_response(response)
@@ -60,7 +52,7 @@ class ScoutsNamespace:
         """
         response = self._client.get(
             f"{self._base_url}/scouting/tasks/{scout_id}",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
         )
         return handle_response(response)
 
@@ -110,7 +102,7 @@ class ScoutsNamespace:
 
         response = self._client.post(
             f"{self._base_url}/scouting/tasks",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
             json=payload,
         )
         return handle_response(response)
@@ -174,7 +166,7 @@ class ScoutsNamespace:
             endpoint = resolve_scout_status_endpoint(status)
             response = self._client.post(
                 f"{self._base_url}/scouting/tasks/{scout_id}/{endpoint}",
-                headers=build_headers(self._api_key),
+                headers=self._headers,
             )
             return handle_response(response)
 
@@ -184,7 +176,7 @@ class ScoutsNamespace:
 
         response = self._client.patch(
             f"{self._base_url}/scouting/tasks/{scout_id}",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
             json=payload,
         )
         return handle_response(response)
@@ -200,7 +192,7 @@ class ScoutsNamespace:
         """
         response = self._client.delete(
             f"{self._base_url}/scouting/tasks/{scout_id}",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
         )
         return handle_response(response)
 
@@ -224,7 +216,7 @@ class ScoutsNamespace:
         params = build_query_params(limit=limit, cursor=cursor)
         response = self._client.get(
             f"{self._base_url}/scouting/tasks/{scout_id}/updates",
-            headers=build_headers(self._api_key),
+            headers=self._headers,
             params=params,
         )
         return handle_response(response)


### PR DESCRIPTION
## Structural issue

All six HTTP namespace classes in the SDK (`ScoutsNamespace`, `BrowsingNamespace`, `ResearchNamespace` and their async counterparts) carried the same three-line `__init__`:

```python
def __init__(self, client, base_url, api_key) -> None:
    self._client = client
    self._base_url = base_url
    self._api_key = api_key
```

and every method on every class called `build_headers(self._api_key)` on each request — rebuilding the same `{"Content-Type": ..., "x-api-key": ...}` dict for every HTTP call.

The `_api_key` attribute was never used for anything except that header construction.

## What changed

- Added a private `_BaseNamespace` class in `yutori/_http.py` that holds `_client`, `_base_url`, and a precomputed `_headers` dict.
- Made all six namespace classes inherit from `_BaseNamespace` and removed their duplicated `__init__` methods.
- Replaced every `headers=build_headers(self._api_key)` with `headers=self._headers`.
- Dropped the now-unused `build_headers` / `TYPE_CHECKING httpx` imports from the six namespace modules.

`YutoriClient` and `AsyncYutoriClient` still instantiate namespaces with `(client, base_url, api_key)` — the signature flows through inheritance unchanged, so no caller needs updating.

## Why it's safe

- **No behavioral change.** The headers returned by `build_headers(api_key)` do not depend on request state, so precomputing them at init time is equivalent to calling per request.
- **Public API untouched.** Class names, constructor signatures, and every method signature remain identical.
- **Covered by existing tests.** `tests/test_client.py` and `tests/test_async_client.py` exercise the namespaces via mocked `httpx` calls and assert on the payloads and URLs that get sent — none of them poke at namespace `__init__` internals beyond what inheritance preserves.
- Scope is contained: one helper addition plus a uniform mechanical edit across six namespace files.

## Changed files

- `yutori/_http.py` — added `_BaseNamespace`.
- `yutori/_sync/{scouts,browsing,research}.py` — inherit, drop `__init__`, use `self._headers`.
- `yutori/_async/{scouts,browsing,research}.py` — same treatment for the async variants.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical refactor that centralizes namespace construction and header creation; main risk is unintended header/state differences if callers relied on per-request header rebuilding.
> 
> **Overview**
> Introduces a shared `_BaseNamespace` in `yutori/_http.py` that stores `_client`, `_base_url`, and a precomputed `_headers` dict.
> 
> Updates the sync/async `Browsing`, `Research`, and `Scouts` namespaces to inherit from `_BaseNamespace`, removes duplicated `__init__` methods, and switches all requests from `build_headers(self._api_key)` to `headers=self._headers` (dropping now-unused imports).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 559294098005cb8e00bca260dcf292054e41de67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->