### PR TITLE
Narrow except blocks in run_login_flow

### DIFF
--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -307,17 +307,13 @@ def run_login_flow(
         save_config(api_key)
         return LoginResult(success=True, api_key=api_key, auth_url=auth_url)
     except httpx.HTTPStatusError as e:
-        detail = ""
-        try:
-            detail = f": {e.response.text}"
-        except Exception:
-            pass
+        detail = f": {e.response.text}" if e.response.text else ""
         return LoginResult(
             success=False,
             error=f"{ERROR_AUTH_FAILED} ({e.response.status_code}){detail}",
             auth_url=auth_url,
         )
-    except Exception as e:
+    except (httpx.HTTPError, KeyError, OSError) as e:
         return LoginResult(success=False, error=str(e), auth_url=auth_url)
 
 


### PR DESCRIPTION
## Summary

Two adjacent `except` blocks in `yutori/auth/flow.py::run_login_flow`
swallowed unrelated runtime errors. This narrows them to the actual
exception types thrown by the wrapped calls.

## What changed

1. **Inner `try/except Exception: pass` around `e.response.text`**
   — dropped entirely. `httpx.Response.text` is a synchronous property
   on a buffered response and does not raise. The dead defensive code
   would have silently swallowed any unrelated bug if it ever fired.
   Replaced with a direct read; the suffix is omitted when `.text` is
   empty.

2. **Outer `except Exception` fallback** — narrowed to
   `(httpx.HTTPError, KeyError, OSError)`. The wrapped calls
   (`exchange_code_for_token`, `register_user`, `generate_api_key`,
   `save_config`) realistically throw:
   - `httpx.HTTPError` — covers `HTTPStatusError`, connection errors,
     timeouts (the broad supertype in httpx's exception hierarchy).
   - `KeyError` — JSON key access on `["access_token"]` and `["key"]`
     when Clerk/Yutori return an unexpected payload shape.
   - `OSError` — `save_config` writes to disk and can fail with
     permission/space errors.

## Why this is a structural improvement

The previous broad `except Exception` caught `AttributeError`,
`TypeError`, `ImportError`, etc. — real bugs — and turned them into
cryptic `Login failed: 'NoneType' object has no attribute X` style
messages that are very hard to root-cause. Narrowing surfaces those
bugs as tracebacks during development instead of silently hiding them.

## Why it's safe

- Single file, two ~3-line edits.
- No happy-path behavior change.
- In the unhappy path, behavior only changes for *unanticipated*
  exception types — which is an improvement, since those previously
  produced misleading user-facing strings.
- Documented exceptions for each wrapped call are covered:
  - `register_user` docstring says it raises `httpx.HTTPStatusError`
    (subclass of `httpx.HTTPError`) — covered.
  - `save_config` writes via `os.replace` — `OSError` covered.
  - JSON key access on the access_token/key responses — `KeyError`
    covered.

## Test plan

- [ ] CI passes.
- [ ] Existing auth-flow tests still cover the documented error paths.

https://claude.ai/code/session_01BhcgMyFtQdtq5RbNP2nxXv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhcgMyFtQdtq5RbNP2nxXv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error handling in the OAuth login flow; unexpected exception types will now propagate instead of being converted to user-facing `LoginResult` errors, which could surface new crashes but improves debuggability.
> 
> **Overview**
> Tightens exception handling in `run_login_flow` to avoid swallowing unrelated runtime errors.
> 
> HTTP status failures now append `response.text` directly (only when non-empty), and the generic catch-all is narrowed to `(httpx.HTTPError, KeyError, OSError)` so unanticipated bugs raise normally instead of being turned into ambiguous login-failed messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e180f5be324a59fccc442fe86021dd5b648b393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->