### PR TITLE
refactor(navigator/replay): inline thin _dump_json wrapper

### DIFF
--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -545,7 +545,7 @@ def _render_step(step: dict[str, Any]) -> str:
 
 
 def _render_json_panel(title: str, payload: Any) -> str:
-    json_text = _dump_json(payload) or "{}"
+    json_text = _safe_json_dumps(payload) or "{}"
     return (
         "<div class=\"panel nested\">"
         f"<h3>{_escape_html(title)}</h3>"
@@ -723,10 +723,6 @@ def _dump_result_json(result: object | None) -> str | None:
     if not handled:
         payload = result
     return _safe_json_dumps(payload, fallback=result)
-
-
-def _dump_json(payload: Any) -> str | None:
-    return _safe_json_dumps(payload)
 
 
 def _json_default(obj: Any) -> Any:


### PR DESCRIPTION
## Summary

`yutori/navigator/replay.py` had a 2-line wrapper `_dump_json(payload)` that simply called `_safe_json_dumps(payload)` with no extra logic. It also declared a misleading `str | None` return type (the underlying `_safe_json_dumps` always returns `str`) and was used in exactly one call site (`_render_json_panel`).

```python
# Before
def _dump_json(payload: Any) -> str | None:
    return _safe_json_dumps(payload)

# Single call site
json_text = _dump_json(payload) or "{}"
```

This PR removes the wrapper and points `_render_json_panel` at `_safe_json_dumps` directly. PR #92 already centralised `model_dump` handling into `_try_model_dump`, so this leftover wrapper provides no abstraction value.

## Why this is a clean refactor

- Wrapper had a single call site and zero added behavior.
- Return-type annotation `str | None` was misleading (`_safe_json_dumps` never returns `None`).
- Leaves the more substantive sibling `_dump_result_json()` (which has real `result is None` handling) untouched.
- Diff is fully contained to one file, with no ripple effects (`grep -rn _dump_json` returns zero hits after the change).

## Behavior

No behavioral change — the call site invokes the same underlying serializer with the same arguments and preserves the existing `or "{}"` guard.

## Test plan
- [x] `python -c "import ast; ast.parse(open('yutori/navigator/replay.py').read())"` — passes
- [x] `grep -rn '_dump_json' .` — zero hits across the repo (incl. tests) after the change

https://claude.ai/code/session_01TYEcuSxggDsf1mwheRWG4m

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYEcuSxggDsf1mwheRWG4m)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to debug-only HTML replay rendering; it removes an unused helper and directly calls the same JSON serializer, so behavior should be unchanged.
> 
> **Overview**
> Simplifies replay HTML rendering by removing the thin `_dump_json` wrapper and calling `_safe_json_dumps` directly from `_render_json_panel`.
> 
> Eliminates the now-unused `_dump_json` helper, reducing indirection without changing serialization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c6700e0ea306a368874167023cd8aee634addc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->