### PR TITLE
refactor(auth): extract _post_auth_api helper for Bearer-auth POSTs

### DIFF
--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -153,17 +153,28 @@ def _build_key_name(source: str = "yutori-cli") -> str:
     return f"{date_prefix}-{source}"
 
 
+def _post_auth_api(jwt: str, path: str, json_payload: dict[str, Any] | None) -> httpx.Response:
+    """POST to a Yutori auth API endpoint with Bearer auth, raising on non-2xx.
+
+    Centralizes the timeout=30 / Bearer header / raise_for_status combination
+    used by both generate_api_key and register_user so the two call sites
+    cannot drift out of sync.
+    """
+    with httpx.Client(timeout=30.0) as client:
+        response = client.post(
+            build_auth_api_url(path),
+            headers={"Authorization": f"Bearer {jwt}"},
+            json=json_payload,
+        )
+        response.raise_for_status()
+        return response
+
+
 def generate_api_key(jwt: str, key_name: str | None = None) -> str:
     """Generate a Yutori API key using a Clerk JWT."""
     payload = {"name": key_name} if key_name else None
-    with httpx.Client(timeout=30.0) as client:
-        response = client.post(
-            build_auth_api_url("/client/generate_key"),
-            headers={"Authorization": f"Bearer {jwt}"},
-            json=payload,
-        )
-        response.raise_for_status()
-        return response.json()["key"]
+    response = _post_auth_api(jwt, "/client/generate_key", payload)
+    return response.json()["key"]
 
 
 def check_registration_status(jwt: str) -> bool | None:
@@ -204,13 +215,7 @@ def register_user(jwt: str, signup_source: str = "cli") -> None:
     Raises ``httpx.HTTPStatusError`` on non-2xx — the outer login flow turns
     that into a user-facing `Authentication failed (<status>): ...` message.
     """
-    with httpx.Client(timeout=30.0) as client:
-        response = client.post(
-            build_auth_api_url("/client/register-api"),
-            headers={"Authorization": f"Bearer {jwt}"},
-            json={"signup_source": signup_source},
-        )
-        response.raise_for_status()
+    _post_auth_api(jwt, "/client/register-api", {"signup_source": signup_source})
 
 
 def run_login_flow(


### PR DESCRIPTION
## Summary
- `generate_api_key` and `register_user` in `yutori/auth/flow.py` each opened a fresh `httpx.Client(timeout=30.0)`, posted JSON to a `build_auth_api_url(...)` endpoint with an `Authorization: Bearer {jwt}` header, and called `response.raise_for_status()`. The only differences were URL path, JSON body, and whether the response JSON was returned.
- Extract `_post_auth_api(jwt, path, json_payload)` to centralize the timeout / header / `raise_for_status` combination so the two call sites cannot drift out of sync.
- `exchange_code_for_token` (form-encoded, no Bearer) and `check_registration_status` (GET, 5 s timeout, returns `None` on failure) have meaningfully different shapes and are intentionally **not** touched.

## Why this is safe
- The `httpx.Client(timeout=30.0)` context, Bearer header, and `raise_for_status` ordering are preserved exactly.
- `HTTPStatusError` surfaces from the helper exactly as it did inline.
- Existing tests cover both call sites: `test_generate_api_key_success`, `test_generate_api_key_uses_build_auth_api_url`, `test_register_user_posts_cli_source`, `test_register_user_raises_httpstatuserror_on_bad_status`.

## Test plan
- [x] `pytest tests/test_auth.py` — all 71 tests pass
- [x] Full SDK suite (skipping unrelated `test_packaging` failure due to missing `build` module): 372 passed / 3 skipped

https://claude.ai/code/session_01RcST3DLYVmfDsV1p3sXNRu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcST3DLYVmfDsV1p3sXNRu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor that consolidates duplicated HTTP request code without changing endpoints, payloads, or error handling; main risk is unintended behavioral drift in request construction.
> 
> **Overview**
> Refactors `yutori/auth/flow.py` to centralize Bearer-authenticated POST requests to the auth API.
> 
> Introduces `_post_auth_api(jwt, path, json_payload)` (shared `httpx.Client(timeout=30)`, `Authorization: Bearer …`, and `raise_for_status()`), and updates `generate_api_key` and `register_user` to call it while keeping their request/response behavior the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5825c2000ce58889160b077b9cbb9b32ec0fc418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->