### PR TITLE
refactor(navigator/content): extract _block_attr helper to dedupe dict/object access

### DIFF
--- a/yutori/navigator/content.py
+++ b/yutori/navigator/content.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from typing import Any
 
 
+def _block_attr(block: Any, key: str, default: Any = None) -> Any:
+    """Read ``key`` from a block whether it is a dict or an attribute-style object."""
+    if isinstance(block, dict):
+        return block.get(key, default)
+    return getattr(block, key, default)
+
+
 def extract_text_content(content: Any) -> str | None:
     """Extract normalized text from chat-completions style content blocks."""
 
@@ -15,12 +22,8 @@ def extract_text_content(content: Any) -> str | None:
     if isinstance(content, list):
         parts: list[str] = []
         for block in content:
-            if isinstance(block, dict):
-                if block.get("type") == "text":
-                    text = block.get("text", "")
-                    parts.append(text if isinstance(text, str) else str(text))
-            elif getattr(block, "type", None) == "text":
-                text = getattr(block, "text", "")
+            if _block_attr(block, "type") == "text":
+                text = _block_attr(block, "text", "")
                 parts.append(text if isinstance(text, str) else str(text))
         normalized = "\n".join(part for part in parts if part).strip()
         return normalized or None


### PR DESCRIPTION
## What

`extract_text_content` in `yutori/navigator/content.py` had two near-identical branches inside its block loop:

- one for dict-style blocks: `block.get("type")` / `block.get("text", "")`
- one for attribute-style objects: `getattr(block, "type", None)` / `getattr(block, "text", "")`

Extract a tiny `_block_attr(block, key, default)` helper that handles both shapes, then collapse the `if/elif` into a single branch.

## Why

The two branches did the same thing with different access primitives. The new helper makes that intent explicit and removes 5+ lines of duplicated text-extraction logic from the hot loop. Adding a third block shape (or another field beyond `type` / `text`) becomes a one-liner.

## Safety

No behavior change:

- dict blocks without a `"type"` key — `_block_attr` returns `None` (matched old `block.get("type")`); the `== "text"` check fails; block skipped.
- dict blocks whose `"type"` is not `"text"` — skipped, same as before.
- attribute-style objects without a `type` attribute — `_block_attr` returns `None` (matches old `getattr(block, "type", None)`); skipped.
- text-block dicts missing `"text"` — both old and new code default to `""`, append empty string, then drop it via the `if part` filter in the join. Identical.

Verified by stepping through the existing `tests/test_navigator_content.py` cases against the refactored version (dict text/image mixes, `SimpleNamespace` blocks, blocks with non-string `text`, etc.).

---
_Generated by [Claude Code](https://claude.ai/code/session_0139CQkKSLxmktJjsnfKjL2f)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to content parsing; behavior should be unchanged but affects how mixed-shape content blocks are read in `extract_text_content`.
> 
> **Overview**
> Refactors `extract_text_content` to remove duplicated handling of dict vs attribute-style content blocks by introducing `_block_attr(block, key, default)` and using it for both `type` and `text` lookups.
> 
> This collapses the per-block `if/elif` into a single branch while preserving the existing normalization behavior for non-text blocks and missing fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f36eef38d5e88289a99cf276ab30c506b3b04585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->