### PR TITLE
release: v0.7.5

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.7.4"
+YUTORI_INSTALLER_VERSION="0.7.5"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.7.4"
+version = "0.7.5"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
Bumps `pyproject.toml` to `0.7.5` and regenerates `install.sh` so `YUTORI_INSTALLER_VERSION` matches.

## What's in this release
- **#106** — installer now also configures the Yutori MCP server (`npx add-mcp`) and installs workflow skills (`npx skills add`) after the auth step. Gated on Node.js + auth; failures surface in the summary table without bumping the installer's exit code.
- **#107** — fixes 6 pre-existing test failures (5 in `test_cli_auth.py`, 1 in `test_auth.py`) caused by stale patch targets that were exposed once #91 introduced `get_stored_api_key` and #99 narrowed the `run_login_flow` exception handler.

## Test plan
- [x] `pytest` — 388 passed, 3 skipped
- [x] `bash scripts/check_install_sh_fresh.sh` — clean after staging install.sh
- [x] `ruff check` — clean
- [ ] Merge → tag `v0.7.5` → cut a GitHub Release. The `publish_to_pypi.yml` workflow auto-builds, uploads to PyPI, and attaches `install.sh` / `uninstall.sh` + sha256 checksums to the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates version metadata in `pyproject.toml` and the corresponding `YUTORI_INSTALLER_VERSION` string in `install.sh`, with no behavioral code changes.
> 
> **Overview**
> Bumps the package release from `0.7.4` to `0.7.5` in `pyproject.toml`.
> 
> Regenerates `install.sh` so `YUTORI_INSTALLER_VERSION` matches `0.7.5` for the installer header/reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b89a5cd8d3ca52dbe4ba323ac75dd0a8189ff3f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->