### PR TITLE
docs: rename install headings and tighten installer section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The official Python SDK and CLI for the [Yutori API](https://docs.yutori.com) �
 
 The SDK offers sync and async clients with full type annotations, plus a `yutori` CLI for authentication and managing resources from the terminal.
 
-## AI Agent Quickstart
+## AI agent install (recommended)
 
 Paste this into Claude Code, Codex, Cursor, Windsurf, or another coding agent:
 
@@ -15,7 +15,7 @@ Paste this into Claude Code, Codex, Cursor, Windsurf, or another coding agent:
 Use https://yutori.com/api/llms.txt and set up Yutori for me.
 ```
 
-## Install
+## Manual install
 
 On macOS or Linux, the recommended setup is the one-line installer:
 
@@ -23,19 +23,18 @@ On macOS or Linux, the recommended setup is the one-line installer:
 curl -fsSL https://yutori.com/install.sh | bash
 ```
 
-The installer installs the global `yutori` CLI with `uv tool install`, then walks the rest of setup. In an **interactive terminal** it prompts (with sensible defaults) for:
-
-- adding the SDK to your project,
-- `yutori auth login`,
-- configuring the Yutori MCP server,
-- installing workflow skills,
-- and running a verification browsing task.
-
-In a **non-interactive session** (CI, pipe, AI coding agent) the SDK install, auth, and verification steps are skipped — auth needs a browser, verification needs an API key. MCP server and workflow skills install automatically without prompts.
-
-To scope the non-interactive MCP install to one coding agent, set `YUTORI_INSTALL_CLIENT=<slug>` (e.g. `claude-code`, `codex`, `cursor`). Unset, it registers for `claude-code`, `codex`, `cursor`, and `gemini-cli`. Run `npx add-mcp list-agents` for the full slug list.
+Installs the global `yutori` CLI via `uv tool install` and prompts to add the SDK to your project, run `yutori auth login`, register the MCP server, install workflow skills, and verify with a browsing task.
 
 Python 3.9+ is required for the SDK.
+
+<details>
+<summary>Non-interactive install (CI, pipe, AI coding agent)</summary>
+
+The SDK install, auth, and verification steps are skipped — auth needs a browser, verification needs an API key. MCP server and workflow skills install automatically without prompts.
+
+To scope the MCP install to one coding agent, set `YUTORI_INSTALL_CLIENT=<slug>` (e.g. `claude-code`, `codex`, `cursor`). Unset, it registers for `claude-code`, `codex`, `cursor`, and `gemini-cli`. Run `npx add-mcp list-agents` for the full slug list.
+
+</details>
 
 <details>
 <summary>Uninstall the CLI later</summary>


### PR DESCRIPTION
## Summary
- Rename "AI Agent Quickstart" → "AI agent install (recommended)" and "Install" → "Manual install"
- Collapse the two non-interactive paragraphs into a single `<details>` block
- Tighten the installer description into one punchy sentence (style matches yutori-mcp README)

## Test plan
- [ ] Render README on GitHub and confirm both headings, the collapsed non-interactive section, and the new one-line installer description display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that affect README wording/formatting but not SDK or CLI behavior.
> 
> **Overview**
> Clarifies the README’s installation flow by renaming the quickstart/install headings (AI-agent vs manual) and replacing the verbose installer explanation with a single, more directive sentence.
> 
> Non-interactive install guidance is now grouped under a collapsible `<details>` section, keeping CI/agent-specific notes (skipped auth/verification and `YUTORI_INSTALL_CLIENT` scoping) out of the main path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf226b92b2ec75218613cb1e553bb81f54bc99c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->