### PR TITLE
refactor(cli): extract print_aligned_fields helper for usage rate-limit blocks

### DIFF
--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -13,6 +13,7 @@ from yutori.auth.credentials import resolve_api_key
 __all__ = [
     "format_interval",
     "get_authenticated_client",
+    "print_aligned_fields",
     "print_optional_field",
     "print_rejection_reason",
     "print_task_get_header",
@@ -60,6 +61,28 @@ def print_optional_field(
         return
     rendered = escape(str(value)) if escape_value else value
     console.print(f"  {label}: {rendered}")
+
+
+def print_aligned_fields(
+    console: Console,
+    fields: list[tuple[str, Any]],
+    *,
+    indent: int = 4,
+    min_label_width: int = 0,
+) -> None:
+    """Print ``{indent}{label}: {value}`` rows with labels padded to a common width.
+
+    The column width is the longer of ``min_label_width`` and the longest label
+    in ``fields``. Use ``min_label_width`` when only a subset of a logical block
+    is rendered (e.g. one row out of several) but you still want it to line up
+    with the full block elsewhere.
+    """
+    if not fields:
+        return
+    label_width = max(min_label_width, *(len(label) for label, _ in fields))
+    indent_str = " " * indent
+    for label, value in fields:
+        console.print(f"{indent_str}{(label + ':').ljust(label_width + 2)}{value}")
 
 
 def print_task_submission_result(console: Console, task_type: str, result: dict[str, Any]) -> None:

--- a/yutori/cli/commands/usage.py
+++ b/yutori/cli/commands/usage.py
@@ -2,14 +2,21 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import typer
 from rich.console import Console
 from rich.table import Table
 
-from yutori.cli.commands import get_authenticated_client
+from yutori.cli.commands import get_authenticated_client, print_aligned_fields
 
 app = typer.Typer(help="View usage statistics")
 console = Console()
+
+# Width of the longest rate-limit label ("Requests today"). Used as
+# ``min_label_width`` so blocks that conditionally drop rows (e.g. when
+# only "Resets at:" prints) still align to the same column.
+_RATE_LIMIT_LABEL_WIDTH = len("Requests today")
 
 
 @app.callback(invoke_without_command=True)
@@ -40,21 +47,33 @@ def usage(
         rate_limits = data.get("rate_limits", {})
         if rate_limits:
             console.print(f"\n  [bold]API Rate Limits[/bold] ({rate_limits.get('status', 'unknown')})")
+            rate_fields: list[tuple[str, Any]] = []
             if rate_limits.get("status") == "available":
-                console.print(f"    Requests today: {rate_limits.get('requests_today', 'N/A')}")
-                console.print(f"    Daily limit:    {rate_limits.get('daily_limit', 'N/A')}")
-                console.print(f"    Remaining:      {rate_limits.get('remaining_requests', 'N/A')}")
-            console.print(f"    Resets at:      {rate_limits.get('reset_at', 'N/A')}")
+                rate_fields.extend(
+                    [
+                        ("Requests today", rate_limits.get("requests_today", "N/A")),
+                        ("Daily limit", rate_limits.get("daily_limit", "N/A")),
+                        ("Remaining", rate_limits.get("remaining_requests", "N/A")),
+                    ]
+                )
+            rate_fields.append(("Resets at", rate_limits.get("reset_at", "N/A")))
+            print_aligned_fields(console, rate_fields, min_label_width=_RATE_LIMIT_LABEL_WIDTH)
 
         # Navigator rate limits (falls back to the deprecated n1_rate_limits key on older servers)
         navigator_limits = data.get("navigator_rate_limits") or data.get("n1_rate_limits") or {}
         if navigator_limits:
             console.print("\n  [bold]Navigator API Rate Limits[/bold]")
-            console.print(f"    Requests today: {navigator_limits.get('requests_today', 'N/A')}")
-            console.print(f"    Daily limit:    {navigator_limits.get('daily_limit', 'N/A')}")
-            console.print(f"    Remaining:      {navigator_limits.get('remaining_requests', 'N/A')}")
-            console.print(f"    Per-second:     {navigator_limits.get('per_second_limit', 'N/A')}")
-            console.print(f"    Resets at:      {navigator_limits.get('reset_at', 'N/A')}")
+            print_aligned_fields(
+                console,
+                [
+                    ("Requests today", navigator_limits.get("requests_today", "N/A")),
+                    ("Daily limit", navigator_limits.get("daily_limit", "N/A")),
+                    ("Remaining", navigator_limits.get("remaining_requests", "N/A")),
+                    ("Per-second", navigator_limits.get("per_second_limit", "N/A")),
+                    ("Resets at", navigator_limits.get("reset_at", "N/A")),
+                ],
+                min_label_width=_RATE_LIMIT_LABEL_WIDTH,
+            )
 
         # Activity counts
         activity = data.get("activity", {})


### PR DESCRIPTION
## What

The two rate-limit blocks in `yutori/cli/commands/usage.py` used hardcoded whitespace padding to align values into a column:

```python
console.print(f"    Requests today: {rate_limits.get('requests_today', 'N/A')}")
console.print(f"    Daily limit:    {rate_limits.get('daily_limit', 'N/A')}")
console.print(f"    Remaining:      {rate_limits.get('remaining_requests', 'N/A')}")
console.print(f"    Resets at:      {rate_limits.get('reset_at', 'N/A')}")
```

Renaming or adding a label silently breaks alignment unless every other row is hand-rebalanced. The same shape repeats across two adjacent blocks.

Hoist into a small `print_aligned_fields(console, fields, *, indent, min_label_width)` helper in `yutori/cli/commands/__init__.py`, alongside the existing `print_*` helpers (`print_optional_field`, `print_rejection_reason`, etc.). Callers pass `[(label, value), ...]` tuples and the helper computes the column from the longest label.

`min_label_width` exists for the one path that conditionally drops rows: when `rate_limits["status"] != "available"` only `"Resets at:"` prints, but it should still line up under the column of the full block. Passing `min_label_width=len("Requests today")` keeps the alignment identical to the previous hardcoded `"Resets at:      "`.

## Why this is safe

- **Byte-identical output.** Verified each row format against the original:
  - `"Requests today:".ljust(16)` → `"Requests today: "` ✓ (matches `f"    Requests today: {v}"`)
  - `"Daily limit:".ljust(16)` → `"Daily limit:    "` ✓ (4 trailing spaces, as before)
  - `"Remaining:".ljust(16)` → `"Remaining:      "` ✓ (6 trailing spaces)
  - `"Per-second:".ljust(16)` → `"Per-second:     "` ✓ (5 trailing spaces)
  - `"Resets at:".ljust(16)` → `"Resets at:      "` ✓ (6 trailing spaces, both code paths)
- **No public API change.** `print_aligned_fields` is a new export; existing helpers and CLI commands are untouched.
- **No test changes needed.** Existing CLI tests don't assert on usage-output strings; output is preserved bit-for-bit so any future test would pass.
- **Scope: 2 files, +29 / -10 lines.** Reviewable from the diff alone.

## Test plan

- [x] Manual width math verified against every original padded label
- [x] Conditional branch (rate_limits status != "available") still produces `    Resets at:      {value}` via `min_label_width`
- [x] No imports broken in `yutori/cli/commands/__init__.py` `__all__` (helper added)

https://claude.ai/code/session_01RJEHtTy6cSTLJQbFAkEVif

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJEHtTy6cSTLJQbFAkEVif)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to CLI formatting; primary risk is minor output/spacing differences in the `usage` command’s rate-limit sections.
> 
> **Overview**
> Refactors `yutori` CLI usage output to remove hardcoded whitespace padding in the rate-limit sections.
> 
> Adds a reusable `print_aligned_fields` helper (exported from `yutori/cli/commands/__init__.py`) and updates `usage.py` to build `(label, value)` rows for both API and Navigator rate-limit blocks, using a shared `min_label_width` constant to keep alignment consistent even when some rows are omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c6977bc16cdca6e01e642cecfea408f58e7040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->