### PR TITLE
refactor(replay): extract _to_percent_xy and merge marker-coord branches

### DIFF
--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -446,6 +446,13 @@ def _parse_tool_calls(message: dict) -> list[dict[str, Any]]:
     return actions
 
 
+def _to_percent_xy(
+    coord: Any, coord_space_width: int, coord_space_height: int
+) -> tuple[float, float]:
+    """Convert an ``(x, y)`` pair from Navigator coordinate space to viewport %."""
+    return coord[0] / coord_space_width * 100, coord[1] / coord_space_height * 100
+
+
 def _get_action_marker_style(
     action: dict[str, Any],
     coord_space_width: int,
@@ -460,26 +467,26 @@ def _get_action_marker_style(
     if "start_coordinates" in action and action_type.lower() in {"drag", "left_click_drag"}:
         start = action["start_coordinates"]
         end = action.get("coordinates", action.get("end_coordinates", action.get("center_coordinates", [0, 0])))
+        start_x, start_y = _to_percent_xy(start, coord_space_width, coord_space_height)
+        end_x, end_y = _to_percent_xy(end, coord_space_width, coord_space_height)
         marker.update(
             {
                 "has_drag": True,
-                "start_x": start[0] / coord_space_width * 100,
-                "start_y": start[1] / coord_space_height * 100,
-                "end_x": end[0] / coord_space_width * 100,
-                "end_y": end[1] / coord_space_height * 100,
+                "start_x": start_x,
+                "start_y": start_y,
+                "end_x": end_x,
+                "end_y": end_y,
             }
         )
         return marker
 
-    if "coordinates" in action:
-        x, y = action["coordinates"]
-        marker.update({"has_point": True, "x": x / coord_space_width * 100, "y": y / coord_space_height * 100})
-        return marker
-
-    if "center_coordinates" in action:
-        x, y = action["center_coordinates"]
-        marker.update({"has_point": True, "x": x / coord_space_width * 100, "y": y / coord_space_height * 100})
-        return marker
+    # `coordinates` and `center_coordinates` carry the same single-point semantics here;
+    # only the field name differs across action schemas.
+    for point_key in ("coordinates", "center_coordinates"):
+        if point_key in action:
+            x, y = _to_percent_xy(action[point_key], coord_space_width, coord_space_height)
+            marker.update({"has_point": True, "x": x, "y": y})
+            return marker
 
     marker["has_point"] = False
     marker["has_ref_only"] = "ref" in action


### PR DESCRIPTION
## Summary

`_get_action_marker_style` in `yutori/navigator/replay.py` had two structural smells:

1. The viewport-percentage formula `coord / coord_space_* * 100` was inlined six times across the drag, `coordinates`, and `center_coordinates` branches.
2. The `coordinates` and `center_coordinates` branches were byte-identical except for the key name — three lines duplicated for no reason.

Extract `_to_percent_xy(coord, w, h)` for the conversion and collapse the two single-point branches into a small loop over the candidate keys.

## Why it's safe

- The new helper produces exactly the same float pair the inlined arithmetic produced.
- Iterating `("coordinates", "center_coordinates")` preserves the original preference order — `coordinates` is checked first, exactly like the old code.
- The drag branch and the final ref-only/no-info fallback are unchanged.
- Smoke-tested locally against drag, single-coordinate, single-center-coordinate, ref-only, and no-info inputs — all produce identical output.

## Test plan

- [x] Local smoke tests over the action shapes the function accepts (drag, coordinates, center_coordinates, ref-only, no-info, left_click_drag).
- [ ] CI passes existing `tests/` suite.

https://claude.ai/code/session_01E534qqE9ShTNuXaUZQLMMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01E534qqE9ShTNuXaUZQLMMF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to replay visualization marker calculations; behavior should remain the same aside from potential edge-case differences if malformed coordinate arrays are passed in.
> 
> **Overview**
> Refactors `yutori/navigator/replay.py` marker generation by extracting `_to_percent_xy()` for converting Navigator coordinates into viewport percentages.
> 
> Simplifies `_get_action_marker_style()` by collapsing the duplicated `coordinates` vs `center_coordinates` handling into a single loop, while keeping drag marker behavior and fallbacks the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d4743aa62aaa305c5e06c32e7cba87c7bd69dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->