### PR TITLE
[codex] Relax httpx dependency pin

### DIFF
--- a/api.md
+++ b/api.md
@@ -587,8 +587,8 @@ Required (installed with `pip install yutori` or `uv add yutori`):
 
 | Package | Version | Purpose |
 |---------|---------|---------|
-| `httpx` | `>=0.26.0,<0.28.0` | HTTP client for browsing/research/scouting. |
-| `openai` | `>=1.0.0` | Backs `client.chat` (provides `ChatCompletion` types). |
+| `httpx` | `>=0.26.0,<1.0.0` | HTTP client for browsing/research/scouting. |
+| `openai` | `>=1.55.3` | Backs `client.chat` (provides `ChatCompletion` types). |
 | `pillow` | `>=10.0.0` | Screenshot helpers in `yutori.navigator`. |
 | `typer` | `>=0.9.0` | CLI framework. |
 | `rich` | `>=13.0.0` | Terminal output for the CLI. |

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -26,13 +26,6 @@ import asyncio
 import json
 import sys
 
-from loguru import logger
-from openai.types.chat import ChatCompletion
-from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from playwright.async_api import Browser, Page, async_playwright
-from pydantic import BaseModel, Field
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
-
 from _common import (
     RETRYABLE_EXCEPTIONS,
     add_agent_arguments,
@@ -43,6 +36,13 @@ from _common import (
     add_task_arguments,
     configure_example_logging,
 )
+from loguru import logger
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
+from playwright.async_api import Browser, Page, async_playwright
+from pydantic import BaseModel, Field
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import (

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -43,13 +43,6 @@ import argparse
 import asyncio
 import json
 
-from loguru import logger
-from openai.types.chat import ChatCompletion
-from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from playwright.async_api import Browser, Page, async_playwright
-from pydantic import BaseModel, Field
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
-
 from _common import (
     RETRYABLE_EXCEPTIONS,
     add_agent_arguments,
@@ -60,6 +53,13 @@ from _common import (
     add_task_arguments,
     configure_example_logging,
 )
+from loguru import logger
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
+from playwright.async_api import Browser, Page, async_playwright
+from pydantic import BaseModel, Field
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import (
@@ -77,8 +77,8 @@ from yutori.navigator.loop import update_trimmed_history
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload  # Optional replay helpers.
 from yutori.navigator.tools import (
-    EXTRACT_ELEMENTS_SCRIPT,
     EXECUTE_JS_SCRIPT,
+    EXTRACT_ELEMENTS_SCRIPT,
     FIND_SCRIPT,
     GET_ELEMENT_BY_REF_SCRIPT,
     SET_ELEMENT_VALUE_SCRIPT,

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -16,7 +16,9 @@ raw request/response payloads in `visualization.html` after the run.
 Usage:
     yutori auth login  # or export YUTORI_API_KEY=...
     uv sync --extra examples
-    uv run python examples/navigator_n1_custom_tools.py --task "Get the titles and links of all the blog posts" --start-url "https://www.yutori.com"
+    uv run python examples/navigator_n1_custom_tools.py \
+        --task "Get the titles and links of all the blog posts" \
+        --start-url "https://www.yutori.com"
 """
 
 import argparse
@@ -25,13 +27,6 @@ import json
 import re
 import sys
 from functools import cached_property
-
-from loguru import logger
-from openai.types.chat import ChatCompletion
-from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from playwright.async_api import Browser, Page, async_playwright
-from pydantic import BaseModel, Field
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from _common import (
     RETRYABLE_EXCEPTIONS,
@@ -42,6 +37,13 @@ from _common import (
     add_task_arguments,
     configure_example_logging,
 )
+from loguru import logger
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
+from playwright.async_api import Browser, Page, async_playwright
+from pydantic import BaseModel, Field
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import N1_MODEL, aplaywright_screenshot_to_data_url, denormalize_coordinates

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -32,13 +32,6 @@ import sys
 from datetime import datetime
 from functools import cached_property
 
-from loguru import logger
-from openai.types.chat import ChatCompletion
-from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from playwright.async_api import Browser, Page, async_playwright
-from pydantic import BaseModel, Field
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
-
 from _common import (
     RETRYABLE_EXCEPTIONS,
     add_agent_arguments,
@@ -48,6 +41,13 @@ from _common import (
     add_task_arguments,
     configure_example_logging,
 )
+from loguru import logger
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
+from playwright.async_api import Browser, Page, async_playwright
+from pydantic import BaseModel, Field
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import N1_MODEL, aplaywright_screenshot_to_data_url, denormalize_coordinates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.7.7"
+version = "0.7.8"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "httpx>=0.26.0,<0.28.0",
-    "openai>=1.0.0",
+    "httpx>=0.26.0,<1.0.0",
+    "openai>=1.55.3",
     "pillow>=10.0.0",
     "typer>=0.9.0",
     "rich>=13.0.0",

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -198,7 +198,9 @@ class TestAsyncBrowsingNamespace:
     async def test_browsing_get_with_rejection_reason(self):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "task-123", "status": "failed", "rejection_reason": "billing_limit_reached"}'
+        mock_response.content = (
+            b'{"task_id": "task-123", "status": "failed", "rejection_reason": "billing_limit_reached"}'
+        )
         mock_response.json.return_value = {
             "task_id": "task-123",
             "status": "failed",
@@ -239,7 +241,9 @@ class TestAsyncResearchNamespace:
     async def test_research_get_with_rejection_reason(self):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "research-123", "status": "failed", "rejection_reason": "rate_limit_exceeded"}'
+        mock_response.content = (
+            b'{"task_id": "research-123", "status": "failed", "rejection_reason": "rate_limit_exceeded"}'
+        )
         mock_response.json.return_value = {
             "task_id": "research-123",
             "status": "failed",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,7 +48,15 @@ def test_browse_run_forwards_local_browser_and_auth():
     with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
         result = runner.invoke(
             app,
-            ["browse", "run", "log in and continue", "https://example.com/login", "--browser", "local", "--require-auth"],
+            [
+                "browse",
+                "run",
+                "log in and continue",
+                "https://example.com/login",
+                "--browser",
+                "local",
+                "--require-auth",
+            ],
         )
 
     assert result.exit_code == 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -243,7 +243,9 @@ class TestBrowsingNamespace:
     def test_browsing_get_with_rejection_reason(self, client):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "task-123", "status": "failed", "rejection_reason": "billing_limit_reached"}'
+        mock_response.content = (
+            b'{"task_id": "task-123", "status": "failed", "rejection_reason": "billing_limit_reached"}'
+        )
         mock_response.json.return_value = {
             "task_id": "task-123",
             "status": "failed",
@@ -285,7 +287,9 @@ class TestResearchNamespace:
     def test_research_get_with_rejection_reason(self, client):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "research-123", "status": "failed", "rejection_reason": "rate_limit_exceeded"}'
+        mock_response.content = (
+            b'{"task_id": "research-123", "status": "failed", "rejection_reason": "rate_limit_exceeded"}'
+        )
         mock_response.json.return_value = {
             "task_id": "research-123",
             "status": "failed",

--- a/tests/test_install_flow.py
+++ b/tests/test_install_flow.py
@@ -287,7 +287,10 @@ def test_install_flow_interactive_auth_decline_still_skips_mcp_and_skills():
         patch("yutori.cli.commands.install_flow.detect_sdk_install_plan", return_value=sdk_plan),
         patch("yutori.cli.commands.install_flow.is_interactive_terminal", return_value=True),
         patch("yutori.cli.commands.install_flow.maybe_repair_path", return_value=StepResult("PATH", "success", "ok")),
-        patch("yutori.cli.commands.install_flow.maybe_install_sdk", return_value=StepResult("SDK", "skipped", "User declined SDK install.")),
+        patch(
+            "yutori.cli.commands.install_flow.maybe_install_sdk",
+            return_value=StepResult("SDK", "skipped", "User declined SDK install."),
+        ),
         patch(
             "yutori.cli.commands.install_flow.maybe_authenticate",
             return_value=(StepResult("Auth", "skipped", "User declined auth."), False),

--- a/tests/test_n1_compat.py
+++ b/tests/test_n1_compat.py
@@ -6,7 +6,6 @@ import warnings
 
 import pytest
 
-
 COMPAT_IMPORTS = [
     ("yutori.n1", "denormalize_coordinates"),
     ("yutori.n1.keys", "map_key_to_playwright"),

--- a/tests/test_navigator_keys.py
+++ b/tests/test_navigator_keys.py
@@ -1,7 +1,5 @@
 """Tests for Navigator n1.5 key mapping helpers."""
 
-import pytest
-
 from yutori.navigator.keys import map_key_to_playwright, map_keys_individual
 
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import pytest
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/yutori/_schema.py
+++ b/yutori/_schema.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-
 _ERROR_MSG = "output_schema must be a dict, a Pydantic BaseModel class, or a BaseModel instance"
 
 


### PR DESCRIPTION
## Summary

- relax the SDK direct `httpx` requirement from `<0.28.0` to `<1.0.0`
- raise the `openai` lower bound to `>=1.55.3`, avoiding the known old `openai`/`httpx 0.28` incompatibility around the removed `proxies` argument
- bump the package version to `0.7.8` for the patch release
- update the API dependency table to match the package metadata
- fix existing Ruff violations so `ruff check .` passes

## Context

Issue #119 asks why the SDK blocks `httpx>=0.28`. I traced the pin back to the initial SDK PR; I did not find SDK code that depends on pre-0.28 HTTPX behavior. The SDK direct HTTPX usage is limited to normal `Client`/`AsyncClient` construction with `timeout=` and standard request methods.

The compatibility risk is transitive: older `openai-python` versions passed the removed `proxies` argument into HTTPX 0.28. Local probes showed `openai==1.55.2` fails with `httpx==0.28.1`, while `openai==1.55.3` works, so this PR pairs the HTTPX relaxation with that OpenAI lower-bound bump.

## Validation

- `.context/httpx028-venv/bin/python -m ruff check .` - all checks passed
- `git diff --check` - clean
- `python -m pytest -q -m "not slow"` - 395 passed, 3 skipped, 1 deselected
- `.context/httpx028-venv/bin/python -m pip install --no-deps -e .`
- `.context/httpx028-venv/bin/python -m pip check` - no broken requirements
- `.context/httpx028-venv/bin/python -m pytest -q -m "not slow"` - 395 passed, 3 skipped, 1 deselected
- verified installed metadata reports version `0.7.8`, `httpx<1.0.0,>=0.26.0`, and `openai>=1.55.3`