### PR TITLE
Bare `yutori` in verification command + version in header (v0.7.4)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,11 @@ YUTORI_SLATE_TEXT=$'\033[38;2;148;163;184m'
 YUTORI_ERROR_RED=$'\033[38;2;255;92;92m'
 YUTORI_RESET=$'\033[0m'
 
+# Installer version, injected at build time from pyproject.toml by
+# scripts/build_install.sh. Surfaced in the header so users can tell at a
+# glance which release they fetched (useful for bug reports).
+YUTORI_INSTALLER_VERSION="0.7.4"
+
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested
 # in `$(...)` mishandles literal apostrophes in the heredoc body — and the
@@ -141,11 +146,11 @@ render_bootstrap_intro() {
     # Gate ANSI codes on use_color so dumb terminals (TERM=dumb, no truecolor,
     # redirected stdout) don't render raw escape bytes. Matches render_static_logo.
     if (( use_color )); then
-        printf '%b> Yutori installer%b\n' "$YUTORI_MINT_HIGHLIGHT" "$YUTORI_RESET"
+        printf '%b> Yutori installer v%s%b\n' "$YUTORI_MINT_HIGHLIGHT" "$YUTORI_INSTALLER_VERSION" "$YUTORI_RESET"
         printf '%b| %s%b\n' "$YUTORI_SLATE_TEXT" "$mode_line" "$YUTORI_RESET"
         printf '%b| Installing Yutori CLI with uv...%b\n\n' "$YUTORI_SLATE_TEXT" "$YUTORI_RESET"
     else
-        printf '> Yutori installer\n'
+        printf '> Yutori installer v%s\n' "$YUTORI_INSTALLER_VERSION"
         printf '| %s\n' "$mode_line"
         printf '| Installing Yutori CLI with uv...\n\n'
     fi

--- a/install.sh.template
+++ b/install.sh.template
@@ -8,6 +8,11 @@ YUTORI_SLATE_TEXT=$'\033[38;2;148;163;184m'
 YUTORI_ERROR_RED=$'\033[38;2;255;92;92m'
 YUTORI_RESET=$'\033[0m'
 
+# Installer version, injected at build time from pyproject.toml by
+# scripts/build_install.sh. Surfaced in the header so users can tell at a
+# glance which release they fetched (useful for bug reports).
+YUTORI_INSTALLER_VERSION="__INLINE_VERSION__"
+
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested
 # in `$(...)` mishandles literal apostrophes in the heredoc body — and the
@@ -137,11 +142,11 @@ render_bootstrap_intro() {
     # Gate ANSI codes on use_color so dumb terminals (TERM=dumb, no truecolor,
     # redirected stdout) don't render raw escape bytes. Matches render_static_logo.
     if (( use_color )); then
-        printf '%b> Yutori installer%b\n' "$YUTORI_MINT_HIGHLIGHT" "$YUTORI_RESET"
+        printf '%b> Yutori installer v%s%b\n' "$YUTORI_MINT_HIGHLIGHT" "$YUTORI_INSTALLER_VERSION" "$YUTORI_RESET"
         printf '%b| %s%b\n' "$YUTORI_SLATE_TEXT" "$mode_line" "$YUTORI_RESET"
         printf '%b| Installing Yutori CLI with uv...%b\n\n' "$YUTORI_SLATE_TEXT" "$YUTORI_RESET"
     else
-        printf '> Yutori installer\n'
+        printf '> Yutori installer v%s\n' "$YUTORI_INSTALLER_VERSION"
         printf '| %s\n' "$mode_line"
         printf '| Installing Yutori CLI with uv...\n\n'
     fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.7.3"
+version = "0.7.4"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/scripts/build_install.sh
+++ b/scripts/build_install.sh
@@ -14,34 +14,51 @@ template_path="$repo_root/install.sh.template"
 output_path="$repo_root/install.sh"
 banner_path="$repo_root/assets/terminal/yutori_banner.txt"
 frames_path="$repo_root/assets/terminal/agent_logo_frames.txt"
+pyproject_path="$repo_root/pyproject.toml"
 
-for path in "$template_path" "$banner_path" "$frames_path"; do
+for path in "$template_path" "$banner_path" "$frames_path" "$pyproject_path"; do
     if [[ ! -f "$path" ]]; then
         printf 'Required asset not found: %s\n' "$path" >&2
         exit 1
     fi
 done
 
-python3 - "$template_path" "$output_path" "$banner_path" "$frames_path" <<'PY'
+python3 - "$template_path" "$output_path" "$banner_path" "$frames_path" "$pyproject_path" <<'PY'
 from pathlib import Path
+import re
 import sys
 
 template_path = Path(sys.argv[1])
 output_path = Path(sys.argv[2])
 banner_path = Path(sys.argv[3])
 frames_path = Path(sys.argv[4])
+pyproject_path = Path(sys.argv[5])
 
 template = template_path.read_text(encoding="utf-8")
 banner = banner_path.read_text(encoding="utf-8").rstrip("\n")
 frames = frames_path.read_text(encoding="utf-8").rstrip("\n")
 
-SENTINELS = ("__INLINE_BANNER__", "__INLINE_AGENT_LOGO_FRAMES__")
+# Read the version from pyproject.toml rather than hardcoding it in the
+# template, so cutting a release (= bumping pyproject.toml + regenerating
+# install.sh) is a single edit that flows through to the installer header.
+pyproject = pyproject_path.read_text(encoding="utf-8")
+version_match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.M)
+if not version_match:
+    sys.exit("Could not find version in pyproject.toml")
+version = version_match.group(1)
+
+SENTINELS = ("__INLINE_BANNER__", "__INLINE_AGENT_LOGO_FRAMES__", "__INLINE_VERSION__")
 for sentinel in SENTINELS:
     count = template.count(sentinel)
     if count != 1:
         sys.exit(f"Template sentinel {sentinel!r} must appear exactly once (found {count}).")
 
-rendered = template.replace("__INLINE_BANNER__", banner).replace("__INLINE_AGENT_LOGO_FRAMES__", frames)
+rendered = (
+    template
+    .replace("__INLINE_BANNER__", banner)
+    .replace("__INLINE_AGENT_LOGO_FRAMES__", frames)
+    .replace("__INLINE_VERSION__", version)
+)
 
 for sentinel in SENTINELS:
     if sentinel in rendered:

--- a/tests/test_install_ui.py
+++ b/tests/test_install_ui.py
@@ -252,6 +252,17 @@ def test_maybe_repair_path_reports_shadowed_binary():
     assert "Reorder PATH" in result.detail
 
 
+def _cli_state(cli_path: Path, *, on_path: bool = True) -> CLIInstallState:
+    return CLIInstallState(
+        cli_path=cli_path,
+        bin_dir=cli_path.parent,
+        uv_path="/tmp/uv",
+        version="yutori 0.7.3",
+        on_path=on_path,
+        shell_cli_path=cli_path if on_path else None,
+    )
+
+
 def test_run_verification_succeeds_via_cli(tmp_path: Path):
     cli_path = tmp_path / "yutori"
     responses = [
@@ -274,14 +285,15 @@ def test_run_verification_succeeds_via_cli(tmp_path: Path):
         patch("yutori.cli.commands.install_ui.run_command", side_effect=responses) as mock_run,
         patch("yutori.cli.commands.install_ui.time.sleep", return_value=None),
     ):
-        result, auth_failed = run_verification(Console(), interactive=True, cli_path=cli_path)
+        result, auth_failed = run_verification(Console(), interactive=True, cli_state=_cli_state(cli_path))
 
     assert auth_failed is False
     assert result.status == "success"
     assert f"{VERIFICATION_TASK_DASHBOARD_BASE_URL}/task-123" in result.detail
     assert "succeeded" in result.detail.lower()
+    # on_path=True → bare `yutori`, matching what the user would type in their shell.
     assert mock_run.call_args_list[0].args[0] == (
-        str(cli_path),
+        "yutori",
         "browse",
         "run",
         VERIFICATION_TASK,
@@ -289,7 +301,30 @@ def test_run_verification_succeeds_via_cli(tmp_path: Path):
         "--max-steps",
         str(VERIFICATION_MAX_STEPS),
     )
-    assert mock_run.call_args_list[1].args[0] == (str(cli_path), "browse", "get", "task-123")
+    assert mock_run.call_args_list[1].args[0] == ("yutori", "browse", "get", "task-123")
+
+
+def test_run_verification_uses_absolute_path_when_not_on_path(tmp_path: Path):
+    """When `yutori` is not on PATH, bare `yutori` would fail — fall back to
+    the absolute cli_path for both display and execution."""
+    cli_path = tmp_path / "yutori"
+    response = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="\nBrowsing task submitted.\n  Task ID: task-xyz\n  Status: succeeded\n",
+        stderr="",
+    )
+    with (
+        patch("yutori.cli.commands.install_ui.Confirm.ask", return_value=True),
+        patch("yutori.cli.commands.install_ui.run_command", return_value=response) as mock_run,
+    ):
+        result, auth_failed = run_verification(
+            Console(), interactive=True, cli_state=_cli_state(cli_path, on_path=False)
+        )
+
+    assert result.status == "success"
+    assert auth_failed is False
+    assert mock_run.call_args_list[0].args[0][0] == str(cli_path)
 
 
 def test_run_verification_classifies_auth_error_as_auth_failure(tmp_path: Path):
