### PR TITLE
refactor(cli): extract _print_rate_limits helper in usage.py

### DIFF
--- a/yutori/cli/commands/usage.py
+++ b/yutori/cli/commands/usage.py
@@ -19,6 +19,37 @@ console = Console()
 _RATE_LIMIT_LABEL_WIDTH = len("Requests today")
 
 
+def _print_rate_limits(
+    console: Console,
+    title: str,
+    limits: dict[str, Any],
+    *,
+    show_per_second: bool = False,
+    gate_on_status_available: bool = False,
+) -> None:
+    """Print a rate-limit block as aligned fields.
+
+    The Requests-today / Daily-limit / Remaining (and optional Per-second)
+    rows are suppressed when ``gate_on_status_available`` is set and the
+    server reports a non-``"available"`` status. ``Resets at`` always prints
+    so the block is never empty.
+    """
+    console.print(title)
+    fields: list[tuple[str, Any]] = []
+    if not gate_on_status_available or limits.get("status") == "available":
+        fields.extend(
+            [
+                ("Requests today", limits.get("requests_today", "N/A")),
+                ("Daily limit", limits.get("daily_limit", "N/A")),
+                ("Remaining", limits.get("remaining_requests", "N/A")),
+            ]
+        )
+        if show_per_second:
+            fields.append(("Per-second", limits.get("per_second_limit", "N/A")))
+    fields.append(("Resets at", limits.get("reset_at", "N/A")))
+    print_aligned_fields(console, fields, min_label_width=_RATE_LIMIT_LABEL_WIDTH)
+
+
 @app.callback(invoke_without_command=True)
 def usage(
     ctx: typer.Context,
@@ -46,33 +77,21 @@ def usage(
         # Rate limits
         rate_limits = data.get("rate_limits", {})
         if rate_limits:
-            console.print(f"\n  [bold]API Rate Limits[/bold] ({rate_limits.get('status', 'unknown')})")
-            rate_fields: list[tuple[str, Any]] = []
-            if rate_limits.get("status") == "available":
-                rate_fields.extend(
-                    [
-                        ("Requests today", rate_limits.get("requests_today", "N/A")),
-                        ("Daily limit", rate_limits.get("daily_limit", "N/A")),
-                        ("Remaining", rate_limits.get("remaining_requests", "N/A")),
-                    ]
-                )
-            rate_fields.append(("Resets at", rate_limits.get("reset_at", "N/A")))
-            print_aligned_fields(console, rate_fields, min_label_width=_RATE_LIMIT_LABEL_WIDTH)
+            _print_rate_limits(
+                console,
+                f"\n  [bold]API Rate Limits[/bold] ({rate_limits.get('status', 'unknown')})",
+                rate_limits,
+                gate_on_status_available=True,
+            )
 
         # Navigator API rate limits (falls back to the deprecated ``n1_rate_limits`` key on older servers)
         navigator_limits = data.get("navigator_rate_limits") or data.get("n1_rate_limits") or {}
         if navigator_limits:
-            console.print("\n  [bold]Navigator API Rate Limits[/bold]")
-            print_aligned_fields(
+            _print_rate_limits(
                 console,
-                [
-                    ("Requests today", navigator_limits.get("requests_today", "N/A")),
-                    ("Daily limit", navigator_limits.get("daily_limit", "N/A")),
-                    ("Remaining", navigator_limits.get("remaining_requests", "N/A")),
-                    ("Per-second", navigator_limits.get("per_second_limit", "N/A")),
-                    ("Resets at", navigator_limits.get("reset_at", "N/A")),
-                ],
-                min_label_width=_RATE_LIMIT_LABEL_WIDTH,
+                "\n  [bold]Navigator API Rate Limits[/bold]",
+                navigator_limits,
+                show_per_second=True,
             )
 
         # Activity counts


### PR DESCRIPTION
## Summary

Extracts the duplicated rate-limit rendering logic in `yutori/cli/commands/usage.py` into a single `_print_rate_limits()` helper.

The two blocks (API rate limits vs. Navigator API rate limits) shared identical `(label, response_key)` tuples for "Requests today" / "Daily limit" / "Remaining" / "Resets at", plus the same `print_aligned_fields` call with the same `min_label_width`. They differed only in:

| flag | API rate limits | Navigator rate limits |
|------|-----------------|------------------------|
| `gate_on_status_available` | suppress counters when `status != "available"` | always print |
| `show_per_second` | omit Per-second row | include Per-second row |

Both differences are now explicit keyword arguments to the helper, instead of hidden in two slightly-divergent inline blocks.

## Why this is safe

- No behavior change: the helper produces the exact same output rows for each call site.
- Single-file diff. No public API surface change (`_print_rate_limits` is module-private and only used inside `usage.py`).
- Eliminates a latent drift bug — the two blocks already differed subtly (only the API block gates on status); a future label rename or field addition would otherwise need to be applied in two places.

## Test plan

- [ ] CI passes
- [ ] Manual: run `yutori usage` against an authenticated client and confirm both rate-limit blocks render identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1rKVCTLnBGSibPVAjMBcW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to CLI output formatting; main risk is minor behavior drift in which rate-limit rows are shown/hidden based on `status` and optional per-second limits.
> 
> **Overview**
> Refactors `yutori/cli/commands/usage.py` to extract duplicated rate-limit printing into a single `_print_rate_limits()` helper.
> 
> Both the API and Navigator rate-limit sections now call the helper with flags to (a) gate counters on `status == "available"` for API limits and (b) optionally include the `Per-second` row for Navigator limits, while keeping alignment via the shared `_RATE_LIMIT_LABEL_WIDTH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d99f5c3c90413f1f73b9bcf60c47d6205400581. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->