### PR TITLE
refactor(_http): add build_payload_with_schema, drop per-namespace _schema imports

### DIFF
--- a/yutori/_async/browsing.py
+++ b/yutori/_async/browsing.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._http import _AsyncBaseNamespace, build_payload
-from .._schema import resolve_output_schema
+from .._http import _AsyncBaseNamespace, build_payload_with_schema
 
 
 class AsyncBrowsingNamespace(_AsyncBaseNamespace):
@@ -42,14 +41,14 @@ class AsyncBrowsingNamespace(_AsyncBaseNamespace):
         Returns:
             Dictionary containing task details including task_id.
         """
-        payload = build_payload(
+        payload = build_payload_with_schema(
             task=task,
             start_url=start_url,
             max_steps=max_steps,
             agent=agent,
             require_auth=require_auth,
             browser=browser,
-            output_schema=resolve_output_schema(output_schema),
+            output_schema=output_schema,
             webhook_url=webhook_url,
             webhook_format=webhook_format,
         )

--- a/yutori/_async/research.py
+++ b/yutori/_async/research.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._http import _AsyncBaseNamespace, build_payload
-from .._schema import resolve_output_schema
+from .._http import _AsyncBaseNamespace, build_payload_with_schema
 
 
 class AsyncResearchNamespace(_AsyncBaseNamespace):
@@ -39,12 +38,12 @@ class AsyncResearchNamespace(_AsyncBaseNamespace):
         Returns:
             Dictionary containing task details including task_id.
         """
