### PR TITLE
flow.py: catch ValueError and decode response bytes safely

### DIFF
--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -307,13 +307,21 @@ def run_login_flow(
         save_config(api_key)
         return LoginResult(success=True, api_key=api_key, auth_url=auth_url)
     except httpx.HTTPStatusError as e:
-        detail = f": {e.response.text}" if e.response.text else ""
+        # `e.response.text` decodes with strict error handling and can raise
+        # UnicodeDecodeError on malformed bytes. Decode bytes directly with
+        # errors="replace" so a corrupt response body still surfaces as an
+        # error detail rather than crashing the login flow.
+        body_text = e.response.content.decode("utf-8", errors="replace")
+        detail = f": {body_text}" if body_text else ""
         return LoginResult(
             success=False,
             error=f"{ERROR_AUTH_FAILED} ({e.response.status_code}){detail}",
             auth_url=auth_url,
         )
-    except (httpx.HTTPError, KeyError, OSError) as e:
+    # ValueError covers json.JSONDecodeError (response.json() on a 2xx
+    # response with a non-JSON body) — same rationale as the ValueError
+    # catch in check_registration_status above.
+    except (httpx.HTTPError, ValueError, KeyError, OSError) as e:
         return LoginResult(success=False, error=str(e), auth_url=auth_url)
 
 


### PR DESCRIPTION
## Summary

Follow-up to #98 addressing two valid regressions Bugbot flagged.

When the prior PR narrowed `except Exception` to
`(httpx.HTTPError, KeyError, OSError)`, two graceful error paths that the
broad handler previously covered stopped being caught:

1. **`response.json()` raising `json.JSONDecodeError`** (a `ValueError`
   subclass) when the auth API returns a 2xx response with a non-JSON
   body. Both `exchange_code_for_token` and `generate_api_key` call
   `response.json()` inside the wrapped try block. The companion
   `check_registration_status` in the same file already catches
   `ValueError` for exactly this reason — restoring symmetry.
2. **`e.response.text` raising `UnicodeDecodeError`** when the response
   body has malformed bytes for the declared encoding. Crucially this
   happens *inside* the `except httpx.HTTPStatusError` handler, so the
   sibling `(httpx.HTTPError, ...)` handler cannot catch it and the
   error would propagate past `run_login_flow`.

## Changes

- Add `ValueError` to the outer `except` tuple so `JSONDecodeError`
  surfaces as a `LoginResult(success=False, ...)` again. Comment cross-
  references the sibling pattern in `check_registration_status`.
- Replace `e.response.text` with
  `e.response.content.decode("utf-8", errors="replace")` so corrupt
  response bytes become replacement characters in the error detail
  rather than raising. Comment explains the rationale.

## Why it's safe

- Single file, two ~3-line edits.
- No happy-path behavior change.
- For valid UTF-8 response bodies, `content.decode("utf-8")` produces
  the same string as the prior `.text` access (httpx defaults to UTF-8
  when the response declares no encoding, and the strict-mode default
  matches `decode("utf-8")` for valid input).
- `ValueError` is intentionally broad enough to cover both
  `JSONDecodeError` and `UnicodeDecodeError`, matching the established
  pattern at `check_registration_status` line 217.

## Test plan

- [ ] CI passes.
- [ ] Bugbot re-review clears both flags.

https://claude.ai/code/session_01BhcgMyFtQdtq5RbNP2nxXv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhcgMyFtQdtq5RbNP2nxXv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts error handling in `run_login_flow` to gracefully surface malformed HTTP bodies/JSON as `LoginResult` errors without changing the happy path.
> 
> **Overview**
> Improves robustness of the OAuth login flow by preventing crashes when the auth API returns malformed data.
> 
> `run_login_flow` now decodes `HTTPStatusError` response bodies from bytes with `errors="replace"` (instead of relying on `response.text`), and expands the fallback exception handler to include `ValueError` so `json.JSONDecodeError` from `response.json()` becomes a clean `LoginResult(success=False, ...)` error again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9e58a49234c0d595bd6a784bfb9d0363beaba1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->