### PR TITLE
refactor(navigator/replay): consolidate log_formatter colorize branches

### DIFF
--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -51,26 +51,21 @@ _PREFERRED_ACTION_KEYS = (
 def log_formatter(record: dict, *, colorize: bool = True) -> str:
     """Format log messages for optional loguru-based task/replay logs."""
 
+    def wrap(text: str, color: str) -> str:
+        return f"<{color}>{text}</{color}>" if colorize else text
+
     extra = record["extra"]
-    if colorize:
-        result = (
-            "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
-            "<level>{level: <8}</level> | "
-            "<cyan>{file}</cyan>:<cyan>{line}</cyan> | "
-        )
-        if "task_id" in extra:
-            result += "<magenta>{extra[task_id]}</magenta> | "
-        if "attempt" in extra:
-            result += "<blue>{extra[attempt]}</blue> | "
-        result += "<level>{message}</level>\n{exception}"
-    else:
-        result = "{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {file}:{line} | "
-        if "task_id" in extra:
-            result += "{extra[task_id]} | "
-        if "attempt" in extra:
-            result += "{extra[attempt]} | "
-        result += "{message}\n{exception}"
-    return result
+    parts = [
+        wrap("{time:YYYY-MM-DD HH:mm:ss.SSS}", "green"),
+        wrap("{level: <8}", "level"),
+        f"{wrap('{file}', 'cyan')}:{wrap('{line}', 'cyan')}",
+    ]
+    if "task_id" in extra:
+        parts.append(wrap("{extra[task_id]}", "magenta"))
+    if "attempt" in extra:
+        parts.append(wrap("{extra[attempt]}", "blue"))
+    parts.append(wrap("{message}", "level"))
+    return " | ".join(parts) + "\n{exception}"
 
 
 def make_run_id(*, prefix: str = "run", label: str | None = None) -> str:


### PR DESCRIPTION
## Summary

`log_formatter` in `yutori/navigator/replay.py` carried two near-identical branches that built the same field structure (`time | level | file:line | task_id? | attempt? | message`), differing only in whether to wrap each field with loguru color tags. Adding a new `extra` field meant duplicating the entry in both branches and risked them silently drifting.

Replace the two branches with a single field list plus a small `wrap()` helper that conditionally adds the color tags, keeping the colorize toggle without restating the layout (~22 lines → ~15 lines, single source of truth for the field order).

## Why this is safe

- Output is byte-for-byte identical across all 2×4 combinations of `colorize` × `{no extras, task_id, attempt, both}` — verified locally with a small parity script.
- `log_formatter` is a module-internal helper: it isn't re-exported from `yutori.navigator.__init__` and no other file in this repo references it.
- `tests/test_navigator_replay.py` (7 tests) passes locally; pre-existing `ruff format` drift on unrelated lines was already present on `main` and is left untouched.

## Test plan

- [x] Parity check: 8/8 combinations of (`colorize`, extras) produce identical output between old and new implementations
- [x] `uv run pytest tests/test_navigator_replay.py` — 7 passed
- [x] `uv run ruff check yutori/navigator/replay.py` — clean

https://claude.ai/code/session_013qp7yuixSCXn4biAJLFxac

---
_Generated by [Claude Code](https://claude.ai/code/session_013qp7yuixSCXn4biAJLFxac)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to log formatting; behavior should remain the same, with only potential risk being subtle output formatting differences in loguru rendering.
> 
> **Overview**
> Refactors `log_formatter` in `yutori/navigator/replay.py` to remove duplicated `colorize` branches by introducing a small `wrap()` helper and building the log line from a single `parts` list.
> 
> This keeps the same field order/conditional extras (`task_id`, `attempt`) while making future formatter tweaks less error-prone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70ec19a3af3449ad895b3335f0057df9cd376b7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->