### PR TITLE
docs(llms): be explicit that the agent runs auth and verify itself

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -33,7 +33,11 @@ Drive setup yourself. The user's only action is clicking **Allow** in a browser 
     yutori auth login
     ```
 
-    Opens a Yutori sign-in tab in the user's default browser, binds `127.0.0.1` for the OAuth callback, and saves the API key to `~/.yutori/config.json`. The Bash call blocks for up to 5 minutes waiting for the user — if it times out, rerun. Tell the user: *"I'm opening a Yutori sign-in tab — click Allow when it loads."* If the command prints `Could not launch a browser` with a URL, relay that URL to the user.
+    **Always run this yourself first**, even on a headless host. The command calls `webbrowser.open(auth_url)`, binds `127.0.0.1` for the OAuth callback, and saves the API key to `~/.yutori/config.json`. The Bash call blocks for up to 5 minutes waiting for the user — if it times out, rerun.
+
+    Two cases:
+    - **Desktop / browser available**: the sign-in tab opens automatically. Tell the user: *"I'm opening a Yutori sign-in tab — click Allow when it loads."*
+    - **Headless host / no browser**: the command prints `Could not launch a browser` followed by an `auth_url`. **Relay that URL to the user** — they paste it into a browser on their own machine, click Allow, and the OAuth callback still completes through your Bash process. Don't skip running `yutori auth login` just because the host might be headless; try it and react to what it prints.
 
 3. Ask the user to restart this coding agent so the MCP tools and skills load.
 
@@ -57,14 +61,14 @@ If `npx` isn't available, native CLIs work for some clients:
 
 ## Verify
 
-Run:
+**You run these yourself** once the user confirms `yutori auth login` completed:
 
 ```bash
-yutori auth status
-yutori usage
+yutori auth status     # confirms the API key is saved and valid
+yutori usage           # shows the user their daily quota and active scouts
 ```
 
-If MCP tools are available in the current agent, call `list_api_usage` as an additional verification.
+If both succeed, proceed to **Demonstrate** below. If MCP tools have already loaded in your session (i.e. the coding agent was restarted), `list_api_usage` is an equivalent MCP check.
 
 ## Demonstrate
 


### PR DESCRIPTION
## Summary

Two coding-agent integration issues spotted in a real Claude Code run against a fresh VM:

1. **Agent deferred `yutori auth login` to the user** instead of running it itself. The VM was headless so the agent (reasonably) assumed the command would fail — but `yutori auth login` already handles that path: `webbrowser.open()` returns False and the command prints a fallback URL the agent can relay. Reword step 2 to make "always try it yourself first; react to what it prints" explicit, and split the desktop case from the headless case so the agent doesn't conflate them.

2. **Agent told the user to run `yutori auth status` and `yutori usage`** themselves. The Verify section's bare `Run:` with no actor was ambiguous compared to step 2's explicit `(you run this; user clicks Allow)`. Rename the actor — "**You run these yourself**" — so the agent doesn't bounce purely-informational CLI calls back to the user.

## Known limitation not addressed here

The Demonstrate section still routes through MCP tools / skills, which only become available after a coding-agent restart. In the same VM run, the agent (correctly) figured "MCP tools aren't loaded yet → can't demo." Fixing that needs a Demonstrate rewrite that leads with the `yutori` CLI commands (no restart required) — happy to follow up if we see the issue persist in practice.

## Test plan

- [ ] In a fresh agent shell (e.g. `claude -p` on a headless host), paste the one-line prompt; confirm the agent runs `yutori auth login` itself and relays the `auth_url` to me to open in a browser.
- [ ] After auth, confirm the agent runs `yutori auth status` and `yutori usage` itself instead of telling me to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that clarify who runs `yutori` commands and how to handle headless OAuth; no runtime or security logic is modified.
> 
> **Overview**
> Updates `llms.txt` to make the coding agent explicitly responsible for running `yutori auth login` and the post-auth verification commands.
> 
> Clarifies the headless vs desktop auth behavior by instructing the agent to always attempt login, then either prompt the user to click Allow in the opened browser or relay the printed `auth_url` when no browser is available, and tightens the **Verify** section to have the agent run `yutori auth status` and `yutori usage` itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98714a5691d2f84e6f52a9a18bc6d9cec4ad805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->