### PR TITLE
refactor: migrate client.get_usage to shared _request helper

### DIFF
--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -12,11 +12,11 @@ from ._async import (
     AsyncResearchNamespace,
     AsyncScoutsNamespace,
 )
-from ._http import build_headers, build_query_params, handle_response
+from ._http import _AsyncBaseNamespace, build_query_params
 from .config import DEFAULT_BASE_URL, DEFAULT_TIMEOUT_SECONDS, sanitize_base_url
 
 
-class AsyncYutoriClient:
+class AsyncYutoriClient(_AsyncBaseNamespace):
     """Asynchronous client for the Yutori API.
 
     Example:
@@ -58,8 +58,8 @@ class AsyncYutoriClient:
         from yutori.auth.credentials import require_api_key
 
         self._api_key = require_api_key(api_key)
-        self._base_url = sanitize_base_url(base_url)
-        self._client = httpx.AsyncClient(timeout=timeout)
+        base_url = sanitize_base_url(base_url)
+        super().__init__(httpx.AsyncClient(timeout=timeout), base_url, self._api_key)
 
         # Initialize async namespaces
         self.scouts = AsyncScoutsNamespace(self._client, self._base_url, self._api_key)
@@ -82,12 +82,7 @@ class AsyncYutoriClient:
             ``navigator_rate_limits`` / ``navigator_calls`` for one
             release; prefer the ``navigator_*`` names.
         """
-        response = await self._client.get(
-            f"{self._base_url}/usage",
-            headers=build_headers(self._api_key),
-            params=build_query_params(period=period),
-        )
-        return handle_response(response)
+        return await self._request("get", "/usage", params=build_query_params(period=period))
 
     async def close(self) -> None:
         """Release the underlying HTTP client resources."""

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -6,12 +6,12 @@ from typing import Any
 
 import httpx
 
-from ._http import build_headers, build_query_params, handle_response
+from ._http import _SyncBaseNamespace, build_query_params
 from ._sync import BrowsingNamespace, ChatNamespace, ResearchNamespace, ScoutsNamespace
 from .config import DEFAULT_BASE_URL, DEFAULT_TIMEOUT_SECONDS, sanitize_base_url
 
 
-class YutoriClient:
+class YutoriClient(_SyncBaseNamespace):
     """Synchronous client for the Yutori API.
 
     Example:
@@ -48,8 +48,8 @@ class YutoriClient:
         from yutori.auth.credentials import require_api_key
 
         self._api_key = require_api_key(api_key)
-        self._base_url = sanitize_base_url(base_url)
-        self._client = httpx.Client(timeout=timeout)
+        base_url = sanitize_base_url(base_url)
+        super().__init__(httpx.Client(timeout=timeout), base_url, self._api_key)
 
         # Initialize namespaces
         self.scouts = ScoutsNamespace(self._client, self._base_url, self._api_key)
@@ -72,12 +72,7 @@ class YutoriClient:
             ``navigator_rate_limits`` / ``navigator_calls`` for one
             release; prefer the ``navigator_*`` names.
         """
-        response = self._client.get(
-            f"{self._base_url}/usage",
-            headers=build_headers(self._api_key),
-            params=build_query_params(period=period),
-        )
-        return handle_response(response)
+        return self._request("get", "/usage", params=build_query_params(period=period))
 
     def close(self) -> None:
         """Release the underlying HTTP client resources."""


### PR DESCRIPTION
## Summary

`YutoriClient.get_usage()` and `AsyncYutoriClient.get_usage()` were the last callers still hand-rolling the raw HTTP pattern that the rest of the SDK migrated off of in #63:

```python
response = self._client.get(
    f"{self._base_url}/usage",
    headers=build_headers(self._api_key),
    params=build_query_params(period=period),
)
return handle_response(response)
```

This PR makes both clients inherit from the existing `_SyncBaseNamespace` / `_AsyncBaseNamespace` bases and delegates `get_usage()` through the shared `_request()` helper, matching how `scouts` / `browsing` / `research` already work. The result: one line per call site instead of five, headers are computed once at init instead of per-call, and a future GET/POST against a root-level endpoint can follow the same pattern.

## Why this is safe

- No behavioral change. `_request()` builds the same `httpx.Client.get(url, headers=..., params=...)` call with identical arguments:
  - URL: `f"{self._base_url}/usage"` (unchanged)
  - `headers`: precomputed `self._headers` via `_BaseNamespace.__init__` which is literally `build_headers(api_key)` — byte-identical to the previous per-call construction.
  - `params`: still `build_query_params(period=period)`; `_request_kwargs` forwards any non-`None` value (so `{}` is still passed when `period is None`, preserving `test_get_usage_no_period_sends_no_params`).
- All existing `get_usage` tests in `tests/test_client.py` and `tests/test_async_client.py` (success, with/without period, 401/403 → `AuthenticationError`, 5xx → `APIError`) patch `httpx.Client.get` / `httpx.AsyncClient.get`, which this refactor still calls the same way.
- `handle_response` and `build_headers` are now unused in `client.py`/`async_client.py` and dropped from the imports. Both remain used inside `_http.py` itself.

## Context

Closes out the `/usage` side of the "migrate namespaces to `_request` helper" item in `.claude/REFACTOR.md`. The browsing/research namespaces were already migrated; `get_usage` was the remaining holdout.

## Test plan

- [ ] CI passes (`pytest tests/test_client.py tests/test_async_client.py`)
- [ ] `get_usage()` still returns the same dict structure
- [ ] `test_get_usage_no_period_sends_no_params` still passes (params dict is `{}` not omitted)

https://claude.ai/code/session_01NwA1CytjrqGe7f9dJo11PS

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwA1CytjrqGe7f9dJo11PS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to the `/usage` call path, delegating to existing `_request()` logic and reusing precomputed headers; main risk is subtle request/param handling differences.
> 
> **Overview**
> `YutoriClient` and `AsyncYutoriClient` now inherit from `_SyncBaseNamespace` / `_AsyncBaseNamespace` and delegate `get_usage()` to the shared `_request("get", "/usage", ...)` helper instead of manually building headers and calling `handle_response()`.
> 
> Client initialization is adjusted to pass the constructed `httpx.Client`/`httpx.AsyncClient`, sanitized `base_url`, and API key into the base class so headers are precomputed once, and direct imports of `build_headers`/`handle_response` are removed from these clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2667556e83fe51afe4a284ed261e983622d8424f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->