### PR TITLE
Remove stale browser parameter from Research API

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ while True:
     time.sleep(5)
 ```
 
-Use `browser="local"` if the research task needs a logged-in browser session. Failed tasks may include a `rejection_reason`.
+Failed tasks may include a `rejection_reason`.
 
 ## Scouting API
 

--- a/api.md
+++ b/api.md
@@ -226,7 +226,7 @@ Deep web research using 100+ MCP tools.
 
 | Method | HTTP | Endpoint | Returns |
 |--------|------|----------|---------|
-| `client.research.create(query, *, user_timezone=None, user_location=None, browser=None, output_schema=None, webhook_url=None, webhook_format=None)` | POST | `/v1/research/tasks` | `dict` |
+| `client.research.create(query, *, user_timezone=None, user_location=None, output_schema=None, webhook_url=None, webhook_format=None)` | POST | `/v1/research/tasks` | `dict` |
 | `client.research.get(task_id)` | GET | `/v1/research/tasks/{task_id}` | `dict` |
 
 #### `research.create`
@@ -236,7 +236,6 @@ task = client.research.create(
     query="What are the latest developments in quantum computing?",
     user_timezone="America/Los_Angeles",
     user_location="San Francisco, CA, US",
-    browser=None,
     output_schema=None,
     webhook_url=None,
     webhook_format=None,
@@ -247,7 +246,6 @@ task = client.research.create(
 - `query` (`str`): Natural language research query.
 - `user_timezone` (`str`, optional): e.g. `"America/Los_Angeles"`.
 - `user_location` (`str`, optional): e.g. `"San Francisco, CA, US"`.
-- `browser` (`str`, optional): `"cloud"` (default) or `"local"`.
 - `output_schema`: See [Structured output](#structured-output).
 - `webhook_url` (`str`, optional): URL for completion notifications.
 - `webhook_format` (`str`, optional): `"scout"` (default), `"slack"`, or `"zapier"`.
@@ -565,7 +563,7 @@ Installed as `yutori` (via the `yutori` script entry point). Run any command wit
 
 | Command | Description |
 |---------|-------------|
-| `yutori research run QUERY [--timezone/-tz TZ] [--location LOC] [--browser cloud\|local]` | Submit a research task. |
+| `yutori research run QUERY [--timezone/-tz TZ] [--location LOC]` | Submit a research task. |
 | `yutori research get TASK_ID` | Get status and result (truncates output to 2000 chars). |
 
 ### Scouts

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -264,23 +264,6 @@ class TestAsyncResearchNamespace:
                 result = await client.research.create(query="Find AI funding")
                 assert result["task_id"] == "research-123"
 
-    async def test_research_create_with_local_browser(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "research-456"}'
-        mock_response.json.return_value = {"task_id": "research-456"}
-
-        with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.research.create(
-                    query="Research a vendor portal behind login",
-                    browser="local",
-                )
-                assert result["task_id"] == "research-456"
-                payload = mock_post.call_args[1]["json"]
-                assert payload["query"] == "Research a vendor portal behind login"
-                assert payload["browser"] == "local"
-
     async def test_research_get(self):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,14 +65,14 @@ def test_browse_run_forwards_local_browser_and_auth():
     assert "Rejection Reason" not in result.stdout
 
 
-def test_research_run_forwards_local_browser():
+def test_research_run_basic():
     client = _make_client_mock()
     client.research.create.return_value = {"task_id": "research-123", "status": "queued"}
 
     with patch("yutori.cli.commands.research.get_authenticated_client", return_value=client):
         result = runner.invoke(
             app,
-            ["research", "run", "latest AI announcements", "--browser", "local", "--timezone", "America/Los_Angeles"],
+            ["research", "run", "latest AI announcements", "--timezone", "America/Los_Angeles"],
         )
 
     assert result.exit_code == 0
@@ -80,7 +80,6 @@ def test_research_run_forwards_local_browser():
         query="latest AI announcements",
         user_timezone="America/Los_Angeles",
         user_location=None,
-        browser="local",
     )
     client.close.assert_called_once()
     assert "Research task submitted" in result.stdout

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -311,22 +311,6 @@ class TestResearchNamespace:
             payload = mock_post.call_args[1]["json"]
             assert payload["query"] == "Find AI startup funding"
 
-    def test_research_create_with_local_browser(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "research-456", "status": "queued"}'
-        mock_response.json.return_value = {"task_id": "research-456", "status": "queued"}
-
-        with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
-            result = client.research.create(
-                query="Research competitors with logged-in dashboards",
-                browser="local",
-            )
-            assert result["task_id"] == "research-456"
-            payload = mock_post.call_args[1]["json"]
-            assert payload["query"] == "Research competitors with logged-in dashboards"
-            assert payload["browser"] == "local"
-
     def test_research_get(self, client):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200

--- a/yutori/_async/research.py
+++ b/yutori/_async/research.py
@@ -16,7 +16,6 @@ class AsyncResearchNamespace(_AsyncBaseNamespace):
         *,
         user_timezone: str | None = None,
         user_location: str | None = None,
-        browser: str | None = None,
         output_schema: object | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
@@ -29,8 +28,6 @@ class AsyncResearchNamespace(_AsyncBaseNamespace):
             query: Natural language research query.
             user_timezone: e.g., "America/Los_Angeles".
             user_location: e.g., "San Francisco, CA, US".
-            browser: "cloud" (default) or "local" to use the desktop app with
-                     the user's logged-in sessions.
             output_schema: JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance.
             webhook_url: URL for completion notifications.
             webhook_format: "scout" (default), "slack", or "zapier".
@@ -42,7 +39,6 @@ class AsyncResearchNamespace(_AsyncBaseNamespace):
             query=query,
             user_timezone=user_timezone,
             user_location=user_location,
-            browser=browser,
             output_schema=output_schema,
             webhook_url=webhook_url,
             webhook_format=webhook_format,

--- a/yutori/_sync/research.py
+++ b/yutori/_sync/research.py
@@ -16,7 +16,6 @@ class ResearchNamespace(_SyncBaseNamespace):
         *,
         user_timezone: str | None = None,
         user_location: str | None = None,
-        browser: str | None = None,
         output_schema: object | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
@@ -29,8 +28,6 @@ class ResearchNamespace(_SyncBaseNamespace):
             query: Natural language research query.
             user_timezone: e.g., "America/Los_Angeles".
             user_location: e.g., "San Francisco, CA, US".
-            browser: "cloud" (default) or "local" to use the desktop app with
-                     the user's logged-in sessions.
             output_schema: JSON schema dict, a Pydantic BaseModel class, or a BaseModel instance.
             webhook_url: URL for completion notifications.
             webhook_format: "scout" (default), "slack", or "zapier".
@@ -42,7 +39,6 @@ class ResearchNamespace(_SyncBaseNamespace):
             query=query,
             user_timezone=user_timezone,
             user_location=user_location,
-            browser=browser,
             output_schema=output_schema,
             webhook_url=webhook_url,
             webhook_format=webhook_format,

--- a/yutori/cli/commands/research.py
+++ b/yutori/cli/commands/research.py
@@ -22,7 +22,6 @@ def run(
     query: str = typer.Argument(help="Natural language research query"),
     timezone: str = typer.Option(None, "--timezone", "-tz", help="e.g., America/Los_Angeles"),
     location: str = typer.Option(None, "--location", help="e.g., San Francisco, CA, US"),
-    browser: str = typer.Option(None, "--browser", help="Browser backend: cloud or local"),
 ) -> None:
     """Start a new research task."""
     with get_authenticated_client() as client:
@@ -30,7 +29,6 @@ def run(
             query=query,
             user_timezone=timezone,
             user_location=location,
-            browser=browser,
         )
 
         print_task_submission_result(console, "Research", result)


### PR DESCRIPTION
## Summary

The server-side Research API removed the `browser` parameter in yutori-ai/yutori#8512 (commit a8c709ca, merged 2026-04-23) because it only injected a prompt-level hint — unlike the Browsing API which enforces browser selection at the config level. The SDK was not updated to match, leaving users with a parameter that is silently ignored by the server.

This PR removes the stale `browser` parameter from:

- **SDK namespaces**: `ResearchNamespace.create()` (sync) and `AsyncResearchNamespace.create()` (async)
- **CLI**: `--browser` flag on `yutori research run`
- **Documentation**: README.md, api.md (method table, signature, example code, parameter list, CLI reference)
- **Tests**: `test_research_create_with_local_browser` (sync and async), `test_research_run_forwards_local_browser` (CLI)

The Browsing API's `browser` parameter is unaffected — it remains functional and documented.

## What introduced the drift

- yutori-ai/yutori#8512 removed `browser` from the server-side Research API route, OpenAPI spec, and request model
- The SDK, CLI, docs, and tests were not updated in that PR since they live in this repo

## Test plan

- [x] All 82 tests pass locally after the change
- [x] Verified no remaining `browser` references in research-related code paths
- [x] Browsing API `browser` parameter is untouched

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoeyfH9CaZEKg41aKbEu5b)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this is a user-facing breaking change: callers passing `browser` to `research.create` or `yutori research run --browser` will now error, though the server already ignored the field.
> 
> **Overview**
> Aligns the SDK/CLI with the server by **removing the stale `browser` parameter from the Research API surface**.
> 
> `ResearchNamespace.create()` and `AsyncResearchNamespace.create()` no longer accept/forward `browser`, the `yutori research run` command drops the `--browser` flag, and docs/tests are updated accordingly (including removing the local-browser research tests and updating `api.md`/README references).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc879b2d2245b485d426352ca6b12cb0db814f47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->