### PR TITLE
refactor(cli): extract print_optional_field helper

### DIFF
--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -13,6 +13,7 @@ from yutori.auth.credentials import resolve_api_key
 __all__ = [
     "format_interval",
     "get_authenticated_client",
+    "print_optional_field",
     "print_rejection_reason",
     "print_task_get_header",
     "print_task_result_output",
@@ -39,6 +40,26 @@ def print_rejection_reason(console: Console, result: dict[str, Any]) -> None:
     reason = result.get("rejection_reason")
     if reason:
         console.print(f"  Rejection Reason: {escape(str(reason))}")
+
+
+def print_optional_field(
+    console: Console,
+    data: dict[str, Any],
+    key: str,
+    label: str,
+    *,
+    escape_value: bool = False,
+) -> None:
+    """Print ``  {label}: {data[key]}`` only when ``data[key]`` is truthy.
+
+    Set ``escape_value=True`` for user-supplied strings that may contain
+    Rich markup (e.g. ``[red]``) so they render literally.
+    """
+    value = data.get(key)
+    if not value:
+        return
+    rendered = escape(str(value)) if escape_value else value
+    console.print(f"  {label}: {rendered}")
 
 
 def print_task_submission_result(console: Console, task_type: str, result: dict[str, Any]) -> None:

--- a/yutori/cli/commands/browse.py
+++ b/yutori/cli/commands/browse.py
@@ -7,6 +7,7 @@ from rich.console import Console
 
 from yutori.cli.commands import (
     get_authenticated_client,
+    print_optional_field,
     print_task_get_header,
     print_task_result_output,
     print_task_submission_result,
@@ -49,11 +50,8 @@ def get(
 
         print_task_get_header(console, "Browsing", task_id, result)
 
-        if result.get("start_url"):
-            console.print(f"  Start URL: {result['start_url']}")
-        if result.get("agent"):
-            console.print(f"  Agent: {result['agent']}")
-        if result.get("created_at"):
-            console.print(f"  Created: {result['created_at']}")
+        print_optional_field(console, result, "start_url", "Start URL")
+        print_optional_field(console, result, "agent", "Agent")
+        print_optional_field(console, result, "created_at", "Created")
 
         print_task_result_output(console, result)

--- a/yutori/cli/commands/research.py
+++ b/yutori/cli/commands/research.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import typer
 from rich.console import Console
-from rich.markup import escape
 
 from yutori.cli.commands import (
     get_authenticated_client,
+    print_optional_field,
     print_task_get_header,
     print_task_result_output,
     print_task_submission_result,
@@ -46,9 +46,7 @@ def get(
 
         print_task_get_header(console, "Research", task_id, result)
 
-        if result.get("query"):
-            console.print(f"  Query: {escape(result['query'])}")
-        if result.get("created_at"):
-            console.print(f"  Created: {result['created_at']}")
+        print_optional_field(console, result, "query", "Query", escape_value=True)
+        print_optional_field(console, result, "created_at", "Created")
 
         print_task_result_output(console, result)

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -7,7 +7,12 @@ from rich.console import Console
 from rich.markup import escape
 from rich.table import Table
 
-from yutori.cli.commands import format_interval, get_authenticated_client, print_rejection_reason
+from yutori.cli.commands import (
+    format_interval,
+    get_authenticated_client,
+    print_optional_field,
+    print_rejection_reason,
+)
 
 app = typer.Typer(help="Manage scouts")
 console = Console()
@@ -68,12 +73,9 @@ def get(
         interval_str = format_interval(scout.get("output_interval") or 0)
         console.print(f"  Interval: {interval_str}")
 
-        if scout.get("user_timezone"):
-            console.print(f"  Timezone: {scout['user_timezone']}")
-        if scout.get("created_at"):
-            console.print(f"  Created: {scout['created_at']}")
-        if scout.get("next_run_at"):
-            console.print(f"  Next Run: {scout['next_run_at']}")
+        print_optional_field(console, scout, "user_timezone", "Timezone")
+        print_optional_field(console, scout, "created_at", "Created")
+        print_optional_field(console, scout, "next_run_at", "Next Run")
 
 
 @app.command()


### PR DESCRIPTION
## Summary

The `if data.get(KEY): console.print(f"  LABEL: {data[KEY]}")` pattern appeared **8 times** across `scouts.py`, `browse.py`, and `research.py` to render truthy optional fields in the verbose `get` outputs. Hoist it into a single `print_optional_field()` helper in `cli/commands/__init__.py`, following the same shape as the existing `print_rejection_reason` / `print_task_*` helpers in this module.

`escape_value=True` preserves the explicit `escape()` previously applied to user-supplied research queries; the other call sites pass values that are API-controlled (timestamps, URLs, agent names, IANA timezone strings) and remain unescaped, matching prior behavior.

## Why this is safe

- **No behavior change.** Each call site renders the same string under the same truthiness condition; the explicit `escape()` is preserved on the only field that previously used it.
- All 10 CLI tests in `tests/test_cli.py` still pass; the full suite (373 tests) passes.
- No public API change — helper is added to `__all__` alongside the other `print_*` helpers; existing imports are unaffected.

## Diff shape

```
 yutori/cli/commands/__init__.py | 21 +++++++++++++++++++++
 yutori/cli/commands/browse.py   | 10 ++++------
 yutori/cli/commands/research.py |  8 +++-----
 yutori/cli/commands/scouts.py   | 16 +++++++++-------
 4 files changed, 37 insertions(+), 18 deletions(-)
```

## Test plan

- [x] `uv run pytest tests/test_cli.py` — 10/10 pass
- [x] `uv run pytest` — 373 pass, 3 skipped (pre-existing slow markers)
- [x] `uv run ruff check yutori/cli/commands/` — clean on touched files
- [x] No call site left behind — verified by grepping `if .*\.get\(.*\):\s*$` in `cli/commands/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVE6jrbMaBJ7s2kbnFd4ue)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to CLI output formatting; behavior is intended to be unchanged except for consolidating repeated print/escape logic.
> 
> **Overview**
> Introduces a shared `print_optional_field()` helper in `cli/commands/__init__.py` (exported via `__all__`) to print optional response fields only when present, with an `escape_value` flag for safe literal rendering of user-supplied strings.
> 
> Updates `browse.get`, `research.get`, and `scouts.get` to replace repeated `if data.get(...): console.print(...)` blocks with calls to this helper, preserving the prior escaping behavior for research queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce54a9a010bc1042f46894663a09c5e414bfeac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->