### PR TITLE
refactor(http): extract _request helper into sync/async namespace bases

### DIFF
--- a/yutori/_async/scouts.py
+++ b/yutori/_async/scouts.py
@@ -5,16 +5,15 @@ from __future__ import annotations
 from typing import Any
 
 from .._http import (
-    _BaseNamespace,
+    _AsyncBaseNamespace,
     build_payload,
     build_query_params,
-    handle_response,
     resolve_scout_status_endpoint,
 )
 from .._schema import resolve_output_schema
 
 
-class AsyncScoutsNamespace(_BaseNamespace):
+class AsyncScoutsNamespace(_AsyncBaseNamespace):
     """Async namespace for scout-related operations (continuous web monitoring)."""
 
     async def list(
@@ -34,12 +33,7 @@ class AsyncScoutsNamespace(_BaseNamespace):
         """
         # API pagination parameter is `page_size`; keep `limit` for SDK ergonomics.
         params = build_query_params(page_size=limit, status=status)
-        response = await self._client.get(
-            f"{self._base_url}/scouting/tasks",
-            headers=self._headers,
-            params=params,
-        )
-        return handle_response(response)
+        return await self._request("get", "/scouting/tasks", params=params)
 
     async def get(self, scout_id: str) -> dict[str, Any]:
         """Get details of a specific scout.
@@ -50,11 +44,7 @@ class AsyncScoutsNamespace(_BaseNamespace):
         Returns:
             Dictionary containing scout details.
         """
-        response = await self._client.get(
-            f"{self._base_url}/scouting/tasks/{scout_id}",
-            headers=self._headers,
-        )
-        return handle_response(response)
+        return await self._request("get", f"/scouting/tasks/{scout_id}")
 
     async def create(
         self,
@@ -100,12 +90,7 @@ class AsyncScoutsNamespace(_BaseNamespace):
             is_public=is_public,
         )
 
-        response = await self._client.post(
-            f"{self._base_url}/scouting/tasks",
-            headers=self._headers,
-            json=payload,
-        )
-        return handle_response(response)
+        return await self._request("post", "/scouting/tasks", json=payload)
 
     async def update(
         self,
@@ -164,22 +149,13 @@ class AsyncScoutsNamespace(_BaseNamespace):
         # Handle status changes via dedicated endpoints
         if status is not None:
             endpoint = resolve_scout_status_endpoint(status)
-            response = await self._client.post(
-                f"{self._base_url}/scouting/tasks/{scout_id}/{endpoint}",
-                headers=self._headers,
-            )
-            return handle_response(response)
+            return await self._request("post", f"/scouting/tasks/{scout_id}/{endpoint}")
 
         # Handle field updates via PATCH
         if not payload:
             raise ValueError("At least one field must be provided for update.")
 
-        response = await self._client.patch(
-            f"{self._base_url}/scouting/tasks/{scout_id}",
-            headers=self._headers,
-            json=payload,
-        )
-        return handle_response(response)
+        return await self._request("patch", f"/scouting/tasks/{scout_id}", json=payload)
 
     async def delete(self, scout_id: str) -> dict[str, Any]:
         """Delete a scout.
@@ -190,11 +166,7 @@ class AsyncScoutsNamespace(_BaseNamespace):
         Returns:
             Empty dictionary on success.
         """
-        response = await self._client.delete(
-            f"{self._base_url}/scouting/tasks/{scout_id}",
-            headers=self._headers,
-        )
-        return handle_response(response)
+        return await self._request("delete", f"/scouting/tasks/{scout_id}")
 
     async def get_updates(
         self,
@@ -214,9 +186,4 @@ class AsyncScoutsNamespace(_BaseNamespace):
             Dictionary containing list of updates and pagination info.
         """
         params = build_query_params(limit=limit, cursor=cursor)
-        response = await self._client.get(
-            f"{self._base_url}/scouting/tasks/{scout_id}/updates",
-            headers=self._headers,
-            params=params,
-        )
-        return handle_response(response)
+        return await self._request("get", f"/scouting/tasks/{scout_id}/updates", params=params)

--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -99,3 +99,54 @@ class _BaseNamespace:
         self._client = client
         self._base_url = base_url
         self._headers = build_headers(api_key)
+
+    def _request_kwargs(self, params: Any, json: Any) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {"headers": self._headers}
+        if params is not None:
+            kwargs["params"] = params
+        if json is not None:
+            kwargs["json"] = json
+        return kwargs
+
+
+class _SyncBaseNamespace(_BaseNamespace):
+    """Sync namespace base with a shared request helper.
+
+    Centralizes the ``self._client.<method>(url, headers=..., ...)`` +
+    ``handle_response(response)`` boilerplate so concrete namespaces read
+    as one-liners.
+    """
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Any = None,
+        json: Any = None,
+    ) -> dict[str, Any]:
+        http_method = getattr(self._client, method)
+        response = http_method(
+            f"{self._base_url}{path}",
+            **self._request_kwargs(params, json),
+        )
+        return handle_response(response)
+
+
+class _AsyncBaseNamespace(_BaseNamespace):
+    """Async counterpart of :class:`_SyncBaseNamespace`."""
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Any = None,
+        json: Any = None,
+    ) -> dict[str, Any]:
+        http_method = getattr(self._client, method)
+        response = await http_method(
+            f"{self._base_url}{path}",
+            **self._request_kwargs(params, json),
+        )
+        return handle_response(response)

