### PR TITLE
refactor(auth): use try/finally for temp-file cleanup in save_config

### DIFF
--- a/yutori/auth/credentials.py
+++ b/yutori/auth/credentials.py
@@ -65,9 +65,11 @@ def save_config(api_key: str) -> None:
             f.write(content)
         os.chmod(tmp_path, 0o600)
         os.replace(tmp_path, config_path)
-    except BaseException:
+    finally:
+        # On success os.replace moved the temp file, so missing_ok handles
+        # both the success path and any mid-write failure (including
+        # KeyboardInterrupt).
         tmp_path.unlink(missing_ok=True)
-        raise
 
 
 def clear_config() -> None:


### PR DESCRIPTION
## Summary

`save_config` was using `except BaseException: tmp_path.unlink(missing_ok=True); raise` purely as a finally-style cleanup hook — the except-block re-raised every exception unchanged. A plain `try/finally` expresses the same intent more idiomatically:

- Cleanup always runs (including on `KeyboardInterrupt` / `SystemExit`).
- `missing_ok=True` handles both the success path (where `os.replace` already moved the temp file) and any mid-write failure.
- Removes the broad `BaseException` catch (canonically discouraged when used as cleanup-then-reraise — `try/finally` is the right tool).

## Why it's safe

- **No behavior change.** The previous code re-raised on every exception, so all observable behavior — including the temp-file cleanup on KeyboardInterrupt — is preserved.
- **All existing tests pass.** `tests/test_auth.py`: 71 passed. Full pytest run: 389 passed, 3 skipped.

## Test plan
- [x] `pytest tests/test_auth.py` — 71 passed
- [x] `pytest tests/` — 389 passed, 3 skipped
- [x] `ruff check yutori/auth/credentials.py` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyUSZQiAb5ZRQpLJTCE4F6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor in config persistence: replaces an `except BaseException` cleanup pattern with `try/finally` while keeping the same temp-file deletion behavior on both success and failure.
> 
> **Overview**
> Refactors `save_config` temp-file handling to use `try/finally` for unconditional cleanup, removing the broad `except BaseException` catch.
> 
> Temp files are now always unlinked via `finally` with `missing_ok=True`, covering both the successful `os.replace` path and mid-write interruptions (e.g., `KeyboardInterrupt`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b47a3ccb4f081aa9387e95dd6dc0b26179be1fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->