### PR TITLE
Tighten README: curl | bash is the primary install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,17 @@ The official Python SDK and CLI for the [Yutori API](https://docs.yutori.com) �
 
 The SDK offers sync and async clients with full type annotations, plus a `yutori` CLI for authentication and managing resources from the terminal.
 
-## Quick Install
+## Install
 
-For the full CLI-first setup on macOS or Linux, use the one-line installer:
+On macOS or Linux, the recommended setup is the one-line installer:
 
 ```bash
 curl -fsSL https://yutori.com/install.sh | bash
 ```
 
-What this does:
+This installs the global `yutori` CLI with `uv tool install`, then — in an interactive terminal — prompts (with sensible defaults) to add the SDK to your project, run `yutori auth login`, and run a verification browsing task. In a non-interactive session (CI, pipe) the auth and verification prompts are skipped with guidance on how to finish setup.
 
-- Installs the global `yutori` CLI with `uv tool install`.
-- In an interactive terminal, prompts (with sensible defaults) to add the SDK to your project, run `yutori auth login`, and run a verification browsing task.
-- In a non-interactive session (CI, pipe), skips the auth and verification prompts with guidance on how to finish setup.
+Python 3.9+ is required for the SDK.
 
 <details>
 <summary>Uninstall the CLI later</summary>
@@ -32,16 +30,14 @@ Removes the global `yutori` CLI. Saved credentials at `~/.yutori/` are left in p
 
 </details>
 
-## Package Installation
+<details>
+<summary>Install the package manually</summary>
 
 ```bash
 pip install yutori
 ```
 
-Python 3.9+ is required.
-
-<details>
-<summary>Or add it to an existing project with uv</summary>
+Or add it to an existing project with uv:
 
 ```bash
 uv add yutori
@@ -49,7 +45,8 @@ uv add yutori
 
 </details>
 
-## Authentication
+<details>
+<summary>Authenticate manually</summary>
 
 Run this once to save your API key:
 
@@ -59,17 +56,9 @@ yutori auth login
 
 This opens your browser to log in with your Yutori account and saves an API key to `~/.yutori/config.json`. The SDK and CLI automatically pick it up.
 
-<details>
-<summary>If you installed with uv add</summary>
+If you installed the package with `uv add`, run `uv run yutori auth login` instead.
 
-```bash
-uv run yutori auth login
-```
-
-</details>
-
-<details>
-<summary>Or use an env var / pass the key explicitly</summary>
+Or use an env var / pass the key explicitly:
 
 ```python
 from yutori import YutoriClient


### PR DESCRIPTION
## Summary

Promotes the one-line installer as the recommended setup and tucks the manual alternatives (`pip install`, `uv add`, `yutori auth login`, `uv run yutori auth login`, env var / explicit key) into collapsed `<details>` sections so they don't compete with the happy path.

Before: `## Quick Install` → `## Package Installation` → `## Authentication`, each visible by default, with four scattered `<details>` blocks mixed in.

After: single `## Install` section — `curl | bash` inline, three `<details>` blocks for "Uninstall", "Install the package manually", and "Authenticate manually".

Matches the structure used in the `yutori-mcp` README where the quickstart is the recommended path and manual per-client setup is folded under `<details>`.

Net: -22 / +11 lines, no behavior change.

## Test plan

- [x] GitHub's markdown renderer supports `<details>`/`<summary>` — no new syntax introduced
- [ ] Visual check on the PR page that the collapsed sections render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only restructuring that changes installation guidance but not runtime behavior.
> 
> **Overview**
> Reworks the README to make the `curl -fsSL https://yutori.com/install.sh | bash` flow the primary, top-level install path, including a clearer explanation of what the installer does and a prominent Python 3.9+ requirement.
> 
> Moves manual alternatives (package install via `pip`/`uv`, authentication steps, and the uninstall command) into collapsed `<details>` sections to reduce clutter and emphasize the recommended setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf04911a999328cc85c5454c79cd88a5c3059cb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->