### PR TITLE
refactor(navigator/replay): use stdlib html.escape() in _escape_html

### DIFF
--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -8,6 +8,7 @@ to persist replay artifacts.
 from __future__ import annotations
 
 import asyncio
+import html
 import json
 import re
 from datetime import datetime
@@ -747,12 +748,7 @@ def _slugify(value: str) -> str:
 
 
 def _escape_html(text: str) -> str:
-    return (
-        text.replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace('"', "&quot;")
-    )
+    return html.escape(text, quote=True)
 
 
 _STYLES = """


### PR DESCRIPTION
## Summary

`yutori/navigator/replay.py:_escape_html` was a hand-rolled chain of four `.replace()` calls covering `&`, `<`, `>`, and `"`. Replace it with `html.escape(text, quote=True)` from the stdlib — exactly the helper the rest of the SDK already uses (`yutori/auth/flow.py:115`).

## Behavior

`html.escape(text, quote=True)` covers the same four entities the hand-rolled version did, **and** additionally escapes `'` to `&#x27;`. That extra escape is:

- Strictly safer (defense-in-depth against XSS in `'`-quoted attribute contexts).
- Invisible to rendered HTML (browsers decode `&#x27;` back to `'`).
- Not asserted on by any test in `tests/` (verified — `_escape_html` is purely internal to replay HTML generation).

## Why this is safe

- One-line change inside an internal helper.
- All 13 call sites of `_escape_html` continue to work unchanged — they pass strings into HTML element content / attribute values, which is exactly what `html.escape(quote=True)` is designed for.
- Matches the existing SDK pattern (`yutori/auth/flow.py` already uses `html.escape`).

https://claude.ai/code/session_01Q2Vs6XUWdM3aoq4PQwy3wD


---
_Generated by [Claude Code](https://claude.ai/code/session_01YQriiHhrKv9nSLP2EbFjhM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small internal refactor in replay HTML generation; behavior is effectively the same aside from additionally escaping single quotes, which should be safe and slightly more defensive against XSS.
> 
> **Overview**
> Switches `yutori/navigator/replay.py`’s internal `_escape_html` helper from a manual `str.replace` chain to `html.escape(text, quote=True)`.
> 
> This standardizes escaping with the stdlib helper already used elsewhere and slightly tightens output safety by also escaping single quotes in generated replay HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 805daf4cc1af9ee1a70744fd712f5a693b9a3f0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->