### PR TITLE
refactor(navigator/context): extract _resolve_user_timezone helper

### DIFF
--- a/yutori/navigator/context.py
+++ b/yutori/navigator/context.py
@@ -7,8 +7,30 @@ string, giving the model awareness of the user's environment.
 from __future__ import annotations
 
 import platform
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+def _resolve_user_timezone(user_timezone: str) -> tuple[tzinfo, str]:
+    """Resolve a tz string to a (tzinfo, display label), with safe fallbacks.
+
+    Falls back to America/Los_Angeles, then UTC, when:
+    - ZoneInfoNotFoundError: unknown key or no tzdata.
+    - ValueError: path-traversal segments (e.g. "../foo").
+    - OSError: on Python <3.13, IANA *directory* keys like "America" or "US"
+      raise IsADirectoryError (a subclass of OSError) instead of
+      ZoneInfoNotFoundError (CPython issue #85702, fixed in 3.13).
+    """
+    try:
+        return ZoneInfo(user_timezone), user_timezone
+    except (ZoneInfoNotFoundError, ValueError, OSError):
+        pass
+    try:
+        tz = ZoneInfo("America/Los_Angeles")
+        return tz, str(tz)
+    except (ZoneInfoNotFoundError, OSError):
+        # No IANA timezone data available (e.g. Windows without tzdata).
+        return timezone.utc, "UTC"
 
 
 def format_user_context(
@@ -26,21 +48,7 @@ def format_user_context(
         Current Time: 10:05:49 PDT
         Today is: Tuesday
     """
-    try:
-        tz = ZoneInfo(user_timezone)
-    except (ZoneInfoNotFoundError, ValueError, OSError):
-        # ZoneInfoNotFoundError: unknown key or no tzdata.
-        # ValueError: path-traversal segments (e.g. "../foo").
-        # OSError: on Python <3.13, IANA *directory* keys like "America" or
-        # "US" raise IsADirectoryError (a subclass of OSError) instead of
-        # ZoneInfoNotFoundError (CPython issue #85702, fixed in 3.13).
-        try:
-            tz = ZoneInfo("America/Los_Angeles")
-            user_timezone = str(tz)
-        except (ZoneInfoNotFoundError, OSError):
-            # No IANA timezone data available (e.g. Windows without tzdata).
-            tz = timezone.utc
-            user_timezone = "UTC"
+    tz, user_timezone = _resolve_user_timezone(user_timezone)
 
     now = datetime.now(tz)
 


### PR DESCRIPTION
## Summary

`format_user_context()` mixed timezone resolution (a 14-line nested try/except chain) with date/time formatting. This PR extracts the resolution into a private `_resolve_user_timezone(user_timezone) -> tuple[tzinfo, str]` helper:

- separates concerns: resolution vs. formatting
- shrinks `format_user_context` to a single tz-resolve call + formatting
- keeps the multi-step fallback (requested tz → America/Los_Angeles → UTC) and the comment about CPython issue #85702 in one place

The helper returns `(tzinfo, str)` so the caller can both build `datetime.now(tz)` and display the resolved name.

## Why this is safe

- No behavior change.
- Smoke-tested all four code paths:
  - default `America/Los_Angeles`
  - invalid key (`Foo/Bar`)
  - path traversal (`../foo`)
  - IANA directory key (`America`, which raises `IsADirectoryError` on Python < 3.13)
- All four fall back identically to the original.

## Test plan
- [x] Smoke-test all four resolution paths
- [ ] CI

🤖 Automated refactor — generated by hourly refactor cron.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHhZCdfuqB9ddCxCgRVE9S)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only restructures timezone resolution into a helper while keeping the same fallback behavior (requested tz → `America/Los_Angeles` → `UTC`). Main risk is subtle behavior drift in edge-case exception handling, but logic is unchanged and centralized.
> 
> **Overview**
> Refactors `format_user_context()` by extracting timezone parsing/fallback logic into a new private `_resolve_user_timezone()` helper that returns both the resolved `tzinfo` and the display label.
> 
> `format_user_context()` now delegates timezone resolution to this helper and focuses only on formatting the context strings, while preserving the same multi-step fallback and exception handling for invalid/unsupported timezone inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5cf2476d8b5445999d0d8613d2da250ec26c902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->