### PR TITLE
refactor(scouts): extract shared prepare_scout_update helper

### DIFF
--- a/yutori/_async/scouts.py
+++ b/yutori/_async/scouts.py
@@ -8,7 +8,7 @@ from .._http import (
     _AsyncBaseNamespace,
     build_payload,
     build_query_params,
-    resolve_scout_status_endpoint,
+    prepare_scout_update,
 )
 from .._schema import resolve_output_schema
 
@@ -139,23 +139,8 @@ class AsyncScoutsNamespace(_AsyncBaseNamespace):
             webhook_format=webhook_format,
         )
 
-        # Check for conflicting parameters - API doesn't support both in one call
-        if status is not None and payload:
-            raise ValueError(
-                "Cannot update status and other fields simultaneously. "
-                "The API requires separate calls: one for status change, another for field updates."
-            )
-
-        # Handle status changes via dedicated endpoints
-        if status is not None:
-            endpoint = resolve_scout_status_endpoint(status)
-            return await self._request("post", f"/scouting/tasks/{scout_id}/{endpoint}")
-
-        # Handle field updates via PATCH
-        if not payload:
-            raise ValueError("At least one field must be provided for update.")
-
-        return await self._request("patch", f"/scouting/tasks/{scout_id}", json=payload)
+        method, path, json = prepare_scout_update(scout_id, status, payload)
+        return await self._request(method, path, json=json)
 
     async def delete(self, scout_id: str) -> dict[str, Any]:
         """Delete a scout.

--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -69,6 +69,31 @@ def resolve_scout_status_endpoint(status: str) -> str:
     return _SCOUT_STATUS_ENDPOINTS[status]
 
 
+def prepare_scout_update(
+    scout_id: str, status: str | None, payload: dict[str, Any]
+) -> tuple[str, str, dict[str, Any] | None]:
+    """Resolve ``(method, path, json)`` for a ``scouts.update()`` call.
+
+    Centralizes the mutual-exclusion rule between ``status`` and field
+    updates so the sync and async namespaces can share a single preflight.
+
+    Raises:
+        ValueError: If ``status`` coexists with other fields, or if neither
+            ``status`` nor any payload field was provided.
+    """
+    if status is not None and payload:
+        raise ValueError(
+            "Cannot update status and other fields simultaneously. "
+            "The API requires separate calls: one for status change, another for field updates."
+        )
+    if status is not None:
+        endpoint = resolve_scout_status_endpoint(status)
+        return "post", f"/scouting/tasks/{scout_id}/{endpoint}", None
+    if not payload:
+        raise ValueError("At least one field must be provided for update.")
+    return "patch", f"/scouting/tasks/{scout_id}", payload
+
+
 def apply_chat_extra_body(kwargs: dict[str, Any], **fields: Any) -> None:
     """Merge non-None ``fields`` into ``kwargs["extra_body"]`` in place.
 

--- a/yutori/_sync/scouts.py
+++ b/yutori/_sync/scouts.py
@@ -8,7 +8,7 @@ from .._http import (
     _SyncBaseNamespace,
     build_payload,
     build_query_params,
-    resolve_scout_status_endpoint,
+    prepare_scout_update,
 )
 from .._schema import resolve_output_schema
 
@@ -139,23 +139,8 @@ class ScoutsNamespace(_SyncBaseNamespace):
             webhook_format=webhook_format,
         )
 
-        # Check for conflicting parameters - API doesn't support both in one call
-        if status is not None and payload:
-            raise ValueError(
-                "Cannot update status and other fields simultaneously. "
-                "The API requires separate calls: one for status change, another for field updates."
-            )
-
-        # Handle status changes via dedicated endpoints
-        if status is not None:
-            endpoint = resolve_scout_status_endpoint(status)
-            return self._request("post", f"/scouting/tasks/{scout_id}/{endpoint}")
-
-        # Handle field updates via PATCH
-        if not payload:
-            raise ValueError("At least one field must be provided for update.")
-
-        return self._request("patch", f"/scouting/tasks/{scout_id}", json=payload)
+        method, path, json = prepare_scout_update(scout_id, status, payload)
+        return self._request(method, path, json=json)
 
     def delete(self, scout_id: str) -> dict[str, Any]:
         """Delete a scout.


### PR DESCRIPTION
## Summary

The sync and async `ScoutsNamespace.update()` methods each duplicated ~15 lines of pure, non-IO preflight logic: the status-vs-fields mutual-exclusion check, status-endpoint resolution, and the `(method, path, json)` selection for the final `self._request` call. The only difference between the two copies was the `await` in front of `self._request`.

This extracts the pure logic into `yutori/_http.prepare_scout_update(scout_id, status, payload) -> (method, path, json)`. Both namespaces now call the helper and hand the triple to their own `_request`.

## Why it's safe

- Pure logic extraction — no I/O or concurrency semantics change.
- Same `ValueError` messages, same endpoints, same payload shapes.
- All 79 existing `test_client.py` / `test_async_client.py` / `test_http.py` tests pass locally.
- Diff is confined to 3 files and trivially reviewable.

## Test plan

- [x] Local `pytest tests/test_client.py tests/test_async_client.py tests/test_http.py` — 79 passed.
- [ ] CI passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbayVi62PBJyWSVUiHYqNX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes preflight validation/route selection for `scouts.update()` without changing request semantics; main risk is a subtle regression in method/path selection if the helper is wrong.
> 
> **Overview**
> Refactors `scouts.update()` (sync + async) to delegate all status-vs-field validation and request routing to a shared `prepare_scout_update()` helper.
> 
> Adds `prepare_scout_update(scout_id, status, payload)` in `yutori/_http.py` to enforce mutual exclusivity, select the correct status transition endpoint vs PATCH update, and return a `(method, path, json)` triple consumed by both namespaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44989ad64e31eeb4b56bc735d2217e5830123f50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->