### PR TITLE
refactor(install_ui): name synthetic subprocess returncode constants

### DIFF
--- a/yutori/cli/commands/install_ui.py
+++ b/yutori/cli/commands/install_ui.py
@@ -94,6 +94,15 @@ INSTALL_CMD_TIMEOUT = 300
 # the installer can't hang indefinitely; users can still Ctrl+C earlier.
 NPX_CMD_TIMEOUT = 600
 
+# Synthetic subprocess return codes used when the child never produced one of
+# its own (timeout, exec failure, user cancel). Mirrored from the well-known
+# POSIX shell conventions so downstream tooling that inspects `returncode`
+# sees familiar values. Callers branch on these directly — see
+# `run_command`, `run_interactive_command`, and `_run_npx_step`.
+RETURNCODE_TIMEOUT = 124  # POSIX `timeout` exit code
+RETURNCODE_EXEC_FAILED = 127  # POSIX "command not found"
+RETURNCODE_CANCELLED = 130  # POSIX SIGINT (128 + 2)
+
 StepStatus = Literal["success", "skipped", "failed"]
 RegistrationState = Literal["creating_account", "logging_in"]
 
@@ -184,14 +193,14 @@ def run_command(
         partial_stderr = _coerce_output_text(exc.stderr)
         return subprocess.CompletedProcess(
             argv,
-            returncode=124,
+            returncode=RETURNCODE_TIMEOUT,
             stdout=partial_stdout,
             stderr=f"{partial_stderr}\nTimed out after {timeout}s waiting for {format_command(argv)}.",
         )
     except (FileNotFoundError, PermissionError) as exc:
         return subprocess.CompletedProcess(
             argv,
-            returncode=127,
+            returncode=RETURNCODE_EXEC_FAILED,
             stdout="",
             stderr=f"Could not execute {argv[0]!r}: {exc}",
         )
@@ -211,10 +220,10 @@ def run_interactive_command(
     which means the returned ``CompletedProcess`` has ``None`` for both
     streams. Callers should not rely on stdout/stderr for failure detail.
 
-    Synthetic returncodes:
-      - 124: timed out waiting for the child
-      - 127: could not start the child (missing binary, exec denied, etc.)
-      - 130: user cancelled with Ctrl+C
+    Synthetic returncodes (see module-level ``RETURNCODE_*`` constants):
+      - ``RETURNCODE_TIMEOUT`` (124): timed out waiting for the child
+      - ``RETURNCODE_EXEC_FAILED`` (127): could not start the child (missing binary, exec denied, etc.)
+      - ``RETURNCODE_CANCELLED`` (130): user cancelled with Ctrl+C
     Any other non-zero value is the child's actual exit code.
     """
     argv = list(command)
@@ -226,18 +235,18 @@ def run_interactive_command(
             timeout=timeout,
         )
     except subprocess.TimeoutExpired:
-        return subprocess.CompletedProcess(argv, returncode=124, stdout=None, stderr=None)
+        return subprocess.CompletedProcess(argv, returncode=RETURNCODE_TIMEOUT, stdout=None, stderr=None)
     except KeyboardInterrupt:
         # Ctrl+C is forwarded to the child via the shared TTY; once it exits,
         # the parent's default SIGINT handler raises here. Convert to a
         # synthetic returncode so callers can render a "Cancelled" row
         # instead of crashing the installer mid-summary.
-        return subprocess.CompletedProcess(argv, returncode=130, stdout=None, stderr=None)
+        return subprocess.CompletedProcess(argv, returncode=RETURNCODE_CANCELLED, stdout=None, stderr=None)
     except OSError:
         # Catches FileNotFoundError, PermissionError, and rarer fork/exec
         # failures (ENOEXEC, EMFILE, ENOMEM). All map to "could not execute"
         # from the user's perspective.
-        return subprocess.CompletedProcess(argv, returncode=127, stdout=None, stderr=None)
+        return subprocess.CompletedProcess(argv, returncode=RETURNCODE_EXEC_FAILED, stdout=None, stderr=None)
 
 
 def describe_completed_process(result: subprocess.CompletedProcess[str], *, max_lines: int = 8) -> str:
@@ -586,9 +595,9 @@ def _run_npx_step(
     # binary exists, so a 127 here is almost always npx's own exit code
     # (e.g. the package's bin entry resolved to a missing executable),
     # not the synthetic OSError 127 from run_interactive_command.
-    if result.returncode == 130:
+    if result.returncode == RETURNCODE_CANCELLED:
         return StepResult(name, "skipped", f"Cancelled by user. {_manual_retry_hint(command)}")
-    if result.returncode == 124:
+    if result.returncode == RETURNCODE_TIMEOUT:
         reason = f"Timed out after {NPX_CMD_TIMEOUT}s."
     else:
         reason = f"Command exited with status {result.returncode}."


### PR DESCRIPTION
## What

`yutori/cli/commands/install_ui.py` referenced the magic numbers `124`, `127`, and `130` directly at 8 sites — both as the `returncode=` argument when synthesizing a `CompletedProcess` from an exception path, and as the right-hand side of branching comparisons. Their meanings were documented prose-only inside the `run_interactive_command` docstring.

Introduces three module-level constants alongside the existing `*_CMD_TIMEOUT` block:

```python
RETURNCODE_TIMEOUT = 124      # POSIX `timeout` exit code
RETURNCODE_EXEC_FAILED = 127  # POSIX "command not found"
RETURNCODE_CANCELLED = 130    # POSIX SIGINT (128 + 2)
```

All 8 call sites in `install_ui.py` use them; the `run_interactive_command` docstring now references the constants by name.

## Why

Magic returncodes are easy to misread and easy to drift away from each other (e.g. one branch checking `130` while another path synthesizes `131`). Named constants tie the synthesis sites and the comparison sites together so it's immediately obvious that "the timeout branch synthesizes the same code the caller checks for".

## Why it's safe

- Pure rename — every numeric literal is replaced with a constant of identical value.
- Tests in `tests/test_install_ui.py` intentionally still reference the literal integers `124/127/130`. They act as the contract that "this code path produces returncode 124", and decoupling them from the constant guards against accidental drift.
- No public API change; the constants live in the same module as their callers.

🤖 Generated automatically by the hourly refactor cron.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYpUdWe7bQ8KcNRhnbVCzg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that replaces a few hard-coded synthetic subprocess exit codes with named module-level constants; behavior and numeric values remain unchanged.
> 
> **Overview**
> Defines module-level constants for synthetic subprocess exit codes in `install_ui.py` (timeout/exec-failure/cancelled) and replaces all existing `124/127/130` literals with the named constants.
> 
> Updates the `run_interactive_command` docstring and npx-step branching to reference these constants, improving readability and keeping synthesis and comparison sites consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e572d7c585c200233390662fb80c30384eb3dc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->