### PR TITLE
docs(llms): CLI-first demos using canonical docs queries

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -72,11 +72,38 @@ If both succeed, proceed to **Demonstrate** below. If MCP tools have already loa
 
 ## Demonstrate
 
-After setup, demonstrate the installed workflow in the current coding agent:
+After auth and verify succeed, run the three demos yourself via the `yutori` CLI in your Bash tool — **no coding-agent restart needed**. (After restart, the MCP tools `run_research_task`, `run_browsing_task`, `create_scout` and the `/yutori-*` skills also become available; use either path.)
 
-1. Scout: use the `yutori-scout` skill or `create_scout` MCP tool to draft a high-quality monitoring query. Ask for confirmation before creating a recurring scout.
-2. Research: use the `yutori-research` skill or `run_research_task` MCP tool for a small one-time research question. Tell the user research tasks are asynchronous and usually take several minutes.
-3. Browsing: use the `yutori-browse` skill or `run_browsing_task` MCP tool for a simple public-page task, such as extracting the headline from `https://www.yutori.com`. Ask for confirmation before running tasks that may spend credits.
+The task APIs are async: `run` starts the task and returns a `task_id`; you then poll `get TASK_ID` until `status` is `succeeded` or `failed`. Examples below mirror the canonical queries at <https://docs.yutori.com/reference/> so demo and docs stay aligned.
+
+### Research (3–10 min)
+
+```bash
+yutori research run "What are the latest developments in quantum computing from the past week? Include company announcements, research papers, and product releases."
+# returns task_id; poll until done
+yutori research get <task_id>
+```
+
+Show the user the returned summary once `status: succeeded`.
+
+### Browsing (30–120 sec)
+
+```bash
+yutori browse run "Give me a list of all employees (names and titles) of Yutori." "https://yutori.com"
+yutori browse get <task_id>
+```
+
+Confirm with the user before running additional browsing tasks — each one spends credits.
+
+### Scout — draft only, **do not auto-create**
+
+Scouts are *recurring* and spend credits on every scheduled run. Show the user the query you would use and ask for explicit confirmation before running:
+
+```bash
+yutori scouts create -q "Tell me about the latest news, product updates, press releases, social media announcements, investments into, or other relevant information about Yutori"
+```
+
+If they decline, skip the Scout demo and end with a recap of Research + Browsing.
 
 For SDK/API integration details, use:
 


### PR DESCRIPTION
## Summary

The previous Demonstrate section routed all three demos through MCP tools and `/yutori-*` skills. MCP tools only become available after a coding-agent restart, so the agent (correctly) figured "MCP isn't available → can't demo" and stopped. The `yutori` CLI works in the same session without a restart — leading with that closes the gap.

Three query strings are now the canonical examples from `docs.yutori.com/reference/{research-create, browsing-create, scouts-create}` so demos, docs, and OpenAPI spec all use the same wording.

The async pattern (`run` returns `task_id` → poll `get TASK_ID` until `succeeded`/`failed`) is named explicitly so the agent doesn't expect `run` to block until completion.

Scout stays **draft-only with explicit user confirmation** — recurring tasks spend credits on every scheduled run.

## Test plan

- [ ] Re-run the one-line prompt on a fresh VM; confirm the agent completes auth (per the previous PR) and then runs `yutori research run` + `yutori browse run` + asks before `yutori scouts create`.
- [ ] Verify the queries match those at <https://docs.yutori.com/reference/research-create>, <https://docs.yutori.com/reference/browsing-create>, and <https://docs.yutori.com/reference/scouts-create>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that change demo instructions and example commands without affecting runtime code or security-sensitive logic.
> 
> **Overview**
> Shifts the **Demonstrate** workflow in `llms.txt` to be *CLI-first* (no coding-agent restart required), while still noting the optional MCP/skill path after restart.
> 
> Clarifies the async task pattern (`run` → `task_id` → poll `get`) and replaces demo prompts with the canonical `research`, `browse`, and `scouts create` query examples from the public reference docs, reiterating **explicit user confirmation** before creating recurring scouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407d798299de2da71dc8dbb8c8266d013bc05eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->