### PR TITLE
refactor(cli): extract print_creation_result helper

### DIFF
--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "format_interval",
     "get_authenticated_client",
     "print_aligned_fields",
+    "print_creation_result",
     "print_optional_field",
     "print_rejection_reason",
     "print_task_get_header",
@@ -101,17 +102,41 @@ def print_aligned_fields(
         console.print(f"{indent_str}{(label + ':').ljust(label_width + 2)}{value}")
 
 
-def print_task_submission_result(console: Console, task_type: str, result: dict[str, Any]) -> None:
-    """Print a task creation response without implying success on failed creates."""
+def print_creation_result(
+    console: Console,
+    result: dict[str, Any],
+    *,
+    success_message: str,
+    failure_message: str,
+    fields: list[tuple[str, Any]] | None = None,
+) -> None:
+    """Print a creation response: colored header, optional fields, status, rejection reason.
+
+    The header is red on ``status == "failed"`` and green otherwise so failed
+    creates do not display a misleading success banner. Each ``(label, value)``
+    in ``fields`` is rendered as ``  label: value`` between the header and the
+    ``Status`` line, mirroring the existing per-command output ordering.
+    """
     status = result.get("status", "N/A")
     if status == "failed":
-        console.print(f"\n[red]{task_type} task failed to start.[/red]")
+        console.print(f"\n[red]{failure_message}[/red]")
     else:
-        console.print(f"\n[green]{task_type} task submitted.[/green]")
-
-    console.print(f"  Task ID: {result.get('task_id', 'N/A')}")
+        console.print(f"\n[green]{success_message}[/green]")
+    for label, value in fields or []:
+        console.print(f"  {label}: {value}")
     console.print(f"  Status: {status}")
     print_rejection_reason(console, result)
+
+
+def print_task_submission_result(console: Console, task_type: str, result: dict[str, Any]) -> None:
+    """Print a task creation response without implying success on failed creates."""
+    print_creation_result(
+        console,
+        result,
+        success_message=f"{task_type} task submitted.",
+        failure_message=f"{task_type} task failed to start.",
+        fields=[("Task ID", result.get("task_id", "N/A"))],
+    )
 
 
 def print_task_get_header(console: Console, task_type: str, task_id: str, result: dict[str, Any]) -> None:

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -11,6 +11,7 @@ from yutori.cli.commands import (
     INTERVAL_PRESETS,
     format_interval,
     get_authenticated_client,
+    print_creation_result,
     print_optional_field,
     print_rejection_reason,
 )
@@ -102,15 +103,16 @@ def create(
             user_timezone=timezone,
         )
 
-        status = result.get("status", "N/A")
-        if status == "failed":
-            console.print("\n[red]Scout creation failed.[/red]")
-        else:
-            console.print("\n[green]Scout created successfully![/green]")
-        console.print(f"  ID: {result.get('id', 'N/A')}")
-        console.print(f"  Query: {escape(result.get('query', query))}")
-        console.print(f"  Status: {status}")
-        print_rejection_reason(console, result)
+        print_creation_result(
+            console,
+            result,
+            success_message="Scout created successfully!",
+            failure_message="Scout creation failed.",
+            fields=[
+                ("ID", result.get("id", "N/A")),
+                ("Query", escape(result.get("query", query))),
+            ],
+        )
 
 
 @app.command()


### PR DESCRIPTION
## Summary

Extracts a `print_creation_result(...)` helper next to the existing `print_task_submission_result()` and migrates the inline `scouts create` handler to use it.

## Why this is structurally better

`scouts.py:create` and `print_task_submission_result()` both implemented the same shape:

1. Pull `status` from the response.
2. Print a red failure header on `status == "failed"`, otherwise a green success header.
3. Print one or more `  label: value` rows.
4. Print `  Status: {status}`.
5. Print the rejection reason via `print_rejection_reason()`.

The only differences were the success/failure copy and which fields to render between the header and the `Status` line. The two call sites had drifted in trivial ways (`Scout creation failed.` vs `Browsing task failed to start.`, different field lists), but the surrounding ordering/formatting was identical.

After this PR, that pattern lives in exactly one place. `print_task_submission_result` is now a thin wrapper that supplies the task-specific copy + Task ID; `scouts create` calls `print_creation_result` directly with its ID/Query fields. Future create commands (or any change to how creation banners are rendered) only need to touch the helper.

## Safety

- **Pure refactor — no behavior change.** Same console output for both call sites.
- All 10 existing CLI tests pass (`tests/test_cli.py`), including the 4 success-banner / failure-banner / rejection-reason cases that pin the exact message strings (`"Browsing task submitted"`, `"Browsing task failed to start"`, `"Research task submitted"`, `"Research task failed to start"`, `"Rejection Reason: ..."`).
- `ruff check` clean.
- 2-file change, contained to `yutori/cli/commands/`.

## Test plan

- [x] `python3 -m pytest tests/test_cli.py -x -q` — 10/10 pass
- [x] `ruff check yutori/cli/commands/__init__.py yutori/cli/commands/scouts.py`
- [x] Manually verified diff preserves field ordering (ID/Query before Status; Task ID before Status) and color choice (red on `status == "failed"`, green otherwise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2134uSctJKk2mstPbYVLB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to CLI output formatting; behavior should remain the same but could slightly change user-facing messaging/field ordering if mis-specified at call sites.
> 
> **Overview**
> Extracts a reusable `print_creation_result()` helper to standardize how CLI “create” commands print success/failure headers, key fields, status, and rejection reasons.
> 
> Refactors `print_task_submission_result()` into a thin wrapper around the helper, and updates `scouts create` to use the helper instead of inline status/field printing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 234ffb450b119cd934cc887dd26656ef6aaf7b09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->