### PR TITLE
docs: use canonical NAVIGATOR_N1*_MODEL in examples

### DIFF
--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -46,7 +46,7 @@ from _common import (
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import (
-    N1_MODEL,
+    NAVIGATOR_N1_MODEL,
     aplaywright_screenshot_to_data_url,
     denormalize_coordinates,
 )
@@ -61,7 +61,7 @@ class Config(BaseModel):
     start_url: str = "https://www.yutori.com"
     # model
     base_url: str = DEFAULT_BASE_URL
-    model: str = N1_MODEL
+    model: str = NAVIGATOR_N1_MODEL
     temperature: float = 0.3
     # agent
     max_steps: int = 100
@@ -81,7 +81,7 @@ class Agent:
     def __init__(
         self,
         base_url: str = DEFAULT_BASE_URL,
-        model: str = N1_MODEL,
+        model: str = NAVIGATOR_N1_MODEL,
         temperature: float = 0.3,
         max_steps: int = 100,
         viewport_width: int = 1280,

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -63,7 +63,7 @@ from _common import (
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import (
-    N1_5_MODEL,
+    NAVIGATOR_N1_5_MODEL,
     TOOL_SET_CORE,
     TOOL_SET_EXPANDED,
     aplaywright_screenshot_to_data_url,
@@ -98,7 +98,7 @@ class Config(BaseModel):
     start_url: str = "https://www.yutori.com"
     # model
     base_url: str = DEFAULT_BASE_URL
-    model: str = N1_5_MODEL
+    model: str = NAVIGATOR_N1_5_MODEL
     temperature: float = 0.3
     tool_set: str = TOOL_SET_CORE
     disable_tools: list[str] = Field(default_factory=list)
@@ -124,7 +124,7 @@ class Agent:
     def __init__(
         self,
         base_url: str = DEFAULT_BASE_URL,
-        model: str = N1_5_MODEL,
+        model: str = NAVIGATOR_N1_5_MODEL,
         temperature: float = 0.3,
         tool_set: str = TOOL_SET_CORE,
         disable_tools: list[str] | None = None,


### PR DESCRIPTION
## Summary
- Replace deprecated `N1_MODEL` with `NAVIGATOR_N1_MODEL` in `examples/navigator_n1.py`
- Replace deprecated `N1_5_MODEL` with `NAVIGATOR_N1_5_MODEL` in `examples/navigator_n1_5.py`
- Examples should model best practices and use the canonical constant names added in PR #79

## Context
Found during daily cross-repo documentation drift review. PR #79 renamed "n1 API" to "Navigator API" and added canonical `NAVIGATOR_N1_MODEL` / `NAVIGATOR_N1_5_MODEL` constants, keeping the old names as deprecated aliases. The SDK README and api.md were updated in that PR, but the example files still used the deprecated aliases.

## Test plan
- [ ] Verify examples still run correctly with the canonical constant names
- [ ] Verify no other stale `N1_MODEL` / `N1_5_MODEL` references remain in examples

---
_Generated by [Claude Code](https://claude.ai/code/session_012f5MAaGzvgrHzNhPF869uz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: examples-only change that swaps deprecated model constant aliases for the canonical `NAVIGATOR_N1_MODEL`/`NAVIGATOR_N1_5_MODEL` identifiers, without altering runtime logic.
> 
> **Overview**
> Updates the Navigator API Python examples to use the canonical model constant names. Specifically, `examples/navigator_n1.py` switches from `N1_MODEL` to `NAVIGATOR_N1_MODEL`, and `examples/navigator_n1_5.py` switches from `N1_5_MODEL` to `NAVIGATOR_N1_5_MODEL` in both imports and default config/agent parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43dac20044860fdeaabd6733eb9504e5abfcbb40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->