### PR TITLE
Extract _truncate_summary helper in install_ui

### DIFF
--- a/yutori/cli/commands/install_ui.py
+++ b/yutori/cli/commands/install_ui.py
@@ -526,6 +526,20 @@ def maybe_authenticate(console: Console, *, interactive: bool) -> tuple[StepResu
     return StepResult("Auth", "failed", inconsistent_detail), False
 
 
+_SUMMARY_MAX_LEN = 180
+
+
+def _truncate_summary(text: str) -> str:
+    """Cap *text* at ``_SUMMARY_MAX_LEN`` chars, appending ``...`` when truncated.
+
+    The trailing ellipsis is included in the budget, so the returned string
+    never exceeds ``_SUMMARY_MAX_LEN`` characters.
+    """
+    if len(text) <= _SUMMARY_MAX_LEN:
+        return text
+    return f"{text[: _SUMMARY_MAX_LEN - 3]}..."
+
+
 def _summarize_cli_output(output: str) -> str:
     rejection_reason = parse_cli_field(output, "Rejection Reason")
     if rejection_reason:
@@ -536,13 +550,12 @@ def _summarize_cli_output(output: str) -> str:
         if line.strip() == "Result:":
             result_lines = [candidate.strip() for candidate in lines[index + 1 :] if candidate.strip()]
             if result_lines:
-                text = " ".join(result_lines)
-                return text if len(text) <= 180 else f"{text[:177]}..."
+                return _truncate_summary(" ".join(result_lines))
 
     compact = " ".join(line.strip() for line in lines if line.strip())
     if not compact:
         return "(no output)"
-    return compact if len(compact) <= 180 else f"{compact[:177]}..."
+    return _truncate_summary(compact)
 
 
 def run_verification(


### PR DESCRIPTION
## What

`_summarize_cli_output` in `yutori/cli/commands/install_ui.py` had two copies of the same truncate-with-ellipsis expression inside one function, each repeating the magic numbers `180`/`177`:

```python
return text if len(text) <= 180 else f"{text[:177]}..."
```

This PR extracts a `_SUMMARY_MAX_LEN = 180` constant and a `_truncate_summary` helper, so the cap lives in one place and the call sites read at the intent level instead of the slicing level.

## Why

- DRY: the two inline copies had to stay in sync by hand; any change to the cap would otherwise need to touch two lines (and risk drifting).
- The `180`/`177` pair was a hidden invariant ("177 + len('...') == 180"); making it `_SUMMARY_MAX_LEN - 3` makes the relationship explicit.
- `_truncate_summary(...)` reads more clearly than the conditional slice expression at the call site.

## Safety

No behavioral change. `_truncate_summary(text)`:

- returns `text` unchanged when `len(text) <= 180` (same condition as before)
- otherwise returns `text[:177] + "..."` (same 177-char prefix + ellipsis)

Verified by direct evaluation that for inputs of length `5`, `180`, `181`, and `250` the new helper produces a string identical to the old inline expression.

`_summarize_cli_output` is a private helper used only inside this module, so the diff alone proves correctness without needing to chase call sites.

---
_Generated by [Claude Code](https://claude.ai/code/session_017LqWutWcmdMT3mmHqh1nAq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to installer output summarization; behavior should remain identical aside from consolidating the truncation logic in one place.
> 
> **Overview**
> Refactors `install_ui` CLI output summarization by extracting a `_SUMMARY_MAX_LEN` constant and a `_truncate_summary()` helper.
> 
> `_summarize_cli_output()` now uses the helper for both “Result:” parsing and compact output truncation, removing duplicated inline slicing/ellipsis logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5428816dbe3fbcf6d2da7e4ca5b65db7ed1b54f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->