### PR TITLE
installer: configure Yutori MCP server + skills after auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ On macOS or Linux, the recommended setup is the one-line installer:
 curl -fsSL https://yutori.com/install.sh | bash
 ```
 
-This installs the global `yutori` CLI with `uv tool install`, then — in an interactive terminal — prompts (with sensible defaults) to add the SDK to your project, run `yutori auth login`, and run a verification browsing task. In a non-interactive session (CI, pipe) the auth and verification prompts are skipped with guidance on how to finish setup.
+This installs the global `yutori` CLI with `uv tool install`, then — in an interactive terminal — prompts (with sensible defaults) to add the SDK to your project, run `yutori auth login`, configure the Yutori MCP server, install workflow skills, and run a verification browsing task. In a non-interactive session (CI, pipe) the auth, MCP, skills, and verification prompts are skipped with guidance on how to finish setup.
 
 Python 3.9+ is required for the SDK.
 

--- a/tests/test_install_ui.py
+++ b/tests/test_install_ui.py
@@ -704,6 +704,26 @@ def test_maybe_install_mcp_server_failure_includes_retry_hint():
     assert "npx add-mcp" in result.detail
 
 
+def test_maybe_install_mcp_server_returncode_127_uses_generic_message():
+    # resolve_npx_path already verified the binary exists, so a 127 reaching
+    # _run_npx_step is almost always npx's own exit code (e.g. package's bin
+    # entry resolved to a missing executable). Don't claim "Could not execute
+    # 'npx'" — that's misleading when npx itself ran fine.
+    failure = subprocess.CompletedProcess(args=[], returncode=127, stdout=None, stderr=None)
+
+    with (
+        patch("yutori.cli.commands.install_ui.resolve_npx_path", return_value="/usr/local/bin/npx"),
+        patch("yutori.cli.commands.install_ui.Confirm.ask", return_value=True),
+        patch("yutori.cli.commands.install_ui.run_interactive_command", return_value=failure),
+    ):
+        result = maybe_install_mcp_server(Console(), interactive=True)
+
+    assert result.status == "failed"
+    assert "status 127" in result.detail
+    assert "Could not execute" not in result.detail
+    assert "npx add-mcp" in result.detail
+
+
 def test_maybe_install_mcp_server_failure_surfaces_timeout():
     timed_out = subprocess.CompletedProcess(args=[], returncode=124, stdout=None, stderr=None)
 

--- a/tests/test_install_ui.py
+++ b/tests/test_install_ui.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
-from pathlib import Path
 import subprocess
+from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from rich.console import Console
 from typer.testing import CliRunner
 
-import pytest
-
 from yutori.auth.types import LoginResult
 from yutori.cli.commands.install_ui import (
+    MCP_SERVER_INSTALL_COMMAND,
+    MCP_SKILLS_INSTALL_COMMAND,
+    VERIFICATION_MAX_STEPS,
+    VERIFICATION_TASK,
+    VERIFICATION_TASK_DASHBOARD_BASE_URL,
+    VERIFICATION_URL,
     CLIInstallState,
     SDKInstallPlan,
     StepResult,
@@ -18,14 +23,14 @@ from yutori.cli.commands.install_ui import (
     inspect_cli_install,
     looks_like_auth_failure,
     maybe_authenticate,
+    maybe_install_mcp_server,
+    maybe_install_mcp_skills,
     maybe_install_sdk,
     maybe_repair_path,
+    resolve_npx_path,
     resolve_uv_path,
+    run_interactive_command,
     run_verification,
-    VERIFICATION_MAX_STEPS,
-    VERIFICATION_TASK,
-    VERIFICATION_TASK_DASHBOARD_BASE_URL,
-    VERIFICATION_URL,
 )
 from yutori.cli.main import app
 
@@ -142,6 +147,14 @@ def test_resolve_uv_path_rejects_non_executable_env_var(monkeypatch):
     assert resolved == "/opt/uv"
 
 
+def test_resolve_npx_path_uses_path_lookup():
+    with patch("yutori.cli.commands.install_ui.shutil.which", return_value="/usr/local/bin/npx") as mock_which:
+        resolved = resolve_npx_path({"PATH": "/usr/local/bin"})
+
+    assert resolved == "/usr/local/bin/npx"
+    mock_which.assert_called_once_with("npx", path="/usr/local/bin")
+
+
 def test_install_ui_noninteractive_skips_optional_steps():
     cli_state = CLIInstallState(
         cli_path=Path("/tmp/yutori"),
@@ -157,12 +170,18 @@ def test_install_ui_noninteractive_skips_optional_steps():
     )
 
     with (
-        patch("yutori.cli.commands.install_ui.inspect_cli_install", return_value=(cli_state, StepResult("CLI", "success", "ok"))),
+        patch(
+            "yutori.cli.commands.install_ui.inspect_cli_install",
+            return_value=(cli_state, StepResult("CLI", "success", "ok")),
+        ),
         patch("yutori.cli.commands.install_ui.detect_sdk_install_plan", return_value=sdk_plan),
         patch("yutori.cli.commands.install_ui.is_interactive_terminal", return_value=False),
         patch(
             "yutori.cli.commands.install_ui.maybe_authenticate",
-            return_value=(StepResult("Auth", "skipped", "Skipped auth because no interactive terminal is available."), False),
+            return_value=(
+                StepResult("Auth", "skipped", "Skipped auth because no interactive terminal is available."),
+                False,
+            ),
         ),
     ):
         result = runner.invoke(app, ["__install_ui"])
@@ -171,6 +190,12 @@ def test_install_ui_noninteractive_skips_optional_steps():
     assert "Non-interactive terminal detected." in result.stdout
     assert "Skipped SDK install because no interactive" in result.stdout
     assert "Skipped auth because no interactive" in result.stdout
+    # Two MCP rows render. In this fixture auth was skipped (no interactive
+    # terminal), so MCP/skills hit the not-authenticated gate before the
+    # non-interactive gate inside the helpers themselves.
+    assert "MCP server" in result.stdout
+    assert "MCP skills" in result.stdout
+    assert "Authenticate first" in result.stdout
     assert "Verification requires a valid API key." in result.stdout
     # Each step should render in the summary table, including PATH (it was
     # already on PATH for this fixture).
@@ -195,7 +220,10 @@ def test_install_ui_exits_nonzero_when_cli_verification_fails():
         patch("yutori.cli.commands.install_ui.maybe_install_sdk", return_value=StepResult("SDK", "skipped", "skip")),
         patch(
             "yutori.cli.commands.install_ui.maybe_authenticate",
-            return_value=(StepResult("Auth", "skipped", "Skipped auth because no interactive terminal is available."), False),
+            return_value=(
+                StepResult("Auth", "skipped", "Skipped auth because no interactive terminal is available."),
+                False,
+            ),
         ),
     ):
         result = runner.invoke(app, ["__install_ui"])
@@ -219,11 +247,17 @@ def test_install_ui_marks_auth_failure_when_verification_rejects_credentials():
     )
 
     with (
-        patch("yutori.cli.commands.install_ui.inspect_cli_install", return_value=(cli_state, StepResult("CLI", "success", "ok"))),
+        patch(
+            "yutori.cli.commands.install_ui.inspect_cli_install",
+            return_value=(cli_state, StepResult("CLI", "success", "ok")),
+        ),
         patch("yutori.cli.commands.install_ui.detect_sdk_install_plan", return_value=sdk_plan),
         patch("yutori.cli.commands.install_ui.is_interactive_terminal", return_value=False),
         patch("yutori.cli.commands.install_ui.maybe_install_sdk", return_value=StepResult("SDK", "skipped", "skip")),
-        patch("yutori.cli.commands.install_ui.maybe_authenticate", return_value=(StepResult("Auth", "success", "ok"), True)),
+        patch(
+            "yutori.cli.commands.install_ui.maybe_authenticate",
+            return_value=(StepResult("Auth", "success", "ok"), True),
+        ),
         patch(
             "yutori.cli.commands.install_ui.run_verification",
             return_value=(StepResult("Verification", "failed", "Authentication failed during verification."), True),
@@ -371,11 +405,17 @@ def test_install_ui_skips_header_when_bootstrap_already_rendered():
     sdk_plan = SDKInstallPlan(reason="ok", command=("uv", "add", "yutori"), default=True)
 
     with (
-        patch("yutori.cli.commands.install_ui.inspect_cli_install", return_value=(cli_state, StepResult("CLI", "success", "ok"))),
+        patch(
+            "yutori.cli.commands.install_ui.inspect_cli_install",
+            return_value=(cli_state, StepResult("CLI", "success", "ok")),
+        ),
         patch("yutori.cli.commands.install_ui.detect_sdk_install_plan", return_value=sdk_plan),
         patch("yutori.cli.commands.install_ui.maybe_install_sdk", return_value=StepResult("SDK", "skipped", "skip")),
         patch("yutori.cli.commands.install_ui.maybe_repair_path", return_value=StepResult("PATH", "success", "ok")),
-        patch("yutori.cli.commands.install_ui.maybe_authenticate", return_value=(StepResult("Auth", "skipped", "skip"), False)),
+        patch(
+            "yutori.cli.commands.install_ui.maybe_authenticate",
+            return_value=(StepResult("Auth", "skipped", "skip"), False),
+        ),
     ):
         result = runner.invoke(app, ["__install_ui"], env={"YUTORI_INSTALLER_BOOTSTRAP_SHOWN": "1"})
 
@@ -399,10 +439,16 @@ def test_install_ui_exits_zero_when_verification_fails_for_non_auth_reason():
     sdk_plan = SDKInstallPlan(reason="ok", command=("uv", "add", "yutori"), default=True)
 
     with (
-        patch("yutori.cli.commands.install_ui.inspect_cli_install", return_value=(cli_state, StepResult("CLI", "success", "ok"))),
+        patch(
+            "yutori.cli.commands.install_ui.inspect_cli_install",
+            return_value=(cli_state, StepResult("CLI", "success", "ok")),
+        ),
         patch("yutori.cli.commands.install_ui.detect_sdk_install_plan", return_value=sdk_plan),
         patch("yutori.cli.commands.install_ui.maybe_install_sdk", return_value=StepResult("SDK", "skipped", "skip")),
-        patch("yutori.cli.commands.install_ui.maybe_authenticate", return_value=(StepResult("Auth", "success", "ok"), True)),
+        patch(
+            "yutori.cli.commands.install_ui.maybe_authenticate",
+            return_value=(StepResult("Auth", "success", "ok"), True),
+        ),
         patch(
             "yutori.cli.commands.install_ui.run_verification",
             return_value=(StepResult("Verification", "failed", "yutori.com unreachable"), False),
@@ -597,6 +643,259 @@ def test_maybe_install_sdk_skipped_beats_availability_error_when_noninteractive(
     )
     result = maybe_install_sdk(Console(), plan, interactive=False)
     assert result.status == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# MCP setup branches
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_install_mcp_server_noninteractive_skips():
+    result = maybe_install_mcp_server(Console(), interactive=False)
+
+    assert result.status == "skipped"
+    assert "no interactive terminal" in result.detail
+    assert "npx add-mcp" in result.detail
+
+
+def test_maybe_install_mcp_server_skips_when_npx_missing():
+    with (
+        patch("yutori.cli.commands.install_ui.resolve_npx_path", return_value=None),
+        patch("yutori.cli.commands.install_ui.Confirm.ask") as mock_ask,
+        patch("yutori.cli.commands.install_ui.run_interactive_command") as mock_run,
+    ):
+        result = maybe_install_mcp_server(Console(), interactive=True)
+
+    assert result.status == "skipped"
+    assert "Node.js/npx" in result.detail
+    mock_ask.assert_not_called()
+    mock_run.assert_not_called()
+
+
+def test_maybe_install_mcp_server_runs_add_mcp_on_consent():
+    success = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+    with (
+        patch("yutori.cli.commands.install_ui.resolve_npx_path", return_value="/usr/local/bin/npx"),
+        patch("yutori.cli.commands.install_ui.Confirm.ask", return_value=True),
+        patch("yutori.cli.commands.install_ui.run_interactive_command", return_value=success) as mock_run,
+    ):
+        result = maybe_install_mcp_server(Console(), interactive=True)
+
+    assert result.status == "success"
+    assert mock_run.call_args.args[0] == ("/usr/local/bin/npx", *MCP_SERVER_INSTALL_COMMAND[1:])
+
+
+def test_maybe_install_mcp_server_failure_includes_retry_hint():
+    # run_interactive_command inherits stdio so stdout/stderr are None in
+    # production. The failure detail should still be useful — a retry hint
+    # with the original (npx-prefixed) command.
+    failure = subprocess.CompletedProcess(args=[], returncode=1, stdout=None, stderr=None)
+
+    with (
+        patch("yutori.cli.commands.install_ui.resolve_npx_path", return_value="/usr/local/bin/npx"),
+        patch("yutori.cli.commands.install_ui.Confirm.ask", return_value=True),
+        patch("yutori.cli.commands.install_ui.run_interactive_command", return_value=failure),
+    ):
+        result = maybe_install_mcp_server(Console(), interactive=True)
+
+    assert result.status == "failed"
+    assert "status 1" in result.detail
+    assert "npx add-mcp" in result.detail
+
+
+def test_maybe_install_mcp_server_failure_surfaces_timeout():
+    timed_out = subprocess.CompletedProcess(args=[], returncode=124, stdout=None, stderr=None)
+
+    with (
+        patch("yutori.cli.commands.install_ui.resolve_npx_path", return_value="/usr/local/bin/npx"),
+        patch("yutori.cli.commands.install_ui.Confirm.ask", return_value=True),
+        patch("yutori.cli.commands.install_ui.run_interactive_command", return_value=timed_out),
+    ):
+        result = maybe_install_mcp_server(Console(), interactive=True)
+
+    assert result.status == "failed"
+    assert "Timed out" in result.detail
+    assert "npx add-mcp" in result.detail
+
+
+def test_maybe_install_mcp_skills_runs_global_skills_on_consent():
+    success = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+    with (
+        patch("yutori.cli.commands.install_ui.resolve_npx_path", return_value="/usr/local/bin/npx"),
+        patch("yutori.cli.commands.install_ui.Confirm.ask", return_value=True),
+        patch("yutori.cli.commands.install_ui.run_interactive_command", return_value=success) as mock_run,
+    ):
+        result = maybe_install_mcp_skills(Console(), interactive=True)
+
+    assert result.status == "success"
+    assert mock_run.call_args.args[0] == ("/usr/local/bin/npx", *MCP_SKILLS_INSTALL_COMMAND[1:])
+
+
+def test_maybe_install_mcp_skills_user_declines():
+    with (
+        patch("yutori.cli.commands.install_ui.resolve_npx_path", return_value="/usr/local/bin/npx"),
+        patch("yutori.cli.commands.install_ui.Confirm.ask", return_value=False),
+        patch("yutori.cli.commands.install_ui.run_interactive_command") as mock_run,
+    ):
+        result = maybe_install_mcp_skills(Console(), interactive=True)
+
+    assert result.status == "skipped"
+    mock_run.assert_not_called()
+
+
+def test_maybe_install_mcp_skills_failure_includes_skills_specific_retry_hint():
+    failure = subprocess.CompletedProcess(args=[], returncode=1, stdout=None, stderr=None)
+
+    with (
+        patch("yutori.cli.commands.install_ui.resolve_npx_path", return_value="/usr/local/bin/npx"),
+        patch("yutori.cli.commands.install_ui.Confirm.ask", return_value=True),
+        patch("yutori.cli.commands.install_ui.run_interactive_command", return_value=failure),
+    ):
+        result = maybe_install_mcp_skills(Console(), interactive=True)
+
+    assert result.status == "failed"
+    assert "skills add yutori-ai/yutori-mcp -g" in result.detail
+
+
+def test_maybe_install_mcp_server_user_cancels_with_ctrl_c():
+    cancelled = subprocess.CompletedProcess(args=[], returncode=130, stdout=None, stderr=None)
+
+    with (
+        patch("yutori.cli.commands.install_ui.resolve_npx_path", return_value="/usr/local/bin/npx"),
+        patch("yutori.cli.commands.install_ui.Confirm.ask", return_value=True),
+        patch("yutori.cli.commands.install_ui.run_interactive_command", return_value=cancelled),
+    ):
+        result = maybe_install_mcp_server(Console(), interactive=True)
+
+    assert result.status == "skipped"
+    assert "Cancelled by user" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# run_interactive_command exception mapping
+# ---------------------------------------------------------------------------
+
+
+def test_run_interactive_command_maps_timeout_to_124():
+    expired = subprocess.TimeoutExpired(cmd="npx", timeout=1)
+    with patch("yutori.cli.commands.install_ui.subprocess.run", side_effect=expired):
+        result = run_interactive_command(("npx", "add-mcp", "uvx yutori-mcp"), timeout=1)
+
+    assert result.returncode == 124
+    assert result.stdout is None
+    assert result.stderr is None
+
+
+def test_run_interactive_command_maps_missing_binary_to_127():
+    with patch(
+        "yutori.cli.commands.install_ui.subprocess.run",
+        side_effect=FileNotFoundError("no such file: 'npx'"),
+    ):
+        result = run_interactive_command(("npx", "add-mcp", "uvx yutori-mcp"))
+
+    assert result.returncode == 127
+
+
+def test_run_interactive_command_maps_oserror_to_127():
+    # Bare OSError covers ENOEXEC, EMFILE, ENOMEM, etc. — fork/exec failures
+    # that aren't FileNotFoundError or PermissionError. They all collapse to
+    # "could not start the child" from the user's perspective.
+    with patch("yutori.cli.commands.install_ui.subprocess.run", side_effect=OSError("ENOMEM")):
+        result = run_interactive_command(("npx", "add-mcp", "uvx yutori-mcp"))
+
+    assert result.returncode == 127
+
+
+def test_run_interactive_command_maps_keyboard_interrupt_to_130():
+    with patch("yutori.cli.commands.install_ui.subprocess.run", side_effect=KeyboardInterrupt()):
+        result = run_interactive_command(("npx", "add-mcp", "uvx yutori-mcp"))
+
+    assert result.returncode == 130
+
+
+# ---------------------------------------------------------------------------
+# install_ui_command: failed MCP/skills must not bump exit_code
+# ---------------------------------------------------------------------------
+
+
+def test_install_ui_failed_mcp_does_not_bump_exit_code():
+    cli_state = CLIInstallState(
+        cli_path=Path("/tmp/yutori"),
+        bin_dir=Path("/tmp"),
+        uv_path="/usr/bin/uv",
+        version="yutori 0.7.0",
+        on_path=True,
+    )
+    sdk_plan = SDKInstallPlan(reason="ok", command=("uv", "add", "yutori"), default=True)
+
+    with (
+        patch(
+            "yutori.cli.commands.install_ui.inspect_cli_install",
+            return_value=(cli_state, StepResult("CLI", "success", "ok")),
+        ),
+        patch("yutori.cli.commands.install_ui.detect_sdk_install_plan", return_value=sdk_plan),
+        patch("yutori.cli.commands.install_ui.maybe_install_sdk", return_value=StepResult("SDK", "skipped", "skip")),
+        patch(
+            "yutori.cli.commands.install_ui.maybe_authenticate",
+            return_value=(StepResult("Auth", "success", "ok"), True),
+        ),
+        patch(
+            "yutori.cli.commands.install_ui.maybe_install_mcp_server",
+            return_value=StepResult("MCP server", "failed", "Command exited with status 1."),
+        ),
+        patch(
+            "yutori.cli.commands.install_ui.maybe_install_mcp_skills",
+            return_value=StepResult("MCP skills", "failed", "Command exited with status 1."),
+        ),
+        patch(
+            "yutori.cli.commands.install_ui.run_verification",
+            return_value=(StepResult("Verification", "success", "ok"), False),
+        ),
+    ):
+        result = runner.invoke(app, ["__install_ui"])
+
+    # MCP/skills are optional; their failure surfaces in the table but
+    # leaves exit_code at 0 since CLI/SDK/auth/verification all succeeded.
+    assert result.exit_code == 0
+    assert "MCP server" in result.stdout
+    assert "MCP skills" in result.stdout
+    assert "FAIL" in result.stdout
+
+
+def test_install_ui_skips_mcp_when_not_authenticated():
+    cli_state = CLIInstallState(
+        cli_path=Path("/tmp/yutori"),
+        bin_dir=Path("/tmp"),
+        uv_path="/usr/bin/uv",
+        version="yutori 0.7.0",
+        on_path=True,
+    )
+    sdk_plan = SDKInstallPlan(reason="ok", command=("uv", "add", "yutori"), default=True)
+
+    with (
+        patch(
+            "yutori.cli.commands.install_ui.inspect_cli_install",
+            return_value=(cli_state, StepResult("CLI", "success", "ok")),
+        ),
+        patch("yutori.cli.commands.install_ui.detect_sdk_install_plan", return_value=sdk_plan),
+        patch("yutori.cli.commands.install_ui.maybe_install_sdk", return_value=StepResult("SDK", "skipped", "skip")),
+        patch(
+            "yutori.cli.commands.install_ui.maybe_authenticate",
+            return_value=(StepResult("Auth", "skipped", "User declined."), False),
+        ),
+        patch("yutori.cli.commands.install_ui.maybe_install_mcp_server") as mock_mcp,
+        patch("yutori.cli.commands.install_ui.maybe_install_mcp_skills") as mock_skills,
+    ):
+        result = runner.invoke(app, ["__install_ui"])
+
+    assert result.exit_code == 0
+    # Neither npx step should be invoked when the user isn't authenticated —
+    # registering a server that needs YUTORI_API_KEY is futile.
+    mock_mcp.assert_not_called()
+    mock_skills.assert_not_called()
+    assert "Authenticate first" in result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/yutori/cli/commands/install_ui.py
+++ b/yutori/cli/commands/install_ui.py
@@ -42,6 +42,11 @@ ERROR_RED = "#FF5C5C"
 VERIFICATION_TASK = "Give me a list of all employees (names and titles) of Yutori."
 VERIFICATION_URL = "https://yutori.com"
 VERIFICATION_MAX_STEPS = 3
+# `add-mcp` takes a single quoted command-string argument. The third tuple
+# element is intentionally one argv token, not two (mirrors the README:
+# `npx add-mcp "uvx yutori-mcp"`).
+MCP_SERVER_INSTALL_COMMAND = ("npx", "add-mcp", "uvx yutori-mcp")
+MCP_SKILLS_INSTALL_COMMAND = ("npx", "skills", "add", "yutori-ai/yutori-mcp", "-g")
 # Route matches api-dashboard's /browsing/tasks/[id] page; the Vercel project
 # serves it on platform.yutori.com (production) and platform.dev.yutori.com (dev).
 VERIFICATION_TASK_DASHBOARD_BASE_URL = "https://platform.yutori.com/browsing/tasks"
@@ -84,6 +89,10 @@ VERIFICATION_POLL_INTERVAL_SECONDS = 5
 # can resolve large dep graphs; polling calls should be snappy.
 QUICK_CMD_TIMEOUT = 30
 INSTALL_CMD_TIMEOUT = 300
+# `npx add-mcp` can prompt for client selection and download packages from npm
+# on first run — slow links can take a few minutes. Bound the worst case so
+# the installer can't hang indefinitely; users can still Ctrl+C earlier.
+NPX_CMD_TIMEOUT = 600
 
 StepStatus = Literal["success", "skipped", "failed"]
 RegistrationState = Literal["creating_account", "logging_in"]
@@ -188,6 +197,49 @@ def run_command(
         )
 
 
+def run_interactive_command(
+    command: Sequence[str],
+    *,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[None]:
+    """Run an interactive subprocess attached to this terminal.
+
+    Commands like ``npx add-mcp`` prompt the user to pick target clients.
+    Capturing stdout/stderr would hide those prompts and can deadlock the
+    child process, so this intentionally inherits stdin/stdout/stderr —
+    which means the returned ``CompletedProcess`` has ``None`` for both
+    streams. Callers should not rely on stdout/stderr for failure detail.
+
+    Synthetic returncodes:
+      - 124: timed out waiting for the child
+      - 127: could not start the child (missing binary, exec denied, etc.)
+      - 130: user cancelled with Ctrl+C
+    Any other non-zero value is the child's actual exit code.
+    """
+    argv = list(command)
+    try:
+        return subprocess.run(
+            argv,
+            env=dict(env) if env else None,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(argv, returncode=124, stdout=None, stderr=None)
+    except KeyboardInterrupt:
+        # Ctrl+C is forwarded to the child via the shared TTY; once it exits,
+        # the parent's default SIGINT handler raises here. Convert to a
+        # synthetic returncode so callers can render a "Cancelled" row
+        # instead of crashing the installer mid-summary.
+        return subprocess.CompletedProcess(argv, returncode=130, stdout=None, stderr=None)
+    except OSError:
+        # Catches FileNotFoundError, PermissionError, and rarer fork/exec
+        # failures (ENOEXEC, EMFILE, ENOMEM). All map to "could not execute"
+        # from the user's perspective.
+        return subprocess.CompletedProcess(argv, returncode=127, stdout=None, stderr=None)
+
+
 def describe_completed_process(result: subprocess.CompletedProcess[str], *, max_lines: int = 8) -> str:
     lines: list[str] = []
     for stream in (result.stderr, result.stdout):
@@ -205,7 +257,11 @@ def describe_completed_process(result: subprocess.CompletedProcess[str], *, max_
 
 
 def collect_process_output(result: subprocess.CompletedProcess[str]) -> str:
-    parts = [part.strip() for part in (_coerce_output_text(result.stderr), _coerce_output_text(result.stdout)) if part.strip()]
+    parts = [
+        part.strip()
+        for part in (_coerce_output_text(result.stderr), _coerce_output_text(result.stdout))
+        if part.strip()
+    ]
     return "\n".join(parts)
 
 
@@ -241,6 +297,11 @@ def resolve_uv_path(env: Mapping[str, str] | None = None) -> str | None:
             return str(candidate)
 
     return None
+
+
+def resolve_npx_path(env: Mapping[str, str] | None = None) -> str | None:
+    resolved_env = env or os.environ
+    return shutil.which("npx", path=resolved_env.get("PATH"))
 
 
 def python_has_pip(interpreter: str, env: Mapping[str, str] | None = None) -> bool:
@@ -368,7 +429,11 @@ def detect_sdk_install_plan(cwd: Path | None = None, env: Mapping[str, str] | No
 
     if resolved_env.get("VIRTUAL_ENV"):
         venv_python = Path(resolved_env["VIRTUAL_ENV"]) / "bin" / "python"
-        python_path = str(venv_python) if _is_executable(venv_python) else shutil.which("python", path=resolved_env.get("PATH"))
+        python_path = (
+            str(venv_python)
+            if _is_executable(venv_python)
+            else shutil.which("python", path=resolved_env.get("PATH"))
+        )
         return SDKInstallPlan(
             reason=f"Detected active virtual environment at {resolved_env['VIRTUAL_ENV']}.",
             command=((python_path or "python"), "-m", "pip", "install", "yutori"),
@@ -418,7 +483,11 @@ def maybe_repair_path(console: Console, state: CLIInstallState, *, interactive: 
     print_prompt_block(console, "Shell PATH update", detail, command=(state.uv_path, "tool", "update-shell"))
 
     if not interactive:
-        return StepResult("PATH", "skipped", f"{detail} Skipped PATH repair because no interactive terminal is available.")
+        return StepResult(
+            "PATH",
+            "skipped",
+            f"{detail} Skipped PATH repair because no interactive terminal is available.",
+        )
 
     if not ask_confirm(console, "Run uv tool update-shell now?", default=True):
         return StepResult("PATH", "skipped", f"{detail} PATH repair was skipped.")
@@ -430,7 +499,13 @@ def maybe_repair_path(console: Console, state: CLIInstallState, *, interactive: 
     return StepResult("PATH", "success", "Updated shell startup files with uv tool update-shell.")
 
 
-def maybe_install_sdk(console: Console, plan: SDKInstallPlan, *, interactive: bool, cwd: Path | None = None) -> StepResult:
+def maybe_install_sdk(
+    console: Console,
+    plan: SDKInstallPlan,
+    *,
+    interactive: bool,
+    cwd: Path | None = None,
+) -> StepResult:
     print_prompt_block(console, "Python SDK", plan.reason, command=plan.command)
 
     # Skip before gating on availability_error: a non-interactive run can't
@@ -462,6 +537,98 @@ def maybe_install_sdk(console: Console, plan: SDKInstallPlan, *, interactive: bo
         return StepResult("SDK", "failed", describe_completed_process(result))
 
     return StepResult("SDK", "success", f"Installed SDK with {format_command(plan.command)}.")
+
+
+def _manual_retry_hint(command: Sequence[str]) -> str:
+    return f"Run `{format_command(command)}` to retry."
+
+
+def _run_npx_step(
+    console: Console,
+    *,
+    name: str,
+    title: str,
+    description: str,
+    command: Sequence[str],
+    confirm_question: str,
+    success_detail: str,
+    interactive: bool,
+    env: Mapping[str, str] | None,
+) -> StepResult:
+    print_prompt_block(console, title, description, command=command)
+
+    if not interactive:
+        return StepResult(
+            name,
+            "skipped",
+            f"Skipped because no interactive terminal is available. {_manual_retry_hint(command)}",
+        )
+
+    npx_path = resolve_npx_path(env)
+    if not npx_path:
+        return StepResult(
+            name,
+            "skipped",
+            f"Node.js/npx is not on PATH. {_manual_retry_hint(command)}",
+        )
+
+    if not ask_confirm(console, confirm_question, default=True):
+        return StepResult(name, "skipped", f"{title} setup was skipped.")
+
+    result = run_interactive_command((npx_path, *command[1:]), env=env, timeout=NPX_CMD_TIMEOUT)
+    if result.returncode == 0:
+        return StepResult(name, "success", success_detail)
+
+    # run_interactive_command inherits stdio, so any stderr from npx has
+    # already scrolled past (or never existed, for the 127/130 branches).
+    # A copy-pasteable retry hint is the only useful detail we can add.
+    if result.returncode == 130:
+        return StepResult(name, "skipped", f"Cancelled by user. {_manual_retry_hint(command)}")
+    if result.returncode == 124:
+        reason = f"Timed out after {NPX_CMD_TIMEOUT}s."
+    elif result.returncode == 127:
+        reason = f"Could not execute {command[0]!r}."
+    else:
+        reason = f"Command exited with status {result.returncode}."
+    return StepResult(name, "failed", f"{reason} {_manual_retry_hint(command)}")
+
+
+def maybe_install_mcp_server(
+    console: Console,
+    *,
+    interactive: bool,
+    env: Mapping[str, str] | None = None,
+) -> StepResult:
+    return _run_npx_step(
+        console,
+        name="MCP server",
+        title="Yutori MCP server",
+        description="Configures the Yutori MCP server for supported AI tools with add-mcp.",
+        command=MCP_SERVER_INSTALL_COMMAND,
+        confirm_question="Install the Yutori MCP server for your AI tools?",
+        success_detail="Configured Yutori MCP server. Restart your AI tool to load it.",
+        interactive=interactive,
+        env=env,
+    )
+
+
+def maybe_install_mcp_skills(
+    console: Console,
+    *,
+    interactive: bool,
+    env: Mapping[str, str] | None = None,
+) -> StepResult:
+    return _run_npx_step(
+        console,
+        name="MCP skills",
+        title="Yutori workflow skills",
+        description="Installs slash-command workflow skills globally via the skills CLI.",
+        command=MCP_SKILLS_INSTALL_COMMAND,
+        confirm_question="Install Yutori workflow skills globally?",
+        success_detail="Installed Yutori workflow skills at user scope.",
+        interactive=interactive,
+        env=env,
+    )
 
 
 def format_auth_status(status: AuthStatus) -> str:
@@ -572,7 +739,10 @@ def run_verification(
     0 once the install/auth steps themselves succeeded.
     """
     if not interactive:
-        return StepResult("Verification", "skipped", "Skipped verification because no interactive terminal is available."), False
+        return (
+            StepResult("Verification", "skipped", "Skipped verification because no interactive terminal is available."),
+            False,
+        )
 
     # Use bare `yutori` when the current shell already resolves it to the
     # freshly-installed binary (on_path=True from inspect_cli_install). This
@@ -687,6 +857,20 @@ def install_ui_command() -> None:
     if auth_result.status == "failed":
         exit_code = 1
 
+    # MCP server and skills are optional add-ons that depend on Node.js,
+    # the npm registry, and an interactive picker. A failure here doesn't
+    # bump exit_code — it surfaces in the summary table as FAIL with a
+    # retry hint, but the install itself (CLI/SDK/auth) is still usable.
+    # Skip when auth was declined or failed: the registered MCP server
+    # would fail on first use without credentials, and the user has
+    # already opted out of finishing setup.
+    if not authenticated:
+        mcp_result = StepResult("MCP server", "skipped", "Authenticate first, then re-run the installer.")
+        skills_result = StepResult("MCP skills", "skipped", "Authenticate first, then re-run the installer.")
+    else:
+        mcp_result = maybe_install_mcp_server(console, interactive=interactive)
+        skills_result = maybe_install_mcp_skills(console, interactive=interactive)
+
     if not authenticated:
         verification_result = StepResult("Verification", "skipped", "Verification requires a valid API key.")
     elif cli_state is None:
@@ -702,7 +886,7 @@ def install_ui_command() -> None:
     results: list[StepResult] = [cli_result]
     if path_result is not None:
         results.append(path_result)
-    results.extend([sdk_result, auth_result, verification_result])
+    results.extend([sdk_result, auth_result, mcp_result, skills_result, verification_result])
     summarize_results(console, results)
 
     raise typer.Exit(exit_code)

--- a/yutori/cli/commands/install_ui.py
+++ b/yutori/cli/commands/install_ui.py
@@ -580,14 +580,16 @@ def _run_npx_step(
         return StepResult(name, "success", success_detail)
 
     # run_interactive_command inherits stdio, so any stderr from npx has
-    # already scrolled past (or never existed, for the 127/130 branches).
+    # already scrolled past (or never existed, for the 130 branch).
     # A copy-pasteable retry hint is the only useful detail we can add.
+    # We don't special-case 127: resolve_npx_path already verified the
+    # binary exists, so a 127 here is almost always npx's own exit code
+    # (e.g. the package's bin entry resolved to a missing executable),
+    # not the synthetic OSError 127 from run_interactive_command.
     if result.returncode == 130:
         return StepResult(name, "skipped", f"Cancelled by user. {_manual_retry_hint(command)}")
     if result.returncode == 124:
         reason = f"Timed out after {NPX_CMD_TIMEOUT}s."
-    elif result.returncode == 127:
-        reason = f"Could not execute {command[0]!r}."
     else:
         reason = f"Command exited with status {result.returncode}."
     return StepResult(name, "failed", f"{reason} {_manual_retry_hint(command)}")


### PR DESCRIPTION
## Summary
- Extends the `curl | bash` one-click installer to also run `npx add-mcp "uvx yutori-mcp"` and `npx skills add yutori-ai/yutori-mcp -g` after the auth step, mirroring the [yutori-mcp README](https://github.com/yutori-ai/yutori-mcp#installation) quickstart so one command sets up CLI + SDK + MCP + workflow skills.
- New steps are gated on `authenticated` (registering an MCP server without credentials would fail on first use) and on `npx` being on PATH; failures surface in the summary table with a copy-pasteable retry hint but do **not** bump the installer's exit code, since MCP/skills are optional add-ons.
- Adds `run_interactive_command` — a stdio-inheriting subprocess wrapper for commands that need to forward npx's interactive client picker — with mapped synthetic returncodes for timeout (124), exec failure (127), and Ctrl+C (130). 600s timeout bounds the worst case (slow npm registry on first run).

## Behavior
| Scenario | Result |
|---|---|
| Interactive TTY, Node.js present, auth ok, user accepts both prompts | Both steps run, success rows in summary |
| Non-interactive (CI / pipe) | Both steps SKIP with a manual-retry hint |
| Auth declined / failed | Both steps SKIP with "Authenticate first, then re-run" |
| `npx` missing | Both steps SKIP with "Node.js/npx is not on PATH" + retry hint |
| `npx` exits non-zero / times out / Ctrl+C | FAIL/SKIP row with reason + retry hint, installer still exits 0 |

## Test plan
- [x] `pytest tests/test_install_ui.py` — 64 tests pass (8 new MCP-related, 4 new `run_interactive_command` mapping tests, 2 new integration tests)
- [x] `pytest` — full suite 388 passes, 3 skipped
- [x] `ruff check` — clean
- [x] Live `python -m yutori.cli.main __install_ui < /dev/null` — non-interactive path renders the new MCP server / MCP skills rows with retry hints
- [ ] Live `curl -fsSL .../install.sh | bash` end-to-end — please run before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the one-click installer flow by adding new `npx`-driven interactive subprocess steps and new exit-code semantics; failures are intentionally non-fatal but could affect user setup experience on different environments (TTY/Node availability).
> 
> **Overview**
> The installer’s hidden `__install_ui` command now runs two **post-auth optional setup steps**: configuring the Yutori MCP server (`npx add-mcp "uvx yutori-mcp"`) and installing global workflow skills (`npx skills add yutori-ai/yutori-mcp -g`). These steps are gated on *successful authentication* and *interactive TTY + `npx` availability*; they surface `SKIP/FAIL` rows with copy-paste retry hints but **do not change the installer exit code** when they fail.
> 
> Adds `run_interactive_command` (stdio-inheriting subprocess runner) plus `resolve_npx_path`, a shared `_run_npx_step` helper, and a 600s `NPX_CMD_TIMEOUT` with mapped synthetic return codes (timeout/exec failure/Ctrl+C). Updates `README` to reflect MCP/skills being part of the guided installer, and expands `tests/test_install_ui.py` with coverage for MCP/skills branches, interactive command error mapping, and exit-code behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b010c4a68c73b0ca6ab0657bb697a5f8fb62f3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->