### PR TITLE
Polish installer prompts and summary table (v0.7.3)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1926,6 +1926,7 @@ print_log_tail_and_exit() {
 }
 
 handoff_to_python_ui() {
+    local use_color="${1:-0}"
     local bin_dir
     local yutori_bin
 
@@ -1966,7 +1967,13 @@ handoff_to_python_ui() {
     # Python UI's first output. Python import + Typer startup can take ~1s,
     # during which the screen is otherwise blank — users may interpret that
     # as a hang. This line gives them something to see during the transition.
-    note "Starting interactive setup..."
+    # Mirrors the `| `-prefix style from render_bootstrap_intro so the message
+    # slots into the same visual block as "Installing Yutori CLI with uv...".
+    if (( use_color )); then
+        printf '%b| Starting interactive setup...%b\n' "$YUTORI_SLATE_TEXT" "$YUTORI_RESET"
+    else
+        printf '| Starting interactive setup...\n'
+    fi
     cleanup_temp_files
     # The Python UI reuses uv via YUTORI_UV_BIN when PATH may not yet include
     # the uv tool bin dir (e.g., first-time installs where update-shell hasn't
@@ -2065,7 +2072,7 @@ main() {
         cat "$INSTALL_LOG"
     fi
 
-    handoff_to_python_ui
+    handoff_to_python_ui "$use_color"
 }
 
 main "$@"

--- a/install.sh.template
+++ b/install.sh.template
@@ -419,6 +419,7 @@ print_log_tail_and_exit() {
 }
 
 handoff_to_python_ui() {
+    local use_color="${1:-0}"
     local bin_dir
     local yutori_bin
 
@@ -459,7 +460,13 @@ handoff_to_python_ui() {
     # Python UI's first output. Python import + Typer startup can take ~1s,
     # during which the screen is otherwise blank — users may interpret that
     # as a hang. This line gives them something to see during the transition.
-    note "Starting interactive setup..."
+    # Mirrors the `| `-prefix style from render_bootstrap_intro so the message
+    # slots into the same visual block as "Installing Yutori CLI with uv...".
+    if (( use_color )); then
+        printf '%b| Starting interactive setup...%b\n' "$YUTORI_SLATE_TEXT" "$YUTORI_RESET"
+    else
+        printf '| Starting interactive setup...\n'
+    fi
     cleanup_temp_files
     # The Python UI reuses uv via YUTORI_UV_BIN when PATH may not yet include
     # the uv tool bin dir (e.g., first-time installs where update-shell hasn't
@@ -558,7 +565,7 @@ main() {
         cat "$INSTALL_LOG"
     fi
 
-    handoff_to_python_ui
+    handoff_to_python_ui "$use_color"
 }
 
 main "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.7.2"
+version = "0.7.3"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/yutori/cli/commands/install_ui.py
+++ b/yutori/cli/commands/install_ui.py
@@ -25,7 +25,6 @@ from typing import Literal, Mapping, Sequence
 import typer
 from rich import box
 from rich.console import Console
-from rich.panel import Panel
 from rich.prompt import Confirm
 from rich.table import Table
 
@@ -41,7 +40,7 @@ ERROR_RED = "#FF5C5C"
 # Canonical first-task example, mirroring docs.yutori.com.
 VERIFICATION_TASK = "Give me a list of all employees (names and titles) of Yutori."
 VERIFICATION_URL = "https://yutori.com"
-VERIFICATION_MAX_STEPS = 5
+VERIFICATION_MAX_STEPS = 3
 # Route matches api-dashboard's /browsing/tasks/[id] page; the Vercel project
 # serves it on platform.yutori.com (production) and platform.dev.yutori.com (dev).
 VERIFICATION_TASK_DASHBOARD_BASE_URL = "https://platform.yutori.com/browsing/tasks"
@@ -261,8 +260,28 @@ def print_prompt_block(console: Console, title: str, description: str, *, comman
         console.print(f"[{SLATE_TEXT}]| Command: {format_command(command)}[/]")
 
 
+def ask_confirm(console: Console, question: str, *, default: bool) -> bool:
+    """Ask a yes/no question with a `| ` prefix so the prompt aligns with the
+    rest of the step block. Rich's Confirm.ask supports markup in the prompt
+    text, so a slate-colored `|` renders exactly like the description lines
+    above it.
+    """
+    return Confirm.ask(f"[{SLATE_TEXT}]|[/] {question}", default=default, console=console)
+
+
 def summarize_results(console: Console, results: Sequence[StepResult]) -> None:
-    table = Table(box=box.ASCII, show_header=True, header_style=f"bold {MINT_HIGHLIGHT}")
+    # box.SIMPLE_HEAD keeps only the rule under the header — no vertical
+    # separators between columns, no corner glyphs. Matches the `| `-prefixed
+    # text style used everywhere else in the installer.
+    table = Table(
+        title="Install summary",
+        title_style=f"bold {MINT_HIGHLIGHT}",
+        box=box.SIMPLE_HEAD,
+        show_header=True,
+        header_style=f"bold {MINT_HIGHLIGHT}",
+        pad_edge=False,
+        show_edge=False,
+    )
     table.add_column("Step", style="bold")
     table.add_column("Status", width=8)
     table.add_column("Detail")
@@ -272,7 +291,7 @@ def summarize_results(console: Console, results: Sequence[StepResult]) -> None:
         table.add_row(result.name, f"[{color}]{label}[/{color}]", result.detail)
 
     console.print("\n")
-    console.print(Panel.fit(table, title="Install summary", border_style=BRAND_MINT, box=box.ASCII))
+    console.print(table)
 
 
 def inspect_cli_install(env: Mapping[str, str] | None = None) -> tuple[CLIInstallState | None, StepResult]:
@@ -389,7 +408,7 @@ def maybe_repair_path(console: Console, state: CLIInstallState, *, interactive: 
     if not interactive:
         return StepResult("PATH", "skipped", f"{detail} Skipped PATH repair because no interactive terminal is available.")
 
-    if not Confirm.ask("Run uv tool update-shell now?", default=True, console=console):
+    if not ask_confirm(console, "Run uv tool update-shell now?", default=True):
         return StepResult("PATH", "skipped", f"{detail} PATH repair was skipped.")
 
     result = run_command((state.uv_path, "tool", "update-shell"))
@@ -413,7 +432,7 @@ def maybe_install_sdk(console: Console, plan: SDKInstallPlan, *, interactive: bo
     if plan.availability_error:
         return StepResult("SDK", "failed", plan.availability_error)
 
-    if not Confirm.ask("Install the Python SDK into this project?", default=plan.default, console=console):
+    if not ask_confirm(console, "Install the Python SDK into this project?", default=plan.default):
         return StepResult("SDK", "skipped", "SDK install was skipped.")
 
     # Show a dot-animation status line so the user sees the installer is alive
@@ -460,7 +479,7 @@ def maybe_authenticate(console: Console, *, interactive: bool) -> tuple[StepResu
             )
 
         print_prompt_block(console, "Authentication", "Browser login saves credentials to ~/.yutori/config.json.")
-        if not Confirm.ask("Log in to Yutori now?", default=True, console=console):
+        if not ask_confirm(console, "Log in to Yutori now?", default=True):
             return StepResult("Auth", "skipped", "Authentication was skipped."), False
 
         messages: dict[RegistrationState, str] = {
@@ -545,7 +564,7 @@ def run_verification(
         f"Runs the canonical browsing task against yutori.com with max_steps={VERIFICATION_MAX_STEPS}.",
         command=submit_command,
     )
-    if not Confirm.ask("Run the verification browsing task now?", default=True, console=console):
+    if not ask_confirm(console, "Run the verification browsing task now?", default=True):
         return StepResult("Verification", "skipped", "Verification task was skipped."), False
 
     submission = run_command(submit_command, timeout=INSTALL_CMD_TIMEOUT)


### PR DESCRIPTION
## Summary

Three UX fixes reported against v0.7.2:

1. **`| ` prefix on the remaining prompt lines.** `Starting interactive setup...`, `Install the Python SDK into this project?`, and `Run the verification browsing task now?` previously printed without the `| ` guide, breaking the visual rhythm of the rest of the flow.
   - Bash handoff message threads `use_color` through `handoff_to_python_ui` and emits `| Starting interactive setup...` in slate.
   - Rich `Confirm.ask` prompts now go through a small `ask_confirm` helper that prepends `[SLATE]|[/] ` using Rich markup, so the prompt renders as `| Install the Python SDK into this project? [y/n] (n):`.

2. **`VERIFICATION_MAX_STEPS` 5 → 3.** The verification browsing task is a liveness check, not a correctness benchmark — 3 steps is enough for the agent to load yutori.com and extract a result, while trimming the "first-task demo" wait.

3. **Install summary table: drop verticals + corner glyphs.** Replaced the outer `Panel.fit(..., box=box.ASCII)` + inner `Table(box=box.ASCII)` with a bare `Table(box=box.SIMPLE_HEAD, show_edge=False, pad_edge=False, title="Install summary", ...)`. No more `|` column separators or `+---+` corners — just a single horizontal rule under the header.

Version bumped to `0.7.3`.

## Test plan

- [x] `pytest` — 372 passed, 3 skipped (bash 3.2 expected skips)
- [x] `./scripts/check_install_sh_fresh.sh` — install.sh regenerated from template
- [x] Smoke-tested `summarize_results` output — table renders with only the header rule, no verticals/corners
- [ ] Post-merge: cut v0.7.3, re-run `curl -fsSL https://yutori.com/install.sh | bash` and verify prompt lines all carry `|` prefix and summary table is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to installer UX/output formatting and a smaller verification max-steps value, with no changes to core auth/data handling logic.
> 
> **Overview**
> Polishes the installer UX by making the bash→Python UI handoff print a `| Starting interactive setup...` line that respects the existing `use_color` setting.
> 
> Updates the Python `__install_ui` flow to align all `Confirm` prompts with the `| `-prefixed visual style via a new `ask_confirm` helper, reduces the verification task `--max-steps` from 5 to 3, and simplifies the install summary rendering to a cleaner `rich` table (no panel/ASCII borders).
> 
> Bumps the package version to `0.7.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83804402d7f825a13d9d2382ea2044fb8a2d992d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->