### PR TITLE
refactor(_http): drop unused build_payload wrapper

### DIFF
--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -40,29 +40,21 @@ def build_query_params(**kwargs: Any) -> dict[str, Any]:
     return {k: v for k, v in kwargs.items() if v is not None}
 
 
-def build_payload(**fields: Any) -> dict[str, Any]:
-    """Build a JSON request payload, filtering out None values.
-
-    Required fields (always non-None) and optional fields can be passed
-    together — any field whose value is ``None`` is omitted.
-    """
-    return {k: v for k, v in fields.items() if v is not None}
-
-
 def build_payload_with_schema(
     *,
     output_schema: object | None = None,
     **fields: Any,
 ) -> dict[str, Any]:
-    """Like :func:`build_payload`, but resolve ``output_schema`` to a JSON dict first.
+    """Build a JSON payload, resolving ``output_schema`` and filtering ``None`` values.
 
     Centralizes the ``output_schema=resolve_output_schema(...)`` step used by
     every scout / research / browsing payload builder so namespace methods do
-    not need to import :func:`resolve_output_schema` directly.
+    not need to import :func:`resolve_output_schema` directly. Any field whose
+    value is ``None`` after resolution is omitted from the returned dict.
     """
     if output_schema is not None:
         fields["output_schema"] = resolve_output_schema(output_schema)
-    return build_payload(**fields)
+    return {k: v for k, v in fields.items() if v is not None}
 
 
 _SCOUT_STATUS_ENDPOINTS = {


### PR DESCRIPTION
## Summary

`build_payload()` in `yutori/_http.py` was a 1-line `None`-filter functionally identical to `build_query_params()`. Its only caller was `build_payload_with_schema()`; no public namespace or client imports it (verified via `grep -rn "build_payload\b"`), and it is not re-exported through `yutori/__init__.py`.

Inline the filter directly into `build_payload_with_schema()` and update its docstring to describe both the schema-resolution and `None`-filtering behavior in one place. `build_query_params()` is unchanged and remains the canonical helper for query-string parameter construction.

## Why this is safe

- `build_payload` is internal-only (the underscore-prefixed `_http.py` module is internal; `__init__.py` only re-exports `YutoriClient`, `AsyncYutoriClient`, and exception classes).
- All `build_payload_with_schema()` call sites continue to work unchanged.
- Same dict comprehension, same key insertion order; Python 3.7+ guarantees `**kwargs` and dict-comprehension insertion order, so `output_schema` lands in the same position relative to the other fields as before.

## Test plan

- [x] `grep -rn "build_payload\b" --include="*.py"` returns no remaining call sites.
- [x] `python -c "import ast; ast.parse(open('yutori/_http.py').read())"` passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MSmM8qFNWWhxPsDrLzgq3T)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit eb909cefc2010a28647f6afa22f5c29f331d6077. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->