@@ -304,7 +339,7 @@ def test_run_verification_classifies_auth_error_as_auth_failure(tmp_path: Path):
         patch("yutori.cli.commands.install_ui.Confirm.ask", return_value=True),
         patch("yutori.cli.commands.install_ui.run_command", return_value=failure),
     ):
-        result, auth_failed = run_verification(Console(), interactive=True, cli_path=cli_path)
+        result, auth_failed = run_verification(Console(), interactive=True, cli_state=_cli_state(cli_path))
 
     assert auth_failed is True
     assert result.status == "failed"
@@ -318,7 +353,7 @@ def test_run_verification_non_auth_api_error_returns_auth_failed_false(tmp_path:
         patch("yutori.cli.commands.install_ui.Confirm.ask", return_value=True),
         patch("yutori.cli.commands.install_ui.run_command", return_value=failure),
     ):
-        result, auth_failed = run_verification(Console(), interactive=True, cli_path=cli_path)
+        result, auth_failed = run_verification(Console(), interactive=True, cli_state=_cli_state(cli_path))
 
     assert auth_failed is False
     assert result.status == "failed"

--- a/yutori/cli/commands/install_ui.py
+++ b/yutori/cli/commands/install_ui.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Literal, Mapping, Sequence
 
@@ -246,9 +247,20 @@ def python_has_pip(interpreter: str, env: Mapping[str, str] | None = None) -> bo
     return run_command((interpreter, "-m", "pip", "--version"), env=env).returncode == 0
 
 
