### PR TITLE
release: v0.7.6

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.7.5"
+YUTORI_INSTALLER_VERSION="0.7.6"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.7.5"
+version = "0.7.6"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` from `0.7.5` → `0.7.6`.
- Regenerate `install.sh` so `YUTORI_INSTALLER_VERSION` matches.

Ships the installer UX fixes from #116 (user-site SDK install prompt now defaults to `y`, MCP server step description tightened) to PyPI once tagged.

## Test plan
- [x] `bash scripts/build_install.sh` produces only the version-line diff in `install.sh`
- [ ] Confirm `scripts/check_install_sh_fresh.sh` (pre-commit hook) doesn't flag drift
- [ ] After merge, cut the `v0.7.6` GitHub release to trigger `publish_to_pypi.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only bumps the package/installer version strings with no functional code changes.
> 
> **Overview**
> Bumps the SDK release version from `0.7.5` to `0.7.6` in `pyproject.toml`.
> 
> Regenerates `install.sh` so `YUTORI_INSTALLER_VERSION` matches `0.7.6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05a4ee3eeda35ebc4146958a18f3eedc5890cd84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->