### PR TITLE
refactor(cli): centralize interval second constants and INTERVAL_PRESETS

### DIFF
--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -11,6 +11,11 @@ from rich.markup import escape
 from yutori.auth.credentials import resolve_api_key
 
 __all__ = [
+    "INTERVAL_PRESETS",
+    "SECONDS_PER_DAY",
+    "SECONDS_PER_HOUR",
+    "SECONDS_PER_MINUTE",
+    "SECONDS_PER_WEEK",
     "format_interval",
     "get_authenticated_client",
     "print_aligned_fields",
@@ -20,6 +25,17 @@ __all__ = [
     "print_task_result_output",
     "print_task_submission_result",
 ]
+
+SECONDS_PER_MINUTE = 60
+SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE
+SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR
+SECONDS_PER_WEEK = 7 * SECONDS_PER_DAY
+
+INTERVAL_PRESETS: dict[str, int] = {
+    "hourly": SECONDS_PER_HOUR,
+    "daily": SECONDS_PER_DAY,
+    "weekly": SECONDS_PER_WEEK,
+}
 
 _console = Console()
 
@@ -129,10 +145,10 @@ def format_interval(seconds: int, *, short: bool = False) -> str:
         short: If True, use compact form (e.g. ``"1d"``). Otherwise use the
             verbose form (e.g. ``"1 day(s)"``).
     """
-    if seconds >= 86400:
-        value, unit_short, unit_long = seconds // 86400, "d", "day(s)"
-    elif seconds >= 3600:
-        value, unit_short, unit_long = seconds // 3600, "h", "hour(s)"
+    if seconds >= SECONDS_PER_DAY:
+        value, unit_short, unit_long = seconds // SECONDS_PER_DAY, "d", "day(s)"
+    elif seconds >= SECONDS_PER_HOUR:
+        value, unit_short, unit_long = seconds // SECONDS_PER_HOUR, "h", "hour(s)"
     else:
-        value, unit_short, unit_long = seconds // 60, "m", "minute(s)"
+        value, unit_short, unit_long = seconds // SECONDS_PER_MINUTE, "m", "minute(s)"
     return f"{value}{unit_short}" if short else f"{value} {unit_long}"

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -8,6 +8,7 @@ from rich.markup import escape
 from rich.table import Table
 
 from yutori.cli.commands import (
+    INTERVAL_PRESETS,
     format_interval,
     get_authenticated_client,
     print_optional_field,
@@ -88,10 +89,10 @@ def create(
     if not query:
         query = typer.prompt("What would you like to monitor?")
 
-    interval_map = {"hourly": 3600, "daily": 86400, "weekly": 604800}
-    output_interval = interval_map.get(interval.lower())
+    output_interval = INTERVAL_PRESETS.get(interval.lower())
     if output_interval is None:
-        console.print(f"[red]Invalid interval '{escape(interval)}'. Choose from: hourly, daily, weekly[/red]")
+        choices = ", ".join(INTERVAL_PRESETS)
+        console.print(f"[red]Invalid interval '{escape(interval)}'. Choose from: {choices}[/red]")
         raise typer.Exit(1)
 
     with get_authenticated_client() as client:


### PR DESCRIPTION
## Summary

Magic seconds constants (60, 3600, 86400, 604800) appeared in three places in the CLI:

- `format_interval()` in `yutori/cli/commands/__init__.py` compared and divided by `86400`, `3600`, `60`.
- `create()` in `yutori/cli/commands/scouts.py` constructed an inline `interval_map = {"hourly": 3600, "daily": 86400, "weekly": 604800}`.
- The "Invalid interval" error message hardcoded the same preset names alongside the dict, so the names and the dict could drift independently.

This PR adds named `SECONDS_PER_{MINUTE,HOUR,DAY,WEEK}` constants and an `INTERVAL_PRESETS` dict in `yutori/cli/commands/__init__.py`, exports them via `__all__`, and has both `format_interval` and the scouts `create()` command import them. The "Invalid interval" message now derives its choices from `", ".join(INTERVAL_PRESETS)`, so the message can never drift from the dict.

## Why it's safe

- Pure refactor; no behavior change.
- 2 files touched. `+25 / -8` LOC.
- Constant values verified equal to the magic numbers (`SECONDS_PER_HOUR == 3600`, `SECONDS_PER_DAY == 86400`, `SECONDS_PER_WEEK == 604800`).
- `format_interval` is exercised by `tests/test_cli.py`. No tests check the magic numbers or the inline `interval_map`.
- The user-visible "Choose from" message keeps the same content (`hourly, daily, weekly`) — it's just sourced from `INTERVAL_PRESETS` now.

## Test plan

- [ ] `pytest tests/test_cli.py` passes
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3w7XM55DQkhqGK1emGQtk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes interval-second values and preset mapping used by the CLI; behavior should remain the same aside from the invalid-interval message now deriving its choices from the shared preset list.
> 
> **Overview**
> Centralizes magic interval-second values into named constants (`SECONDS_PER_{MINUTE,HOUR,DAY,WEEK}`) and a shared `INTERVAL_PRESETS` mapping exported from `yutori/cli/commands/__init__.py`.
> 
> Updates `format_interval()` and `scouts create` to use these shared values, and makes the invalid-interval error message derive its allowed choices from `INTERVAL_PRESETS` to prevent drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 071742b6da2fcf076d2c8fbe59e20216950af0b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->