+def _yutori_version() -> str:
+    try:
+        return version("yutori")
+    except PackageNotFoundError:
+        return "unknown"
+
+
 def render_header(console: Console, *, interactive: bool) -> None:
     mode = "Interactive terminal detected." if interactive else "Non-interactive terminal detected."
-    console.print(f"[bold {MINT_HIGHLIGHT}]> Yutori installer[/bold {MINT_HIGHLIGHT}]")
+    # Only used when bash didn't render its own intro (direct
+    # `yutori __install_ui` invocation). The bash intro reads its version
+    # from pyproject.toml at build time; here we read from installed
+    # package metadata. In a `curl | bash` flow the two match.
+    console.print(f"[bold {MINT_HIGHLIGHT}]> Yutori installer v{_yutori_version()}[/bold {MINT_HIGHLIGHT}]")
     console.print(f"[{SLATE_TEXT}]| {mode}[/]")
 
 
@@ -537,7 +549,7 @@ def run_verification(
     console: Console,
     *,
     interactive: bool,
-    cli_path: Path,
+    cli_state: CLIInstallState,
 ) -> tuple[StepResult, bool]:
     """Run the canonical browsing task through the installed CLI.
 
@@ -549,8 +561,15 @@ def run_verification(
     if not interactive:
         return StepResult("Verification", "skipped", "Skipped verification because no interactive terminal is available."), False
 
+    # Use bare `yutori` when the current shell already resolves it to the
+    # freshly-installed binary (on_path=True from inspect_cli_install). This
+    # keeps the demonstrated command copy-pasteable — users see what they
+    # would actually type. Fall back to the absolute path when `yutori` is
+    # not on PATH (first-time install without an opened new shell), since
+    # the bare name would fail there.
+    cli_invocation = "yutori" if cli_state.on_path else str(cli_state.cli_path)
     submit_command = (
-        str(cli_path),
+        cli_invocation,
         "browse",
         "run",
         VERIFICATION_TASK,
@@ -602,7 +621,7 @@ def run_verification(
                 return StepResult("Verification", "failed", detail), False
 
             time.sleep(VERIFICATION_POLL_INTERVAL_SECONDS)
-            poll = run_command((str(cli_path), "browse", "get", task_id))
+            poll = run_command((cli_invocation, "browse", "get", task_id))
             poll_output = collect_process_output(poll)
             if poll.returncode != 0:
                 auth_failed = looks_like_auth_failure(poll_output)
@@ -660,7 +679,7 @@ def install_ui_command() -> None:
     elif cli_state is None:
         verification_result = StepResult("Verification", "skipped", "Verification requires a working CLI install.")
     else:
-        verification_result, auth_failed = run_verification(console, interactive=interactive, cli_path=cli_state.cli_path)
+        verification_result, auth_failed = run_verification(console, interactive=interactive, cli_state=cli_state)
         if auth_failed:
             auth_result = StepResult(
                 "Auth", "failed", "Saved credentials were rejected by the API during verification."


### PR DESCRIPTION
## Summary

Two small installer polish fixes in response to post-v0.7.3 testing:

1. **Bare `yutori` in the verification command.** Previously the installer showed and ran `/Users/dbatra/.local/bin/yutori browse run ...` even when `yutori` was on PATH. Now `run_verification` accepts the full `CLIInstallState` and uses bare `yutori` when `on_path=True`, falling back to the absolute `cli_path` when the current shell hasn't picked up the uv bin dir yet (first-time install, no shell reload). The displayed command matches what a user would actually type — copy-pasteable.

2. **Installer header shows the installer version.** `> Yutori installer` → `> Yutori installer v0.7.4`. At bash level, the version is injected at build time from `pyproject.toml` by `scripts/build_install.sh` via a new `__INLINE_VERSION__` sentinel. In the Python UI's fallback header path (direct `yutori __install_ui` invocation), the version comes from `importlib.metadata.version("yutori")`.

Version bumped to 0.7.4.

## Test plan

- [x] `pytest` — 373 passed, 3 skipped
  - New `test_run_verification_uses_absolute_path_when_not_on_path` covers the `on_path=False` fallback.
  - Existing `test_run_verification_succeeds_via_cli` now asserts bare `yutori` in the command args.
- [x] `./scripts/build_install.sh` — version injected correctly (`YUTORI_INSTALLER_VERSION="0.7.4"`)
- [ ] Post-merge: re-run `curl -fsSL https://yutori.com/install.sh | bash` and verify:
  - `> Yutori installer v0.7.4` in the header
  - Verification command shows `yutori browse run ...` not full path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to installer UX/output and how the verification subprocess is invoked, with minimal impact on core SDK/runtime behavior.
> 
> **Overview**
> **Installer polish for v0.7.4.** The bash bootstrap header now prints an installer version (`vX.Y.Z`), with `scripts/build_install.sh` injecting it from `pyproject.toml` into `install.sh.template` (and generating `install.sh` accordingly).
> 
> **Verification command invocation is now PATH-aware.** `run_verification` takes `CLIInstallState` and uses bare `yutori` when the freshly installed CLI is already on `PATH`, falling back to the absolute `cli_path` otherwise; tests were updated and a new case was added for the non-`PATH` fallback.
> 
> Bumps package version to `0.7.4`, and the Python UI fallback header now includes the installed package version via `importlib.metadata`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fdab2fbcd255e10da2baeff85f1f737266795fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->