### PR TITLE
refactor(auth): extract _bearer_headers helper for Clerk JWT calls

### DIFF
--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -153,6 +153,16 @@ def _build_key_name(source: str = "yutori-cli") -> str:
     return f"{date_prefix}-{source}"
 
 
+def _bearer_headers(jwt: str) -> dict[str, str]:
+    """Authorization header dict for Clerk-JWT-authenticated calls.
+
+    Centralized so the bearer-scheme literal lives in exactly one place
+    across the auth flow (token exchange does not use this — it sends the
+    code via form data, not a header).
+    """
+    return {"Authorization": f"Bearer {jwt}"}
+
+
 def _post_auth_api(jwt: str, path: str, json_payload: dict[str, Any] | None) -> httpx.Response:
     """POST to a Yutori auth API endpoint with Bearer auth, raising on non-2xx.
 
@@ -163,7 +173,7 @@ def _post_auth_api(jwt: str, path: str, json_payload: dict[str, Any] | None) -> 
     with httpx.Client(timeout=30.0) as client:
         response = client.post(
             build_auth_api_url(path),
-            headers={"Authorization": f"Bearer {jwt}"},
+            headers=_bearer_headers(jwt),
             json=json_payload,
         )
         response.raise_for_status()
@@ -193,7 +203,7 @@ def check_registration_status(jwt: str) -> bool | None:
         with httpx.Client(timeout=5.0) as client:
             response = client.get(
                 build_auth_api_url("/client/registration-status"),
-                headers={"Authorization": f"Bearer {jwt}"},
+                headers=_bearer_headers(jwt),
             )
             if response.status_code == 200:
                 body = response.json()


### PR DESCRIPTION
Fresh replacement for #80, which was closed due to merge conflicts.

## What

Introduces a private `_bearer_headers(jwt)` helper in `yutori/auth/flow.py` that centralises the `"Authorization: Bearer <jwt>"` construction. Both `_post_auth_api` and `check_registration_status` now call this helper, so the bearer-scheme literal lives in exactly one place and the two call sites cannot drift out of sync.

## Changes

- `yutori/auth/flow.py` — add `_bearer_headers` helper; apply it in `_post_auth_api` and `check_registration_status`

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWUez5F2wPYNamepWKRXqV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to header construction for Clerk JWT calls, with no change to request endpoints or payloads; main risk is a typo/regression affecting authenticated API calls.
> 
> **Overview**
> Introduces a private `_bearer_headers(jwt)` helper in `yutori/auth/flow.py` to centralize construction of the `Authorization: Bearer <jwt>` header.
> 
> Updates `_post_auth_api` and `check_registration_status` to use this helper, reducing duplication and preventing the bearer-scheme literal from drifting between call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdb46071eac051ffca6c86f54c398caaecbffffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->