--- a/yutori/_sync/scouts.py
+++ b/yutori/_sync/scouts.py
@@ -5,16 +5,15 @@ from __future__ import annotations
 from typing import Any
 
 from .._http import (
-    _BaseNamespace,
+    _SyncBaseNamespace,
     build_payload,
     build_query_params,
-    handle_response,
     resolve_scout_status_endpoint,
 )
 from .._schema import resolve_output_schema
 
 
-class ScoutsNamespace(_BaseNamespace):
+class ScoutsNamespace(_SyncBaseNamespace):
     """Namespace for scout-related operations (continuous web monitoring)."""
 
     def list(
@@ -34,12 +33,7 @@ class ScoutsNamespace(_BaseNamespace):
         """
         # API pagination parameter is `page_size`; keep `limit` for SDK ergonomics.
         params = build_query_params(page_size=limit, status=status)
-        response = self._client.get(
-            f"{self._base_url}/scouting/tasks",
-            headers=self._headers,
-            params=params,
-        )
-        return handle_response(response)
+        return self._request("get", "/scouting/tasks", params=params)
 
     def get(self, scout_id: str) -> dict[str, Any]:
         """Get details of a specific scout.
@@ -50,11 +44,7 @@ class ScoutsNamespace(_BaseNamespace):
         Returns:
             Dictionary containing scout details.
         """
-        response = self._client.get(
-            f"{self._base_url}/scouting/tasks/{scout_id}",
-            headers=self._headers,
-        )
-        return handle_response(response)
+        return self._request("get", f"/scouting/tasks/{scout_id}")
 
     def create(
         self,
@@ -100,12 +90,7 @@ class ScoutsNamespace(_BaseNamespace):
             is_public=is_public,
         )
 
-        response = self._client.post(
-            f"{self._base_url}/scouting/tasks",
-            headers=self._headers,
-            json=payload,
-        )
-        return handle_response(response)
+        return self._request("post", "/scouting/tasks", json=payload)
 
     def update(
         self,
@@ -164,22 +149,13 @@ class ScoutsNamespace(_BaseNamespace):
         # Handle status changes via dedicated endpoints
         if status is not None:
             endpoint = resolve_scout_status_endpoint(status)
-            response = self._client.post(
-                f"{self._base_url}/scouting/tasks/{scout_id}/{endpoint}",
-                headers=self._headers,
-            )
-            return handle_response(response)
+            return self._request("post", f"/scouting/tasks/{scout_id}/{endpoint}")
 
         # Handle field updates via PATCH
         if not payload:
             raise ValueError("At least one field must be provided for update.")
 
-        response = self._client.patch(
-            f"{self._base_url}/scouting/tasks/{scout_id}",
-            headers=self._headers,
-            json=payload,
-        )
-        return handle_response(response)
+        return self._request("patch", f"/scouting/tasks/{scout_id}", json=payload)
 
     def delete(self, scout_id: str) -> dict[str, Any]:
         """Delete a scout.
@@ -190,11 +166,7 @@ class ScoutsNamespace(_BaseNamespace):
         Returns:
             Empty dictionary on success.
         """
-        response = self._client.delete(
-            f"{self._base_url}/scouting/tasks/{scout_id}",
-            headers=self._headers,
-        )
-        return handle_response(response)
+        return self._request("delete", f"/scouting/tasks/{scout_id}")
 
     def get_updates(
         self,
@@ -214,9 +186,4 @@ class ScoutsNamespace(_BaseNamespace):
             Dictionary containing list of updates and pagination info.
         """
         params = build_query_params(limit=limit, cursor=cursor)
-        response = self._client.get(
-            f"{self._base_url}/scouting/tasks/{scout_id}/updates",
-            headers=self._headers,
-            params=params,
-        )
-        return handle_response(response)
+        return self._request("get", f"/scouting/tasks/{scout_id}/updates", params=params)


### PR DESCRIPTION
## Summary

Every HTTP call in the SDK namespaces followed the same 4–5 line boilerplate — `self._client.<method>(f"{self._base_url}/path", headers=self._headers, ...)` then `return handle_response(response)` — duplicated once per operation and then again across sync/async. A change to response handling, URL composition, or header injection would have to be mirrored in 14+ places for scouts alone.

This PR:

1. Adds two new base classes in `yutori/_http.py`:
   - `_SyncBaseNamespace._request(method, path, *, params, json)` — sync variant
   - `_AsyncBaseNamespace._request(method, path, *, params, json)` — async variant
   Both reuse a small `_BaseNamespace._request_kwargs()` helper so the `params`/`json`/`headers` assembly lives in one place.
2. Migrates `ScoutsNamespace` (sync) and `AsyncScoutsNamespace` (async) to use `_request`. Seven call sites in each file collapse from 5 lines to 1.

Net: 3 files, +69 / −84 lines.

## Why it's safe

- Pure structural extraction — same headers, same URL composition, same `handle_response` semantics.
- `_BaseNamespace` keeps its existing `__init__` contract, so `BrowsingNamespace` / `AsyncBrowsingNamespace` / `ResearchNamespace` / `AsyncResearchNamespace` (which still inherit directly from it) are untouched and can be migrated in a separate PR.
- Full test suite still green: **371 passed, 3 skipped** (`uv run pytest`).
- `ruff check` clean on the three modified files.

## Test plan
- [x] `uv run pytest` — 371 passed, 3 skipped
- [x] `uv run ruff check yutori/_http.py yutori/_sync/scouts.py yutori/_async/scouts.py`
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDAKe2oEvxb6DwWz4Raz2W)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how scout API calls are constructed and executed by centralizing URL/kwargs assembly and response handling behind new `_request` helpers, so any subtle mismatch affects all scout operations. Scope is limited to scouts (other namespaces still use the old direct client calls).
> 
> **Overview**
> Refactors the SDK’s HTTP call pattern by introducing `_SyncBaseNamespace` and `_AsyncBaseNamespace` in `yutori/_http.py`, adding a shared `_request()` helper (plus `_request_kwargs()`) to centralize URL composition, header injection, and optional `params`/`json` handling.
> 
> Updates both `ScoutsNamespace` and `AsyncScoutsNamespace` to inherit from these new bases and replace their per-method `self._client.<method>(...)` + `handle_response(...)` boilerplate with one-line `self._request(...)` calls, without changing the public scouts API surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a09f2c6bba659ea9a199d9c04831c40ab2044cf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->