### PR TITLE
refactor(replay): extract _safe_json_dumps helper

### DIFF
--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -687,6 +687,14 @@ def _clip_image_url(value: str, *, max_len: int = 96) -> str:
     return value[:max_len] + "...[clipped]"
 
 
+def _safe_json_dumps(payload: Any, *, fallback: Any = None) -> str:
+    """Serialize ``payload`` to JSON, falling back to ``str(fallback)`` on TypeError."""
+    try:
+        return json.dumps(payload, indent=2, ensure_ascii=False, default=_json_default)
+    except TypeError:
+        return str(payload if fallback is None else fallback)
+
+
 def _stringify_content(content: Any) -> str | None:
     text = extract_text_content(content)
     if text:
@@ -696,10 +704,7 @@ def _stringify_content(content: Any) -> str | None:
     if isinstance(content, str):
         stripped = content.strip()
         return stripped or None
-    try:
-        return json.dumps(content, ensure_ascii=False, indent=2, default=_json_default)
-    except TypeError:
-        return str(content)
+    return _safe_json_dumps(content)
 
 
 def _dump_result_json(result: object | None) -> str | None:
@@ -711,17 +716,11 @@ def _dump_result_json(result: object | None) -> str | None:
         payload = result
     else:
         payload = result
-    try:
-        return json.dumps(payload, indent=2, ensure_ascii=False, default=_json_default)
-    except TypeError:
-        return str(result)
+    return _safe_json_dumps(payload, fallback=result)
 
 
 def _dump_json(payload: Any) -> str | None:
-    try:
-        return json.dumps(payload, indent=2, ensure_ascii=False, default=_json_default)
-    except TypeError:
-        return str(payload)
+    return _safe_json_dumps(payload)
 
 
 def _json_default(obj: Any) -> Any:


### PR DESCRIPTION
## Summary

Three `try/except TypeError` blocks in `yutori/navigator/replay.py` (`_stringify_content`, `_dump_result_json`, `_dump_json`) repeated the same `json.dumps(payload, indent=2, ensure_ascii=False, default=_json_default)` + `str()` fallback. Consolidate into a single `_safe_json_dumps()` helper.

The helper takes an optional `fallback` keyword so `_dump_result_json` can preserve its `str(result)` (not `str(payload)`) divergence on the `model_dump` path — that branch is the only reason the three blocks weren't already collapsed.

## Why it's safe

- **No behavior change.** Each call site keeps its previous return value:
  - `_stringify_content`: falls back to `str(content)` (default uses payload).
  - `_dump_result_json`: explicit `fallback=result` preserves `str(result)`.
  - `_dump_json`: falls back to `str(payload)` (default).
- **Verified by full pytest run** — 373 passed (only `test_packaging` fails on this sandbox, which is unrelated and missing the `build` module). The 9 replay/stringify/json tests all pass.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_packaging.py` → 373 passed
- [x] `pytest tests/ -k "replay or stringify or json"` → 9 passed
- [x] Diff: one new helper, three call sites collapse from try/except to a single line.

https://claude.ai/code/session_019BQqFFtXRNbYYH7mb2V4yz

---
_Generated by [Claude Code](https://claude.ai/code/session_019BQqFFtXRNbYYH7mb2V4yz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small internal refactor in optional replay/debug output code; behavior is intended to be unchanged aside from centralizing error handling.
> 
> **Overview**
> Refactors `yutori/navigator/replay.py` to consolidate repeated `json.dumps(...)+str(...)` `TypeError` fallback logic into a single `_safe_json_dumps()` helper.
> 
> Updates `_stringify_content`, `_dump_result_json`, and `_dump_json` to delegate to the helper, including a `fallback` option to preserve `_dump_result_json`’s prior behavior when stringifying non-JSON-serializable results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48ffc2e245e96d574d866111771ff7095c5c108a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->