### PR TITLE
Migrate Browsing and Research namespaces to _request helper

### DIFF
--- a/yutori/_async/browsing.py
+++ b/yutori/_async/browsing.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._http import _BaseNamespace, build_payload, handle_response
+from .._http import _AsyncBaseNamespace, build_payload
 from .._schema import resolve_output_schema
 
 
-class AsyncBrowsingNamespace(_BaseNamespace):
+class AsyncBrowsingNamespace(_AsyncBaseNamespace):
     """Async namespace for browsing operations (one-time browser automation)."""
 
     async def create(
@@ -53,13 +53,7 @@ class AsyncBrowsingNamespace(_BaseNamespace):
             webhook_url=webhook_url,
             webhook_format=webhook_format,
         )
-
-        response = await self._client.post(
-            f"{self._base_url}/browsing/tasks",
-            headers=self._headers,
-            json=payload,
-        )
-        return handle_response(response)
+        return await self._request("post", "/browsing/tasks", json=payload)
 
     async def get(self, task_id: str) -> dict[str, Any]:
         """Get the status and results of a browsing task.
@@ -70,8 +64,4 @@ class AsyncBrowsingNamespace(_BaseNamespace):
         Returns:
             Dictionary containing task status and results (if completed).
         """
-        response = await self._client.get(
-            f"{self._base_url}/browsing/tasks/{task_id}",
-            headers=self._headers,
-        )
-        return handle_response(response)
+        return await self._request("get", f"/browsing/tasks/{task_id}")

--- a/yutori/_async/research.py
+++ b/yutori/_async/research.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._http import _BaseNamespace, build_payload, handle_response
+from .._http import _AsyncBaseNamespace, build_payload
 from .._schema import resolve_output_schema
 
 
-class AsyncResearchNamespace(_BaseNamespace):
+class AsyncResearchNamespace(_AsyncBaseNamespace):
     """Async namespace for research operations (one-time deep web research)."""
 
     async def create(
@@ -48,13 +48,7 @@ class AsyncResearchNamespace(_BaseNamespace):
             webhook_url=webhook_url,
             webhook_format=webhook_format,
         )
-
-        response = await self._client.post(
-            f"{self._base_url}/research/tasks",
-            headers=self._headers,
-            json=payload,
-        )
-        return handle_response(response)
+        return await self._request("post", "/research/tasks", json=payload)
 
     async def get(self, task_id: str) -> dict[str, Any]:
         """Get the status and results of a research task.
@@ -65,8 +59,4 @@ class AsyncResearchNamespace(_BaseNamespace):
         Returns:
             Dictionary containing task status and results (if completed).
         """
-        response = await self._client.get(
-            f"{self._base_url}/research/tasks/{task_id}",
-            headers=self._headers,
-        )
-        return handle_response(response)
+        return await self._request("get", f"/research/tasks/{task_id}")

--- a/yutori/_sync/browsing.py
+++ b/yutori/_sync/browsing.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._http import _BaseNamespace, build_payload, handle_response
+from .._http import _SyncBaseNamespace, build_payload
 from .._schema import resolve_output_schema
 
 
-class BrowsingNamespace(_BaseNamespace):
+class BrowsingNamespace(_SyncBaseNamespace):
     """Namespace for browsing operations (one-time browser automation)."""
 
     def create(
@@ -53,13 +53,7 @@ class BrowsingNamespace(_BaseNamespace):
             webhook_url=webhook_url,
             webhook_format=webhook_format,
         )
-
-        response = self._client.post(
-            f"{self._base_url}/browsing/tasks",
-            headers=self._headers,
-            json=payload,
-        )
-        return handle_response(response)
+        return self._request("post", "/browsing/tasks", json=payload)
 
     def get(self, task_id: str) -> dict[str, Any]:
         """Get the status and results of a browsing task.
@@ -70,8 +64,4 @@ class BrowsingNamespace(_BaseNamespace):
         Returns:
             Dictionary containing task status and results (if completed).
         """
