### PR TITLE
refactor(auth): extract get_stored_api_key helper

### DIFF
--- a/yutori/auth/credentials.py
+++ b/yutori/auth/credentials.py
@@ -84,6 +84,21 @@ def _is_real_key(key: str | None) -> bool:
     return bool(key and key.strip() and key.strip() not in _PLACEHOLDER_KEYS)
 
 
+def get_stored_api_key() -> str | None:
+    """Return the stored API key from the config file, or ``None``.
+
+    Returns ``None`` when the config file is absent, unreadable, malformed,
+    or holds a placeholder value such as ``"YOUR_API_KEY"``.
+    """
+    config = load_config()
+    if not config:
+        return None
+    stored = config.get("api_key")
+    if isinstance(stored, str) and _is_real_key(stored):
+        return stored
+    return None
+
+
 def _resolve_api_key_with_source(api_key: str | None = None) -> tuple[str, str] | None:
     """Resolve an API key using the standard precedence chain and report its source.
 
@@ -102,11 +117,9 @@ def _resolve_api_key_with_source(api_key: str | None = None) -> tuple[str, str] 
     if _is_real_key(env_key):
         return env_key, "env_var"
 
-    config = load_config()
-    if config:
-        stored_key = config.get("api_key")
-        if isinstance(stored_key, str) and _is_real_key(stored_key):
-            return stored_key, "config_file"
+    stored_key = get_stored_api_key()
+    if stored_key is not None:
+        return stored_key, "config_file"
 
     return None
 

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -8,7 +8,7 @@ import typer
 from rich.console import Console
 from rich.markup import escape
 
-from yutori.auth.credentials import _is_real_key, clear_config, load_config
+from yutori.auth.credentials import _is_real_key, clear_config, get_stored_api_key, load_config
 from yutori.auth.flow import get_auth_status, run_login_flow
 
 app = typer.Typer(help="Manage authentication")
@@ -35,9 +35,7 @@ def login() -> None:
         console.print("Unset it first if you want to use browser login.")
         raise typer.Exit(1)
 
-    config = load_config()
-    existing_key = config.get("api_key") if config else None
-    if isinstance(existing_key, str) and _is_real_key(existing_key):
+    if get_stored_api_key() is not None:
         console.print("[yellow]You are already authenticated.[/yellow]")
         console.print("Run [bold]yutori auth logout[/bold] first to re-authenticate.")
         raise typer.Exit(1)


### PR DESCRIPTION
## Summary

`yutori/cli/commands/auth.py::login()` reaches into the private `_is_real_key` helper from `credentials.py` and duplicates the exact "load config → get `api_key` field → check `str` + real-key" check that `_resolve_api_key_with_source` already performs internally for the config-file branch.

This PR adds a public `get_stored_api_key()` helper to `credentials.py` that returns the stored real key (or `None` when the file is absent / corrupt / a placeholder). Both `_resolve_api_key_with_source` (config-file branch) and `cli/commands/auth.py::login()` now call it.

## Why this is an improvement

- Eliminates a duplicated 3-part validity check (`config truthy` + `isinstance str` + `_is_real_key`).
- Removes the CLI's leak into the private `_is_real_key` symbol via that call site — the storage shape and placeholder semantics now have a single canonical entry point.
- Future placeholder tokens added to `_PLACEHOLDER_KEYS` automatically apply to the CLI's "already authenticated?" check.

## Why this is safe

- Pure refactor: the helper returns the same string/`None` values that the inlined code produced; placeholder keys still resolve to `None`.
- 2 files touched. Reviewer can verify correctness by checking that the new `get_stored_api_key()` body is identical in semantics to the two call sites it replaces.
- `_is_real_key` is still imported by `auth.py` for the separate `YUTORI_API_KEY` env-var precedence check, which is correct and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Vb4NsiyBq6vpYLHpTMMv3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes config-file API key validation; behavior should remain the same aside from edge cases around malformed/placeholder values now being handled consistently.
> 
> **Overview**
> Introduces a public `get_stored_api_key()` helper to read and validate the persisted API key from the config file (returning `None` for missing/malformed/placeholder values).
> 
> Updates `_resolve_api_key_with_source()` and `yutori auth login` to use this helper instead of duplicating the config-load/validation logic, keeping the same precedence rules while centralizing placeholder handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03c15d4627c8d13a32354bcdb040792e46c578ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->