### PR TITLE
refactor: rename "n1 API" to "Navigator API" throughout SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,17 +77,17 @@ Resolution order: explicit `api_key` > `YUTORI_API_KEY` env var > `~/.yutori/con
 The Yutori API provides four main capabilities:
 
 
-| API           | Description                                | SDK Namespace     |
-| ------------- | ------------------------------------------ | ----------------- |
-| **Navigator** | Computer-use model for navigating websites | `client.chat`     |
-| **Browsing**  | One-time browser automation tasks          | `client.browsing` |
-| **Research**  | Deep web research using 100+ tools         | `client.research` |
-| **Scouting**  | Continuous web monitoring on a schedule    | `client.scouts`   |
+| API           | Description                                                    | SDK Namespace     |
+| ------------- | -------------------------------------------------------------- | ----------------- |
+| **Navigator** | Computer-use model family (Navigator-n1, Navigator-n1.5)       | `client.chat`     |
+| **Browsing**  | One-time browser automation tasks                              | `client.browsing` |
+| **Research**  | Deep web research using 100+ tools                             | `client.research` |
+| **Scouting**  | Continuous web monitoring on a schedule                        | `client.scouts`   |
 
 
 ## Navigator API
 
-The Navigator API provides a computer-use model for navigating websites. Capture a screenshot, send it to the model, and execute the returned tool calls. The endpoint follows the OpenAI Chat Completions interface, so `client.chat` is a drop-in OpenAI-compatible client:
+The Navigator API hosts Yutori's family of computer-use models for navigating websites. The current public versions are **Navigator-n1** (model id `n1-latest`) and **Navigator-n1.5** (model id `n1.5-latest`). Capture a screenshot, send it to the model, and execute the returned tool calls. The endpoint follows the OpenAI Chat Completions interface, so `client.chat` is a drop-in OpenAI-compatible client:
 
 ```python
 from yutori import AsyncYutoriClient
@@ -124,7 +124,7 @@ async with AsyncYutoriClient() as client, async_playwright() as p:
 
 This snippet shows a single model call. In practice, you'll usually run an agent loop: execute the returned actions on the page, capture a fresh screenshot, and call the model again until it emits `stop`. Complete agent loops live in [examples/](examples/).
 
