### PR TITLE
docs: add manual MCP/skills setup section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ Resolution order: explicit `api_key` > `YUTORI_API_KEY` env var > `~/.yutori/con
 
 </details>
 
+<details>
+<summary>Configure MCP server and skills manually</summary>
+
+The installer sets these up automatically when Node.js is available. To do it manually:
+
+```bash
+npx add-mcp uvx yutori-mcp
+npx skills add yutori-ai/yutori-mcp -g
+```
+
+The first command registers the Yutori MCP server with your editor. The second installs workflow skills for Claude Code and compatible agents.
+
+</details>
+
 
 ## API Overview
 


### PR DESCRIPTION
## Summary
- Add a "Configure MCP server and skills manually" collapsible section to `README.md`, documenting the `npx add-mcp` and `npx skills add` commands

## Context
Daily documentation drift review for May 5-6, 2026 commits. PR #106 (`installer: configure Yutori MCP server + skills after auth`) added post-auth MCP and skills setup to the installer, but the README — which has explicit manual-fallback `<details>` blocks for uninstall, install, and auth — had no equivalent section for the two new `npx` commands. Users in CI or non-interactive shells are told in the terminal to re-run those commands but had no README reference.

## Test plan
- [x] Verified the exact commands match what `install_ui.py` runs
- [x] New section follows the existing `<details>` block pattern
- [x] No code changes, documentation-only fix

https://claude.ai/code/session_01M3QerJ8pY6sGJoSXKHjsdj

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3QerJ8pY6sGJoSXKHjsdj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds manual setup commands; no runtime code paths or security-sensitive logic are modified.
> 
> **Overview**
> Adds a new README `<details>` section explaining how to manually configure the Yutori MCP server and install workflow skills when the installer can’t do it automatically (e.g., missing Node.js), including the two `npx` commands and brief explanations of what each does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f488330ad8f6bd198aa55986712902ef6fb288. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->