### PR TITLE
refactor(tests): extract shared usage-endpoint fixture for sync/async tests

### DIFF
--- a/tests/_usage_fixtures.py
+++ b/tests/_usage_fixtures.py
@@ -1,0 +1,50 @@
+"""Shared usage-endpoint response fixtures for sync/async client tests."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import httpx
+
+# Mirrors the current server dual-emit: both navigator_* and n1_* keys
+# are present with equal values. See yutori.codex PR #8174.
+_NAVIGATOR_LIMITS = {
+    "requests_today": 50,
+    "daily_limit": 50000,
+    "remaining_requests": 49950,
+    "reset_at": "2026-03-04T00:00:00+00:00",
+    "per_second_limit": 20,
+}
+
+USAGE_RESPONSE = {
+    "num_active_scouts": 2,
+    "active_scout_ids": ["id-1", "id-2"],
+    "rate_limits": {
+        "requests_today": 100,
+        "daily_limit": 10000,
+        "remaining_requests": 9900,
+        "reset_at": "2026-03-04T00:00:00+00:00",
+        "status": "available",
+    },
+    "navigator_rate_limits": _NAVIGATOR_LIMITS,
+    "n1_rate_limits": _NAVIGATOR_LIMITS,
+    "activity": {
+        "period": "24h",
+        "scout_runs": 10,
+        "browsing_tasks": 3,
+        "research_tasks": 2,
+        "navigator_calls": 50,
+        "n1_calls": 50,
+    },
+}
+
+
+def make_mock_usage_response(period: str = "24h") -> MagicMock:
+    """Build a mocked 200 OK :class:`httpx.Response` for ``GET /usage``."""
+    data = {**USAGE_RESPONSE, "activity": {**USAGE_RESPONSE["activity"], "period": period}}
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.content = json.dumps(data).encode()
+    mock_response.json.return_value = data
+    return mock_response

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -7,6 +7,8 @@ import pytest
 
 from yutori import APIError, AsyncYutoriClient, AuthenticationError
 
+from ._usage_fixtures import make_mock_usage_response
+
 
 class TestAsyncYutoriClientInit:
     @pytest.mark.asyncio
@@ -38,49 +40,8 @@ class TestAsyncYutoriClientInit:
 
 @pytest.mark.asyncio
 class TestAsyncYutoriClientGetUsage:
-    # Mirrors the current server dual-emit: both navigator_* and n1_* keys
-    # are present with equal values. See yutori.codex PR #8174.
-    _NAVIGATOR_LIMITS = {
-        "requests_today": 50,
-        "daily_limit": 50000,
-        "remaining_requests": 49950,
-        "reset_at": "2026-03-04T00:00:00+00:00",
-        "per_second_limit": 20,
-    }
-    USAGE_RESPONSE = {
-        "num_active_scouts": 2,
-        "active_scout_ids": ["id-1", "id-2"],
-        "rate_limits": {
-            "requests_today": 100,
-            "daily_limit": 10000,
-            "remaining_requests": 9900,
-            "reset_at": "2026-03-04T00:00:00+00:00",
-            "status": "available",
-        },
-        "navigator_rate_limits": _NAVIGATOR_LIMITS,
-        "n1_rate_limits": _NAVIGATOR_LIMITS,
-        "activity": {
-            "period": "24h",
-            "scout_runs": 10,
-            "browsing_tasks": 3,
-            "research_tasks": 2,
-            "navigator_calls": 50,
-            "n1_calls": 50,
-        },
-    }
-
-    def _mock_usage_response(self, period: str = "24h"):
-        import json
-
-        data = {**self.USAGE_RESPONSE, "activity": {**self.USAGE_RESPONSE["activity"], "period": period}}
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = json.dumps(data).encode()
-        mock_response.json.return_value = data
-        return mock_response
-
     async def test_get_usage_success(self):
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=self._mock_usage_response()):
+        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=make_mock_usage_response()):
             async with AsyncYutoriClient(api_key="yt-test") as client:
                 result = await client.get_usage()
                 assert result["num_active_scouts"] == 2
@@ -88,7 +49,7 @@ class TestAsyncYutoriClientGetUsage:
 
     async def test_get_usage_with_period(self):
         with patch.object(
-            httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=self._mock_usage_response("30d")
+            httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=make_mock_usage_response("30d")
         ) as mock_get:
             async with AsyncYutoriClient(api_key="yt-test") as client:
                 result = await client.get_usage(period="30d")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,6 +7,8 @@ import pytest
 
 from yutori import APIError, AuthenticationError, YutoriClient
 
+from ._usage_fixtures import make_mock_usage_response
+
 
 class TestYutoriClientInit:
     def test_init_with_api_key(self):
@@ -44,49 +46,8 @@ class TestYutoriClientInit:
 
 
 class TestYutoriClientGetUsage:
-    # Mirrors the current server dual-emit: both navigator_* and n1_* keys
-    # are present with equal values. See yutori.codex PR #8174.
-    _NAVIGATOR_LIMITS = {
-        "requests_today": 50,
-        "daily_limit": 50000,
-        "remaining_requests": 49950,
-        "reset_at": "2026-03-04T00:00:00+00:00",
-        "per_second_limit": 20,
-    }
-    USAGE_RESPONSE = {
-        "num_active_scouts": 2,
-        "active_scout_ids": ["id-1", "id-2"],
-        "rate_limits": {
-            "requests_today": 100,
-            "daily_limit": 10000,
-            "remaining_requests": 9900,
-            "reset_at": "2026-03-04T00:00:00+00:00",
-            "status": "available",
-        },
-        "navigator_rate_limits": _NAVIGATOR_LIMITS,
-        "n1_rate_limits": _NAVIGATOR_LIMITS,
-        "activity": {
-            "period": "24h",
-            "scout_runs": 10,
-            "browsing_tasks": 3,
-            "research_tasks": 2,
-            "navigator_calls": 50,
-            "n1_calls": 50,
-        },
-    }
-
-    def _mock_usage_response(self, period: str = "24h"):
-        import json
-
-        data = {**self.USAGE_RESPONSE, "activity": {**self.USAGE_RESPONSE["activity"], "period": period}}
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = json.dumps(data).encode()
-        mock_response.json.return_value = data
-        return mock_response
-
     def test_get_usage_success(self):
-        with patch.object(httpx.Client, "get", return_value=self._mock_usage_response()):
+        with patch.object(httpx.Client, "get", return_value=make_mock_usage_response()):
             client = YutoriClient(api_key="yt-test")
             result = client.get_usage()
             assert result["num_active_scouts"] == 2
@@ -95,7 +56,7 @@ class TestYutoriClientGetUsage:
             client.close()
 
     def test_get_usage_with_period(self):
-        with patch.object(httpx.Client, "get", return_value=self._mock_usage_response("7d")) as mock_get:
+        with patch.object(httpx.Client, "get", return_value=make_mock_usage_response("7d")) as mock_get:
             client = YutoriClient(api_key="yt-test")
             result = client.get_usage(period="7d")
             assert result["activity"]["period"] == "7d"
@@ -105,7 +66,7 @@ class TestYutoriClientGetUsage:
             client.close()
 
     def test_get_usage_no_period_sends_no_params(self):
-        with patch.object(httpx.Client, "get", return_value=self._mock_usage_response()) as mock_get:
+        with patch.object(httpx.Client, "get", return_value=make_mock_usage_response()) as mock_get:
             client = YutoriClient(api_key="yt-test")
             client.get_usage()
             call_kwargs = mock_get.call_args[1]


### PR DESCRIPTION
## Summary

`tests/test_client.py` (sync) and `tests/test_async_client.py` (async) carried ~35 lines of byte-identical duplication:

- `_NAVIGATOR_LIMITS` constant
- `USAGE_RESPONSE` constant
- the `# Mirrors the current server dual-emit ...` comment
- `_mock_usage_response(self, period="24h")` method (the `self` was unused — it only read class-level constants)

Extracted to `tests/_usage_fixtures.py`:
- `USAGE_RESPONSE` — the canonical response dict.
- `make_mock_usage_response(period="24h")` — builds a mocked 200 OK `httpx.Response` with the period-overridden payload.

Both test files import `make_mock_usage_response` and call it directly. Net diff: `+59 / −87`.

## Why this is an improvement

- **Removes hand-maintained duplication.** Any future change to the `USAGE_RESPONSE` shape (e.g. another server dual-emit, a new activity field) now lives in one place instead of two.
- **Removes pretend-instance-state.** `_mock_usage_response` was a method only because the test classes happened to host the constants; nothing in the body actually depended on `self`.
- **No behavior change.** The fixture content is byte-identical to what each test class produced before.

## Test plan

- [x] `python -m pytest tests/test_client.py tests/test_async_client.py` — 72 passed locally.
- [x] Confirmed `MagicMock`/`AsyncMock` are still referenced elsewhere in each file, so imports remain.
- [ ] CI passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HSHY8ejaAwMgSKYkxekRpo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only refactor that centralizes duplicated mock response data; main risk is unintended fixture drift affecting multiple tests at once.
> 
> **Overview**
> **Test refactor only:** extracts the duplicated `GET /usage` mock payload (`USAGE_RESPONSE` + navigator/n1 dual-emit limits) and response builder into new `tests/_usage_fixtures.py`.
> 
> Updates `tests/test_client.py` and `tests/test_async_client.py` to import `make_mock_usage_response()` and removes the inline class constants/helper methods, keeping the usage tests’ behavior the same while eliminating duplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a469c8e39246348cb89b6d62772961011e2fe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->