### PR TITLE
tests(auth): patch real call paths in auth login tests

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -547,7 +547,14 @@ class TestRunLoginFlow:
 
     @patch("yutori.auth.flow.webbrowser.open")
     @patch("yutori.auth.flow.generate_api_key")
-    @patch("yutori.auth.flow.register_user", side_effect=httpx.HTTPError("backend missing"))
+    @patch(
+        "yutori.auth.flow.register_user",
+        side_effect=httpx.HTTPStatusError(
+            "500 Server Error",
+            request=httpx.Request("POST", "https://example.com/client/register-api"),
+            response=httpx.Response(500, content=b"backend missing"),
+        ),
+    )
     @patch("yutori.auth.flow.check_registration_status", return_value=False)
     @patch("yutori.auth.flow.exchange_code_for_token", return_value="jwt123")
     @patch("yutori.auth.flow.save_config")
@@ -586,6 +593,9 @@ class TestRunLoginFlow:
                     result = run_login_flow()
 
         assert result.success is False
+        # register_user raises httpx.HTTPStatusError per its docstring; the
+        # outer flow wraps it as "Authentication failed (<status>): <body>".
+        assert "Authentication failed (500)" in str(result.error)
         assert "backend missing" in str(result.error)
         mock_gen_key.assert_not_called()
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -547,7 +547,7 @@ class TestRunLoginFlow:
 
     @patch("yutori.auth.flow.webbrowser.open")
     @patch("yutori.auth.flow.generate_api_key")
-    @patch("yutori.auth.flow.register_user", side_effect=RuntimeError("backend missing"))
+    @patch("yutori.auth.flow.register_user", side_effect=httpx.HTTPError("backend missing"))
     @patch("yutori.auth.flow.check_registration_status", return_value=False)
     @patch("yutori.auth.flow.exchange_code_for_token", return_value="jwt123")
     @patch("yutori.auth.flow.save_config")

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -18,7 +18,7 @@ def test_auth_login_prints_creating_account_message(monkeypatch):
         return LoginResult(success=True, api_key="yt-key")
 
     with (
-        patch("yutori.cli.commands.auth.load_config", return_value=None),
+        patch("yutori.auth.credentials.load_config", return_value=None),
         patch("yutori.cli.commands.auth.run_login_flow", side_effect=fake_run_login_flow),
     ):
         result = runner.invoke(app, ["auth", "login"])
@@ -36,7 +36,7 @@ def test_auth_login_prints_logging_in_message(monkeypatch):
         return LoginResult(success=True, api_key="yt-key")
 
     with (
-        patch("yutori.cli.commands.auth.load_config", return_value=None),
+        patch("yutori.auth.credentials.load_config", return_value=None),
         patch("yutori.cli.commands.auth.run_login_flow", side_effect=fake_run_login_flow),
     ):
         result = runner.invoke(app, ["auth", "login"])
@@ -62,7 +62,7 @@ def test_auth_login_surfaces_backend_error(monkeypatch):
         )
 
     with (
-        patch("yutori.cli.commands.auth.load_config", return_value=None),
+        patch("yutori.auth.credentials.load_config", return_value=None),
         patch("yutori.cli.commands.auth.run_login_flow", side_effect=fake_run_login_flow),
     ):
         result = runner.invoke(app, ["auth", "login"])
@@ -77,7 +77,7 @@ def test_auth_login_ignores_placeholder_env_var(monkeypatch):
     monkeypatch.setenv("YUTORI_API_KEY", "YOUR_API_KEY")
 
     with (
-        patch("yutori.cli.commands.auth.load_config", return_value=None),
+        patch("yutori.auth.credentials.load_config", return_value=None),
         patch("yutori.cli.commands.auth.run_login_flow", return_value=LoginResult(success=True, api_key="yt-key")),
     ):
         result = runner.invoke(app, ["auth", "login"])
@@ -90,7 +90,7 @@ def test_auth_login_ignores_placeholder_config_key(monkeypatch):
     monkeypatch.delenv("YUTORI_API_KEY", raising=False)
 
     with (
-        patch("yutori.cli.commands.auth.load_config", return_value={"api_key": "YOUR_API_KEY"}),
+        patch("yutori.auth.credentials.load_config", return_value={"api_key": "YOUR_API_KEY"}),
         patch("yutori.cli.commands.auth.run_login_flow", return_value=LoginResult(success=True, api_key="yt-key")),
     ):
         result = runner.invoke(app, ["auth", "login"])


### PR DESCRIPTION
## Summary
Two pre-existing failures in `tests/test_auth.py` and `tests/test_cli_auth.py` that fail on `main` once a developer's machine has real credentials in `~/.yutori/config.json`.

**`test_cli_auth.py` (5 tests)** — patches targeted `yutori.cli.commands.auth.load_config`, but `auth login` calls `get_stored_api_key()`, which in turn calls `load_config` from its own module (`yutori.auth.credentials`). The patch never intercepted the real lookup, so the command read the developer's actual config file and exited 1 with "You are already authenticated." Re-pointed the patches to `yutori.auth.credentials.load_config` so they hit the call site that `get_stored_api_key` reaches. This also keeps `test_auth_login_ignores_placeholder_config_key` honest — the placeholder-rejection logic in `get_stored_api_key` now actually runs end-to-end in the test.

**`test_auth.py::test_register_failure_stops_before_generate_key`** — mocked `register_user` to raise `RuntimeError("backend missing")`, but #99 narrowed the surrounding `except` clause in `run_login_flow` to `(httpx.HTTPError, ValueError, KeyError, OSError)`. `RuntimeError` propagated uncaught and the test crashed instead of returning a `LoginResult(success=False, ...)`. Switched to `httpx.HTTPError`, which is the documented failure mode for `register_user` (per its docstring: `Raises httpx.HTTPStatusError on non-2xx`).

## Test plan
- [x] `pytest tests/test_auth.py tests/test_cli_auth.py` — 76 tests pass (up from 70 + 6 failing)
- [x] `pytest` — full suite passes
- [x] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust mocks to match real call paths and documented exception types; low risk beyond potentially tightening expectations on error messages.
> 
> **Overview**
> Fixes auth-related tests that could accidentally read a developer’s real `~/.yutori/config.json` by patching the *actual* credential lookup target (`yutori.auth.credentials.load_config`) instead of `yutori.cli.commands.auth.load_config`.
> 
> Updates `test_register_failure_stops_before_generate_key` to mock `register_user`’s documented failure mode (`httpx.HTTPStatusError`) and asserts the login flow wraps it into the expected `Authentication failed (500): ...` error, ensuring the flow returns a failed `LoginResult` and does not call `generate_api_key`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 986918e62329cd19e879ed0216eff6fa5525ace7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->