### PR TITLE
Consolidate input validation in coordinates helpers

### DIFF
--- a/yutori/navigator/coordinates.py
+++ b/yutori/navigator/coordinates.py
@@ -26,10 +26,7 @@ def denormalize_coordinates(
     indices are always valid for a viewport of the given size.
     """
 
-    x, y = _coerce_coordinates(coordinates)
-    _validate_dimension("width", width)
-    _validate_dimension("height", height)
-    _validate_scale(scale)
+    x, y = _coerce_and_validate(coordinates, width, height, scale)
 
     raw_x = round(x / scale * width)
     raw_y = round(y / scale * height)
@@ -55,10 +52,7 @@ def normalize_coordinates(
     normalized action space.
     """
 
-    x, y = _coerce_coordinates(coordinates)
-    _validate_dimension("width", width)
-    _validate_dimension("height", height)
-    _validate_scale(scale)
+    x, y = _coerce_and_validate(coordinates, width, height, scale)
 
     raw_x = round(x / width * scale)
     raw_y = round(y / height * scale)
@@ -67,6 +61,20 @@ def normalize_coordinates(
         return raw_x, raw_y
 
     return _clamp(raw_x, 0, scale), _clamp(raw_y, 0, scale)
+
+
+def _coerce_and_validate(
+    coordinates: Sequence[int | float],
+    width: int,
+    height: int,
+    scale: int,
+) -> tuple[float, float]:
+    """Coerce *coordinates* and validate viewport dimensions and scale."""
+    x, y = _coerce_coordinates(coordinates)
+    _validate_dimension("width", width)
+    _validate_dimension("height", height)
+    _validate_scale(scale)
+    return x, y
 
 
 def _coerce_coordinates(coordinates: Sequence[int | float]) -> tuple[float, float]:


### PR DESCRIPTION
## Structural issue

`denormalize_coordinates` and `normalize_coordinates` in `yutori/navigator/coordinates.py` each open with the identical 4-line "coerce coordinates, then validate width / height / scale" preamble. The two blocks have to be kept in lock-step by hand — if a future change adjusts validation order, error messages, or adds a new dimension check, both functions need an identical edit.

## Refactor

Extract the shared preamble into `_coerce_and_validate(coordinates, width, height, scale) -> tuple[float, float]`. Both public helpers now begin with a single line:

```python
x, y = _coerce_and_validate(coordinates, width, height, scale)
```

## Why it's safe

- Pure refactor, no behavior change. Same exceptions, same messages, same validation order, same return types.
- The new helper is module-private (underscore prefix). All public surface (`denormalize_coordinates`, `normalize_coordinates`, scale constants, `_clamp_to_dimension`) is unchanged.
- `tests/test_navigator_coordinates.py` already covers every validation path:
  - wrong coordinate length (`exactly 2 items`)
  - `None` coordinates
  - inf / NaN coordinates
  - non-positive `width` / `height`
  - non-positive `scale`
  - default and custom-scale clamping behavior in both directions
  - normalize ↔ denormalize roundtrip

No call sites to update — the public API is byte-for-byte equivalent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrQ7ZrRPhw5y1ZDB4eRU2q)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor that centralizes existing validation logic; risk is limited to accidentally changing validation order/messages or raising different exceptions.
> 
> **Overview**
> Refactors `denormalize_coordinates` and `normalize_coordinates` to share a single `_coerce_and_validate()` helper for coordinate coercion plus `width`/`height`/`scale` validation, removing duplicated preamble logic.
> 
> No public API changes are intended; this is a small internal cleanup to keep validation behavior consistent between the two conversions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9950329211528ec36d66f4169399b600d6330897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->