### PR TITLE
refactor(auth): share precedence chain between resolve_api_key and get_auth_status

### DIFF
--- a/yutori/auth/credentials.py
+++ b/yutori/auth/credentials.py
@@ -78,6 +78,33 @@ def _is_real_key(key: str | None) -> bool:
     return bool(key and key.strip() and key.strip() not in _PLACEHOLDER_KEYS)
 
 
+def _resolve_api_key_with_source(api_key: str | None = None) -> tuple[str, str] | None:
+    """Resolve an API key using the standard precedence chain and report its source.
+
+    Order: explicit parameter > ``YUTORI_API_KEY`` env var > config file.
+    Placeholder values like ``"YOUR_API_KEY"`` are treated as missing.
+
+    Returns a ``(key, source)`` tuple where ``source`` is one of
+    ``"param"``, ``"env_var"``, or ``"config_file"``, or ``None`` if no key
+    is found. Callers that only need the key itself should use
+    :func:`resolve_api_key`.
+    """
+    if _is_real_key(api_key):
+        return api_key, "param"
+
+    env_key = os.environ.get("YUTORI_API_KEY")
+    if _is_real_key(env_key):
+        return env_key, "env_var"
+
+    config = load_config()
+    if config:
+        stored_key = config.get("api_key")
+        if isinstance(stored_key, str) and _is_real_key(stored_key):
+            return stored_key, "config_file"
+
+    return None
+
+
 def resolve_api_key(api_key: str | None = None) -> str | None:
     """Resolve an API key using the standard precedence chain.
 
@@ -85,20 +112,8 @@ def resolve_api_key(api_key: str | None = None) -> str | None:
     Placeholder values like ``"YOUR_API_KEY"`` are treated as missing.
     Returns None if no key is found (caller decides error behavior).
     """
-    if _is_real_key(api_key):
-        return api_key
-
-    env_key = os.environ.get("YUTORI_API_KEY")
-    if _is_real_key(env_key):
-        return env_key
-
-    config = load_config()
-    if config:
-        stored_key = config.get("api_key")
-        if isinstance(stored_key, str) and _is_real_key(stored_key):
-            return stored_key
-
-    return None
+    resolved = _resolve_api_key_with_source(api_key)
+    return resolved[0] if resolved else None
 
 
 def require_api_key(api_key: str | None = None) -> str:

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -11,7 +11,6 @@ import hashlib
 import html
 import http.server
 import logging
-import os
 import secrets
 import socketserver
 import sys
@@ -40,7 +39,7 @@ from .constants import (
     REDIRECT_URI,
     build_auth_api_url,
 )
-from .credentials import _is_real_key, get_config_path, load_config, save_config
+from .credentials import _resolve_api_key_with_source, get_config_path, save_config
 from .types import AuthStatus, LoginResult
 
 logger = logging.getLogger(__name__)
@@ -318,28 +317,21 @@ def _mask_key(key: str) -> str:
 def get_auth_status() -> AuthStatus:
     """Check current authentication status.
 
-    Precedence matches resolve_api_key(): env var > config file.
+    Precedence matches resolve_api_key(): env var > config file. (The
+    explicit-parameter source of :func:`_resolve_api_key_with_source` is
+    unreachable here because no ``api_key`` is ever passed in.)
     Returns an AuthStatus — never prints directly.
     """
     config_path = str(get_config_path())
 
-    env_key = os.environ.get("YUTORI_API_KEY")
-    if _is_real_key(env_key):
-        return AuthStatus(
-            authenticated=True,
-            masked_key=_mask_key(env_key),
-            source="env_var",
-            config_path=config_path,
-        )
+    resolved = _resolve_api_key_with_source()
+    if resolved is None:
+        return AuthStatus(authenticated=False, config_path=config_path)
 
-    config = load_config()
-    config_key = config.get("api_key") if config else None
-    if isinstance(config_key, str) and _is_real_key(config_key):
-        return AuthStatus(
-            authenticated=True,
-            masked_key=_mask_key(config_key),
-            source="config_file",
-            config_path=config_path,
-        )
-
-    return AuthStatus(authenticated=False, config_path=config_path)
+    key, source = resolved
+    return AuthStatus(
+        authenticated=True,
+        masked_key=_mask_key(key),
+        source=source,
+        config_path=config_path,
+    )


### PR DESCRIPTION
## What

`yutori/auth/flow.py::get_auth_status` re-walked the same env-var-then-config-file precedence chain that `yutori/auth/credentials.py::resolve_api_key` already defined, duplicating:

- the `os.environ.get("YUTORI_API_KEY")` check,
- the `load_config()` + `isinstance(stored_key, str)` + `_is_real_key` guard on the config-file branch,
- the placeholder (`"YOUR_API_KEY"`) handling,

with only the added twist that `get_auth_status` needed to report *which source* produced the key.

This PR:

1. Adds a private `_resolve_api_key_with_source(api_key=None) -> tuple[str, str] | None` helper in `credentials.py`. It returns `(key, source)` where `source` is `"param"`, `"env_var"`, or `"config_file"`, or `None` if no key is found.
2. Rewrites `resolve_api_key()` to delegate and discard the source.
3. Rewrites `get_auth_status()` on top of the helper: one call, one branch for the unauthenticated case, one `AuthStatus(...)` for the authenticated case.

## Why it's an improvement

- **Precedence is defined once.** Previously, any change (adding a keyring source, reordering env vs config, tweaking placeholder semantics) had to be made in two functions, with silent drift as the failure mode.
- **Three identical `AuthStatus(authenticated=True, masked_key=..., source=..., config_path=...)` constructions collapse into one.** Reviewer can see at a glance that the "success shape" is uniform.
- Dead imports (`_is_real_key`, `load_config`, `os`) drop out of `flow.py`.

## Why it's safe

- **No public signatures change.** `resolve_api_key`, `require_api_key`, `get_auth_status`, `AuthStatus` are untouched on the outside.
- **Behavior is byte-for-byte identical** across every scenario covered by `tests/test_auth.py`:
  - `TestResolveApiKey`: explicit param wins; env used when no param; config used when no env; placeholder fall-through; non-string config value ignored; empty string falls through.
  - `TestGetAuthStatus`: `source == "config_file"` / `"env_var"` reporting; env takes precedence over config; placeholder env/config treated as unauthenticated; non-string api_key treated as unauthenticated; `masked_key` preserves the `_mask_key` output.
- `get_auth_status` calls the helper without an `api_key` argument, so the `"param"` source branch is unreachable there — `AuthStatus.source` still only ever takes `"config_file"` / `"env_var"` / `None`, matching the existing docstring and tests.
- **Scope: 2 files** (`yutori/auth/credentials.py`, `yutori/auth/flow.py`). No changes to callers, tests, or exports.

Does not overlap with open PR #60 (installer UX) or merged PRs #38 (`build_payload`), #48 (`format_interval`), #50 (docs).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VRAQGvQoGDG16u1dwvRcba)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that de-duplicates API key precedence logic; main risk is an unintended change in key-source detection or placeholder handling that could affect auth status reporting.
> 
> **Overview**
> Refactors API key resolution to share a single precedence implementation across `resolve_api_key()` and `get_auth_status()`.
> 
> Adds `_resolve_api_key_with_source()` in `credentials.py` to return both the resolved key and its source (`param`/`env_var`/`config_file`), updates `resolve_api_key()` to delegate to it, and rewrites `get_auth_status()` in `flow.py` to call the helper instead of re-implementing env/config checks (removing now-unneeded imports).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53404e6a076ea143a8566650c7219db586fb67d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->