### PR TITLE
refactor(navigator/context): narrow except Exception around ZoneInfo

### DIFF
--- a/yutori/navigator/context.py
+++ b/yutori/navigator/context.py
@@ -28,11 +28,16 @@ def format_user_context(
     """
     try:
         tz = ZoneInfo(user_timezone)
-    except (ZoneInfoNotFoundError, ValueError):
+    except (ZoneInfoNotFoundError, ValueError, OSError):
+        # ZoneInfoNotFoundError: unknown key or no tzdata.
+        # ValueError: path-traversal segments (e.g. "../foo").
+        # OSError: on Python <3.13, IANA *directory* keys like "America" or
+        # "US" raise IsADirectoryError (a subclass of OSError) instead of
+        # ZoneInfoNotFoundError (CPython issue #85702, fixed in 3.13).
         try:
             tz = ZoneInfo("America/Los_Angeles")
             user_timezone = str(tz)
-        except ZoneInfoNotFoundError:
+        except (ZoneInfoNotFoundError, OSError):
             # No IANA timezone data available (e.g. Windows without tzdata).
             tz = timezone.utc
             user_timezone = "UTC"

--- a/yutori/navigator/context.py
+++ b/yutori/navigator/context.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import platform
 from datetime import datetime, timezone
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 
 def format_user_context(
@@ -28,11 +28,11 @@ def format_user_context(
     """
     try:
         tz = ZoneInfo(user_timezone)
-    except Exception:
+    except (ZoneInfoNotFoundError, ValueError):
         try:
             tz = ZoneInfo("America/Los_Angeles")
             user_timezone = str(tz)
-        except Exception:
+        except ZoneInfoNotFoundError:
             # No IANA timezone data available (e.g. Windows without tzdata).
             tz = timezone.utc
             user_timezone = "UTC"


### PR DESCRIPTION
## What

Narrow the two `except Exception:` clauses in `format_user_context` (`yutori/navigator/context.py`) to the specific exceptions `zoneinfo.ZoneInfo` actually raises:

- Outer fallback (caller-supplied `user_timezone`): `(ZoneInfoNotFoundError, ValueError)` — covers both unknown keys and unsafe `..`-style keys.
- Inner fallback (default `"America/Los_Angeles"`): `ZoneInfoNotFoundError` — the documented case where no IANA `tzdata` is installed (e.g. Windows without `tzdata`).

## Why

`ZoneInfo(key)` raises:
- `zoneinfo.ZoneInfoNotFoundError` when the key is unknown or no `tzdata` is installed.
- `ValueError` when the key contains path-traversal segments (`../foo`).

Catching the broad `Exception` swallows unrelated programming errors and makes timezone bugs hard to spot. Narrowing keeps every documented failure mode handled while letting unexpected errors surface.

Verified locally:

```python
>>> ZoneInfo("invalid/tz")
ZoneInfoNotFoundError: 'No time zone found with key invalid/tz'
>>> ZoneInfo("../foo")
ValueError: ZoneInfo keys must refer to subdirectories of TZPATH, got: ../foo
```

## Safety

No behavior change for any input that previously hit the fallback paths. Manually exercised with both a valid (`"America/Los_Angeles"`) and an invalid (`"Invalid/Timezone"`) `user_timezone` — both produce identical output to `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019iqPEbVDTWxXbZwHkdFwbh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tightens exception handling around `ZoneInfo` lookup while preserving the same fallback behavior, though unexpected errors will now surface instead of being swallowed.
> 
> **Overview**
> Improves robustness of `format_user_context` timezone resolution by replacing broad `except Exception` blocks with specific `ZoneInfo`-related exceptions and documenting Python version edge-cases.
> 
> Keeps the existing fallback chain (caller timezone 
> 
>  default `America/Los_Angeles` 
> 
>  UTC when tzdata is unavailable) but avoids masking unrelated runtime/programming errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd19f42bde465f06a1bb1fca3092e8f026945a00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->