-        response = self._client.get(
-            f"{self._base_url}/browsing/tasks/{task_id}",
-            headers=self._headers,
-        )
-        return handle_response(response)
+        return self._request("get", f"/browsing/tasks/{task_id}")

--- a/yutori/_sync/research.py
+++ b/yutori/_sync/research.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._http import _BaseNamespace, build_payload, handle_response
+from .._http import _SyncBaseNamespace, build_payload
 from .._schema import resolve_output_schema
 
 
-class ResearchNamespace(_BaseNamespace):
+class ResearchNamespace(_SyncBaseNamespace):
     """Namespace for research operations (one-time deep web research)."""
 
     def create(
@@ -48,13 +48,7 @@ class ResearchNamespace(_BaseNamespace):
             webhook_url=webhook_url,
             webhook_format=webhook_format,
         )
-
-        response = self._client.post(
-            f"{self._base_url}/research/tasks",
-            headers=self._headers,
-            json=payload,
-        )
-        return handle_response(response)
+        return self._request("post", "/research/tasks", json=payload)
 
     def get(self, task_id: str) -> dict[str, Any]:
         """Get the status and results of a research task.
@@ -65,8 +59,4 @@ class ResearchNamespace(_BaseNamespace):
         Returns:
             Dictionary containing task status and results (if completed).
         """
-        response = self._client.get(
-            f"{self._base_url}/research/tasks/{task_id}",
-            headers=self._headers,
-        )
-        return handle_response(response)
+        return self._request("get", f"/research/tasks/{task_id}")


### PR DESCRIPTION
## Summary

Follow-up to #63, which introduced `_SyncBaseNamespace` / `_AsyncBaseNamespace`
and migrated `ScoutsNamespace`. `BrowsingNamespace` / `ResearchNamespace`
(sync + async, 4 files) were still calling
`self._client.<method>(f"{self._base_url}/path", headers=self._headers, ...)`
followed by `handle_response(response)` directly — the same boilerplate
Scouts already sheds.

Each of the 4 namespace files now inherits from `_{Sync,Async}BaseNamespace`
and delegates to `self._request(...)`. Every namespace now speaks to the
underlying httpx client through the same helper, so path construction,
header wiring, and response handling stay uniform.

Diff shape per file: ~8 fewer lines; 2 two-liner call sites collapse to
one-liners, and the `handle_response` import drops out.

## Why it's safe

- No behavioral change: `_request` forwards `headers`, `params`, and `json`
  through the exact same `httpx.Client.<method>(url, headers=..., json=...)`
  call shape the existing tests patch (see `TestBrowsingNamespace` and
  `TestResearchNamespace` in `tests/test_client.py` + `tests/test_async_client.py`).
- Tests assert on request payload contents, query params, and status codes —
  all unchanged.
- `_request` / `_BaseNamespace` are already exercised in production by
  `ScoutsNamespace` (merged in #63).

## Test plan
- [ ] `pytest tests/test_client.py::TestBrowsingNamespace tests/test_client.py::TestResearchNamespace`
- [ ] `pytest tests/test_async_client.py` (browsing + research)
- [ ] Full `pytest` suite

_Tracked in `.claude/REFACTOR.md` in the yutori monorepo; will be checked off there._

https://claude.ai/code/session_01BjGDZgfiKdMT7adTHsHgZG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjGDZgfiKdMT7adTHsHgZG)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes URL/header/response handling for browsing and research calls; main risk is any subtle mismatch in request construction, but it now matches the already-used base helper.
> 
> **Overview**
> Updates the Browsing and Research namespaces (sync + async) to inherit from `_{Sync,Async}BaseNamespace` and route `create`/`get` API calls through the common `self._request(...)` helper.
> 
> This removes per-method boilerplate (`self._client.<method>(...)` + `handle_response`) so URL construction, headers, and response handling are consistently applied across these namespaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fe2d1df6862a31380b823b90c551bb7e9d4a0b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->