### PR TITLE
docs: drop hyphen in "Navigator-n1" / "Navigator-n1.5" prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The Yutori API provides four main capabilities:
 
 | API           | Description                                                    | SDK Namespace     |
 | ------------- | -------------------------------------------------------------- | ----------------- |
-| **Navigator** | Computer-use model family (Navigator-n1, Navigator-n1.5)       | `client.chat`     |
+| **Navigator** | Computer-use model family (Navigator n1, Navigator n1.5)       | `client.chat`     |
 | **Browsing**  | One-time browser automation tasks                              | `client.browsing` |
 | **Research**  | Deep web research using 100+ tools                             | `client.research` |
 | **Scouting**  | Continuous web monitoring on a schedule                        | `client.scouts`   |
@@ -87,7 +87,7 @@ The Yutori API provides four main capabilities:
 
 ## Navigator API
 
-The Navigator API hosts Yutori's family of computer-use models for navigating websites. The current public versions are **Navigator-n1** (model id `n1-latest`) and **Navigator-n1.5** (model id `n1.5-latest`). Capture a screenshot, send it to the model, and execute the returned tool calls. The endpoint follows the OpenAI Chat Completions interface, so `client.chat` is a drop-in OpenAI-compatible client:
+The Navigator API hosts Yutori's family of computer-use models for navigating websites. The current public versions are **Navigator n1** (model id `n1-latest`) and **Navigator n1.5** (model id `n1.5-latest`). Capture a screenshot, send it to the model, and execute the returned tool calls. The endpoint follows the OpenAI Chat Completions interface, so `client.chat` is a drop-in OpenAI-compatible client:
 
 ```python
 from yutori import AsyncYutoriClient
@@ -124,7 +124,7 @@ async with AsyncYutoriClient() as client, async_playwright() as p:
 
 This snippet shows a single model call. In practice, you'll usually run an agent loop: execute the returned actions on the page, capture a fresh screenshot, and call the model again until it emits `stop`. Complete agent loops live in [examples/](examples/).
 
-The SDK defaults to Navigator-n1.5 (`n1.5-latest`). Navigator-n1 (`n1-latest`) is still supported for callers that want the older model. Navigator-n1.5 adds selectable tool sets, `disable_tools`, and structured JSON output via `json_schema` (returned as `response.parsed_json`). See the [Navigator-n1.5 reference](https://docs.yutori.com/reference/n1-5) and [Navigator-n1 reference](https://docs.yutori.com/reference/n1) for model IDs, parameters, and the full action space.
+The SDK defaults to Navigator n1.5 (`n1.5-latest`). Navigator n1 (`n1-latest`) is still supported for callers that want the older model. Navigator n1.5 adds selectable tool sets, `disable_tools`, and structured JSON output via `json_schema` (returned as `response.parsed_json`). See the [Navigator n1.5 reference](https://docs.yutori.com/reference/n1-5) and [Navigator n1 reference](https://docs.yutori.com/reference/n1) for model IDs, parameters, and the full action space.
 
 ### Agent-loop helpers
 
@@ -138,8 +138,8 @@ The `yutori.navigator` subpackage exposes optional helpers for typical agent loo
 | `format_task_with_context(task, ...)`                       | Append location, timezone, and current date to a task message.                                                                           |
 | `format_stop_and_summarize(task)`                           | Ask the model to summarize when hitting max steps or an error.                                                                           |
 | `trimmed_messages_to_fit(messages, max_bytes, keep_recent)` | Drop older screenshots to stay under the API size limit.                                                                                 |
-| `map_key_to_playwright(key)` / `map_keys_individual(keys)`  | Convert Navigator-n1.5's lowercase key names to Playwright format.                                                                       |
-| `yutori.navigator.tools`                                    | Packaged JS reference implementations for the Navigator-n1.5 expanded tools (`extract_elements`, `find`, `set_element_value`, `execute_js`). |
+| `map_key_to_playwright(key)` / `map_keys_individual(keys)`  | Convert Navigator n1.5's lowercase key names to Playwright format.                                                                       |
+| `yutori.navigator.tools`                                    | Packaged JS reference implementations for the Navigator n1.5 expanded tools (`extract_elements`, `find`, `set_element_value`, `execute_js`). |
 
 
 Full helper reference: [api.md](api.md).
@@ -292,7 +292,7 @@ Run `yutori --help` or `yutori <command> --help` for full options.
 
 ## Examples
 
-See [examples/](examples/) for complete working examples, including Navigator agent loops for both Navigator-n1 and Navigator-n1.5.
+See [examples/](examples/) for complete working examples, including Navigator agent loops for both Navigator n1 and Navigator n1.5.
 
 ## Contributing
 

--- a/api.md
+++ b/api.md
@@ -7,8 +7,8 @@ A dense reference to everything the Yutori Python SDK and CLI expose. The [READM
 | Import | Purpose |
 |--------|---------|
 | `yutori` | Clients (`YutoriClient`, `AsyncYutoriClient`) and exceptions (`APIError`, `AuthenticationError`, `YutoriSDKError`) |
-| `yutori.navigator` | Agent-loop helpers for the Navigator API (Navigator-n1 / Navigator-n1.5 chat completions) |
-| `yutori.navigator.tools` | Packaged JavaScript reference implementations for the Navigator-n1.5 expanded browser tools |
+| `yutori.navigator` | Agent-loop helpers for the Navigator API (Navigator n1 / Navigator n1.5 chat completions) |
+| `yutori.navigator.tools` | Packaged JavaScript reference implementations for the Navigator n1.5 expanded browser tools |
 
 All SDK calls go through `YutoriClient` / `AsyncYutoriClient`. The Navigator helpers are optional and do not change the shape of `client.chat.completions.create(...)`.
 
@@ -53,7 +53,7 @@ YutoriClient(
 
 | Attribute | Class | Purpose |
 |-----------|-------|---------|
-| `client.chat` | `ChatNamespace` | Navigator API (Navigator-n1 / Navigator-n1.5) chat completions |
+| `client.chat` | `ChatNamespace` | Navigator API (Navigator n1 / Navigator n1.5) chat completions |
 | `client.browsing` | `BrowsingNamespace` | One-time browser automation |
 | `client.research` | `ResearchNamespace` | One-time deep web research |
 | `client.scouts` | `ScoutsNamespace` | Continuous monitoring scouts |
@@ -101,9 +101,9 @@ from yutori.navigator import (
 
 | Constant | Value | Notes |
 |----------|-------|-------|
-| `NAVIGATOR_N1_MODEL` | `"n1-latest"` | Alias for the latest stable Navigator-n1 model. |
-| `NAVIGATOR_N1_5_MODEL` | `"n1.5-latest"` | Alias for the latest stable Navigator-n1.5 model (current default). |
-| `TOOL_SET_CORE` | `"browser_tools_core-20260403"` | Default Navigator-n1.5 tool set — 18 coordinate-based browser tools. |
+| `NAVIGATOR_N1_MODEL` | `"n1-latest"` | Alias for the latest stable Navigator n1 model. |
+| `NAVIGATOR_N1_5_MODEL` | `"n1.5-latest"` | Alias for the latest stable Navigator n1.5 model (current default). |
+| `TOOL_SET_CORE` | `"browser_tools_core-20260403"` | Default Navigator n1.5 tool set — 18 coordinate-based browser tools. |
 | `TOOL_SET_EXPANDED` | `"browser_tools_expanded-20260403"` | Core tools + `extract_elements`, `find`, `set_element_value`, `execute_js`. |
 | `NAVIGATOR_COORDINATE_SCALE` | `1000` | The normalized action space is `NAVIGATOR_COORDINATE_SCALE × NAVIGATOR_COORDINATE_SCALE`. |
 
@@ -115,7 +115,7 @@ For pinned versions (e.g. `n1-20260203`, `n1-experimental-20260309`) see [docs.y
 
 ### `client.chat` — Navigator API
 
-OpenAI-compatible pixels-to-actions chat completions. Works with both Navigator-n1 and Navigator-n1.5 models.
+OpenAI-compatible pixels-to-actions chat completions. Works with both Navigator n1 and Navigator n1.5 models.
 
 | Method | HTTP | Endpoint | Returns |
 |--------|------|----------|---------|
@@ -137,9 +137,9 @@ response = client.chat.completions.create(
             ],
         }
     ],
-    tool_set=TOOL_SET_EXPANDED,           # Navigator-n1.5 only
-    disable_tools=["hold_key", "drag"],    # Navigator-n1.5 only
-    json_schema={...},                     # Navigator-n1.5 only
+    tool_set=TOOL_SET_EXPANDED,           # Navigator n1.5 only
+    disable_tools=["hold_key", "drag"],    # Navigator n1.5 only
+    json_schema={...},                     # Navigator n1.5 only
 )
 
 message = response.choices[0].message
@@ -154,16 +154,16 @@ parsed = getattr(response, "parsed_json", None)
 **Parameters:**
 - `messages` (`Iterable[ChatCompletionMessageParam]`): OpenAI-format chat messages. Include screenshots as `image_url` content blocks.
 - `model` (`str`, default `"n1.5-latest"`): Model alias or pinned ID. Pass `NAVIGATOR_N1_MODEL` / `NAVIGATOR_N1_5_MODEL` for clarity.
-- `tool_set` (`str | None`, **Navigator-n1.5 only**): Which built-in tool set to activate. Use `TOOL_SET_CORE` or `TOOL_SET_EXPANDED`. Forwarded via `extra_body`.
-- `disable_tools` (`list[str] | None`, **Navigator-n1.5 only**): Tool names to remove from the active tool set.
-- `json_schema` (`dict | None`, **Navigator-n1.5 only**): JSON Schema object. When provided, the API constrains decoding and attaches the parsed result as `response.parsed_json`.
-- `**kwargs`: Any other OpenAI Chat Completions parameter (`temperature`, `tools`, `tool_choice`, `response_format`, etc.). If the caller already passes `extra_body`, the SDK merges Navigator-n1.5 params into it.
+- `tool_set` (`str | None`, **Navigator n1.5 only**): Which built-in tool set to activate. Use `TOOL_SET_CORE` or `TOOL_SET_EXPANDED`. Forwarded via `extra_body`.
+- `disable_tools` (`list[str] | None`, **Navigator n1.5 only**): Tool names to remove from the active tool set.
+- `json_schema` (`dict | None`, **Navigator n1.5 only**): JSON Schema object. When provided, the API constrains decoding and attaches the parsed result as `response.parsed_json`.
+- `**kwargs`: Any other OpenAI Chat Completions parameter (`temperature`, `tools`, `tool_choice`, `response_format`, etc.). If the caller already passes `extra_body`, the SDK merges Navigator n1.5 params into it.
 
-**Returns:** `openai.types.chat.ChatCompletion`. When `json_schema` is set on Navigator-n1.5 and parsing succeeds, the API also sets `response.parsed_json`.
+**Returns:** `openai.types.chat.ChatCompletion`. When `json_schema` is set on Navigator n1.5 and parsing succeeds, the API also sets `response.parsed_json`.
 
-**Navigator-n1 vs. Navigator-n1.5 summary** (reference: [docs.yutori.com](https://docs.yutori.com/reference/n1-5)):
+**Navigator n1 vs. Navigator n1.5 summary** (reference: [docs.yutori.com](https://docs.yutori.com/reference/n1-5)):
 
-| Feature | Navigator-n1 | Navigator-n1.5 |
+| Feature | Navigator n1 | Navigator n1.5 |
 |---------|----|----|
 | Tool sets | Fixed | `tool_set` (core / expanded) |
 | Disable tools | — | `disable_tools` supported |
@@ -402,7 +402,7 @@ task = client.browsing.create(
 )
 ```
 
