### PR TITLE
refactor(coordinates): unify _validate_dimension and _validate_scale

### DIFF
--- a/yutori/navigator/coordinates.py
+++ b/yutori/navigator/coordinates.py
@@ -71,9 +71,9 @@ def _coerce_and_validate(
 ) -> tuple[float, float]:
     """Coerce *coordinates* and validate viewport dimensions and scale."""
     x, y = _coerce_coordinates(coordinates)
-    _validate_dimension("width", width)
-    _validate_dimension("height", height)
-    _validate_scale(scale)
+    _validate_positive("width", width)
+    _validate_positive("height", height)
+    _validate_positive("scale", scale)
     return x, y
 
 
@@ -88,14 +88,9 @@ def _coerce_coordinates(coordinates: Sequence[int | float]) -> tuple[float, floa
     return x, y
 
 
-def _validate_dimension(name: str, value: int) -> None:
+def _validate_positive(name: str, value: int) -> None:
     if value <= 0:
         raise ValueError(f"{name} must be positive, got {value}")
-
-
-def _validate_scale(scale: int) -> None:
-    if scale <= 0:
-        raise ValueError(f"scale must be positive, got {scale}")
 
 
 def _clamp(value: int, lower: int, upper: int) -> int:


### PR DESCRIPTION
## What

Collapse `_validate_dimension(name, value)` and `_validate_scale(scale)` in `yutori/navigator/coordinates.py` into a single `_validate_positive(name, value)` helper.

## Why

The two helpers had identical bodies — both just check `value <= 0` and raise `ValueError(f"{name} must be positive, got {value}")`. They existed only because the dimension variant accepted an explicit label while the scale variant hardcoded `"scale"`. Passing the label through the call site removes the redundancy and gives us one positive-int validator instead of two near-clones.

```diff
-    _validate_dimension("width", width)
-    _validate_dimension("height", height)
-    _validate_scale(scale)
+    _validate_positive("width", width)
+    _validate_positive("height", height)
+    _validate_positive("scale", scale)
```

## Why it's safe

- No behavior change. The error message format (`"{name} must be positive, got {value}"`) and exception type (`ValueError`) are preserved verbatim.
- The existing parametrized `test_rejects_non_positive_dimensions` (matches `"{name} must be positive"`) and `test_rejects_non_positive_scale` (matches `"scale must be positive"`) in `tests/test_navigator_coordinates.py` continue to pass unchanged — verified locally (25/25 coordinate tests pass).
- Single-file change, three call sites, all in the same private helper.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DVxvbfpgpkfzeAbqxiXDhA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: consolidates duplicate input validation helpers without changing validation rules or error messages.
> 
> **Overview**
> Refactors `yutori/navigator/coordinates.py` to **collapse `_validate_dimension` and `_validate_scale` into a single `_validate_positive(name, value)`** helper.
> 
> Updates `_coerce_and_validate` to call `_validate_positive` for `width`, `height`, and `scale`, removing the redundant private validators while keeping the same `ValueError` behavior/message format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8795163e3ac4673420e7d35e629b88f0e72403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->