### PR TITLE
docs: tighten quickstart prompt and Install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The SDK offers sync and async clients with full type annotations, plus a `yutori
 Paste this into Claude Code, Codex, Cursor, Windsurf, or another coding agent:
 
 ```text
-Use https://yutori.com/api/llms.txt to set up Yutori for this project: install the CLI, authenticate through Yutori Platform, install the Yutori MCP server and workflow skills, then show me one Scout, Research, and Browsing demo.
+Use https://yutori.com/api/llms.txt and set up Yutori for me.
 ```
 
 ## Install
@@ -23,7 +23,17 @@ On macOS or Linux, the recommended setup is the one-line installer:
 curl -fsSL https://yutori.com/install.sh | bash
 ```
 
-This installs the global `yutori` CLI with `uv tool install`, then — in an interactive terminal — prompts (with sensible defaults) to add the SDK to your project, run `yutori auth login`, configure the Yutori MCP server, install workflow skills, and run a verification browsing task. In a non-interactive session (CI, pipe, AI coding agent) the SDK install, auth, and verification prompts are skipped (auth needs a browser; verification needs a key); the Yutori MCP server and workflow skills install automatically without prompts. Set `YUTORI_INSTALL_CLIENT=<slug>` (e.g. `claude-code`, `codex`, `cursor`) to scope the MCP install to one coding agent — otherwise it registers for the default set (`claude-code`, `codex`, `cursor`, `gemini-cli`). See `npx add-mcp list-agents` for the full slug list to use with `YUTORI_INSTALL_CLIENT`.
+The installer installs the global `yutori` CLI with `uv tool install`, then walks the rest of setup. In an **interactive terminal** it prompts (with sensible defaults) for:
+
+- adding the SDK to your project,
+- `yutori auth login`,
+- configuring the Yutori MCP server,
+- installing workflow skills,
+- and running a verification browsing task.
+
+In a **non-interactive session** (CI, pipe, AI coding agent) the SDK install, auth, and verification steps are skipped — auth needs a browser, verification needs an API key. MCP server and workflow skills install automatically without prompts.
+
+To scope the non-interactive MCP install to one coding agent, set `YUTORI_INSTALL_CLIENT=<slug>` (e.g. `claude-code`, `codex`, `cursor`). Unset, it registers for `claude-code`, `codex`, `cursor`, and `gemini-cli`. Run `npx add-mcp list-agents` for the full slug list.
 
 Python 3.9+ is required for the SDK.
 


### PR DESCRIPTION
## Summary

- Collapse the agent quickstart prompt to one line — drops the redundant restatement of what `llms.txt` itself covers.
- Break the wall-of-text Install paragraph into a lead-in plus two bulleted sub-sections (interactive vs non-interactive) so readers can skim.

## Before / after

**Prompt — before** (1 line, ~360 chars):
> Use https://yutori.com/api/llms.txt to set up Yutori for this project: install the CLI, authenticate through Yutori Platform, install the Yutori MCP server and workflow skills, then show me one Scout, Research, and Browsing demo.

**Prompt — after** (1 line, ~70 chars):
> Use https://yutori.com/api/llms.txt and set up Yutori for me.

The agent reads `llms.txt` and gets the full instructions there; restating them in the prompt just wastes tokens on every paste.

Same prompt now byte-identical across SDK README, MCP README, and the Mintlify mdx page.

## Test plan

- [ ] README renders correctly on GitHub.
- [ ] Paste the one-liner into Claude Code / Codex / Cursor and confirm the agent fetches `llms.txt` and walks through CLI install + auth + MCP + skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that adjust README wording and structure without affecting SDK/CLI behavior.
> 
> **Overview**
> **Simplifies the README quickstart prompt** by shortening the AI-agent copy/paste instruction to a single line that just points at `llms.txt`.
> 
> **Reworks the Install section for readability** by splitting the long installer explanation into interactive vs non-interactive behavior, listing what steps are prompted vs skipped, and clarifying how `YUTORI_INSTALL_CLIENT` scopes MCP registration (including the default agent set).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1da0160a48d1c9c3c67d64122e6dfec03c9934e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->