### PR TITLE
refactor(_schema): extract _try_call_schema_method helper

### DIFF
--- a/yutori/_schema.py
+++ b/yutori/_schema.py
@@ -8,6 +8,24 @@ from typing import Any
 _ERROR_MSG = "output_schema must be a dict, a Pydantic BaseModel class, or a BaseModel instance"
 
 
+def _try_call_schema_method(cls: type, method_name: str) -> dict[str, Any] | None:
+    """Call a Pydantic schema method on `cls` and return its dict result.
+
+    Returns None if the method is missing or not callable. Raises TypeError
+    if the method exists but errors or returns a non-dict.
+    """
+    method = getattr(cls, method_name, None)
+    if method is None or not callable(method):
+        return None
+    try:
+        result = method()
+    except TypeError:
+        raise TypeError(_ERROR_MSG) from None
+    if not isinstance(result, dict):
+        raise TypeError(f"{method_name}() returned {type(result).__name__}, expected dict")
+    return result
+
+
 def resolve_output_schema(output_schema: object | None) -> dict[str, Any] | None:
     """Convert an output_schema value to a JSON schema dict.
 
@@ -30,26 +48,10 @@ def resolve_output_schema(output_schema: object | None) -> dict[str, Any] | None
     # Resolve instances to their class
     cls = output_schema if isinstance(output_schema, type) else type(output_schema)
 
-    # Pydantic v2: model_json_schema (check before v1 to avoid deprecation warnings)
-    v2_method = getattr(cls, "model_json_schema", None)
-    if v2_method is not None and callable(v2_method):
-        try:
-            result = v2_method()
-        except TypeError:
-            raise TypeError(_ERROR_MSG) from None
-        if not isinstance(result, dict):
-            raise TypeError(f"model_json_schema() returned {type(result).__name__}, expected dict")
-        return result
-
-    # Pydantic v1: schema
-    v1_method = getattr(cls, "schema", None)
-    if v1_method is not None and callable(v1_method):
-        try:
-            result = v1_method()
-        except TypeError:
-            raise TypeError(_ERROR_MSG) from None
-        if not isinstance(result, dict):
-            raise TypeError(f"schema() returned {type(result).__name__}, expected dict")
-        return result
+    # Pydantic v2 first to avoid deprecation warnings, fall back to v1.
+    for method_name in ("model_json_schema", "schema"):
+        result = _try_call_schema_method(cls, method_name)
+        if result is not None:
+            return result
 
     raise TypeError(_ERROR_MSG)


### PR DESCRIPTION
## Summary

`resolve_output_schema()` has two near-identical 9-line blocks for invoking the Pydantic v2 `model_json_schema` and v1 `schema` methods — same `getattr`+callable check, same `try/except TypeError`, same `isinstance(result, dict)` guard, same error wording. Extracting the shared logic into `_try_call_schema_method(cls, method_name)` collapses them to a 4-line loop.

The v2-first ordering is preserved (the loop iterates `("model_json_schema", "schema")`), so the existing "check v2 first to avoid deprecation warnings" behavior still holds.

## Why it's safe

- No behavior change. The helper preserves the exact control flow:
  - missing/non-callable method → fall through to next branch (returns `None`).
  - method raises `TypeError` → re-raise as `TypeError(_ERROR_MSG)`.
  - method returns non-dict → raise `TypeError(f"{name}() returned ...")`.
- Error message format is preserved (uses `method_name` so `model_json_schema()` and `schema()` still appear verbatim in the message).
- `_try_call_schema_method` is module-private (leading underscore).

## Test plan

- [x] `pytest tests/test_schema.py` — all 18 cases pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HawUgxp217TVvnzQy7Njhv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that deduplicates schema-method invocation logic while preserving the same method order and error behavior. Any risk is limited to subtle exception/message differences when calling `model_json_schema`/`schema`.
> 
> **Overview**
> Refactors `resolve_output_schema()` to remove duplicated Pydantic v2/v1 schema-calling blocks by introducing a private `_try_call_schema_method()` helper.
> 
> The function now iterates `("model_json_schema", "schema")` to preserve v2-first behavior, while centralizing callable checks, `TypeError` normalization, and non-dict return validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc0b2acc68da4b001bd479ac52ebeaec5cd7599d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->