### PR TITLE
installer: default user-site SDK install to yes, tighten MCP copy

### DIFF
--- a/tests/test_install_ui.py
+++ b/tests/test_install_ui.py
@@ -106,7 +106,7 @@ def test_detect_sdk_install_plan_defaults_to_user_install(tmp_path: Path, monkey
         plan = detect_sdk_install_plan()
 
     assert plan.command == ("/usr/bin/python3", "-m", "pip", "install", "--user", "yutori")
-    assert plan.default is False
+    assert plan.default is True
     assert "requirements.txt" in plan.reason
 
 

--- a/yutori/cli/commands/install_ui.py
+++ b/yutori/cli/commands/install_ui.py
@@ -457,7 +457,7 @@ def detect_sdk_install_plan(cwd: Path | None = None, env: Mapping[str, str] | No
     return SDKInstallPlan(
         reason=reason,
         command=((interpreter or "python3"), "-m", "pip", "install", "--user", "yutori"),
-        default=False,
+        default=True,
         availability_error=(
             None if available else "A Python interpreter with pip is required for a user-site SDK install."
         ),
@@ -605,7 +605,7 @@ def maybe_install_mcp_server(
         console,
         name="MCP server",
         title="Yutori MCP server",
-        description="Configures the Yutori MCP server for supported AI tools with add-mcp.",
+        description="Installs Yutori MCP tools with add-mcp.",
         command=MCP_SERVER_INSTALL_COMMAND,
         confirm_question="Install the Yutori MCP server for your AI tools?",
         success_detail="Configured Yutori MCP server. Restart your AI tool to load it.",


### PR DESCRIPTION
## Summary
- Flip the user-site SDK install prompt default from `n` to `y` in `detect_sdk_install_plan` — when no project Python env is detected, hitting Enter now installs the SDK instead of skipping it.
- Reword the MCP server step description: "Configures the Yutori MCP server for supported AI tools with add-mcp." → "Installs Yutori MCP tools with add-mcp."

Both changes live in `yutori/cli/commands/install_ui.py`; the existing fallback-case test in `tests/test_install_ui.py` is updated to assert the new default.

## Test plan
- [x] `pytest tests/test_install_ui.py -k detect_sdk_install_plan` — 6/6 pass
- [ ] Spot-check the prompt in an interactive `install.sh` run after the next release picks up the new CLI version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: flips the default answer for an interactive installer prompt and adjusts displayed copy; behavior change is limited to opting users into `pip install --user yutori` when they press Enter in the fallback case.
> 
> **Overview**
> Updates `detect_sdk_install_plan` so the *fallback* user-site SDK install (`python -m pip install --user yutori`) is now **default-yes** when no project environment is detected, meaning hitting Enter in the installer will install the SDK instead of skipping.
> 
> Rewords the MCP server install step description shown to users (“Configures…” → “Installs…”), and updates the corresponding unit test to assert the new SDK-install default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968d92e4a4ebb653bfde3b916a57def320a1a391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->