### PR TITLE
Clear animation frame region before Python UI handoff

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1890,6 +1890,11 @@ play_animation_until_done() {
     done
 
     printf '\033[%s;1H' "$frame_top"
+    # Clear from the cursor to the end of the screen. Without this, the final
+    # animation frame stays drawn below frame_top, and when the Python UI
+    # starts printing it only overwrites the first few rows — residual frame
+    # characters bleed through below the step prompts and summary table.
+    printf '\033[0J'
     printf '\033[0m\033[?25h'
     # cleanup_temp_files (EXIT trap) will rm the render dir on any exit path.
 }

--- a/install.sh.template
+++ b/install.sh.template
@@ -383,6 +383,11 @@ play_animation_until_done() {
     done
 
     printf '\033[%s;1H' "$frame_top"
+    # Clear from the cursor to the end of the screen. Without this, the final
+    # animation frame stays drawn below frame_top, and when the Python UI
+    # starts printing it only overwrites the first few rows — residual frame
+    # characters bleed through below the step prompts and summary table.
+    printf '\033[0J'
     printf '\033[0m\033[?25h'
     # cleanup_temp_files (EXIT trap) will rm the render dir on any exit path.
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.7.0"
+version = "0.7.1"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_bash_scripts.py
+++ b/tests/test_bash_scripts.py
@@ -256,3 +256,23 @@ def test_full_animation_renders_at_least_two_frames() -> None:
     content = INSTALL_TEMPLATE.read_text()
     assert 'local minimum_frames=2' in content
     assert 'while kill -0 "$install_pid" 2>/dev/null || (( displayed_frames < minimum_frames )); do' in content
+
+
+def test_full_animation_clears_frame_region_before_handoff() -> None:
+    """Regression: the final animation frame persists below frame_top. If the
+    Python UI that takes over prints fewer lines than the frame is tall, old
+    frame rows bleed through below the step prompts and summary table. The
+    animation loop must emit a `\\033[0J` (clear from cursor to end of screen)
+    after repositioning the cursor, so the region below is guaranteed blank
+    when the handoff happens.
+    """
+    content = INSTALL_TEMPLATE.read_text()
+    # Look inside play_animation_until_done's teardown — the cursor repositions
+    # to frame_top and should be followed by a clear-to-end-of-screen before
+    # the reset-colors line.
+    play_animation_region = content.split("play_animation_until_done()")[1].split("render_static_logo()")[0]
+    assert "\\033[0J" in play_animation_region, (
+        "play_animation_until_done must emit \\033[0J (clear from cursor to "
+        "end of screen) after the animation loop, or leftover frame rows "
+        "will bleed through when the Python UI starts printing."
+    )


### PR DESCRIPTION
## What

Fixes the "scrambled animation frame bleeds into step layout" bug surfaced after PR #60 shipped. After the animation ended, the final frame was left drawn from `frame_top` downwards. The Python UI that took over overwrote the first few rows but the tail of the old frame bled through below the step prompts and summary table.

## Fix

Emit `\033[0J` (clear from cursor to end of screen) right after repositioning the cursor to `frame_top`, before the color reset. One-line change in `play_animation_until_done`'s teardown.

Also adds a regression test (`test_full_animation_clears_frame_region_before_handoff`) that asserts `\033[0J` is present in the function, so a future refactor can't accidentally drop it.

## Testing

- 372 unit tests pass locally on bash 3.2 (macOS `/bin/bash`).
- Docker live end-to-end with pty, interactive full-animation mode: captured the animation-end → Python UI transition — cursor-show, then clean `CLI → PATH → Python SDK → Auth → Install summary` with zero frame residue.

## Context

After this merges, cut **v0.7.1** so the fix ships via `yutori.com/install.sh`. The release asset at `releases/latest/download/install.sh` is still pointing at v0.7.0's pre-polish installer, which is what users currently download when they run `curl | bash`.

Fixes the screenshot issue from [ENG-4862](https://linear.app/yutori/issue/ENG-4862).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small terminal-rendering change plus a regression test and patch version bump; main risk is minor ANSI compatibility differences across terminals.
> 
> **Overview**
> Fixes a terminal UI glitch where the last installer animation frame could remain visible and bleed into the subsequent Python-driven UI by clearing from `frame_top` to end-of-screen (`\033[0J`) during the animation teardown.
> 
> Adds a regression test asserting the clear-screen escape is emitted, and bumps the package version to `0.7.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 735651c9eb76ac816420ba6bff5e417a1c6c38bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->