### PR TITLE
refactor(navigator/images): centralize playwright screenshot capture policy

### DIFF
--- a/yutori/navigator/images.py
+++ b/yutori/navigator/images.py
@@ -60,6 +60,26 @@ def screenshot_to_data_url(
     return f"data:image/webp;base64,{encoded}"
 
 
+_PLAYWRIGHT_SCREENSHOT_KWARGS = {
+    "type": DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
+    "quality": DEFAULT_PLAYWRIGHT_SCREENSHOT_QUALITY,
+}
+
+
+def _playwright_bytes_to_data_url(
+    screenshot_bytes: bytes,
+    *,
+    resize_to: tuple[int, int],
+    webp_quality: int | None,
+) -> str:
+    return screenshot_to_data_url(
+        screenshot_bytes,
+        resize_to=resize_to,
+        source_format=DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
+        webp_quality=webp_quality,
+    )
+
+
 def playwright_screenshot_to_data_url(
     page: SupportsSyncScreenshot,
     *,
@@ -68,14 +88,9 @@ def playwright_screenshot_to_data_url(
 ) -> str:
     """Capture and convert a sync Playwright-style screenshot for Navigator."""
 
-    screenshot_bytes = page.screenshot(
-        type=DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
-        quality=DEFAULT_PLAYWRIGHT_SCREENSHOT_QUALITY,
-    )
-    return screenshot_to_data_url(
-        screenshot_bytes,
+    return _playwright_bytes_to_data_url(
+        page.screenshot(**_PLAYWRIGHT_SCREENSHOT_KWARGS),
         resize_to=resize_to,
-        source_format=DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
         webp_quality=webp_quality,
     )
 
@@ -88,13 +103,8 @@ async def aplaywright_screenshot_to_data_url(
 ) -> str:
     """Capture and convert an async Playwright-style screenshot for Navigator."""
 
-    screenshot_bytes = await page.screenshot(
-        type=DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
-        quality=DEFAULT_PLAYWRIGHT_SCREENSHOT_QUALITY,
-    )
-    return screenshot_to_data_url(
-        screenshot_bytes,
+    return _playwright_bytes_to_data_url(
+        await page.screenshot(**_PLAYWRIGHT_SCREENSHOT_KWARGS),
         resize_to=resize_to,
-        source_format=DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE,
         webp_quality=webp_quality,
     )


### PR DESCRIPTION
## What

`playwright_screenshot_to_data_url` and `aplaywright_screenshot_to_data_url` were nearly identical: each duplicated the screenshot-capture kwargs (`type`, `quality`) and the conversion call (`screenshot_to_data_url(..., source_format=DEFAULT_PLAYWRIGHT_SCREENSHOT_TYPE, ...)`). The only real difference between the two was the `await` on the screenshot call.

This extracts:
- `_PLAYWRIGHT_SCREENSHOT_KWARGS` — the capture policy (jpeg/quality 75)
- `_playwright_bytes_to_data_url(...)` — the post-capture conversion that ties `source_format` to the same JPEG capture type

After the refactor, the sync/async difference is isolated to a single line per helper.

## Why this is an improvement

- **Single source of truth** for the Playwright capture policy. Changing capture type/quality (or the linked `source_format`) is now a one-place edit instead of two.
- **Clearer DRY structure**: sync vs. async is the only meaningful axis of variation, and it now reads that way.
- **No new public API** — the two private helpers (`_*`) are not exported.

## Why it's safe

- Pure refactor — no behavioral change. The kwargs passed to `page.screenshot()` and to `screenshot_to_data_url()` are identical to before.
- Verified by existing `tests/test_navigator_images.py` coverage for both sync and async paths (`test_sync_helper_uses_sdk_capture_policy`, `test_async_helper_uses_sdk_capture_policy`), which assert the exact `{type, quality}` kwargs are forwarded — both still pass.
- Full local test suite green (373 passed, 3 skipped; the only failure was an unrelated `test_packaging.py` case requiring the `build` module).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Csf8rKiDwZJSeWBJYWdS9k)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only deduplicates Playwright screenshot kwargs and conversion wiring; behavior should remain the same unless downstream code relied on duplicated inline constants.
> 
> **Overview**
> **Refactors Playwright screenshot helpers to remove duplication.** The Playwright capture policy (`type`/`quality`) is centralized in `_PLAYWRIGHT_SCREENSHOT_KWARGS`, and the common “bytes → WebP data URL” conversion is extracted into `_playwright_bytes_to_data_url()`.
> 
> `playwright_screenshot_to_data_url()` and `aplaywright_screenshot_to_data_url()` now differ only in whether they `await` the screenshot call, both delegating to the shared helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf8e5df3f32a25b67e7ae3fa5a182b8eee8c7ea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->