### PR TITLE
docs: add canonical AI agent quickstart at llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ The official Python SDK and CLI for the [Yutori API](https://docs.yutori.com) â€
 
 The SDK offers sync and async clients with full type annotations, plus a `yutori` CLI for authentication and managing resources from the terminal.
 
+## AI Agent Quickstart
+
+Paste this into Claude Code, Codex, Cursor, Windsurf, or another coding agent:
+
+```text
+Use https://yutori.com/api/llms.txt to set up Yutori for this project: install the CLI, authenticate through Yutori Platform, install the Yutori MCP server and workflow skills, then show me one Scout, Research, and Browsing demo.
+```
+
 ## Install
 
 On macOS or Linux, the recommended setup is the one-line installer:
@@ -77,7 +85,7 @@ Resolution order: explicit `api_key` > `YUTORI_API_KEY` env var > `~/.yutori/con
 The installer sets these up automatically when Node.js is available. To do it manually:
 
 ```bash
-npx add-mcp uvx yutori-mcp
+npx add-mcp "uvx yutori-mcp"
 npx skills add yutori-ai/yutori-mcp -g
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -15,13 +15,17 @@ Prioritize the CLI/MCP setup first. Do not ask the user to paste API keys into c
 
 Drive setup yourself. The user's only action is clicking **Allow** in a browser tab that opens during auth.
 
-1. Install the CLI (you run this):
+1. Install the CLI, MCP server, and skills in one shot (you run this):
 
     ```bash
-    curl -fsSL https://yutori.com/install.sh | bash
+    YUTORI_INSTALL_CLIENT=<client> curl -fsSL https://yutori.com/install.sh | bash
     ```
 
-    In a non-TTY shell this installs only the CLI; the steps below cover what the interactive installer would have done. If `~/.local/bin` isn't on your PATH yet, invoke `yutori` via `$(uv tool dir --bin)/yutori` or run `export PATH="$(uv tool dir --bin):$PATH"` for the rest of this session.
+    Substitute `<client>` with your agent's slug — common values: `claude-code`, `codex`, `cursor`, `vscode`, `claude-desktop`, `gemini-cli`, `zed`, `opencode` (run `npx add-mcp list-agents` for the full list). If `YUTORI_INSTALL_CLIENT` is unset the installer registers MCP for the default set (`claude-code`, `codex`, `cursor`, `gemini-cli`).
+
+    In non-TTY mode the installer does the CLI install via `uv tool install yutori`, registers the Yutori MCP server for the chosen client(s), and installs the six workflow skills (`yutori-scout`, `yutori-research`, `yutori-browse`, `yutori-competitor-watch`, `yutori-api-monitor`, `yutori-login`) at user scope. Auth and verification are skipped — they need a browser and an API key (step 2 below).
+
+    If `~/.local/bin` isn't on your PATH yet, invoke `yutori` via `$(uv tool dir --bin)/yutori` or run `export PATH="$(uv tool dir --bin):$PATH"` for the rest of this session.
 
 2. Authenticate (you run this; **user clicks Allow**):
 
@@ -31,29 +35,25 @@ Drive setup yourself. The user's only action is clicking **Allow** in a browser 
 
     Opens a Yutori sign-in tab in the user's default browser, binds `127.0.0.1` for the OAuth callback, and saves the API key to `~/.yutori/config.json`. The Bash call blocks for up to 5 minutes waiting for the user — if it times out, rerun. Tell the user: *"I'm opening a Yutori sign-in tab — click Allow when it loads."* If the command prints `Could not launch a browser` with a URL, relay that URL to the user.
 
-3. Register the Yutori MCP server for your client (idempotent):
+3. Ask the user to restart this coding agent so the MCP tools and skills load.
 
-    ```bash
-    npx add-mcp -y -g -n yutori -a <client> "uvx yutori-mcp"
-    ```
+### Fallback: if step 1 didn't configure MCP or skills
 
-    Substitute `<client>` with your agent's slug. Common values: `claude-code`, `codex`, `cursor`, `vscode`, `claude-desktop`, `gemini-cli`, `zed`, `opencode`. Run `npx add-mcp list-agents` for the full list.
+The installer's status table will say `MCP server: SKIP` or `MCP skills: SKIP` if Node.js/npx wasn't on PATH. Run only the failed step(s):
 
-    If `npx` isn't available, native CLIs work for some clients:
-    - Claude Code: `claude mcp add --scope user yutori -- uvx yutori-mcp`
-    - Codex: `codex mcp add yutori -- uvx yutori-mcp`
+```bash
+# MCP server
+npx add-mcp -y -g -n yutori -a <client> "uvx yutori-mcp"
 
-4. Install workflow skills (idempotent):
+# Workflow skills
+npx skills add yutori-ai/yutori-mcp -g
+```
 
-    ```bash
-    npx skills add yutori-ai/yutori-mcp -g
-    ```
+If `npx` isn't available, native CLIs work for some clients:
+- Claude Code: `claude mcp add --scope user yutori -- uvx yutori-mcp`
+- Codex: `codex mcp add yutori -- uvx yutori-mcp`
 
-    Adds six slash-command skills at user scope: `yutori-scout`, `yutori-research`, `yutori-browse`, `yutori-competitor-watch`, `yutori-api-monitor`, and `yutori-login` (re-prompts the user to authenticate if the API key goes missing).
-
-5. Ask the user to restart this coding agent so the MCP tools and skills load.
-
-**Fallback path:** if your Bash tool can't bind `127.0.0.1` (remote dev environment, sandboxed agent) or the user is on a different machine, ask the user to run `curl -fsSL https://yutori.com/install.sh | bash` in their own terminal — the interactive installer handles all five steps.
+**Fallback path:** if your Bash tool can't bind `127.0.0.1` for the auth callback (remote dev environment, sandboxed agent) or the user is on a different machine, ask the user to run `curl -fsSL https://yutori.com/install.sh | bash` in their own terminal — the interactive installer walks through CLI, auth, MCP, skills, and a verification task end-to-end.
 
 ## Verify
 

--- a/llms.txt
+++ b/llms.txt
@@ -13,29 +13,47 @@ Prioritize the CLI/MCP setup first. Do not ask the user to paste API keys into c
 
 ## Setup
 
-Tell the user to run this in their own terminal — the installer is interactive (opens a browser for auth, prompts for client selection) and will not work through the agent's Bash shell:
+Drive setup yourself. The user's only action is clicking **Allow** in a browser tab that opens during auth.
 
-```bash
-curl -fsSL https://yutori.com/install.sh | bash
-```
+1. Install the CLI (you run this):
 
-This single command runs the entire setup end-to-end:
+    ```bash
+    curl -fsSL https://yutori.com/install.sh | bash
+    ```
 
-- Installs the `yutori` CLI via `uv tool install yutori`
-- Runs `yutori auth login` — opens Yutori Platform in the browser, creates/selects an API key, saves it to `~/.yutori/config.json` (read automatically by the SDK, CLI, and MCP server)
-- Configures the Yutori MCP server in compatible clients via `npx add-mcp "uvx yutori-mcp"`
-- Installs workflow skills via `npx skills add yutori-ai/yutori-mcp -g` — adds `yutori-scout`, `yutori-research`, `yutori-browse`, `yutori-competitor-watch`, and `yutori-api-monitor`
-- Runs a verification browsing task
+    In a non-TTY shell this installs only the CLI; the steps below cover what the interactive installer would have done. If your PATH hasn't picked up `~/.local/bin` yet, use `$(uv tool dir --bin)/yutori` or run `eval "$(uv tool update-shell --print)"`.
 
-When it exits, the installer prints a per-step status table (success / skipped / failed). Do **not** re-run the commands above unless a step is marked failed or skipped — re-running succeeded steps wastes time and can prompt the user again. If a step needs retry, run only that fallback:
+2. Authenticate (you run this; **user clicks Allow**):
 
-| Step | Fallback |
-| --- | --- |
-| Authentication | `yutori auth login` |
-| MCP server | `npx add-mcp "uvx yutori-mcp"` |
-| Workflow skills | `npx skills add yutori-ai/yutori-mcp -g` |
+    ```bash
+    yutori auth login
+    ```
 
-After the installer finishes, ask the user to restart their coding agent so the MCP tools and skills load.
+    Opens a Yutori sign-in tab in the user's default browser, binds `127.0.0.1` for the OAuth callback, and saves the API key to `~/.yutori/config.json`. The Bash call blocks for several minutes waiting for the user. Tell the user: *"I'm opening a Yutori sign-in tab — click Allow when it loads."* If the command prints `Could not launch a browser` with a URL, relay that URL to the user to open manually.
+
+3. Register the Yutori MCP server for your client (idempotent):
+
+    ```bash
+    npx add-mcp -y -g -n yutori -a <client> "uvx yutori-mcp"
+    ```
+
+    Substitute `<client>` with your agent's slug. Common values: `claude-code`, `codex`, `cursor`, `vscode`, `claude-desktop`, `gemini-cli`, `zed`, `opencode`. Run `npx add-mcp list-agents` for the full list.
+
+    If `npx` isn't available, native CLIs work for some clients:
+    - Claude Code: `claude mcp add --scope user yutori -- uvx yutori-mcp`
+    - Codex: `codex mcp add yutori -- uvx yutori-mcp`
+
+4. Install workflow skills (idempotent):
+
+    ```bash
+    npx skills add yutori-ai/yutori-mcp -g
+    ```
+
+    Adds `yutori-scout`, `yutori-research`, `yutori-browse`, `yutori-competitor-watch`, and `yutori-api-monitor` at user scope.
+
+5. Ask the user to restart this coding agent so the MCP tools and skills load.
+
+**Fallback path:** if your Bash tool can't bind `127.0.0.1` (remote dev environment, sandboxed agent) or the user is on a different machine, ask the user to run `curl -fsSL https://yutori.com/install.sh | bash` in their own terminal — the interactive installer handles all five steps.
 
 ## Verify
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,13 +1,5 @@
 # Yutori AI Agent Quickstart
 
-Copy this one-line prompt into Claude Code, Codex, Cursor, Windsurf, or another coding agent:
-
-```text
-Use https://yutori.com/api/llms.txt to set up Yutori for this project: install the CLI, authenticate through Yutori Platform, install the Yutori MCP server and workflow skills, then show me one Scout, Research, and Browsing demo.
-```
-
-## Agent Instructions
-
 You are helping a user set up Yutori from scratch. Yutori provides APIs and agent tools for:
 
 | Capability | Use it for |

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,79 @@
+# Yutori AI Agent Quickstart
+
+Copy this one-line prompt into Claude Code, Codex, Cursor, Windsurf, or another coding agent:
+
+```text
+Use https://yutori.com/api/llms.txt to set up Yutori for this project: install the CLI, authenticate through Yutori Platform, install the Yutori MCP server and workflow skills, then show me one Scout, Research, and Browsing demo.
+```
+
+## Agent Instructions
+
+You are helping a user set up Yutori from scratch. Yutori provides APIs and agent tools for:
+
+| Capability | Use it for |
+| --- | --- |
+| Scout | Continuous web monitoring on a schedule |
+| Research | One-time deep web research |
+| Browsing | One-time browser automation |
+| Navigator | A computer-use model API for custom browser agents |
+
+Prioritize the CLI/MCP setup first. Do not ask the user to paste API keys into chat.
+
+## Setup
+
+1. Install the Yutori CLI and SDK:
+
+    ```bash
+    curl -fsSL https://yutori.com/install.sh | bash
+    ```
+
+    The installer uses `uv tool install yutori`. In an interactive terminal, it can also prompt to authenticate, configure MCP, install skills, and run a verification task.
+
+2. Authenticate:
+
+    ```bash
+    yutori auth login
+    ```
+
+    This opens Yutori Platform in the browser, creates or selects an API key, and saves it to `~/.yutori/config.json`. The SDK, CLI, and MCP server read this file automatically. If the agent shell cannot open a browser or run an interactive login, ask the user to run this command in their own terminal.
+
+3. Install the Yutori MCP server:
+
+    ```bash
+    npx add-mcp "uvx yutori-mcp"
+    ```
+
+    Have the user select the coding clients they want to configure, then restart those clients so the MCP tools load.
+
+4. Install Yutori workflow skills:
+
+    ```bash
+    npx skills add yutori-ai/yutori-mcp -g
+    ```
+
+    This installs global skills for compatible agents, including `yutori-scout`, `yutori-research`, `yutori-browse`, `yutori-competitor-watch`, and `yutori-api-monitor`.
+
+## Verify
+
+Run:
+
+```bash
+yutori auth status
+yutori usage
+```
+
+If MCP tools are available in the current agent, call `list_api_usage` as an additional verification.
+
+## Demonstrate
+
+After setup, demonstrate the installed workflow in the current coding agent:
+
+1. Scout: use the `yutori-scout` skill or `create_scout` MCP tool to draft a high-quality monitoring query. Ask for confirmation before creating a recurring scout.
+2. Research: use the `yutori-research` skill or `run_research_task` MCP tool for a small one-time research question. Tell the user research tasks are asynchronous and usually take several minutes.
+3. Browsing: use the `yutori-browse` skill or `run_browsing_task` MCP tool for a simple public-page task, such as extracting the headline from `https://www.yutori.com`. Ask for confirmation before running tasks that may spend credits.
+
+For SDK/API integration details, use:
+
+- Python SDK and CLI reference: https://github.com/yutori-ai/yutori-sdk-python/blob/main/api.md
+- MCP server and skill setup: https://github.com/yutori-ai/yutori-mcp
+- API docs index for agents: https://docs.yutori.com/llms.txt

--- a/llms.txt
+++ b/llms.txt
@@ -13,37 +13,29 @@ Prioritize the CLI/MCP setup first. Do not ask the user to paste API keys into c
 
 ## Setup
 
-1. Install the Yutori CLI and SDK:
+Tell the user to run this in their own terminal — the installer is interactive (opens a browser for auth, prompts for client selection) and will not work through the agent's Bash shell:
 
-    ```bash
-    curl -fsSL https://yutori.com/install.sh | bash
-    ```
+```bash
+curl -fsSL https://yutori.com/install.sh | bash
+```
 
-    The installer uses `uv tool install yutori`. In an interactive terminal, it can also prompt to authenticate, configure MCP, install skills, and run a verification task.
+This single command runs the entire setup end-to-end:
 
-2. Authenticate:
+- Installs the `yutori` CLI via `uv tool install yutori`
+- Runs `yutori auth login` — opens Yutori Platform in the browser, creates/selects an API key, saves it to `~/.yutori/config.json` (read automatically by the SDK, CLI, and MCP server)
+- Configures the Yutori MCP server in compatible clients via `npx add-mcp "uvx yutori-mcp"`
+- Installs workflow skills via `npx skills add yutori-ai/yutori-mcp -g` — adds `yutori-scout`, `yutori-research`, `yutori-browse`, `yutori-competitor-watch`, and `yutori-api-monitor`
+- Runs a verification browsing task
 
-    ```bash
-    yutori auth login
-    ```
+When it exits, the installer prints a per-step status table (success / skipped / failed). Do **not** re-run the commands above unless a step is marked failed or skipped — re-running succeeded steps wastes time and can prompt the user again. If a step needs retry, run only that fallback:
 
-    This opens Yutori Platform in the browser, creates or selects an API key, and saves it to `~/.yutori/config.json`. The SDK, CLI, and MCP server read this file automatically. If the agent shell cannot open a browser or run an interactive login, ask the user to run this command in their own terminal.
+| Step | Fallback |
+| --- | --- |
+| Authentication | `yutori auth login` |
+| MCP server | `npx add-mcp "uvx yutori-mcp"` |
+| Workflow skills | `npx skills add yutori-ai/yutori-mcp -g` |
 
-3. Install the Yutori MCP server:
-
-    ```bash
-    npx add-mcp "uvx yutori-mcp"
-    ```
-
-    Have the user select the coding clients they want to configure, then restart those clients so the MCP tools load.
-
-4. Install Yutori workflow skills:
-
-    ```bash
-    npx skills add yutori-ai/yutori-mcp -g
-    ```
-
-    This installs global skills for compatible agents, including `yutori-scout`, `yutori-research`, `yutori-browse`, `yutori-competitor-watch`, and `yutori-api-monitor`.
+After the installer finishes, ask the user to restart their coding agent so the MCP tools and skills load.
 
 ## Verify
 

--- a/llms.txt
+++ b/llms.txt
@@ -21,7 +21,7 @@ Drive setup yourself. The user's only action is clicking **Allow** in a browser 
     curl -fsSL https://yutori.com/install.sh | bash
     ```
 
-    In a non-TTY shell this installs only the CLI; the steps below cover what the interactive installer would have done. If your PATH hasn't picked up `~/.local/bin` yet, use `$(uv tool dir --bin)/yutori` or run `eval "$(uv tool update-shell --print)"`.
+    In a non-TTY shell this installs only the CLI; the steps below cover what the interactive installer would have done. If `~/.local/bin` isn't on your PATH yet, invoke `yutori` via `$(uv tool dir --bin)/yutori` or run `export PATH="$(uv tool dir --bin):$PATH"` for the rest of this session.
 
 2. Authenticate (you run this; **user clicks Allow**):
 
@@ -29,7 +29,7 @@ Drive setup yourself. The user's only action is clicking **Allow** in a browser 
     yutori auth login
     ```
 
-    Opens a Yutori sign-in tab in the user's default browser, binds `127.0.0.1` for the OAuth callback, and saves the API key to `~/.yutori/config.json`. The Bash call blocks for several minutes waiting for the user. Tell the user: *"I'm opening a Yutori sign-in tab — click Allow when it loads."* If the command prints `Could not launch a browser` with a URL, relay that URL to the user to open manually.
+    Opens a Yutori sign-in tab in the user's default browser, binds `127.0.0.1` for the OAuth callback, and saves the API key to `~/.yutori/config.json`. The Bash call blocks for up to 5 minutes waiting for the user — if it times out, rerun. Tell the user: *"I'm opening a Yutori sign-in tab — click Allow when it loads."* If the command prints `Could not launch a browser` with a URL, relay that URL to the user.
 
 3. Register the Yutori MCP server for your client (idempotent):
 
@@ -49,7 +49,7 @@ Drive setup yourself. The user's only action is clicking **Allow** in a browser 
     npx skills add yutori-ai/yutori-mcp -g
     ```
 
-    Adds `yutori-scout`, `yutori-research`, `yutori-browse`, `yutori-competitor-watch`, and `yutori-api-monitor` at user scope.
+    Adds six slash-command skills at user scope: `yutori-scout`, `yutori-research`, `yutori-browse`, `yutori-competitor-watch`, `yutori-api-monitor`, and `yutori-login` (re-prompts the user to authenticate if the API key goes missing).
 
 5. Ask the user to restart this coding agent so the MCP tools and skills load.
 


### PR DESCRIPTION
## Summary

- Adds a root-level `llms.txt` containing setup instructions for AI coding agents (Claude Code, Codex, Cursor, Windsurf, etc.): install the CLI, authenticate, install the MCP server and workflow skills, then demo Scout / Research / Browsing.
- Adds an **AI Agent Quickstart** section to the README with a one-line prompt users can paste into any coding agent.
- Canonical URL: https://yutori.com/api/llms.txt (proxies to this file on `main`).

## Why

Follows the [llmstxt.org](https://llmstxt.org) convention. Hosting the agent-facing quickstart next to the installer it describes keeps setup instructions in lockstep with the tooling.

## Test plan

- [ ] Paste the README one-liner into a coding agent (Claude Code, Codex, Cursor) and verify it fetches `llms.txt`, runs `curl -fsSL https://yutori.com/install.sh | bash`, completes auth, installs MCP + skills, and demos a workflow.
- [ ] Confirm `llms.txt` renders on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes adjusting installation and fallback instructions; no runtime code paths are modified.
> 
> **Overview**
> Updates `llms.txt` setup instructions to treat the installer as the primary path for installing the CLI *and* configuring MCP + workflow skills, including a new `YUTORI_INSTALL_CLIENT=<client>` env var to target specific agents.
> 
> Replaces the standalone MCP registration step with a “restart agent” step, and adds a clearer fallback section for when MCP/skills were skipped (e.g., missing `npx`) plus improved guidance for remote auth callback limitations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d17c2b5e06320601ccce2bc23757aaebfe081ea6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->