### PR TITLE
Make animation + handoff visible on fast reinstalls (v0.7.2)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1842,7 +1842,10 @@ play_animation_until_done() {
     local frame_top
     local frame_index=0
     local displayed_frames=0
-    local minimum_frames=2
+    # ~1.5s at 12fps minimum. Fast reinstalls (user already has yutori
+    # installed; version bump) can finish in under a second — without a
+    # sensible minimum the animation flashes past and users don't see it.
+    local minimum_frames=18
     # Animation cadence ~12fps; inlined to avoid forking awk for 1/12.
     local frame_sleep="0.0833"
 
@@ -1959,7 +1962,11 @@ handoff_to_python_ui() {
         exit 1
     fi
 
-    printf '\n'
+    # A visible "we're alive" message between the animation end and the
+    # Python UI's first output. Python import + Typer startup can take ~1s,
+    # during which the screen is otherwise blank — users may interpret that
+    # as a hang. This line gives them something to see during the transition.
+    note "Starting interactive setup..."
     cleanup_temp_files
     # The Python UI reuses uv via YUTORI_UV_BIN when PATH may not yet include
     # the uv tool bin dir (e.g., first-time installs where update-shell hasn't

--- a/install.sh.template
+++ b/install.sh.template
@@ -335,7 +335,10 @@ play_animation_until_done() {
     local frame_top
     local frame_index=0
     local displayed_frames=0
-    local minimum_frames=2
+    # ~1.5s at 12fps minimum. Fast reinstalls (user already has yutori
+    # installed; version bump) can finish in under a second — without a
+    # sensible minimum the animation flashes past and users don't see it.
+    local minimum_frames=18
     # Animation cadence ~12fps; inlined to avoid forking awk for 1/12.
     local frame_sleep="0.0833"
 
@@ -452,7 +455,11 @@ handoff_to_python_ui() {
         exit 1
     fi
 
-    printf '\n'
+    # A visible "we're alive" message between the animation end and the
+    # Python UI's first output. Python import + Typer startup can take ~1s,
+    # during which the screen is otherwise blank — users may interpret that
+    # as a hang. This line gives them something to see during the transition.
+    note "Starting interactive setup..."
     cleanup_temp_files
     # The Python UI reuses uv via YUTORI_UV_BIN when PATH may not yet include
     # the uv tool bin dir (e.g., first-time installs where update-shell hasn't

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.7.1"
+version = "0.7.2"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_bash_scripts.py
+++ b/tests/test_bash_scripts.py
@@ -249,12 +249,23 @@ def test_full_animation_keeps_bootstrap_intro_in_shell() -> None:
     assert 'export YUTORI_INSTALLER_BOOTSTRAP_SHOWN="1"' in content
 
 
-def test_full_animation_renders_at_least_two_frames() -> None:
-    """Fast reinstalls can finish before the first loop iteration. Keep a
-    minimum of two frames so users still see the Navigator move at least once.
+def test_full_animation_renders_enough_frames_for_fast_reinstalls() -> None:
+    """Fast reinstalls (version bumps over an existing install) can complete
+    in well under a second. Without a sensible minimum-frames floor, the
+    animation flashes past in ~170ms and users perceive a hang when the
+    screen is cleared for the Python UI handoff. Lock in at least ~1s of
+    animation at 12fps cadence.
     """
     content = INSTALL_TEMPLATE.read_text()
-    assert 'local minimum_frames=2' in content
+    import re
+
+    match = re.search(r"local minimum_frames=(\d+)", content)
+    assert match, "minimum_frames must be defined in play_animation_until_done"
+    minimum_frames = int(match.group(1))
+    assert minimum_frames >= 12, (
+        f"minimum_frames={minimum_frames} is under 1s at 12fps — fast "
+        "reinstalls will flash the animation past unreadably fast."
+    )
     assert 'while kill -0 "$install_pid" 2>/dev/null || (( displayed_frames < minimum_frames )); do' in content
 
 


### PR DESCRIPTION
## The bug

User report: ran `curl -fsSL https://yutori.com/install.sh | bash` on macOS with an existing yutori CLI. Saw banner + installer intro. Then blank screen. Appeared hung.

## Diagnosis

They already had `yutori` 0.7.0 installed, so `uv tool install --force --upgrade yutori` (bumping 0.7.0 → 0.7.1) completed in well under a second. With `minimum_frames=2` the animation played for ~170ms — easily missed. Then `\033[0J` cleared the region. Python UI's cold-start took another ~1s during which the screen was blank. Total unexplained blank gap: ~1s, long enough to read as a hang.

## Fix

Two complementary changes:

1. **`minimum_frames` raised from 2 → 18** (~1.5s of visible animation at 12fps). Long enough to register as motion; short enough to not feel slow on fresh installs where `uv` takes 10+ seconds anyway.

2. **"Starting interactive setup..." note** printed immediately after the animation ends, before the `exec` to the Python UI. Covers the Python-import / Typer-startup gap with a visible signal. Also serves as a diagnostic waypoint — if a future "hung" report comes in, we can ask whether the user saw this message.

## Testing

- 372 unit tests pass (added `test_full_animation_renders_enough_frames_for_fast_reinstalls` to pin the ≥1s invariant).
- Live Docker e2e with a pty: animation visible for ~1.5s, then "Starting interactive setup..." prints, then Python UI takes over cleanly.

## After merge

Cut v0.7.2 — publish workflow uploads the updated `install.sh` to release assets, `yutori.com/install.sh` picks it up.

Fixes a regression surfaced in [ENG-4862](https://linear.app/yutori/issue/ENG-4862).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX-only changes to the bash installer flow (animation timing + an extra status line) plus a patch version bump; minimal impact beyond installer output timing.
> 
> **Overview**
> Improves perceived reliability of `install.sh` on *fast reinstalls* by enforcing a longer minimum animation duration (`minimum_frames` raised to 18) so the transition to the Python UI isn’t an easily-missed flash.
> 
> Adds a visible handoff message (`note "Starting interactive setup..."`) between animation teardown and the Python UI `exec`, and updates tests to assert a ≥1s minimum-frames invariant. Also bumps the project version to `0.7.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d725b9b4be914021229a5d64826d104f2ad8520f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->