### PR TITLE
refactor(n1): consolidate deprecation shim boilerplate

### DIFF
--- a/yutori/n1/__init__.py
+++ b/yutori/n1/__init__.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-import warnings
+from ._compat import warn_renamed
 
-warnings.warn(
-    "yutori.n1 has been renamed to yutori.navigator. Update imports to 'from yutori.navigator import ...'.",
-    DeprecationWarning,
-    stacklevel=2,
-)
+warn_renamed(__name__, suffix="Update imports to 'from yutori.navigator import ...'.")
 
-from yutori.navigator import *  # noqa: F401,F403
-from yutori.navigator import __all__  # noqa: F401
+from yutori.navigator import *  # noqa: E402,F401,F403
+from yutori.navigator import __all__  # noqa: E402,F401

--- a/yutori/n1/_assets.py
+++ b/yutori/n1/_assets.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import warnings as _warnings
+from ._compat import warn_renamed
 
-_warnings.warn("yutori.n1._assets has been renamed to yutori.navigator._assets.", DeprecationWarning, stacklevel=2)
+warn_renamed(__name__)
 
-from yutori.navigator._assets import *  # noqa: F401,F403
+from yutori.navigator._assets import *  # noqa: E402,F401,F403

--- a/yutori/n1/_compat.py
+++ b/yutori/n1/_compat.py
@@ -1,0 +1,31 @@
+"""Internal helper for the yutori.n1 -> yutori.navigator deprecation shims.
+
+Each submodule under :mod:`yutori.n1` is a thin compatibility wrapper that
+emits a :class:`DeprecationWarning` at import time and re-exports everything
+from the corresponding ``yutori.navigator`` submodule. :func:`warn_renamed`
+centralizes the warning text and ``stacklevel`` accounting so each shim only
+declares its own name and the star-import.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+
+def warn_renamed(old_name: str, *, suffix: str = "") -> None:
+    """Emit a DeprecationWarning announcing the ``yutori.n1`` rename.
+
+    ``old_name`` is the importing shim's ``__name__`` (e.g.
+    ``"yutori.n1.replay"`` or ``"yutori.n1"`` for the package shim itself).
+    The replacement is derived by swapping the ``yutori.n1`` prefix for
+    ``yutori.navigator``. ``stacklevel=3`` walks past this helper and the
+    shim module body so the warning surfaces at the user's import statement.
+
+    ``suffix`` is appended after the rename sentence; the package-level
+    shim uses it to nudge callers toward updating their imports.
+    """
+    new_name = old_name.replace("yutori.n1", "yutori.navigator", 1)
+    message = f"{old_name} has been renamed to {new_name}."
+    if suffix:
+        message = f"{message} {suffix}"
+    warnings.warn(message, DeprecationWarning, stacklevel=3)

--- a/yutori/n1/content.py
+++ b/yutori/n1/content.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import warnings as _warnings
+from ._compat import warn_renamed
 
-_warnings.warn("yutori.n1.content has been renamed to yutori.navigator.content.", DeprecationWarning, stacklevel=2)
+warn_renamed(__name__)
 
-from yutori.navigator.content import *  # noqa: F401,F403
+from yutori.navigator.content import *  # noqa: E402,F401,F403

--- a/yutori/n1/context.py
+++ b/yutori/n1/context.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import warnings as _warnings
+from ._compat import warn_renamed
 
-_warnings.warn("yutori.n1.context has been renamed to yutori.navigator.context.", DeprecationWarning, stacklevel=2)
+warn_renamed(__name__)
 
-from yutori.navigator.context import *  # noqa: F401,F403
+from yutori.navigator.context import *  # noqa: E402,F401,F403

--- a/yutori/n1/coordinates.py
+++ b/yutori/n1/coordinates.py
@@ -2,12 +2,8 @@
 
 from __future__ import annotations
 
-import warnings as _warnings
+from ._compat import warn_renamed
 
-_warnings.warn(
-    "yutori.n1.coordinates has been renamed to yutori.navigator.coordinates.",
-    DeprecationWarning,
-    stacklevel=2,
-)
+warn_renamed(__name__)
 
-from yutori.navigator.coordinates import *  # noqa: F401,F403
+from yutori.navigator.coordinates import *  # noqa: E402,F401,F403

--- a/yutori/n1/hooks.py
+++ b/yutori/n1/hooks.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import warnings as _warnings
+from ._compat import warn_renamed
 
-_warnings.warn("yutori.n1.hooks has been renamed to yutori.navigator.hooks.", DeprecationWarning, stacklevel=2)
+warn_renamed(__name__)
 
-from yutori.navigator.hooks import *  # noqa: F401,F403
+from yutori.navigator.hooks import *  # noqa: E402,F401,F403

--- a/yutori/n1/images.py
+++ b/yutori/n1/images.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import warnings as _warnings
+from ._compat import warn_renamed
 
-_warnings.warn("yutori.n1.images has been renamed to yutori.navigator.images.", DeprecationWarning, stacklevel=2)
+warn_renamed(__name__)
 
-from yutori.navigator.images import *  # noqa: F401,F403
+from yutori.navigator.images import *  # noqa: E402,F401,F403

--- a/yutori/n1/keys.py
+++ b/yutori/n1/keys.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import warnings as _warnings
+from ._compat import warn_renamed
 
-_warnings.warn("yutori.n1.keys has been renamed to yutori.navigator.keys.", DeprecationWarning, stacklevel=2)
+warn_renamed(__name__)
 
-from yutori.navigator.keys import *  # noqa: F401,F403
+from yutori.navigator.keys import *  # noqa: E402,F401,F403

--- a/yutori/n1/loop.py
+++ b/yutori/n1/loop.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import warnings as _warnings
+from ._compat import warn_renamed
 
-_warnings.warn("yutori.n1.loop has been renamed to yutori.navigator.loop.", DeprecationWarning, stacklevel=2)
+warn_renamed(__name__)
 
-from yutori.navigator.loop import *  # noqa: F401,F403
+from yutori.navigator.loop import *  # noqa: E402,F401,F403

--- a/yutori/n1/models.py
+++ b/yutori/n1/models.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import warnings as _warnings
+from ._compat import warn_renamed
 
-_warnings.warn("yutori.n1.models has been renamed to yutori.navigator.models.", DeprecationWarning, stacklevel=2)
+warn_renamed(__name__)
 
-from yutori.navigator.models import *  # noqa: F401,F403
+from yutori.navigator.models import *  # noqa: E402,F401,F403

--- a/yutori/n1/page_ready.py
+++ b/yutori/n1/page_ready.py
@@ -2,12 +2,8 @@
 
 from __future__ import annotations
 
-import warnings as _warnings
+from ._compat import warn_renamed
 
-_warnings.warn(
-    "yutori.n1.page_ready has been renamed to yutori.navigator.page_ready.",
-    DeprecationWarning,
-    stacklevel=2,
-)
+warn_renamed(__name__)
 
-from yutori.navigator.page_ready import *  # noqa: F401,F403
+from yutori.navigator.page_ready import *  # noqa: E402,F401,F403

--- a/yutori/n1/payload.py
+++ b/yutori/n1/payload.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import warnings as _warnings
+from ._compat import warn_renamed
 
-_warnings.warn("yutori.n1.payload has been renamed to yutori.navigator.payload.", DeprecationWarning, stacklevel=2)
+warn_renamed(__name__)
 
-from yutori.navigator.payload import *  # noqa: F401,F403
+from yutori.navigator.payload import *  # noqa: E402,F401,F403

--- a/yutori/n1/replay.py
+++ b/yutori/n1/replay.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import warnings as _warnings
+from ._compat import warn_renamed
 
-_warnings.warn("yutori.n1.replay has been renamed to yutori.navigator.replay.", DeprecationWarning, stacklevel=2)
+warn_renamed(__name__)
 
-from yutori.navigator.replay import *  # noqa: F401,F403
+from yutori.navigator.replay import *  # noqa: E402,F401,F403

--- a/yutori/n1/stop.py
+++ b/yutori/n1/stop.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import warnings as _warnings
+from ._compat import warn_renamed
 
-_warnings.warn("yutori.n1.stop has been renamed to yutori.navigator.stop.", DeprecationWarning, stacklevel=2)
+warn_renamed(__name__)
 
-from yutori.navigator.stop import *  # noqa: F401,F403
+from yutori.navigator.stop import *  # noqa: E402,F401,F403


### PR DESCRIPTION
## What

Each of the 14 `yutori.n1[.X]` compatibility modules was repeating the same
`warnings.warn(...)` + `from yutori.navigator.X import *` idiom verbatim
with the module name spelled out three times (docstring, message, import
target). Extracted the warning emit into a single `warn_renamed()` helper
in a new `yutori/n1/_compat.py`, so every shim now reduces to:

```python
"""Compatibility shim for yutori.navigator.<MOD>."""

from __future__ import annotations

from ._compat import warn_renamed

warn_renamed(__name__)

from yutori.navigator.<MOD> import *  # noqa: E402,F401,F403
```

## Why

- Single source of truth for the deprecation warning text format and
  `stacklevel`. Today each shim spells out the message string by hand,
  so any future tweak (e.g. adding a planned removal version) would
  require editing 14 files in lockstep.
- New shim files, if ever needed, are one line shorter and can't
  accidentally mismatch the message/`stacklevel` pattern.
- The `__init__.py` package shim still threads its slightly-different
  message through the same helper via the optional `suffix=` arg, so
  the message logic isn't forked.

## Safety

No behavioral change. The existing `tests/test_n1_compat.py`
parametrized test imports each `yutori.n1[.X]` shim in a fresh interpreter
state and asserts that (a) a `DeprecationWarning` is emitted and
(b) the expected attribute is reachable on the resulting module. That
contract — warning category + star-import surface — is preserved
exactly: every shim still calls `warnings.warn(..., DeprecationWarning,
stacklevel=...)` exactly once before the same `from yutori.navigator.X
import *`. Stack level is now `3` (helper -> shim body -> importer)
instead of `2` (shim body -> importer); the test does not assert on
the warning's `filename`/`lineno`, and either value points at the
same import-site frame.

The new `_compat.py` is sibling to the existing `_assets.py`-style
private modules, so it does not show up under any public path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RkmARkMRUK7V46VsFgPLaM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to `yutori.n1` compatibility shims; behavior should remain the same aside from warning message/stacklevel being standardized via a shared helper.
> 
> **Overview**
> Refactors the `yutori.n1` compatibility shims to remove repeated `warnings.warn(...)` boilerplate by introducing a shared `warn_renamed()` helper in new `yutori/n1/_compat.py`.
> 
> All `yutori.n1[.*]` modules now call `warn_renamed(__name__)` (with a custom `suffix` for the package `__init__`) before re-exporting from the corresponding `yutori.navigator` module, and updates the `# noqa` markers accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1eb028f76c92f5e78ffd272c6b7e62489e527de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->