-Structured output for the Navigator API (Navigator-n1.5 only) is a separate parameter on `client.chat.completions.create(...)`: `json_schema=...` with results on `response.parsed_json`.
+Structured output for the Navigator API (Navigator n1.5 only) is a separate parameter on `client.chat.completions.create(...)`: `json_schema=...` with results on `response.parsed_json`.
 
 ## `yutori.navigator`
 
@@ -418,7 +418,7 @@ from yutori.navigator import (
     denormalize_coordinates, normalize_coordinates,
     # Task / prompt formatting
     format_task_with_context, format_user_context, format_stop_and_summarize,
-    # Key mapping (Navigator-n1.5)
+    # Key mapping (Navigator n1.5)
     map_key_to_playwright, map_keys_individual,
     # Payload trimming
     estimate_messages_size_bytes, trim_images_to_fit, trimmed_messages_to_fit,
@@ -458,9 +458,9 @@ Raises `ValueError` on bad input (non-finite values, wrong length, non-positive 
 | `format_task_with_context` | `(task: str, *, user_timezone=..., user_location=...) -> str` | `f"{task}\n\n{format_user_context(...)}"`. |
 | `format_stop_and_summarize` | `(task: str) -> str` | Prompt that asks the model to stop iterating and produce a summary — for use when hitting max steps or an error. |
 
-### Key mapping (Navigator-n1.5)
+### Key mapping (Navigator n1.5)
 
-Navigator-n1.5 returns lowercase key names (`ctrl+c`, `enter`, `down`) which must be converted for Playwright.
+Navigator n1.5 returns lowercase key names (`ctrl+c`, `enter`, `down`) which must be converted for Playwright.
 
 | Helper | Signature | Description |
 |--------|-----------|-------------|
@@ -499,7 +499,7 @@ Additionally, `yutori.navigator.loop.update_trimmed_history(messages, request_me
 
 ### `yutori.navigator.tools`
 
-Packaged JavaScript reference implementations for the Navigator-n1.5 expanded browser tool set. The scripts are shipped as `.js` files inside the wheel (`yutori.navigator.tools.js`).
+Packaged JavaScript reference implementations for the Navigator n1.5 expanded browser tool set. The scripts are shipped as `.js` files inside the wheel (`yutori.navigator.tools.js`).
 
 ```python
 from yutori.navigator.tools import (

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@ The examples rely on the SDK's normal credential resolution. They do not expose 
 
 ## navigator_n1.py
 
-A complete browsing agent using the Navigator API with the Navigator-n1 model. Launches a local Playwright browser, captures screenshots through `yutori.navigator.aplaywright_screenshot_to_data_url(...)`, converts tool-call coordinates with `yutori.navigator.denormalize_coordinates(...)`, sends them to Navigator-n1, and executes predicted actions until the task is complete. The example keeps its own long-lived message history bounded with `estimate_messages_size_bytes(...)` plus `trimmed_messages_to_fit(...)`, then still ends with a standard `client.chat.completions.create(...)` call.
+A complete browsing agent using the Navigator API with the Navigator n1 model. Launches a local Playwright browser, captures screenshots through `yutori.navigator.aplaywright_screenshot_to_data_url(...)`, converts tool-call coordinates with `yutori.navigator.denormalize_coordinates(...)`, sends them to Navigator n1, and executes predicted actions until the task is complete. The example keeps its own long-lived message history bounded with `estimate_messages_size_bytes(...)` plus `trimmed_messages_to_fit(...)`, then still ends with a standard `client.chat.completions.create(...)` call.
 
 ```bash
 uv run python examples/navigator_n1.py --task "List the team member names" --start-url "https://www.yutori.com"
@@ -33,7 +33,7 @@ Options:
 
 ## navigator_n1_5.py
 
-A Navigator agent using the Navigator-n1.5 model. Demonstrates selectable tool sets (`TOOL_SET_CORE`, `TOOL_SET_EXPANDED`), optional structured JSON output via `--json-schema`, a redesigned action space with lowercase key names, and the packaged JS helpers from `yutori.navigator.tools` for expanded browser tools.
+A Navigator agent using the Navigator n1.5 model. Demonstrates selectable tool sets (`TOOL_SET_CORE`, `TOOL_SET_EXPANDED`), optional structured JSON output via `--json-schema`, a redesigned action space with lowercase key names, and the packaged JS helpers from `yutori.navigator.tools` for expanded browser tools.
 
 ```bash
 uv run python examples/navigator_n1_5.py --task "List the team member names" --start-url "https://www.yutori.com"
@@ -52,7 +52,7 @@ Options:
 
 ## navigator_n1_custom_tools.py
 
-Extends the basic Navigator-n1 agent with a custom tool for extracting content and links from the page. Demonstrates how to define custom tools and pass them to the Navigator API.
+Extends the basic Navigator n1 agent with a custom tool for extracting content and links from the page. Demonstrates how to define custom tools and pass them to the Navigator API.
 
 ```bash
 uv run python examples/navigator_n1_custom_tools.py \

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-A web browsing agent using Yutori's Navigator API with the Navigator-n1 model
+A web browsing agent using Yutori's Navigator API with the Navigator n1 model
 (OpenAI API compatible).
 
 This script takes a user query, launches a local Playwright browser session,
@@ -443,10 +443,10 @@ async def main():
 
     default_config = Config()
     parser = argparse.ArgumentParser(
-        description="Example of using the Yutori Navigator API (Navigator-n1) to perform a web browsing task"
+        description="Example of using the Yutori Navigator API (Navigator n1) to perform a web browsing task"
     )
     add_task_arguments(parser, default_config)
-    add_model_arguments(parser, default_config, api_label="Yutori Navigator-n1")
+    add_model_arguments(parser, default_config, api_label="Yutori Navigator n1")
     add_agent_arguments(parser, default_config)
     add_browser_arguments(parser, default_config)
     add_payload_trim_arguments(parser, default_config)

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 """
-A web browsing agent using Yutori's Navigator API with the Navigator-n1.5 model.
+A web browsing agent using Yutori's Navigator API with the Navigator n1.5 model.
 
-Navigator-n1.5 introduces a new action space with renamed tools, selectable
+Navigator n1.5 introduces a new action space with renamed tools, selectable
 tool sets, optional structured JSON output, and lowercase key names.
 
 Replay logging in this example is optional. Here, "replay" means saving the
 agent trajectory to local files so you can inspect screenshots, actions, and
 raw request/response payloads in `visualization.html` after the run.
 
-Key differences from Navigator-n1:
+Key differences from Navigator n1:
 - model: "n1.5-latest" (instead of "n1-latest")
 - tool_set / disable_tools: select which built-in tools the model can use
 - json_schema: request structured output (returned as parsed_json on the response)
@@ -442,7 +442,7 @@ class Agent:
 
     @staticmethod
     def _map_modifier(modifier: str | None) -> str | None:
-        """Map a single Navigator-n1.5 modifier name to a Playwright key name.
+        """Map a single Navigator n1.5 modifier name to a Playwright key name.
 
         The modifier field is always a single key (ctrl, shift, alt, meta,
         command, super) — not a combo. Uses the key map for lookup but
@@ -461,7 +461,7 @@ class Agent:
         return mapped[0].split("+")[0]
 
     # ------------------------------------------------------------------
-    # Action execution — Navigator-n1.5 action space
+    # Action execution — Navigator n1.5 action space
     # ------------------------------------------------------------------
 
     def _url_suffix(self) -> str:
@@ -724,10 +724,10 @@ async def main():
 
     default_config = Config()
     parser = argparse.ArgumentParser(
-        description="Example of using the Yutori Navigator API (Navigator-n1.5) to perform a web browsing task"
+        description="Example of using the Yutori Navigator API (Navigator n1.5) to perform a web browsing task"
     )
     add_task_arguments(parser, default_config)
-    add_model_arguments(parser, default_config, api_label="Yutori Navigator-n1.5")
+    add_model_arguments(parser, default_config, api_label="Yutori Navigator n1.5")
     parser.add_argument(
         "--tool-set", default=default_config.tool_set,
         choices=[TOOL_SET_CORE, TOOL_SET_EXPANDED, "core", "expanded"],

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-A web browsing agent using Yutori's Navigator API (Navigator-n1, OpenAI API
+A web browsing agent using Yutori's Navigator API (Navigator n1, OpenAI API
 compatible) with custom tools.
 
 This script takes a user query, launches a local Playwright browser session,
@@ -496,10 +496,10 @@ async def main():
 
     default_config = Config()
     parser = argparse.ArgumentParser(
-        description="Example of using the Yutori Navigator API (Navigator-n1) to perform a web browsing task"
+        description="Example of using the Yutori Navigator API (Navigator n1) to perform a web browsing task"
     )
     add_task_arguments(parser, default_config)
-    add_model_arguments(parser, default_config, api_label="Yutori Navigator-n1")
+    add_model_arguments(parser, default_config, api_label="Yutori Navigator n1")
     add_agent_arguments(parser, default_config)
     add_browser_arguments(parser, default_config)
     add_replay_arguments(parser, default_config)

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-A web browsing agent using Yutori's Navigator API (Navigator-n1, OpenAI API
+A web browsing agent using Yutori's Navigator API (Navigator n1, OpenAI API
 compatible) with custom tools.
 
 This script demonstrates how to use custom tools to let the model memorize information (into files) as it navigates.
@@ -558,10 +558,10 @@ async def main():
 
     default_config = Config()
     parser = argparse.ArgumentParser(
-        description="Example of using the Yutori Navigator API (Navigator-n1) to perform a web browsing task"
+        description="Example of using the Yutori Navigator API (Navigator n1) to perform a web browsing task"
     )
     add_task_arguments(parser, default_config)
-    add_model_arguments(parser, default_config, api_label="Yutori Navigator-n1")
+    add_model_arguments(parser, default_config, api_label="Yutori Navigator n1")
     add_agent_arguments(parser, default_config)
     add_browser_arguments(parser, default_config)
     add_replay_arguments(parser, default_config)

--- a/tests/test_navigator_keys.py
+++ b/tests/test_navigator_keys.py
@@ -1,4 +1,4 @@
-"""Tests for Navigator-n1.5 key mapping helpers."""
+"""Tests for Navigator n1.5 key mapping helpers."""
 
 import pytest
 
@@ -6,7 +6,7 @@ from yutori.navigator.keys import map_key_to_playwright, map_keys_individual
 
 
 class TestMapKeyToPlaywright:
-    """map_key_to_playwright converts Navigator-n1.5 key expressions to Playwright press() strings."""
+    """map_key_to_playwright converts Navigator n1.5 key expressions to Playwright press() strings."""
 
     def test_single_modifier_combo(self):
         assert map_key_to_playwright("ctrl+c") == ["Control+c"]

--- a/yutori/_async/chat.py
+++ b/yutori/_async/chat.py
@@ -30,13 +30,13 @@ class AsyncChatCompletions:
 
         Args:
             messages: List of messages following OpenAI Chat format.
-            model: Model to use (default: ``"n1.5-latest"`` — Navigator-n1.5).
-            tool_set: (Navigator-n1.5 only) Built-in tool set to use, e.g.
+            model: Model to use (default: ``"n1.5-latest"`` — Navigator n1.5).
+            tool_set: (Navigator n1.5 only) Built-in tool set to use, e.g.
                 ``"browser_tools_core-20260403"`` or
                 ``"browser_tools_expanded-20260403"``.
-            disable_tools: (Navigator-n1.5 only) List of tool names to remove
+            disable_tools: (Navigator n1.5 only) List of tool names to remove
                 from the selected tool set.
-            json_schema: (Navigator-n1.5 only) JSON Schema for structured output.
+            json_schema: (Navigator n1.5 only) JSON Schema for structured output.
                 When provided, the model returns a ``parsed_json`` field
                 on the response.
             **kwargs: Additional parameters (e.g., temperature).

--- a/yutori/_sync/chat.py
+++ b/yutori/_sync/chat.py
@@ -30,13 +30,13 @@ class ChatCompletions:
 
         Args:
             messages: List of messages following OpenAI Chat format.
-            model: Model to use (default: ``"n1.5-latest"`` — Navigator-n1.5).
-            tool_set: (Navigator-n1.5 only) Built-in tool set to use, e.g.
+            model: Model to use (default: ``"n1.5-latest"`` — Navigator n1.5).
+            tool_set: (Navigator n1.5 only) Built-in tool set to use, e.g.
                 ``"browser_tools_core-20260403"`` or
                 ``"browser_tools_expanded-20260403"``.
-            disable_tools: (Navigator-n1.5 only) List of tool names to remove
+            disable_tools: (Navigator n1.5 only) List of tool names to remove
                 from the selected tool set.
-            json_schema: (Navigator-n1.5 only) JSON Schema for structured output.
+            json_schema: (Navigator n1.5 only) JSON Schema for structured output.
                 When provided, the model returns a ``parsed_json`` field
                 on the response.
             **kwargs: Additional parameters (e.g., temperature).

--- a/yutori/navigator/__init__.py
+++ b/yutori/navigator/__init__.py
@@ -1,13 +1,13 @@
 """Utilities for building agents with the Yutori Navigator API.
 
-Provides reusable helpers for common patterns in Navigator-n1 and
-Navigator-n1.5 agent loops:
+Provides reusable helpers for common patterns in Navigator n1 and
+Navigator n1.5 agent loops:
 
 - Screenshot preparation: capture and encode screenshots as optimized WebP data URLs
 - Coordinate conversion: map the 1000x1000 tool-call space to viewport pixels
 - Payload management: trim old screenshots to stay within API size limits
 - Loop helpers: create trimmed requests without mutating caller state
-- Key mapping: convert Navigator-n1.5 lowercase key names to Playwright-compatible names
+- Key mapping: convert Navigator n1.5 lowercase key names to Playwright-compatible names
 - Model constants: canonical model identifiers and tool set names
 """
 

--- a/yutori/navigator/keys.py
+++ b/yutori/navigator/keys.py
@@ -1,9 +1,9 @@
-"""Key name mapping for the Navigator-n1.5 lowercase key format.
+"""Key name mapping for the Navigator n1.5 lowercase key format.
 
-Navigator-n1.5 returns lowercase key names (e.g. ``ctrl+c``, ``enter``, ``left``)
+Navigator n1.5 returns lowercase key names (e.g. ``ctrl+c``, ``enter``, ``left``)
 while Playwright expects Playwright-style names (e.g. ``Control+c``,
 ``Enter``, ``ArrowLeft``).  Use :func:`map_key_to_playwright` to convert
-a full Navigator-n1.5 key expression to a Playwright-compatible string.
+a full Navigator n1.5 key expression to a Playwright-compatible string.
 
 Only the Playwright ``key`` name is needed here (not ``code`` / ``keyCode``).
 """
@@ -139,9 +139,9 @@ def _split_into_combos(key_expr: str) -> list[list[str]]:
 
 
 def map_key_to_playwright(key_expr: str) -> list[str]:
-    """Convert a Navigator-n1.5 key expression to a list of Playwright key-press strings.
+    """Convert a Navigator n1.5 key expression to a list of Playwright key-press strings.
 
-    Navigator-n1.5 uses ``+`` for simultaneous combos and spaces for sequential
+    Navigator n1.5 uses ``+`` for simultaneous combos and spaces for sequential
     presses.  For example:
 
     * ``"ctrl+c"``         → ``["Control+c"]``
@@ -158,7 +158,7 @@ def map_key_to_playwright(key_expr: str) -> list[str]:
 
 
 def map_keys_individual(key_expr: str) -> list[str]:
-    """Convert a Navigator-n1.5 key expression to a flat list of individual Playwright keys.
+    """Convert a Navigator n1.5 key expression to a flat list of individual Playwright keys.
 
     Unlike :func:`map_key_to_playwright`, this never joins keys with ``+``.
     Each token is mapped individually, making the result safe for

--- a/yutori/navigator/models.py
+++ b/yutori/navigator/models.py
@@ -1,7 +1,7 @@
 """Model identifiers and tool set constants for the Navigator API.
 
 The Navigator API hosts a family of computer-use models. Current public
-versions are Navigator-n1 and Navigator-n1.5. The API model ID strings
+versions are Navigator n1 and Navigator n1.5. The API model ID strings
 (``n1-latest`` / ``n1.5-latest``) are unchanged — only the user-facing
 naming was updated.
 """
@@ -13,17 +13,17 @@ from __future__ import annotations
 # ---------------------------------------------------------------------------
 
 NAVIGATOR_N1_MODEL = "n1-latest"
-"""Alias for the latest stable Navigator-n1 model."""
+"""Alias for the latest stable Navigator n1 model."""
 
 NAVIGATOR_N1_5_MODEL = "n1.5-latest"
-"""Alias for the latest stable Navigator-n1.5 model (current default)."""
+"""Alias for the latest stable Navigator n1.5 model (current default)."""
 
 # Back-compat aliases. Prefer the ``NAVIGATOR_*`` names above.
 N1_MODEL = NAVIGATOR_N1_MODEL
 N1_5_MODEL = NAVIGATOR_N1_5_MODEL
 
 # ---------------------------------------------------------------------------
-# Tool sets (Navigator-n1.5 only)
+# Tool sets (Navigator n1.5 only)
 # ---------------------------------------------------------------------------
 
 TOOL_SET_CORE = "browser_tools_core-20260403"


### PR DESCRIPTION
The user-facing model names now read "Navigator n1" and "Navigator n1.5" (with a space, not a hyphen). Pure prose change across README, api.md, example docstrings/argparse, and inline docstrings/comments.

Wire-level values are untouched: model IDs n1-latest / n1.5-latest, the agent enum "navigator-n1-latest", and Python identifiers NAVIGATOR_N1_MODEL / NAVIGATOR_N1_5_MODEL all stay.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure documentation/comment/string updates that rename the user-facing model names; no runtime behavior, APIs, or wire-level model IDs are changed.
> 
> **Overview**
> Updates user-facing prose across `README.md`, `api.md`, examples, tests, and inline docstrings/comments to consistently refer to models as **Navigator n1** and **Navigator n1.5** (space-separated) instead of **Navigator-n1** / **Navigator-n1.5**.
> 
> No functional changes: the underlying model IDs (e.g. `n1-latest`, `n1.5-latest`) and exported constants remain the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b558841e9e532eeef762dc98f997f2924e1d2d78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->