-        payload = build_payload(
+        payload = build_payload_with_schema(
             query=query,
             user_timezone=user_timezone,
             user_location=user_location,
             browser=browser,
-            output_schema=resolve_output_schema(output_schema),
+            output_schema=output_schema,
             webhook_url=webhook_url,
             webhook_format=webhook_format,
         )

--- a/yutori/_async/scouts.py
+++ b/yutori/_async/scouts.py
@@ -6,11 +6,10 @@ from typing import Any
 
 from .._http import (
     _AsyncBaseNamespace,
-    build_payload,
+    build_payload_with_schema,
     build_query_params,
     prepare_scout_update,
 )
-from .._schema import resolve_output_schema
 
 
 class AsyncScoutsNamespace(_AsyncBaseNamespace):
@@ -77,13 +76,13 @@ class AsyncScoutsNamespace(_AsyncBaseNamespace):
         Returns:
             Dictionary containing created scout details.
         """
-        payload = build_payload(
+        payload = build_payload_with_schema(
             query=query,
             output_interval=output_interval,
             start_timestamp=start_timestamp,
             user_timezone=user_timezone,
             user_location=user_location,
-            output_schema=resolve_output_schema(output_schema),
+            output_schema=output_schema,
             skip_email=skip_email,
             webhook_url=webhook_url,
             webhook_format=webhook_format,
@@ -128,12 +127,12 @@ class AsyncScoutsNamespace(_AsyncBaseNamespace):
         Raises:
             ValueError: If status is provided along with other fields (API limitation).
         """
-        payload = build_payload(
+        payload = build_payload_with_schema(
             query=query,
             output_interval=output_interval,
             user_timezone=user_timezone,
             user_location=user_location,
-            output_schema=resolve_output_schema(output_schema),
+            output_schema=output_schema,
             skip_email=skip_email,
             webhook_url=webhook_url,
             webhook_format=webhook_format,

--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import httpx
 
+from ._schema import resolve_output_schema
 from .exceptions import APIError, AuthenticationError
 
 
@@ -46,6 +47,22 @@ def build_payload(**fields: Any) -> dict[str, Any]:
     together — any field whose value is ``None`` is omitted.
     """
     return {k: v for k, v in fields.items() if v is not None}
+
+
+def build_payload_with_schema(
+    *,
+    output_schema: object | None = None,
+    **fields: Any,
+) -> dict[str, Any]:
+    """Like :func:`build_payload`, but resolve ``output_schema`` to a JSON dict first.
+
+    Centralizes the ``output_schema=resolve_output_schema(...)`` step used by
+    every scout / research / browsing payload builder so namespace methods do
+    not need to import :func:`resolve_output_schema` directly.
+    """
+    if output_schema is not None:
+        fields["output_schema"] = resolve_output_schema(output_schema)
+    return build_payload(**fields)
 
 
 _SCOUT_STATUS_ENDPOINTS = {

--- a/yutori/_sync/browsing.py
+++ b/yutori/_sync/browsing.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._http import _SyncBaseNamespace, build_payload
-from .._schema import resolve_output_schema
+from .._http import _SyncBaseNamespace, build_payload_with_schema
 
 
 class BrowsingNamespace(_SyncBaseNamespace):
@@ -42,14 +41,14 @@ class BrowsingNamespace(_SyncBaseNamespace):
         Returns:
             Dictionary containing task details including task_id.
         """
-        payload = build_payload(
+        payload = build_payload_with_schema(
             task=task,
             start_url=start_url,
             max_steps=max_steps,
             agent=agent,
             require_auth=require_auth,
             browser=browser,
-            output_schema=resolve_output_schema(output_schema),
+            output_schema=output_schema,
             webhook_url=webhook_url,
             webhook_format=webhook_format,
         )

--- a/yutori/_sync/research.py
+++ b/yutori/_sync/research.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._http import _SyncBaseNamespace, build_payload
-from .._schema import resolve_output_schema
+from .._http import _SyncBaseNamespace, build_payload_with_schema
 
 
 class ResearchNamespace(_SyncBaseNamespace):
@@ -39,12 +38,12 @@ class ResearchNamespace(_SyncBaseNamespace):
         Returns:
             Dictionary containing task details including task_id.
         """
-        payload = build_payload(
+        payload = build_payload_with_schema(
             query=query,
             user_timezone=user_timezone,
             user_location=user_location,
             browser=browser,
-            output_schema=resolve_output_schema(output_schema),
+            output_schema=output_schema,
             webhook_url=webhook_url,
             webhook_format=webhook_format,
         )

--- a/yutori/_sync/scouts.py
+++ b/yutori/_sync/scouts.py
@@ -6,11 +6,10 @@ from typing import Any
 
 from .._http import (
     _SyncBaseNamespace,
-    build_payload,
+    build_payload_with_schema,
     build_query_params,
     prepare_scout_update,
 )
-from .._schema import resolve_output_schema
 
 
 class ScoutsNamespace(_SyncBaseNamespace):
@@ -77,13 +76,13 @@ class ScoutsNamespace(_SyncBaseNamespace):
         Returns:
             Dictionary containing created scout details.
         """
-        payload = build_payload(
+        payload = build_payload_with_schema(
             query=query,
             output_interval=output_interval,
             start_timestamp=start_timestamp,
             user_timezone=user_timezone,
             user_location=user_location,
-            output_schema=resolve_output_schema(output_schema),
+            output_schema=output_schema,
             skip_email=skip_email,
             webhook_url=webhook_url,
             webhook_format=webhook_format,
@@ -128,12 +127,12 @@ class ScoutsNamespace(_SyncBaseNamespace):
         Raises:
             ValueError: If status is provided along with other fields (API limitation).
         """
-        payload = build_payload(
+        payload = build_payload_with_schema(
             query=query,
             output_interval=output_interval,
             user_timezone=user_timezone,
             user_location=user_location,
-            output_schema=resolve_output_schema(output_schema),
+            output_schema=output_schema,
             skip_email=skip_email,
             webhook_url=webhook_url,
             webhook_format=webhook_format,


### PR DESCRIPTION
## Summary

Every namespace payload builder (`browsing`, `research`, `scouts` × `sync`,
`async`) repeated the same pattern:

```python
from .._http import build_payload
from .._schema import resolve_output_schema
...
payload = build_payload(
    ...,
    output_schema=resolve_output_schema(output_schema),
    ...,
)
```

This PR adds a thin `build_payload_with_schema()` helper to `_http.py` that
runs `resolve_output_schema` on the `output_schema` keyword (when not `None`)
and delegates to `build_payload`. All six call sites switch to it, dropping
their direct `_schema` import.

## Why it's safe

- **No behavior change.**
  - `resolve_output_schema(None)` returns `None`, and `None` is already
    filtered by `build_payload`, so the no-schema path is identical.
  - For non-None inputs, `resolve_output_schema` is invoked once per call,
    just as before — the wrapper just inlines the call.
- **Single helper, six mechanical call-site swaps.** Each call site changes
  the imported name and replaces `output_schema=resolve_output_schema(x)`
  with `output_schema=x` — no other arguments touched.
- **No test churn.** `tests/test_schema.py` continues to cover the
  resolution logic; the new helper has no logic of its own beyond the
  conditional call.

## Test plan

- [x] `python -m py_compile` succeeds for all touched files.
- [ ] Existing test suite passes (no behavior change expected).


---
_Generated by [Claude Code](https://claude.ai/code/session_01F7p8tQNdHrGxEHiqZWRmZL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical refactor that centralizes `output_schema` resolution in one helper; main risk is an unintended change in payload shape if `build_payload_with_schema` differs from prior call-site behavior.
> 
> **Overview**
> Refactors payload construction for `browsing`, `research`, and `scouts` (sync + async) to route `output_schema` handling through a new `_http.build_payload_with_schema()` helper instead of resolving schemas inside each namespace.
> 
> Adds `build_payload_with_schema()` to `_http.py` (calling `resolve_output_schema` only when `output_schema` is provided) and removes the per-namespace `resolve_output_schema` imports, keeping the namespace methods focused on passing through `output_schema` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bacee3d35570a3b1b316cb345489dee25a39022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->