### PR TITLE
refactor(navigator): share JS resource loader between _assets and tools

### DIFF
--- a/yutori/navigator/_assets.py
+++ b/yutori/navigator/_assets.py
@@ -7,5 +7,10 @@ from importlib.resources import files
 
 
 @lru_cache(maxsize=None)
+def _load_js_resource(package: str, name: str) -> str:
+    """Read a bundled ``<package>/js/<name>`` file, stripped of surrounding whitespace."""
+    return files(package).joinpath("js", name).read_text(encoding="utf-8").strip()
+
+
 def load_js_asset(name: str) -> str:
-    return files("yutori.navigator").joinpath("js", name).read_text(encoding="utf-8").strip()
+    return _load_js_resource("yutori.navigator", name)

--- a/yutori/navigator/tools/_loader.py
+++ b/yutori/navigator/tools/_loader.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from functools import lru_cache
-from importlib.resources import files
+from .._assets import _load_js_resource
 
 
-@lru_cache(maxsize=None)
 def load_tool_script(name: str) -> str:
-    return files(__package__).joinpath("js", name).read_text(encoding="utf-8").strip()
+    return _load_js_resource(__package__, name)


### PR DESCRIPTION
## Summary

`load_js_asset` and `load_tool_script` had identical bodies — read a bundled `.js` file from a `<package>/js/` directory, strip whitespace, cache the result. The only difference was the package path: hardcoded `"yutori.navigator"` vs `__package__` (resolving to `yutori.navigator.tools`).

Extract a single private `_load_js_resource(package, name)` helper in `_assets.py` and have both public functions delegate to it.

## Why it's safe

- **Public API preserved.** Both `load_js_asset(name)` and `load_tool_script(name)` keep the same signature and behavior. `yutori.navigator.tools.__all__` still exports `load_tool_script`. The `yutori.n1._assets` compat shim still finds `load_js_asset` via its `from yutori.navigator._assets import *`.
- **Cache semantics preserved.** The `@lru_cache` moves to `_load_js_resource`; cache keys are `(package, name)`. Each public wrapper always passes the same package, so cardinality and hit rate are unchanged.
- **Star-import safe.** `_load_js_resource` is underscore-prefixed, so `from yutori.navigator._assets import *` (used by the n1 compat shim) skips it.

## Test plan

- [x] `pytest tests/test_navigator_tools.py tests/test_n1_compat.py` — 20/20 pass locally.
- [x] Ruff check + format clean.
- [ ] CI green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcMkHGhjZH8QRDR9pwLNyU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes the bundled JS file-loading/caching logic without changing the public `load_js_asset`/`load_tool_script` APIs. Main risk is subtle cache-key/package-path differences, but behavior remains equivalent for existing callers.
> 
> **Overview**
> Refactors Navigator’s bundled JS asset loading to use a single cached helper, `_load_js_resource(package, name)`, that reads `<package>/js/<name>` and strips whitespace.
> 
> `load_js_asset()` and `load_tool_script()` now delegate to this shared loader (with `load_tool_script` passing `__package__`), removing duplicated `lru_cache`/`importlib.resources` logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 151b6b17b7224d863770aafde92e3f88e315a4cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->