### PR TITLE
refactor(navigator/payload): extract _strip_until_fits helper

### DIFF
--- a/yutori/navigator/payload.py
+++ b/yutori/navigator/payload.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 from copy import deepcopy
-from typing import Any
+from typing import Any, Callable
 
 DEFAULT_MAX_REQUEST_BYTES = 9_500_000
 DEFAULT_KEEP_RECENT_SCREENSHOTS = 6
@@ -62,6 +62,33 @@ def _strip_one_image(message: dict[str, Any]) -> bool:
     return True
 
 
+def _strip_until_fits(
+    messages: list[dict[str, Any]],
+    image_indices: list[int],
+    *,
+    skip: Callable[[int], bool],
+    max_bytes: int,
+    starting_size: int,
+) -> tuple[int, int]:
+    """Strip images in place until *messages* fit within *max_bytes*.
+
+    Iterates ``image_indices`` and calls :func:`_strip_one_image` for each
+    index where ``skip(idx)`` is False, stopping as soon as the payload is
+    within budget. Returns the updated ``(size_bytes, images_removed)``.
+    """
+    size_bytes = starting_size
+    removed = 0
+    for idx in image_indices:
+        if size_bytes <= max_bytes:
+            break
+        if skip(idx):
+            continue
+        if _strip_one_image(messages[idx]):
+            removed += 1
+            size_bytes = estimate_messages_size_bytes(messages)
+    return size_bytes, removed
+
+
 def trim_images_to_fit(
     messages: list[dict[str, Any]],
     *,
@@ -92,28 +119,27 @@ def trim_images_to_fit(
 
     keep_recent = max(1, keep_recent)
     protected = set(image_indices[-keep_recent:])
-    removed = 0
 
     # Phase 1: remove old images outside the protected window
-    for idx in image_indices:
-        if size_bytes <= max_bytes:
-            break
-        if idx in protected:
-            continue
-        if _strip_one_image(messages[idx]):
-            removed += 1
-            size_bytes = estimate_messages_size_bytes(messages)
+    size_bytes, removed = _strip_until_fits(
+        messages,
+        image_indices,
+        skip=lambda idx: idx in protected,
+        max_bytes=max_bytes,
+        starting_size=size_bytes,
+    )
 
     # Phase 2: if still over limit, remove from protected set (except the latest)
     if size_bytes > max_bytes:
-        for idx in image_indices:
-            if size_bytes <= max_bytes:
-                break
-            if idx == image_indices[-1]:
-                continue
-            if _strip_one_image(messages[idx]):
-                removed += 1
-                size_bytes = estimate_messages_size_bytes(messages)
+        last_idx = image_indices[-1]
+        size_bytes, extra_removed = _strip_until_fits(
+            messages,
+            image_indices,
+            skip=lambda idx: idx == last_idx,
+            max_bytes=max_bytes,
+            starting_size=size_bytes,
+        )
+        removed += extra_removed
 
     return size_bytes, removed
 


### PR DESCRIPTION
## Summary

The two phases of `trim_images_to_fit` were running the same image-stripping loop with the same break/strip/recompute structure, differing only in which indices to skip:

- **Phase 1** skips `idx in protected` (the recent-window guard).
- **Phase 2** skips `idx == image_indices[-1]` (always keep the last image).

That parallelism was easy to miss with both bodies inlined back-to-back, and any future tweak to the loop body had to be made in two places.

Pull the loop into a `_strip_until_fits` helper that takes the skip predicate as a parameter. The two phases now read as the helper invoked with two different `skip=lambda ...` closures, which makes the semantic difference between them the only difference in the code.

## Why it's safe

No behavior change. The helper performs the same break/skip/strip/recompute sequence; the only thing that varies between the two phases — which indices to skip — is now passed in via a callable instead of repeated inline.

## Test plan

- [x] `python -m pytest tests/test_navigator_payload.py -v` — all 24 tests pass, including `test_phase2_removes_protected_except_latest` which exercises both phases (forces protection windows to the entire list and verifies only the very last image survives).
- [x] `ruff check` and `ruff format --check` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X13AhfsErDf6nebrzMHv61)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that deduplicates image-stripping loop logic without changing trimming behavior; main risk is subtle regression in skip/break conditions affecting payload size trimming.
> 
> **Overview**
> Refactors `trim_images_to_fit` by extracting the repeated “strip images until under size limit” loop into a new `_strip_until_fits` helper that takes a `skip` predicate.
> 
> Both trimming phases now call this helper (phase 1 skips the protected recent window; phase 2 skips only the latest image), reducing duplicated control flow while preserving the existing removal strategy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 824e382714e92f3ba94103b4edc9bc7deccd492c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->