### PR TITLE
refactor(navigator/replay): centralise Pydantic model_dump call

### DIFF
--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -707,22 +707,24 @@ def _stringify_content(content: Any) -> str | None:
     return _safe_json_dumps(content)
 
 
-def _model_dump_or_none(obj: Any) -> Any | None:
-    """Return the JSON form of ``obj`` if it exposes Pydantic-style ``model_dump``, else ``None``.
+def _try_model_dump(obj: Any) -> tuple[bool, Any]:
+    """Return ``(True, obj.model_dump(...))`` if ``obj`` is Pydantic-style, else ``(False, None)``.
 
     Centralises the ``mode="json", exclude_none=True`` kwargs so the two call
-    sites below cannot drift out of sync as the dump contract evolves.
+    sites below cannot drift out of sync. The boolean explicitly distinguishes
+    "no ``model_dump`` method" from "``model_dump`` returned ``None``" so
+    callers can preserve the latter as a real payload.
     """
     if hasattr(obj, "model_dump"):
-        return obj.model_dump(mode="json", exclude_none=True)
-    return None
+        return True, obj.model_dump(mode="json", exclude_none=True)
+    return False, None
 
 
 def _dump_result_json(result: object | None) -> str | None:
     if result is None:
         return None
-    payload = _model_dump_or_none(result)
-    if payload is None:
+    handled, payload = _try_model_dump(result)
+    if not handled:
         payload = result
     return _safe_json_dumps(payload, fallback=result)
 
@@ -732,8 +734,8 @@ def _dump_json(payload: Any) -> str | None:
 
 
 def _json_default(obj: Any) -> Any:
-    payload = _model_dump_or_none(obj)
-    if payload is not None:
+    handled, payload = _try_model_dump(obj)
+    if handled:
         return payload
     if hasattr(obj, "__dict__"):
         return obj.__dict__

--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -707,14 +707,22 @@ def _stringify_content(content: Any) -> str | None:
     return _safe_json_dumps(content)
 
 
+def _model_dump_or_none(obj: Any) -> Any | None:
+    """Return the JSON form of ``obj`` if it exposes Pydantic-style ``model_dump``, else ``None``.
+
+    Centralises the ``mode="json", exclude_none=True`` kwargs so the two call
+    sites below cannot drift out of sync as the dump contract evolves.
+    """
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump(mode="json", exclude_none=True)
+    return None
+
+
 def _dump_result_json(result: object | None) -> str | None:
     if result is None:
         return None
-    if hasattr(result, "model_dump"):
-        payload = result.model_dump(mode="json", exclude_none=True)
-    elif isinstance(result, dict):
-        payload = result
-    else:
+    payload = _model_dump_or_none(result)
+    if payload is None:
         payload = result
     return _safe_json_dumps(payload, fallback=result)
 
@@ -724,8 +732,9 @@ def _dump_json(payload: Any) -> str | None:
 
 
 def _json_default(obj: Any) -> Any:
-    if hasattr(obj, "model_dump"):
-        return obj.model_dump(mode="json", exclude_none=True)
+    payload = _model_dump_or_none(obj)
+    if payload is not None:
+        return payload
     if hasattr(obj, "__dict__"):
         return obj.__dict__
     return str(obj)


### PR DESCRIPTION
## Summary

`_dump_result_json` and `_json_default` in `yutori/navigator/replay.py` both hand-rolled the same `hasattr(obj, "model_dump")` check followed by `obj.model_dump(mode="json", exclude_none=True)`. If either argument needed to change (new kwarg, different mode), both sites would have to be updated in sync.

Extract `_model_dump_or_none()` so the dump contract is defined once. Both functions now delegate to it. The dead `elif isinstance(result, dict): payload = result` branch in `_dump_result_json` (identical to the `else: payload = result` branch right below it) is also dropped.

## Why

- One source of truth for the SDK's "Pydantic-style dump" kwargs.
- Makes the relationship between `_dump_result_json` and `_json_default` explicit at a glance.
- Removes a dead branch.

## Safety

No behavior change:

- `_model_dump_or_none(obj)` returns the same `obj.model_dump(mode="json", exclude_none=True)` for Pydantic-style objects, and `None` otherwise.
- `_dump_result_json` falls back to `payload = result` when `_model_dump_or_none` returns `None`, matching both the pre-existing dict branch and the trailing `else` branch.
- `_json_default` checks `is not None` before returning, then falls through to the existing `__dict__` / `str(obj)` branches.

`tests/test_navigator_replay.py` passes (7/7).


---
_Generated by [Claude Code](https://claude.ai/code/session_01X28YzK9pLKJ2EvzzWuSyrK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor in optional replay JSON serialization: behavior should be unchanged but impacts how replay artifacts are JSON-encoded for Pydantic-style objects.
> 
> **Overview**
> **Refactors replay JSON serialization** by extracting a shared `_try_model_dump()` helper used by both `_dump_result_json()` and the JSON `default` hook `_json_default()`, centralizing the `model_dump(mode="json", exclude_none=True)` contract.
> 
> Removes a redundant `dict` branch in `_dump_result_json()` and uses an explicit `(handled, payload)` return to distinguish “no `model_dump` method” from “`model_dump` returned `None`.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f0df567563721fdb58d804e4b80f303cf5f87b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->