### PR TITLE
refactor(navigator/replay): extract _render_text_details_panel helper

### DIFF
--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -233,24 +233,10 @@ def generate_visualization_html(
     html.extend(["</header>", "<main>"])
 
     if system_prompt:
-        html.extend(
-            [
-                "<details class=\"panel\">",
-                "<summary>System Prompt</summary>",
-                f"<pre>{_escape_html(system_prompt)}</pre>",
-                "</details>",
-            ]
-        )
+        html.extend(_render_text_details_panel("System Prompt", system_prompt))
 
     if user_query:
-        html.extend(
-            [
-                "<details class=\"panel\" open>",
-                "<summary>User Prompt</summary>",
-                f"<pre>{_escape_html(user_query)}</pre>",
-                "</details>",
-            ]
-        )
+        html.extend(_render_text_details_panel("User Prompt", user_query, open=True))
 
     if not steps:
         html.append("<section class=\"panel empty\">No assistant steps were recorded.</section>")
@@ -259,14 +245,7 @@ def generate_visualization_html(
         html.append(_render_step(step))
 
     if result_json:
-        html.extend(
-            [
-                "<details class=\"panel\">",
-                "<summary>Result Artifact</summary>",
-                f"<pre>{_escape_html(result_json)}</pre>",
-                "</details>",
-            ]
-        )
+        html.extend(_render_text_details_panel("Result Artifact", result_json))
 
     html.extend(
         [
@@ -559,6 +538,22 @@ def _render_json_panel(title: str, payload: Any) -> str:
         f"<pre class=\"json-block\">{_escape_html(json_text)}</pre>"
         "</div>"
     )
+
+
+def _render_text_details_panel(title: str, content: str, *, open: bool = False) -> list[str]:
+    """Build the collapsible ``<details class="panel">`` block used by ``generate_visualization_html``
+    for the System Prompt, User Prompt, and Result Artifact sections.
+
+    Returned as a 4-line list to match the existing ``html.extend([...])`` call style
+    so the on-disk visualization HTML keeps its line layout exactly.
+    """
+    open_attr = " open" if open else ""
+    return [
+        f"<details class=\"panel\"{open_attr}>",
+        f"<summary>{_escape_html(title)}</summary>",
+        f"<pre>{_escape_html(content)}</pre>",
+        "</details>",
+    ]
 
 
 def _render_markers(step_num: int, markers: list[dict[str, Any]]) -> str:


### PR DESCRIPTION
## What

`generate_visualization_html` in `yutori/navigator/replay.py` had three near-identical 4-line blocks that emit a collapsible `<details class="panel">` panel for plain text content:

- `System Prompt` (closed)
- `User Prompt` (open)
- `Result Artifact` (closed)

Each block followed the exact same structure — only the title and whether the `open` attribute was set varied. Each was written out inline as a 7-line `html.extend([...])` literal.

This PR collapses the three blocks into a single `_render_text_details_panel(title, content, *, open=False)` helper, sitting next to the existing `_render_json_panel` helper that already plays the same role for the per-step "Raw Request" / "Raw Response" panels.

## Why it's an improvement

- One place to evolve the shared markup (consistent with how `_render_json_panel` is used by `_render_step`).
- Makes the "open by default" distinction explicit at the call site (`open=True`) instead of hidden inside one of three otherwise-identical literal blocks.
- Net `-5` LOC and a clearer top-level structure of `generate_visualization_html`.

## Why it's safe

- No behavior change. The three hardcoded titles ("System Prompt", "User Prompt", "Result Artifact") contain no HTML-special characters, so applying `_escape_html` to the title inside the helper is a no-op for these call sites — the produced HTML lines are byte-identical.
- The helper returns a 4-line list and is consumed via `html.extend([...])` exactly like the existing inline lists, so the on-disk visualization HTML keeps its line layout.
- The full test suite (`pytest`, 389 passed / 3 skipped) passes locally, including the `test_navigator_replay.py` tests that assert "Result Artifact" appears in the generated HTML.

https://claude.ai/code/session_014t9Hqgo7SQ8dw2VePfcyYS

---
_Generated by [Claude Code](https://claude.ai/code/session_014t9Hqgo7SQ8dw2VePfcyYS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that deduplicates HTML generation for replay viewer panels without changing data flow or runtime behavior.
> 
> **Overview**
> Refactors `generate_visualization_html` to replace three duplicated `<details class="panel">` blocks (System Prompt, User Prompt, Result Artifact) with a shared helper, `_render_text_details_panel(...)`, including support for the `open` attribute.
> 
> This centralizes escaping/markup for these text sections while keeping the emitted HTML structure and line layout consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e1828fc82bd7d5c6a8565a38f3ebaa62979bff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->