-The SDK defaults to `n1.5-latest`. `n1-latest` is still supported for callers that want the older model. n1.5 adds selectable tool sets, `disable_tools`, and structured JSON output via `json_schema` (returned as `response.parsed_json`). See [docs](https://docs.yutori.com/reference/n1-5) for model IDs, parameters, and the full action space.
+The SDK defaults to Navigator-n1.5 (`n1.5-latest`). Navigator-n1 (`n1-latest`) is still supported for callers that want the older model. Navigator-n1.5 adds selectable tool sets, `disable_tools`, and structured JSON output via `json_schema` (returned as `response.parsed_json`). See the [Navigator-n1.5 reference](https://docs.yutori.com/reference/n1-5) and [Navigator-n1 reference](https://docs.yutori.com/reference/n1) for model IDs, parameters, and the full action space.
 
 ### Agent-loop helpers
 
@@ -133,13 +133,13 @@ The `yutori.navigator` subpackage exposes optional helpers for typical agent loo
 
 | Helper                                                      | Purpose                                                                                                                        |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `aplaywright_screenshot_to_data_url(page)`                  | Capture a Playwright screenshot as a Navigator-optimized WebP data URL.                                                        |
-| `denormalize_coordinates(coords, width, height)`            | Map the model's 1000×1000 coordinate space to viewport pixels.                                                                 |
-| `format_task_with_context(task, ...)`                       | Append location, timezone, and current date to a task message.                                                                 |
-| `format_stop_and_summarize(task)`                           | Ask the model to summarize when hitting max steps or an error.                                                                 |
-| `trimmed_messages_to_fit(messages, max_bytes, keep_recent)` | Drop older screenshots to stay under the API size limit.                                                                       |
-| `map_key_to_playwright(key)` / `map_keys_individual(keys)`  | Convert n1.5's lowercase key names to Playwright format.                                                                       |
-| `yutori.navigator.tools`                                    | Packaged JS reference implementations for n1.5 expanded tools (`extract_elements`, `find`, `set_element_value`, `execute_js`). |
+| `aplaywright_screenshot_to_data_url(page)`                  | Capture a Playwright screenshot as a Navigator-optimized WebP data URL.                                                                  |
+| `denormalize_coordinates(coords, width, height)`            | Map the Navigator 1000×1000 coordinate space to viewport pixels.                                                                         |
+| `format_task_with_context(task, ...)`                       | Append location, timezone, and current date to a task message.                                                                           |
+| `format_stop_and_summarize(task)`                           | Ask the model to summarize when hitting max steps or an error.                                                                           |
+| `trimmed_messages_to_fit(messages, max_bytes, keep_recent)` | Drop older screenshots to stay under the API size limit.                                                                                 |
+| `map_key_to_playwright(key)` / `map_keys_individual(keys)`  | Convert Navigator-n1.5's lowercase key names to Playwright format.                                                                       |
+| `yutori.navigator.tools`                                    | Packaged JS reference implementations for the Navigator-n1.5 expanded tools (`extract_elements`, `find`, `set_element_value`, `execute_js`). |
 
 
 Full helper reference: [api.md](api.md).
@@ -292,7 +292,7 @@ Run `yutori --help` or `yutori <command> --help` for full options.
 
 ## Examples
 
-See [examples/](examples/) for complete working examples, including Navigator agent loops for both n1 and n1.5.
+See [examples/](examples/) for complete working examples, including Navigator agent loops for both Navigator-n1 and Navigator-n1.5.
 
 ## Contributing
 

--- a/api.md
+++ b/api.md
@@ -7,8 +7,8 @@ A dense reference to everything the Yutori Python SDK and CLI expose. The [READM
 | Import | Purpose |
 |--------|---------|
 | `yutori` | Clients (`YutoriClient`, `AsyncYutoriClient`) and exceptions (`APIError`, `AuthenticationError`, `YutoriSDKError`) |
-| `yutori.navigator` | Agent-loop helpers for the Navigator (n1 / n1.5) chat completions endpoint |
-| `yutori.navigator.tools` | Packaged JavaScript reference implementations for n1.5 expanded browser tools |
+| `yutori.navigator` | Agent-loop helpers for the Navigator API (Navigator-n1 / Navigator-n1.5 chat completions) |
+| `yutori.navigator.tools` | Packaged JavaScript reference implementations for the Navigator-n1.5 expanded browser tools |
 
 All SDK calls go through `YutoriClient` / `AsyncYutoriClient`. The Navigator helpers are optional and do not change the shape of `client.chat.completions.create(...)`.
 
@@ -53,7 +53,7 @@ YutoriClient(
 
 | Attribute | Class | Purpose |
 |-----------|-------|---------|
-| `client.chat` | `ChatNamespace` | Navigator (n1 / n1.5) chat completions |
+| `client.chat` | `ChatNamespace` | Navigator API (Navigator-n1 / Navigator-n1.5) chat completions |
 | `client.browsing` | `BrowsingNamespace` | One-time browser automation |
 | `client.research` | `ResearchNamespace` | One-time deep web research |
 | `client.scouts` | `ScoutsNamespace` | Continuous monitoring scouts |
@@ -90,16 +90,24 @@ The response also includes `n1_rate_limits` and `activity.n1_calls` as deprecate
 Importable from `yutori.navigator`. Prefer these over hard-coded strings so upgrades land automatically.
 
 ```python
-from yutori.navigator import N1_MODEL, N1_5_MODEL, TOOL_SET_CORE, TOOL_SET_EXPANDED
+from yutori.navigator import (
+    NAVIGATOR_N1_MODEL,
+    NAVIGATOR_N1_5_MODEL,
+    NAVIGATOR_COORDINATE_SCALE,
+    TOOL_SET_CORE,
+    TOOL_SET_EXPANDED,
+)
 ```
 
 | Constant | Value | Notes |
 |----------|-------|-------|
-| `N1_MODEL` | `"n1-latest"` | Alias for the latest stable n1 model. |
-| `N1_5_MODEL` | `"n1.5-latest"` | Alias for the latest stable n1.5 model (current default). |
-| `TOOL_SET_CORE` | `"browser_tools_core-20260403"` | Default n1.5 tool set — 18 coordinate-based browser tools. |
+| `NAVIGATOR_N1_MODEL` | `"n1-latest"` | Alias for the latest stable Navigator-n1 model. |
+| `NAVIGATOR_N1_5_MODEL` | `"n1.5-latest"` | Alias for the latest stable Navigator-n1.5 model (current default). |
+| `TOOL_SET_CORE` | `"browser_tools_core-20260403"` | Default Navigator-n1.5 tool set — 18 coordinate-based browser tools. |
 | `TOOL_SET_EXPANDED` | `"browser_tools_expanded-20260403"` | Core tools + `extract_elements`, `find`, `set_element_value`, `execute_js`. |
-| `N1_COORDINATE_SCALE` | `1000` | The normalized action space is `N1_COORDINATE_SCALE × N1_COORDINATE_SCALE`. |
+| `NAVIGATOR_COORDINATE_SCALE` | `1000` | The normalized action space is `NAVIGATOR_COORDINATE_SCALE × NAVIGATOR_COORDINATE_SCALE`. |
+
+`N1_MODEL`, `N1_5_MODEL`, and `N1_COORDINATE_SCALE` are still importable from the same module as deprecated aliases of the `NAVIGATOR_*` constants and may be removed in a future release.
 
 For pinned versions (e.g. `n1-20260203`, `n1-experimental-20260309`) see [docs.yutori.com/reference/n1](https://docs.yutori.com/reference/n1) and [docs.yutori.com/reference/n1-5](https://docs.yutori.com/reference/n1-5).
 
@@ -107,7 +115,7 @@ For pinned versions (e.g. `n1-20260203`, `n1-experimental-20260309`) see [docs.y
 
 ### `client.chat` — Navigator API
 
-OpenAI-compatible pixels-to-actions chat completions. Works with both n1 and n1.5 models.
+OpenAI-compatible pixels-to-actions chat completions. Works with both Navigator-n1 and Navigator-n1.5 models.
 
 | Method | HTTP | Endpoint | Returns |
 |--------|------|----------|---------|
@@ -116,10 +124,10 @@ OpenAI-compatible pixels-to-actions chat completions. Works with both n1 and n1.
 #### `chat.completions.create`
 
 ```python
-from yutori.navigator import N1_5_MODEL
+from yutori.navigator import NAVIGATOR_N1_5_MODEL, TOOL_SET_EXPANDED
 
 response = client.chat.completions.create(
-    model=N1_5_MODEL,
+    model=NAVIGATOR_N1_5_MODEL,
     messages=[
         {
             "role": "user",
@@ -129,9 +137,9 @@ response = client.chat.completions.create(
             ],
         }
     ],
-    tool_set=TOOL_SET_EXPANDED,           # n1.5 only
-    disable_tools=["hold_key", "drag"],    # n1.5 only
-    json_schema={...},                     # n1.5 only
+    tool_set=TOOL_SET_EXPANDED,           # Navigator-n1.5 only
+    disable_tools=["hold_key", "drag"],    # Navigator-n1.5 only
+    json_schema={...},                     # Navigator-n1.5 only
 )
 
 message = response.choices[0].message
@@ -145,17 +153,17 @@ parsed = getattr(response, "parsed_json", None)
 
 **Parameters:**
 - `messages` (`Iterable[ChatCompletionMessageParam]`): OpenAI-format chat messages. Include screenshots as `image_url` content blocks.
-- `model` (`str`, default `"n1.5-latest"`): Model alias or pinned ID. Pass `N1_MODEL` / `N1_5_MODEL` for clarity.
-- `tool_set` (`str | None`, **n1.5 only**): Which built-in tool set to activate. Use `TOOL_SET_CORE` or `TOOL_SET_EXPANDED`. Forwarded via `extra_body`.
-- `disable_tools` (`list[str] | None`, **n1.5 only**): Tool names to remove from the active tool set.
-- `json_schema` (`dict | None`, **n1.5 only**): JSON Schema object. When provided, the API constrains decoding and attaches the parsed result as `response.parsed_json`.
-- `**kwargs`: Any other OpenAI Chat Completions parameter (`temperature`, `tools`, `tool_choice`, `response_format`, etc.). If the caller already passes `extra_body`, the SDK merges n1.5 params into it.
+- `model` (`str`, default `"n1.5-latest"`): Model alias or pinned ID. Pass `NAVIGATOR_N1_MODEL` / `NAVIGATOR_N1_5_MODEL` for clarity.
+- `tool_set` (`str | None`, **Navigator-n1.5 only**): Which built-in tool set to activate. Use `TOOL_SET_CORE` or `TOOL_SET_EXPANDED`. Forwarded via `extra_body`.
+- `disable_tools` (`list[str] | None`, **Navigator-n1.5 only**): Tool names to remove from the active tool set.
+- `json_schema` (`dict | None`, **Navigator-n1.5 only**): JSON Schema object. When provided, the API constrains decoding and attaches the parsed result as `response.parsed_json`.
+- `**kwargs`: Any other OpenAI Chat Completions parameter (`temperature`, `tools`, `tool_choice`, `response_format`, etc.). If the caller already passes `extra_body`, the SDK merges Navigator-n1.5 params into it.
 
-**Returns:** `openai.types.chat.ChatCompletion`. When `json_schema` is set on n1.5 and parsing succeeds, the API also sets `response.parsed_json`.
+**Returns:** `openai.types.chat.ChatCompletion`. When `json_schema` is set on Navigator-n1.5 and parsing succeeds, the API also sets `response.parsed_json`.
 
-**n1 vs. n1.5 summary** (reference: [docs.yutori.com](https://docs.yutori.com/reference/n1-5)):
+**Navigator-n1 vs. Navigator-n1.5 summary** (reference: [docs.yutori.com](https://docs.yutori.com/reference/n1-5)):
 
-| Feature | n1 | n1.5 |
+| Feature | Navigator-n1 | Navigator-n1.5 |
 |---------|----|----|
 | Tool sets | Fixed | `tool_set` (core / expanded) |
 | Disable tools | — | `disable_tools` supported |
@@ -394,7 +402,7 @@ task = client.browsing.create(
 )
 ```
 
-Structured output for the Navigator API (n1.5 only) is a separate parameter on `client.chat.completions.create(...)`: `json_schema=...` with results on `response.parsed_json`.
+Structured output for the Navigator API (Navigator-n1.5 only) is a separate parameter on `client.chat.completions.create(...)`: `json_schema=...` with results on `response.parsed_json`.
 
 ## `yutori.navigator`
 
@@ -403,14 +411,14 @@ Opt-in helpers for custom agent loops. They do **not** change the shape of `clie
 ```python
 from yutori.navigator import (
     # Models / tool sets
-    N1_MODEL, N1_5_MODEL, TOOL_SET_CORE, TOOL_SET_EXPANDED, N1_COORDINATE_SCALE,
+    NAVIGATOR_N1_MODEL, NAVIGATOR_N1_5_MODEL, TOOL_SET_CORE, TOOL_SET_EXPANDED, NAVIGATOR_COORDINATE_SCALE,
     # Screenshots
     aplaywright_screenshot_to_data_url, playwright_screenshot_to_data_url, screenshot_to_data_url,
     # Coordinates
     denormalize_coordinates, normalize_coordinates,
     # Task / prompt formatting
     format_task_with_context, format_user_context, format_stop_and_summarize,
-    # Key mapping (n1.5)
+    # Key mapping (Navigator-n1.5)
     map_key_to_playwright, map_keys_individual,
     # Payload trimming
     estimate_messages_size_bytes, trim_images_to_fit, trimmed_messages_to_fit,
@@ -433,7 +441,7 @@ Default quality is WebP q=90 (or q=30 for PNG sources).
 
 ### Coordinate helpers
 
-The Navigator emits tool-call coordinates in a normalized `N1_COORDINATE_SCALE × N1_COORDINATE_SCALE` (1000×1000) space.
+The Navigator emits tool-call coordinates in a normalized `NAVIGATOR_COORDINATE_SCALE × NAVIGATOR_COORDINATE_SCALE` (1000×1000) space.
 
 | Helper | Signature | Description |
 |--------|-----------|-------------|
@@ -450,9 +458,9 @@ Raises `ValueError` on bad input (non-finite values, wrong length, non-positive 
 | `format_task_with_context` | `(task: str, *, user_timezone=..., user_location=...) -> str` | `f"{task}\n\n{format_user_context(...)}"`. |
 | `format_stop_and_summarize` | `(task: str) -> str` | Prompt that asks the model to stop iterating and produce a summary — for use when hitting max steps or an error. |
 
-### Key mapping (n1.5)
+### Key mapping (Navigator-n1.5)
 
-n1.5 returns lowercase key names (`ctrl+c`, `enter`, `down`) which must be converted for Playwright.
+Navigator-n1.5 returns lowercase key names (`ctrl+c`, `enter`, `down`) which must be converted for Playwright.
 
 | Helper | Signature | Description |
 |--------|-----------|-------------|
@@ -477,8 +485,8 @@ Thin wrappers around `chat.completions.create(...)` that trim the request copy b
 
 | Helper | Signature | Description |
 |--------|-----------|-------------|
-| `create_trimmed` | `(completions, messages, *, model=N1_5_MODEL, max_bytes=9_500_000, keep_recent=6, **kwargs) -> ChatCompletion` | Sync. Expects `completions` to quack like `ChatCompletions`. |
-| `acreate_trimmed` | `(completions, messages, *, model=N1_5_MODEL, max_bytes=9_500_000, keep_recent=6, **kwargs) -> ChatCompletion` | Async. |
+| `create_trimmed` | `(completions, messages, *, model=NAVIGATOR_N1_5_MODEL, max_bytes=9_500_000, keep_recent=6, **kwargs) -> ChatCompletion` | Sync. Expects `completions` to quack like `ChatCompletions`. |
+| `acreate_trimmed` | `(completions, messages, *, model=NAVIGATOR_N1_5_MODEL, max_bytes=9_500_000, keep_recent=6, **kwargs) -> ChatCompletion` | Async. |
 
 Additionally, `yutori.navigator.loop.update_trimmed_history(messages, request_messages=None, *, max_bytes=..., keep_recent=...)` is available for long-lived loops that keep a complete replayable history separate from the trimmed request copy. It returns `(request_messages, size_bytes, removed)`.
 
@@ -491,7 +499,7 @@ Additionally, `yutori.navigator.loop.update_trimmed_history(messages, request_me
 
 ### `yutori.navigator.tools`
 
-Packaged JavaScript reference implementations for n1.5's expanded browser tool set. The scripts are shipped as `.js` files inside the wheel (`yutori.navigator.tools.js`).
+Packaged JavaScript reference implementations for the Navigator-n1.5 expanded browser tool set. The scripts are shipped as `.js` files inside the wheel (`yutori.navigator.tools.js`).
 
 ```python
 from yutori.navigator.tools import (

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@ The examples rely on the SDK's normal credential resolution. They do not expose 
 
 ## navigator_n1.py
 
-A complete browsing agent using the n1 API. Launches a local Playwright browser, captures screenshots through `yutori.navigator.aplaywright_screenshot_to_data_url(...)`, converts tool-call coordinates with `yutori.navigator.denormalize_coordinates(...)`, sends them to n1, and executes predicted actions until the task is complete. The example keeps its own long-lived message history bounded with `estimate_messages_size_bytes(...)` plus `trimmed_messages_to_fit(...)`, then still ends with a standard `client.chat.completions.create(...)` call.
+A complete browsing agent using the Navigator API with the Navigator-n1 model. Launches a local Playwright browser, captures screenshots through `yutori.navigator.aplaywright_screenshot_to_data_url(...)`, converts tool-call coordinates with `yutori.navigator.denormalize_coordinates(...)`, sends them to Navigator-n1, and executes predicted actions until the task is complete. The example keeps its own long-lived message history bounded with `estimate_messages_size_bytes(...)` plus `trimmed_messages_to_fit(...)`, then still ends with a standard `client.chat.completions.create(...)` call.
 
 ```bash
 uv run python examples/navigator_n1.py --task "List the team member names" --start-url "https://www.yutori.com"
@@ -33,7 +33,7 @@ Options:
 
 ## navigator_n1_5.py
 
-A navigator agent using the n1.5 API. Demonstrates selectable tool sets (`TOOL_SET_CORE`, `TOOL_SET_EXPANDED`), optional structured JSON output via `--json-schema`, a redesigned action space with lowercase key names, and the packaged JS helpers from `yutori.navigator.tools` for expanded browser tools.
+A Navigator agent using the Navigator-n1.5 model. Demonstrates selectable tool sets (`TOOL_SET_CORE`, `TOOL_SET_EXPANDED`), optional structured JSON output via `--json-schema`, a redesigned action space with lowercase key names, and the packaged JS helpers from `yutori.navigator.tools` for expanded browser tools.
 
 ```bash
 uv run python examples/navigator_n1_5.py --task "List the team member names" --start-url "https://www.yutori.com"
@@ -52,7 +52,7 @@ Options:
 
 ## navigator_n1_custom_tools.py
 
-Extends the basic agent with a custom tool for extracting content and links from the page. Demonstrates how to define custom tools and pass them to the n1 API.
+Extends the basic Navigator-n1 agent with a custom tool for extracting content and links from the page. Demonstrates how to define custom tools and pass them to the Navigator API.
 
 ```bash
 uv run python examples/navigator_n1_custom_tools.py \

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 """
-A web browsing agent using Yutori's n1 API (OpenAI API compatible)
+A web browsing agent using Yutori's Navigator API with the Navigator-n1 model
+(OpenAI API compatible).
 
 This script takes a user query, launches a local Playwright browser session,
-calls the n1 API to get actions, executes them, and iterates until the task is complete.
+calls the Navigator API to get actions, executes them, and iterates until the
+task is complete.
 
 Replay logging in this example is optional. Here, "replay" means saving the
 agent trajectory to local files so you can inspect screenshots, actions, and
@@ -440,9 +442,11 @@ async def main():
     configure_example_logging()
 
     default_config = Config()
-    parser = argparse.ArgumentParser(description="Example of using Yutori n1 API to perform a web browsing task")
+    parser = argparse.ArgumentParser(
+        description="Example of using the Yutori Navigator API (Navigator-n1) to perform a web browsing task"
+    )
     add_task_arguments(parser, default_config)
-    add_model_arguments(parser, default_config, api_label="Yutori n1")
+    add_model_arguments(parser, default_config, api_label="Yutori Navigator-n1")
     add_agent_arguments(parser, default_config)
     add_browser_arguments(parser, default_config)
     add_payload_trim_arguments(parser, default_config)

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 """
-A web browsing agent using Yutori's n1.5 API.
+A web browsing agent using Yutori's Navigator API with the Navigator-n1.5 model.
 
-n1.5 introduces a new action space with renamed tools, selectable tool sets,
-optional structured JSON output, and lowercase key names.
+Navigator-n1.5 introduces a new action space with renamed tools, selectable
+tool sets, optional structured JSON output, and lowercase key names.
 
 Replay logging in this example is optional. Here, "replay" means saving the
 agent trajectory to local files so you can inspect screenshots, actions, and
 raw request/response payloads in `visualization.html` after the run.
 
-Key differences from n1:
+Key differences from Navigator-n1:
 - model: "n1.5-latest" (instead of "n1-latest")
 - tool_set / disable_tools: select which built-in tools the model can use
 - json_schema: request structured output (returned as parsed_json on the response)
@@ -417,7 +417,7 @@ class Agent:
         1. If ``ref`` is present, try to resolve it to viewport pixels.
            Ref resolution also scrolls the element into view.
         2. If ref resolution fails (or no ref), fall back to denormalizing
-           ``coordinates`` from n1's 1000x1000 space.
+           ``coordinates`` from the Navigator 1000x1000 space.
         3. If neither ref nor coordinates are usable, return an error.
         """
         coords = arguments.get("coordinates")
@@ -442,7 +442,7 @@ class Agent:
 
     @staticmethod
     def _map_modifier(modifier: str | None) -> str | None:
-        """Map a single n1.5 modifier name to a Playwright key name.
+        """Map a single Navigator-n1.5 modifier name to a Playwright key name.
 
         The modifier field is always a single key (ctrl, shift, alt, meta,
         command, super) — not a combo. Uses the key map for lookup but
@@ -461,7 +461,7 @@ class Agent:
         return mapped[0].split("+")[0]
 
     # ------------------------------------------------------------------
-    # Action execution — n1.5 action space
+    # Action execution — Navigator-n1.5 action space
     # ------------------------------------------------------------------
 
     def _url_suffix(self) -> str:
@@ -723,9 +723,11 @@ async def main():
     configure_example_logging()
 
     default_config = Config()
-    parser = argparse.ArgumentParser(description="Example of using Yutori n1.5 API to perform a web browsing task")
+    parser = argparse.ArgumentParser(
+        description="Example of using the Yutori Navigator API (Navigator-n1.5) to perform a web browsing task"
+    )
     add_task_arguments(parser, default_config)
-    add_model_arguments(parser, default_config, api_label="Yutori n1.5")
+    add_model_arguments(parser, default_config, api_label="Yutori Navigator-n1.5")
     parser.add_argument(
         "--tool-set", default=default_config.tool_set,
         choices=[TOOL_SET_CORE, TOOL_SET_EXPANDED, "core", "expanded"],

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 """
-A web browsing agent using Yutori's n1 API (OpenAI API compatible) with custom tools
+A web browsing agent using Yutori's Navigator API (Navigator-n1, OpenAI API
+compatible) with custom tools.
 
 This script takes a user query, launches a local Playwright browser session,
-calls the n1 API to get actions, executes them, and iterates until the task is complete.
+calls the Navigator API to get actions, executes them, and iterates until the
+task is complete.
 
 In addition, we implement a custom tool to extract content and links from the page.
 
@@ -493,9 +495,11 @@ async def main():
     configure_example_logging()
 
     default_config = Config()
-    parser = argparse.ArgumentParser(description="Example of using Yutori n1 API to perform a web browsing task")
+    parser = argparse.ArgumentParser(
+        description="Example of using the Yutori Navigator API (Navigator-n1) to perform a web browsing task"
+    )
     add_task_arguments(parser, default_config)
-    add_model_arguments(parser, default_config, api_label="Yutori n1")
+    add_model_arguments(parser, default_config, api_label="Yutori Navigator-n1")
     add_agent_arguments(parser, default_config)
     add_browser_arguments(parser, default_config)
     add_replay_arguments(parser, default_config)

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """
-A web browsing agent using Yutori's n1 API (OpenAI API compatible) with custom tools
+A web browsing agent using Yutori's Navigator API (Navigator-n1, OpenAI API
+compatible) with custom tools.
 
 This script demonstrates how to use custom tools to let the model memorize information (into files) as it navigates.
 
@@ -556,9 +557,11 @@ async def main():
     configure_example_logging()
 
     default_config = Config()
-    parser = argparse.ArgumentParser(description="Example of using Yutori n1 API to perform a web browsing task")
+    parser = argparse.ArgumentParser(
+        description="Example of using the Yutori Navigator API (Navigator-n1) to perform a web browsing task"
+    )
     add_task_arguments(parser, default_config)
-    add_model_arguments(parser, default_config, api_label="Yutori n1")
+    add_model_arguments(parser, default_config, api_label="Yutori Navigator-n1")
     add_agent_arguments(parser, default_config)
     add_browser_arguments(parser, default_config)
     add_replay_arguments(parser, default_config)

--- a/tests/test_navigator_coordinates.py
+++ b/tests/test_navigator_coordinates.py
@@ -2,11 +2,16 @@
 
 import pytest
 
-from yutori.navigator import N1_COORDINATE_SCALE, denormalize_coordinates, normalize_coordinates
+from yutori.navigator import (
+    N1_COORDINATE_SCALE,
+    NAVIGATOR_COORDINATE_SCALE,
+    denormalize_coordinates,
+    normalize_coordinates,
+)
 
 
 class TestDenormalizeCoordinates:
-    def test_scales_n1_coordinates_to_viewport_pixels(self):
+    def test_scales_navigator_coordinates_to_viewport_pixels(self):
         assert denormalize_coordinates([500, 250], width=1280, height=800) == (640, 200)
 
     def test_origin_returns_zero(self):
@@ -32,7 +37,7 @@ class TestDenormalizeCoordinates:
 
 
 class TestNormalizeCoordinates:
-    def test_scales_viewport_pixels_to_n1_coordinates(self):
+    def test_scales_viewport_pixels_to_navigator_coordinates(self):
         assert normalize_coordinates([640, 200], width=1280, height=800) == (500, 250)
 
     def test_origin_returns_zero(self):
@@ -40,9 +45,11 @@ class TestNormalizeCoordinates:
 
     def test_clamps_out_of_bounds_values_by_default(self):
         assert normalize_coordinates([1400, 900], width=1280, height=800) == (
-            N1_COORDINATE_SCALE,
-            N1_COORDINATE_SCALE,
+            NAVIGATOR_COORDINATE_SCALE,
+            NAVIGATOR_COORDINATE_SCALE,
         )
+        # Legacy alias is kept for backward compatibility.
+        assert N1_COORDINATE_SCALE is NAVIGATOR_COORDINATE_SCALE
         assert normalize_coordinates([-1, -5], width=1280, height=800) == (0, 0)
 
     def test_can_return_unclamped_coordinates(self):

--- a/tests/test_navigator_keys.py
+++ b/tests/test_navigator_keys.py
@@ -1,4 +1,4 @@
-"""Tests for n1.5 key mapping helpers."""
+"""Tests for Navigator-n1.5 key mapping helpers."""
 
 import pytest
 
@@ -6,7 +6,7 @@ from yutori.navigator.keys import map_key_to_playwright, map_keys_individual
 
 
 class TestMapKeyToPlaywright:
-    """map_key_to_playwright converts n1.5 key expressions to Playwright press() strings."""
+    """map_key_to_playwright converts Navigator-n1.5 key expressions to Playwright press() strings."""
 
     def test_single_modifier_combo(self):
         assert map_key_to_playwright("ctrl+c") == ["Control+c"]

--- a/tests/test_navigator_models.py
+++ b/tests/test_navigator_models.py
@@ -1,14 +1,28 @@
-"""Tests for navigator model constants and tool set identifiers."""
+"""Tests for Navigator model constants and tool set identifiers."""
 
-from yutori.navigator import N1_5_MODEL, N1_MODEL, TOOL_SET_CORE, TOOL_SET_EXPANDED
+from yutori.navigator import (
+    N1_5_MODEL,
+    N1_MODEL,
+    NAVIGATOR_N1_5_MODEL,
+    NAVIGATOR_N1_MODEL,
+    TOOL_SET_CORE,
+    TOOL_SET_EXPANDED,
+)
 
 
 class TestModelConstants:
-    def test_n1_model_identifier(self):
-        assert N1_MODEL == "n1-latest"
+    def test_navigator_n1_model_identifier(self):
+        assert NAVIGATOR_N1_MODEL == "n1-latest"
 
-    def test_n1_5_model_identifier(self):
-        assert N1_5_MODEL == "n1.5-latest"
+    def test_navigator_n1_5_model_identifier(self):
+        assert NAVIGATOR_N1_5_MODEL == "n1.5-latest"
+
+    def test_legacy_aliases_match_canonical(self):
+        # ``N1_MODEL`` / ``N1_5_MODEL`` are kept as deprecated aliases of the
+        # canonical ``NAVIGATOR_*`` names. Asserting identity (``is``) catches
+        # accidental drift if anyone re-defines either constant independently.
+        assert N1_MODEL is NAVIGATOR_N1_MODEL
+        assert N1_5_MODEL is NAVIGATOR_N1_5_MODEL
 
 
 class TestToolSetConstants:

--- a/yutori/_async/chat.py
+++ b/yutori/_async/chat.py
@@ -11,7 +11,7 @@ from .._http import apply_chat_extra_body
 
 
 class AsyncChatCompletions:
-    """OpenAI-compatible chat completions for n1 API (async)."""
+    """OpenAI-compatible chat completions for the Navigator API (async)."""
 
     def __init__(self, openai_client: AsyncOpenAI) -> None:
         self._client = openai_client
@@ -26,17 +26,17 @@ class AsyncChatCompletions:
         json_schema: dict | None = None,
         **kwargs: Any,
     ) -> ChatCompletion:
-        """Create a chat completion using the n1 API.
+        """Create a chat completion using the Navigator API.
 
         Args:
             messages: List of messages following OpenAI Chat format.
-            model: Model to use (default: "n1.5-latest").
-            tool_set: (n1.5 only) Built-in tool set to use, e.g.
+            model: Model to use (default: ``"n1.5-latest"`` — Navigator-n1.5).
+            tool_set: (Navigator-n1.5 only) Built-in tool set to use, e.g.
                 ``"browser_tools_core-20260403"`` or
                 ``"browser_tools_expanded-20260403"``.
-            disable_tools: (n1.5 only) List of tool names to remove from the
-                selected tool set.
-            json_schema: (n1.5 only) JSON Schema for structured output.
+            disable_tools: (Navigator-n1.5 only) List of tool names to remove
+                from the selected tool set.
+            json_schema: (Navigator-n1.5 only) JSON Schema for structured output.
                 When provided, the model returns a ``parsed_json`` field
                 on the response.
             **kwargs: Additional parameters (e.g., temperature).
@@ -55,7 +55,7 @@ class AsyncChatCompletions:
 
 
 class AsyncChatNamespace:
-    """Async namespace for n1 API operations (pixels-to-actions LLM)."""
+    """Async namespace for Navigator API operations (pixels-to-actions LLM)."""
 
     def __init__(self, base_url: str, api_key: str, timeout: float) -> None:
         self._openai_client = AsyncOpenAI(base_url=base_url, api_key=api_key, timeout=timeout)

--- a/yutori/_sync/chat.py
+++ b/yutori/_sync/chat.py
@@ -11,7 +11,7 @@ from .._http import apply_chat_extra_body
 
 
 class ChatCompletions:
-    """OpenAI-compatible chat completions for n1 API."""
+    """OpenAI-compatible chat completions for the Navigator API."""
 
     def __init__(self, openai_client: OpenAI) -> None:
         self._client = openai_client
@@ -26,17 +26,17 @@ class ChatCompletions:
         json_schema: dict | None = None,
         **kwargs: Any,
     ) -> ChatCompletion:
-        """Create a chat completion using the n1 API.
+        """Create a chat completion using the Navigator API.
 
         Args:
             messages: List of messages following OpenAI Chat format.
-            model: Model to use (default: "n1.5-latest").
-            tool_set: (n1.5 only) Built-in tool set to use, e.g.
+            model: Model to use (default: ``"n1.5-latest"`` — Navigator-n1.5).
+            tool_set: (Navigator-n1.5 only) Built-in tool set to use, e.g.
                 ``"browser_tools_core-20260403"`` or
                 ``"browser_tools_expanded-20260403"``.
-            disable_tools: (n1.5 only) List of tool names to remove from the
-                selected tool set.
-            json_schema: (n1.5 only) JSON Schema for structured output.
+            disable_tools: (Navigator-n1.5 only) List of tool names to remove
+                from the selected tool set.
+            json_schema: (Navigator-n1.5 only) JSON Schema for structured output.
                 When provided, the model returns a ``parsed_json`` field
                 on the response.
             **kwargs: Additional parameters (e.g., temperature).
@@ -55,7 +55,7 @@ class ChatCompletions:
 
 
 class ChatNamespace:
-    """Namespace for n1 API operations (pixels-to-actions LLM)."""
+    """Namespace for Navigator API operations (pixels-to-actions LLM)."""
 
     def __init__(self, base_url: str, api_key: str, timeout: float) -> None:
         self._openai_client = OpenAI(base_url=base_url, api_key=api_key, timeout=timeout)

--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -34,7 +34,7 @@ class AsyncYutoriClient(_AsyncBaseNamespace):
         - client.scouts: Scout management (continuous monitoring)
         - client.browsing: Browser automation tasks
         - client.research: Deep web research tasks
-        - client.chat: n1 API (pixels-to-actions LLM)
+        - client.chat: Navigator API (pixels-to-actions LLM)
     """
 
     def __init__(
@@ -79,8 +79,8 @@ class AsyncYutoriClient(_AsyncBaseNamespace):
             ``rate_limits``, ``navigator_rate_limits``, and ``activity``
             counts. The response also includes ``n1_rate_limits`` and
             ``activity.n1_calls`` as deprecated aliases of
-            ``navigator_rate_limits`` / ``navigator_calls`` for one
-            release; prefer the ``navigator_*`` names.
+            ``navigator_rate_limits`` / ``navigator_calls`` and will be
+            removed in a future release; prefer the ``navigator_*`` names.
         """
         return await self._request("get", "/usage", params=build_query_params(period=period))
 

--- a/yutori/cli/commands/usage.py
+++ b/yutori/cli/commands/usage.py
@@ -59,7 +59,7 @@ def usage(
             rate_fields.append(("Resets at", rate_limits.get("reset_at", "N/A")))
             print_aligned_fields(console, rate_fields, min_label_width=_RATE_LIMIT_LABEL_WIDTH)
 
-        # Navigator rate limits (falls back to the deprecated n1_rate_limits key on older servers)
+        # Navigator API rate limits (falls back to the deprecated ``n1_rate_limits`` key on older servers)
         navigator_limits = data.get("navigator_rate_limits") or data.get("n1_rate_limits") or {}
         if navigator_limits:
             console.print("\n  [bold]Navigator API Rate Limits[/bold]")

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -24,7 +24,7 @@ class YutoriClient(_SyncBaseNamespace):
         - client.scouts: Scout management (continuous monitoring)
         - client.browsing: Browser automation tasks
         - client.research: Deep web research tasks
-        - client.chat: n1 API (pixels-to-actions LLM)
+        - client.chat: Navigator API (pixels-to-actions LLM)
     """
 
     def __init__(
@@ -69,8 +69,8 @@ class YutoriClient(_SyncBaseNamespace):
             ``rate_limits``, ``navigator_rate_limits``, and ``activity``
             counts. The response also includes ``n1_rate_limits`` and
             ``activity.n1_calls`` as deprecated aliases of
-            ``navigator_rate_limits`` / ``navigator_calls`` for one
-            release; prefer the ``navigator_*`` names.
+            ``navigator_rate_limits`` / ``navigator_calls`` and will be
+            removed in a future release; prefer the ``navigator_*`` names.
         """
         return self._request("get", "/usage", params=build_query_params(period=period))
 

--- a/yutori/navigator/__init__.py
+++ b/yutori/navigator/__init__.py
@@ -1,11 +1,13 @@
-"""Utilities for building agents with the Yutori navigator and n1.5 APIs.
+"""Utilities for building agents with the Yutori Navigator API.
 
-Provides reusable helpers for common patterns in navigator/n1.5 agent loops:
+Provides reusable helpers for common patterns in Navigator-n1 and
+Navigator-n1.5 agent loops:
+
 - Screenshot preparation: capture and encode screenshots as optimized WebP data URLs
 - Coordinate conversion: map the 1000x1000 tool-call space to viewport pixels
 - Payload management: trim old screenshots to stay within API size limits
 - Loop helpers: create trimmed requests without mutating caller state
-- Key mapping: convert n1.5 lowercase key names to Playwright-compatible names
+- Key mapping: convert Navigator-n1.5 lowercase key names to Playwright-compatible names
 - Model constants: canonical model identifiers and tool set names
 """
 
@@ -13,7 +15,12 @@ from __future__ import annotations
 
 from .content import extract_text_content
 from .context import format_task_with_context, format_user_context
-from .coordinates import N1_COORDINATE_SCALE, denormalize_coordinates, normalize_coordinates
+from .coordinates import (
+    N1_COORDINATE_SCALE,
+    NAVIGATOR_COORDINATE_SCALE,
+    denormalize_coordinates,
+    normalize_coordinates,
+)
 from .hooks import RunHooksBase
 from .images import (
     aplaywright_screenshot_to_data_url,
@@ -22,7 +29,14 @@ from .images import (
 )
 from .keys import map_key_to_playwright, map_keys_individual
 from .loop import acreate_trimmed, create_trimmed
-from .models import N1_5_MODEL, N1_MODEL, TOOL_SET_CORE, TOOL_SET_EXPANDED
+from .models import (
+    N1_5_MODEL,
+    N1_MODEL,
+    NAVIGATOR_N1_5_MODEL,
+    NAVIGATOR_N1_MODEL,
+    TOOL_SET_CORE,
+    TOOL_SET_EXPANDED,
+)
 from .payload import estimate_messages_size_bytes, trim_images_to_fit, trimmed_messages_to_fit
 from .stop import format_stop_and_summarize
 
@@ -30,6 +44,9 @@ __all__ = [
     "N1_5_MODEL",
     "N1_COORDINATE_SCALE",
     "N1_MODEL",
+    "NAVIGATOR_COORDINATE_SCALE",
+    "NAVIGATOR_N1_5_MODEL",
+    "NAVIGATOR_N1_MODEL",
     "RunHooksBase",
     "TOOL_SET_CORE",
     "TOOL_SET_EXPANDED",

--- a/yutori/navigator/_assets.py
+++ b/yutori/navigator/_assets.py
@@ -1,4 +1,4 @@
-"""Helpers for loading bundled static assets used by navigator utilities."""
+"""Helpers for loading bundled static assets used by Navigator utilities."""
 
 from __future__ import annotations
 

--- a/yutori/navigator/content.py
+++ b/yutori/navigator/content.py
@@ -1,4 +1,4 @@
-"""Content normalization helpers for Yutori navigator loops."""
+"""Content normalization helpers for Yutori Navigator loops."""
 
 from __future__ import annotations
 

--- a/yutori/navigator/context.py
+++ b/yutori/navigator/context.py
@@ -1,4 +1,4 @@
-"""User context formatting for navigator task messages.
+"""User context formatting for Navigator task messages.
 
 Appends location, timezone, and current date/time information to a task
 string, giving the model awareness of the user's environment.

--- a/yutori/navigator/coordinates.py
+++ b/yutori/navigator/coordinates.py
@@ -1,11 +1,14 @@
-"""Coordinate helpers for the 1000x1000 action space."""
+"""Coordinate helpers for the Navigator 1000x1000 action space."""
 
 from __future__ import annotations
 
 import math
 from typing import Sequence
 
-N1_COORDINATE_SCALE = 1000
+NAVIGATOR_COORDINATE_SCALE = 1000
+
+# Back-compat alias. Prefer ``NAVIGATOR_COORDINATE_SCALE``.
+N1_COORDINATE_SCALE = NAVIGATOR_COORDINATE_SCALE
 
 
 def denormalize_coordinates(
@@ -13,7 +16,7 @@ def denormalize_coordinates(
     width: int,
     height: int,
     *,
-    scale: int = N1_COORDINATE_SCALE,
+    scale: int = NAVIGATOR_COORDINATE_SCALE,
     clamp: bool = True,
 ) -> tuple[int, int]:
     """Convert normalized coordinates into viewport pixels.
@@ -42,7 +45,7 @@ def normalize_coordinates(
     width: int,
     height: int,
     *,
-    scale: int = N1_COORDINATE_SCALE,
+    scale: int = NAVIGATOR_COORDINATE_SCALE,
     clamp: bool = True,
 ) -> tuple[int, int]:
     """Convert viewport pixels into normalized coordinates.

--- a/yutori/navigator/hooks.py
+++ b/yutori/navigator/hooks.py
@@ -1,4 +1,4 @@
-"""Agents-inspired lifecycle hooks for chat-completions-based navigator loops."""
+"""Agents-inspired lifecycle hooks for chat-completions-based Navigator loops."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from openai.types.chat import ChatCompletionMessageParam
 
 
 class RunHooksBase:
-    """Agents-inspired lifecycle hooks for chat-completions-based navigator loops.
+    """Agents-inspired lifecycle hooks for chat-completions-based Navigator loops.
 
     This is intentionally not a drop-in replacement for the OpenAI Agents SDK
     RunHooksBase. It mirrors the lifecycle phases, not the exact signatures.

--- a/yutori/navigator/images.py
+++ b/yutori/navigator/images.py
@@ -1,4 +1,4 @@
-"""Screenshot preparation helpers for navigator image inputs."""
+"""Screenshot preparation helpers for Navigator image inputs."""
 
 from __future__ import annotations
 
@@ -43,7 +43,7 @@ def screenshot_to_data_url(
     source_format: str | None = None,
     webp_quality: int | None = None,
 ) -> str:
-    """Convert screenshot bytes into a WebP data URL optimized for navigator."""
+    """Convert screenshot bytes into a WebP data URL optimized for Navigator."""
 
     with Image.open(io.BytesIO(image_bytes)) as img:
         detected_format = (source_format or img.format or "").upper()
@@ -66,7 +66,7 @@ def playwright_screenshot_to_data_url(
     resize_to: tuple[int, int] = DEFAULT_SCREENSHOT_SIZE,
     webp_quality: int | None = None,
 ) -> str:
-    """Capture and convert a sync Playwright-style screenshot for navigator."""
+    """Capture and convert a sync Playwright-style screenshot for Navigator."""
 
     screenshot_bytes = page.screenshot(
         type=DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
@@ -86,7 +86,7 @@ async def aplaywright_screenshot_to_data_url(
     resize_to: tuple[int, int] = DEFAULT_SCREENSHOT_SIZE,
     webp_quality: int | None = None,
 ) -> str:
-    """Capture and convert an async Playwright-style screenshot for navigator."""
+    """Capture and convert an async Playwright-style screenshot for Navigator."""
 
     screenshot_bytes = await page.screenshot(
         type=DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,

--- a/yutori/navigator/keys.py
+++ b/yutori/navigator/keys.py
@@ -1,9 +1,9 @@
-"""Key name mapping for navigator/n1.5's lowercase key format.
+"""Key name mapping for the Navigator-n1.5 lowercase key format.
 
-Navigator n1.5 returns lowercase key names (e.g. ``ctrl+c``, ``enter``, ``left``)
+Navigator-n1.5 returns lowercase key names (e.g. ``ctrl+c``, ``enter``, ``left``)
 while Playwright expects Playwright-style names (e.g. ``Control+c``,
 ``Enter``, ``ArrowLeft``).  Use :func:`map_key_to_playwright` to convert
-a full navigator n1.5 key expression to a Playwright-compatible string.
+a full Navigator-n1.5 key expression to a Playwright-compatible string.
 
 Only the Playwright ``key`` name is needed here (not ``code`` / ``keyCode``).
 """
@@ -128,9 +128,9 @@ def _map_single_key(key: str) -> str:
 
 
 def map_key_to_playwright(key_expr: str) -> list[str]:
-    """Convert a navigator n1.5 key expression to a list of Playwright key-press strings.
+    """Convert a Navigator-n1.5 key expression to a list of Playwright key-press strings.
 
-    Navigator n1.5 uses ``+`` for simultaneous combos and spaces for sequential
+    Navigator-n1.5 uses ``+`` for simultaneous combos and spaces for sequential
     presses.  For example:
 
     * ``"ctrl+c"``         → ``["Control+c"]``
@@ -155,7 +155,7 @@ def map_key_to_playwright(key_expr: str) -> list[str]:
 
 
 def map_keys_individual(key_expr: str) -> list[str]:
-    """Convert a navigator n1.5 key expression to a flat list of individual Playwright keys.
+    """Convert a Navigator-n1.5 key expression to a flat list of individual Playwright keys.
 
     Unlike :func:`map_key_to_playwright`, this never joins keys with ``+``.
     Each token is mapped individually, making the result safe for

--- a/yutori/navigator/loop.py
+++ b/yutori/navigator/loop.py
@@ -1,4 +1,4 @@
-"""Higher-level helpers for screenshot-heavy navigator agent loops."""
+"""Higher-level helpers for screenshot-heavy Navigator agent loops."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from typing import Any, Iterable, Protocol
 
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 
-from .models import N1_5_MODEL
+from .models import NAVIGATOR_N1_5_MODEL
 from .payload import (
     DEFAULT_KEEP_RECENT_SCREENSHOTS,
     DEFAULT_MAX_REQUEST_BYTES,
@@ -77,7 +77,7 @@ def create_trimmed(
     completions: SupportsSyncChatCompletionsCreate,
     messages: list[dict[str, Any]],
     *,
-    model: str = N1_5_MODEL,
+    model: str = NAVIGATOR_N1_5_MODEL,
     max_bytes: int = DEFAULT_MAX_REQUEST_BYTES,
     keep_recent: int = DEFAULT_KEEP_RECENT_SCREENSHOTS,
     **kwargs: Any,
@@ -96,7 +96,7 @@ async def acreate_trimmed(
     completions: SupportsAsyncChatCompletionsCreate,
     messages: list[dict[str, Any]],
     *,
-    model: str = N1_5_MODEL,
+    model: str = NAVIGATOR_N1_5_MODEL,
     max_bytes: int = DEFAULT_MAX_REQUEST_BYTES,
     keep_recent: int = DEFAULT_KEEP_RECENT_SCREENSHOTS,
     **kwargs: Any,

--- a/yutori/navigator/models.py
+++ b/yutori/navigator/models.py
@@ -1,4 +1,10 @@
-"""Model identifiers and tool set constants for navigator and n1.5."""
+"""Model identifiers and tool set constants for the Navigator API.
+
+The Navigator API hosts a family of computer-use models. Current public
+versions are Navigator-n1 and Navigator-n1.5. The API model ID strings
+(``n1-latest`` / ``n1.5-latest``) are unchanged — only the user-facing
+naming was updated.
+"""
 
 from __future__ import annotations
 
@@ -6,11 +12,18 @@ from __future__ import annotations
 # Model identifiers
 # ---------------------------------------------------------------------------
 
-N1_MODEL = "n1-latest"
-N1_5_MODEL = "n1.5-latest"
+NAVIGATOR_N1_MODEL = "n1-latest"
+"""Alias for the latest stable Navigator-n1 model."""
+
+NAVIGATOR_N1_5_MODEL = "n1.5-latest"
+"""Alias for the latest stable Navigator-n1.5 model (current default)."""
+
+# Back-compat aliases. Prefer the ``NAVIGATOR_*`` names above.
+N1_MODEL = NAVIGATOR_N1_MODEL
+N1_5_MODEL = NAVIGATOR_N1_5_MODEL
 
 # ---------------------------------------------------------------------------
-# Tool sets (n1.5 only)
+# Tool sets (Navigator-n1.5 only)
 # ---------------------------------------------------------------------------
 
 TOOL_SET_CORE = "browser_tools_core-20260403"

--- a/yutori/navigator/page_ready.py
+++ b/yutori/navigator/page_ready.py
@@ -1,4 +1,4 @@
-"""Page readiness helpers for Playwright-style navigator agent loops."""
+"""Page readiness helpers for Playwright-style Navigator agent loops."""
 
 from __future__ import annotations
 

--- a/yutori/navigator/payload.py
+++ b/yutori/navigator/payload.py
@@ -1,4 +1,4 @@
-"""Payload management utilities for navigator agent loops.
+"""Payload management utilities for Navigator agent loops.
 
 When using the API in an agentic loop, the message history grows with each
 step because every tool response includes a new screenshot. These utilities

--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -1,4 +1,4 @@
-"""Optional trajectory logging and replay helpers for navigator browser loops.
+"""Optional trajectory logging and replay helpers for Navigator browser loops.
 
 These helpers are only for local debugging and inspection. Agent runs do not
 depend on them, and callers can ignore this module entirely if they do not want
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from .content import extract_text_content
-from .coordinates import N1_COORDINATE_SCALE
+from .coordinates import NAVIGATOR_COORDINATE_SCALE
 
 _ACTION_COLOR_CLASS = {
     "left_click": "click",
@@ -85,7 +85,7 @@ def make_run_id(*, prefix: str = "run", label: str | None = None) -> str:
 
 
 class TrajectoryRecorder:
-    """Persist optional local replay artifacts for a navigator run.
+    """Persist optional local replay artifacts for a Navigator run.
 
     This recorder is intentionally separate from the agent loop itself. If you
     do not want replay files, skip constructing it and the rest of your loop can
@@ -171,8 +171,8 @@ class TrajectoryRecorder:
         result: object | None = None,
         step_payloads: list[dict[str, Any]] | None = None,
         *,
-        coord_space_width: int = N1_COORDINATE_SCALE,
-        coord_space_height: int = N1_COORDINATE_SCALE,
+        coord_space_width: int = NAVIGATOR_COORDINATE_SCALE,
+        coord_space_height: int = NAVIGATOR_COORDINATE_SCALE,
     ) -> None:
         """Render the optional static HTML replay viewer for one run."""
 
@@ -193,8 +193,8 @@ def generate_visualization_html(
     messages: list[dict],
     result: object | None = None,
     step_payloads: list[dict[str, Any]] | None = None,
-    coord_space_width: int = N1_COORDINATE_SCALE,
-    coord_space_height: int = N1_COORDINATE_SCALE,
+    coord_space_width: int = NAVIGATOR_COORDINATE_SCALE,
+    coord_space_height: int = NAVIGATOR_COORDINATE_SCALE,
 ) -> str:
     """Generate a static HTML viewer for an optional message replay."""
 

--- a/yutori/navigator/tools/__init__.py
+++ b/yutori/navigator/tools/__init__.py
@@ -1,4 +1,4 @@
-"""Bundled browser tool scripts for navigator agents."""
+"""Bundled browser tool scripts for Navigator agents."""
 
 from __future__ import annotations
 

--- a/yutori/navigator/tools/_loader.py
+++ b/yutori/navigator/tools/_loader.py
@@ -1,4 +1,4 @@
-"""Load bundled JS tool scripts for navigator helpers."""
+"""Load bundled JS tool scripts for Navigator helpers."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
The browser-use model family is now consistently called "Navigator", with the public versions named "Navigator-n1" and "Navigator-n1.5". API model ID strings (n1-latest / n1.5-latest) are unchanged — that's the live wire contract, only user-facing naming was updated.

- Add NAVIGATOR_N1_MODEL, NAVIGATOR_N1_5_MODEL, NAVIGATOR_COORDINATE_SCALE as canonical constants on yutori.navigator. The N1_MODEL / N1_5_MODEL / N1_COORDINATE_SCALE aliases are kept as live re-exports so existing user code keeps working without warnings.
- Update docstrings, comments, and example argparse descriptions to use "Navigator API" / "Navigator-n1" / "Navigator-n1.5" terminology.
- README.md and api.md updated to match.
- Server-contract values left untouched: the agent enum "navigator-n1-latest", model IDs n1-latest / n1.5-latest, and the deprecated n1_rate_limits / n1_calls fallback in the CLI usage view.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a documentation/terminology refactor with small constant/alias additions; runtime behavior should be unchanged except for default constant references, so risk is low and limited to potential import-name confusion.
> 
> **Overview**
> Updates the SDK’s user-facing naming from *“n1 API / n1.5”* to **“Navigator API / Navigator-n1 / Navigator-n1.5”** across README, `api.md`, CLI help text, examples, and internal docstrings/comments.
> 
> Introduces canonical Navigator constants (`NAVIGATOR_N1_MODEL`, `NAVIGATOR_N1_5_MODEL`, `NAVIGATOR_COORDINATE_SCALE`) while keeping `N1_MODEL`, `N1_5_MODEL`, and `N1_COORDINATE_SCALE` as backward-compatible aliases, and adjusts helper defaults/tests to prefer the new names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39d0690387c8759b32299305c867bd28f281772c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->