### PR TITLE
refactor(auth): extract _bearer_headers helper for Clerk JWT calls

### DIFF
--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -130,16 +130,6 @@ class _CallbackHandler(http.server.BaseHTTPRequestHandler):
         self.wfile.write(f"<html><body>{body}</body></html>".encode())
 
 
-def _bearer_headers(jwt: str) -> dict[str, str]:
-    """Authorization header dict for Clerk-JWT-authenticated calls.
-
-    Centralized so the bearer-scheme literal lives in exactly one place
-    across the auth flow (token exchange does not use this — it sends the
-    code via form data, not a header).
-    """
-    return {"Authorization": f"Bearer {jwt}"}
-
-
 def exchange_code_for_token(code: str, code_verifier: str) -> str:
     """Exchange authorization code for JWT via Clerk token endpoint."""
     with httpx.Client(timeout=30.0) as client:
@@ -163,17 +153,38 @@ def _build_key_name(source: str = "yutori-cli") -> str:
     return f"{date_prefix}-{source}"
 
 
+def _bearer_headers(jwt: str) -> dict[str, str]:
+    """Authorization header dict for Clerk-JWT-authenticated calls.
+
+    Centralized so the bearer-scheme literal lives in exactly one place
+    across the auth flow (token exchange does not use this — it sends the
+    code via form data, not a header).
+    """
+    return {"Authorization": f"Bearer {jwt}"}
+
+
+def _post_auth_api(jwt: str, path: str, json_payload: dict[str, Any] | None) -> httpx.Response:
+    """POST to a Yutori auth API endpoint with Bearer auth, raising on non-2xx.
+
+    Centralizes the timeout=30 / Bearer header / raise_for_status combination
+    used by both generate_api_key and register_user so the two call sites
+    cannot drift out of sync.
+    """
+    with httpx.Client(timeout=30.0) as client:
+        response = client.post(
+            build_auth_api_url(path),
+            headers=_bearer_headers(jwt),
+            json=json_payload,
+        )
+        response.raise_for_status()
+        return response
+
+
 def generate_api_key(jwt: str, key_name: str | None = None) -> str:
     """Generate a Yutori API key using a Clerk JWT."""
     payload = {"name": key_name} if key_name else None
-    with httpx.Client(timeout=30.0) as client:
-        response = client.post(
-            build_auth_api_url("/client/generate_key"),
-            headers=_bearer_headers(jwt),
-            json=payload,
-        )
-        response.raise_for_status()
-        return response.json()["key"]
+    response = _post_auth_api(jwt, "/client/generate_key", payload)
+    return response.json()["key"]
 
 
 def check_registration_status(jwt: str) -> bool | None:
@@ -214,13 +225,7 @@ def register_user(jwt: str, signup_source: str = "cli") -> None:
     Raises ``httpx.HTTPStatusError`` on non-2xx — the outer login flow turns
     that into a user-facing `Authentication failed (<status>): ...` message.
     """
-    with httpx.Client(timeout=30.0) as client:
-        response = client.post(
-            build_auth_api_url("/client/register-api"),
-            headers=_bearer_headers(jwt),
-            json={"signup_source": signup_source},
-        )
-        response.raise_for_status()
+    _post_auth_api(jwt, "/client/register-api", {"signup_source": signup_source})
 
 
 def run_login_flow(

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -130,6 +130,16 @@ class _CallbackHandler(http.server.BaseHTTPRequestHandler):
         self.wfile.write(f"<html><body>{body}</body></html>".encode())
 
 
+def _bearer_headers(jwt: str) -> dict[str, str]:
+    """Authorization header dict for Clerk-JWT-authenticated calls.
+
+    Centralized so the bearer-scheme literal lives in exactly one place
+    across the auth flow (token exchange does not use this — it sends the
+    code via form data, not a header).
+    """
+    return {"Authorization": f"Bearer {jwt}"}
+
+
 def exchange_code_for_token(code: str, code_verifier: str) -> str:
     """Exchange authorization code for JWT via Clerk token endpoint."""
     with httpx.Client(timeout=30.0) as client:
@@ -159,7 +169,7 @@ def generate_api_key(jwt: str, key_name: str | None = None) -> str:
     with httpx.Client(timeout=30.0) as client:
         response = client.post(
             build_auth_api_url("/client/generate_key"),
-            headers={"Authorization": f"Bearer {jwt}"},
+            headers=_bearer_headers(jwt),
             json=payload,
         )
         response.raise_for_status()
@@ -182,7 +192,7 @@ def check_registration_status(jwt: str) -> bool | None:
         with httpx.Client(timeout=5.0) as client:
             response = client.get(
                 build_auth_api_url("/client/registration-status"),
-                headers={"Authorization": f"Bearer {jwt}"},
+                headers=_bearer_headers(jwt),
             )
             if response.status_code == 200:
                 body = response.json()
@@ -207,7 +217,7 @@ def register_user(jwt: str, signup_source: str = "cli") -> None:
     with httpx.Client(timeout=30.0) as client:
         response = client.post(
             build_auth_api_url("/client/register-api"),
-            headers={"Authorization": f"Bearer {jwt}"},
+            headers=_bearer_headers(jwt),
             json={"signup_source": signup_source},
         )
         response.raise_for_status()


### PR DESCRIPTION
## Structural issue

Three call sites in `yutori/auth/flow.py` hand-built the same `{"Authorization": f"Bearer {jwt}"}` dict literal:

- `generate_api_key`
- `check_registration_status`
- `register_user`

The bearer-scheme construction is the same authentication contract across all three; one place to fix it (or evolve it) is preferable to three.

## Refactor

Add a tiny `_bearer_headers(jwt)` helper next to `_build_key_name` and route the three sites through it.

```python
def _bearer_headers(jwt: str) -> dict[str, str]:
    """Authorization header dict for Clerk-JWT-authenticated calls."""
    return {"Authorization": f"Bearer {jwt}"}
```

`exchange_code_for_token` is intentionally left untouched: it doesn't use a bearer header (it sends the auth code via form data).

## Why this is safe

- Pure code-motion of a dict literal into a helper that returns the same dict.
- Identical key/value at every call site — confirmed by reading the diff.
- No public API surface changes; `_bearer_headers` is module-private.

## Test plan

- [ ] Existing auth-flow tests (no behavioral change expected).

---
_Generated by [Claude Code](https://claude.ai/code/session_013oBx6YSqKjNYeFeUM5MCfV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that deduplicates header/POST boilerplate without changing endpoints or response handling; potential risk is limited to accidental request-shape drift if the helper is incorrect.
> 
> **Overview**
> **Refactors Clerk JWT auth calls** by extracting a shared `_bearer_headers(jwt)` helper and routing existing requests through it.
> 
> Also adds `_post_auth_api()` to centralize the common `POST` pattern (timeout, Bearer header, `raise_for_status`) and updates `generate_api_key` and `register_user` to use it, reducing duplicated request setup and keeping the call sites consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c3655d66c0619e208d02ac401b4363fcf05724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->