### PR TITLE
Fix full-codebase review findings: hermetic tests, py.typed, CLI error handling, installer hardening, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check .
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e ".[dev]"
+      - run: pytest -m "not slow"
+
+  # The wheel-content test and metadata validation are slower, so they run
+  # once rather than across the whole matrix.
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]" twine
+      - name: Wheel content test
+        run: pytest -m slow
+      - name: Build and validate metadata
+        run: |
+          python -m build
+          twine check dist/*
+
+  install-sh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify install.sh matches template + assets + version
+        run: bash scripts/check_install_sh_fresh.sh
+      - name: Syntax-check shell scripts
+        run: |
+          bash -n install.sh
+          bash -n install.sh.template
+          bash -n uninstall.sh

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Upload installer assets to release
         # Pinned to a commit SHA: this third-party action runs with
         # contents:write and uploads the curl|sh installer artifact, so a
-        # mutable tag would be a supply-chain risk. (v2 at time of pinning.)
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
+        # mutable tag would be a supply-chain risk.
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             install.sh

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -19,8 +19,17 @@ jobs:
       - name: Install build tools
         run: pip install build twine
 
+      # Gate publishing on the test suite — a broken tag must not ship.
+      - name: Run tests
+        run: |
+          pip install -e ".[dev]"
+          pytest -m "not slow"
+
       - name: Build package
         run: python -m build
+
+      - name: Validate package metadata
+        run: twine check dist/*
 
       # install.sh is regenerated from the committed template + banner +
       # frames so the uploaded release asset matches the tagged commit
@@ -42,7 +51,10 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Upload installer assets to release
-        uses: softprops/action-gh-release@v2
+        # Pinned to a commit SHA: this third-party action runs with
+        # contents:write and uploads the curl|sh installer artifact, so a
+        # mutable tag would be a supply-chain risk. (v2 at time of pinning.)
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           files: |
             install.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,5 +6,7 @@ repos:
         entry: bash scripts/check_install_sh_fresh.sh
         language: system
         pass_filenames: false
-        # Only rerun when the inputs or the generator change.
-        files: '^(install\.sh\.template|assets/terminal/(yutori_banner|agent_logo_frames)\.txt|scripts/build_install\.sh|scripts/check_install_sh_fresh\.sh|install\.sh)$'
+        # Only rerun when the inputs or the generator change. pyproject.toml
+        # is an input: the generator embeds its `version`, so version bumps
+        # must regenerate install.sh too.
+        files: '^(pyproject\.toml|install\.sh\.template|assets/terminal/(yutori_banner|agent_logo_frames)\.txt|scripts/build_install\.sh|scripts/check_install_sh_fresh\.sh|install\.sh)$'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+# Ship the complete test suite in the sdist. Without this, setuptools'
+# default glob picks up tests/test_*.py but not conftest.py, tests/__init__.py,
+# or tests/_usage_fixtures.py — files those tests import — leaving sdist
+# consumers (e.g. distro packagers) with a suite that cannot even collect.
+graft tests
+global-exclude __pycache__ *.py[cod]

--- a/api.md
+++ b/api.md
@@ -556,14 +556,14 @@ Installed as `yutori` (via the `yutori` script entry point). Run any command wit
 
 | Command | Description |
 |---------|-------------|
-| `yutori browse run TASK START_URL [--max-steps N] [--agent NAME] [--require-auth] [--browser cloud\|local]` | Submit a browsing task. |
+| `yutori browse run TASK START_URL [--max-steps N] [--agent NAME] [--require-auth] [--browser cloud\|local]` | Submit a browsing task. Exit code 1 if the API rejects the task (`status: failed`). |
 | `yutori browse get TASK_ID` | Get status and result (truncates output to 2000 chars). |
 
 ### Research
 
 | Command | Description |
 |---------|-------------|
-| `yutori research run QUERY [--timezone/-tz TZ] [--location LOC]` | Submit a research task. |
+| `yutori research run QUERY [--timezone/-tz TZ] [--location LOC]` | Submit a research task. Exit code 1 if the API rejects the task (`status: failed`). |
 | `yutori research get TASK_ID` | Get status and result (truncates output to 2000 chars). |
 
 ### Scouts
@@ -572,7 +572,7 @@ Installed as `yutori` (via the `yutori` script entry point). Run any command wit
 |---------|-------------|
 | `yutori scouts list [--limit N] [--status active\|paused\|done]` | List scouts (rich table). |
 | `yutori scouts get SCOUT_ID` | Show scout detail. |
-| `yutori scouts create [--query/-q Q] [--interval/-i hourly\|daily\|weekly] [--timezone/-tz TZ]` | Create a scout. Prompts for `query` interactively if `-q` is omitted. Only the three named intervals are accepted; for arbitrary seconds, call `scouts.create` from Python. |
+| `yutori scouts create [--query/-q Q] [--interval/-i hourly\|daily\|weekly] [--timezone/-tz TZ]` | Create a scout. Prompts for `query` interactively if `-q` is omitted. Only the three named intervals are accepted; for arbitrary seconds, call `scouts.create` from Python. Exit code 1 if the API rejects the scout (`status: failed`). |
 | `yutori scouts delete SCOUT_ID [--force/-f]` | Delete a scout. Prompts for confirmation unless `--force`. |
 
 ### Usage

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -46,7 +46,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
-from yutori.navigator import N1_MODEL, aplaywright_screenshot_to_data_url, denormalize_coordinates
+from yutori.navigator import NAVIGATOR_N1_MODEL, aplaywright_screenshot_to_data_url, denormalize_coordinates
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload  # Optional replay helpers.
 
@@ -57,7 +57,7 @@ class Config(BaseModel):
     start_url: str = "https://www.yutori.com"
     # model
     base_url: str = DEFAULT_BASE_URL
-    model: str = N1_MODEL
+    model: str = NAVIGATOR_N1_MODEL
     temperature: float = 0.3
     # agent
     max_steps: int = 100
@@ -141,7 +141,7 @@ class Agent:
     def __init__(
         self,
         base_url: str = DEFAULT_BASE_URL,
-        model: str = N1_MODEL,
+        model: str = NAVIGATOR_N1_MODEL,
         temperature: float = 0.3,
         max_steps: int = 100,
         viewport_width: int = 1280,

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -50,7 +50,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
-from yutori.navigator import N1_MODEL, aplaywright_screenshot_to_data_url, denormalize_coordinates
+from yutori.navigator import NAVIGATOR_N1_MODEL, aplaywright_screenshot_to_data_url, denormalize_coordinates
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload  # Optional replay helpers.
 
@@ -63,7 +63,7 @@ class Config(BaseModel):
     start_url: str = "https://www.triviaplaza.com/three-letter-computer-terms-quiz/"
     # model
     base_url: str = DEFAULT_BASE_URL
-    model: str = N1_MODEL
+    model: str = NAVIGATOR_N1_MODEL
     temperature: float = 0.3
     # agent
     max_steps: int = 100
@@ -187,7 +187,7 @@ class Agent:
     def __init__(
         self,
         base_url: str = DEFAULT_BASE_URL,
-        model: str = N1_MODEL,
+        model: str = NAVIGATOR_N1_MODEL,
         temperature: float = 0.3,
         max_steps: int = 100,
         viewport_width: int = 1280,

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.7.7"
+YUTORI_INSTALLER_VERSION="0.7.8"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested
@@ -1748,8 +1748,10 @@ prerender_frames() {
     local frame_count="$1"
     local use_color="$2"
     local idx
-    FRAMES_RENDER_DIR="${FRAMES_CACHE_FILE}.rendered.d"
-    mkdir -p "$FRAMES_RENDER_DIR"
+    # mktemp -d, not a name derived from FRAMES_CACHE_FILE: a predictable
+    # path under a shared /tmp could be pre-created (with symlinks inside)
+    # by another local user, and `mkdir -p` would happily adopt it.
+    FRAMES_RENDER_DIR="$(mktemp -d "${TMPDIR:-/tmp}/yutori-install-frames-rendered.XXXXXX")"
     for (( idx = 0; idx < frame_count; idx++ )); do
         render_frame "$idx" "$use_color" >"$FRAMES_RENDER_DIR/$idx"
     done

--- a/install.sh.template
+++ b/install.sh.template
@@ -241,8 +241,10 @@ prerender_frames() {
     local frame_count="$1"
     local use_color="$2"
     local idx
-    FRAMES_RENDER_DIR="${FRAMES_CACHE_FILE}.rendered.d"
-    mkdir -p "$FRAMES_RENDER_DIR"
+    # mktemp -d, not a name derived from FRAMES_CACHE_FILE: a predictable
+    # path under a shared /tmp could be pre-created (with symlinks inside)
+    # by another local user, and `mkdir -p` would happily adopt it.
+    FRAMES_RENDER_DIR="$(mktemp -d "${TMPDIR:-/tmp}/yutori-install-frames-rendered.XXXXXX")"
     for (( idx = 0; idx < frame_count; idx++ )); do
         render_frame "$idx" "$use_color" >"$FRAMES_RENDER_DIR/$idx"
     done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["setuptools>=67.0"]
+# >=77 is required for the PEP 639 string form of `license`; older
+# setuptools fails pyproject validation on it.
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -51,6 +53,7 @@ where = ["."]
 include = ["yutori*"]
 
 [tool.setuptools.package-data]
+"yutori" = ["py.typed"]
 "yutori.navigator" = ["js/*.js"]
 "yutori.navigator.tools" = ["js/*.js"]
 

--- a/tests/_usage_fixtures.py
+++ b/tests/_usage_fixtures.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import httpx
 
 # Mirrors the current server dual-emit: both navigator_* and n1_* keys
-# are present with equal values. See yutori.codex PR #8174.
+# are present with equal values (n1_* is the deprecated alias).
 _NAVIGATOR_LIMITS = {
     "requests_today": 50,
     "daily_limit": 50000,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import errno
 import hashlib
 import io
 import json
@@ -251,8 +252,10 @@ class TestResolveApiKey:
         save_config("yt-stored")
         assert resolve_api_key() == "yt-stored"
 
-    # A trailing newline (e.g. `export YUTORI_API_KEY=$(cat key.txt)`) is an
-    # illegal HTTP header value; the resolved key must come back stripped.
+    # A trailing newline (e.g. a key file read verbatim, or a CI secret with
+    # its newline) is an illegal HTTP header value; the key must come back
+    # stripped. (Note `$(cat file)` would NOT reproduce this — command
+    # substitution strips trailing newlines.)
     def test_param_key_is_stripped(self):
         assert resolve_api_key("yt-explicit\n") == "yt-explicit"
 
@@ -654,10 +657,25 @@ class TestRunLoginFlow:
         mock_gen_key.assert_not_called()
 
     def test_port_in_use(self):
-        with patch("yutori.auth.flow.socketserver.TCPServer.__init__", side_effect=OSError("Address already in use")):
+        # The errno must be set: a bare OSError("Address already in use") has
+        # errno=None and would silently exercise the generic fallback branch.
+        with patch(
+            "yutori.auth.flow.socketserver.TCPServer.__init__",
+            side_effect=OSError(errno.EADDRINUSE, "Address already in use"),
+        ):
             result = run_login_flow()
             assert result.success is False
-            assert "already in use" in result.error
+            assert "Close other applications" in result.error
+
+    def test_other_bind_error_names_the_callback_server(self):
+        with patch(
+            "yutori.auth.flow.socketserver.TCPServer.__init__",
+            side_effect=OSError(errno.EACCES, "Permission denied"),
+        ):
+            result = run_login_flow()
+            assert result.success is False
+            assert "callback server" in result.error
+            assert "Permission denied" in result.error
 
     def test_timeout(self):
         def fake_server_init(self, addr, handler):
@@ -863,3 +881,21 @@ class TestTypes:
         assert s.authenticated is False
         assert s.masked_key is None
         assert s.source is None
+
+
+class TestAuthApiBaseUrlOverride:
+    def test_env_override_applies_and_is_sanitized(self, monkeypatch):
+        import importlib
+
+        from yutori.auth import constants
+
+        monkeypatch.setenv("YUTORI_API_BASE_URL", "https://api.example.test/v1/")
+        importlib.reload(constants)
+        try:
+            assert constants.build_auth_api_url("/client/generate_key") == (
+                "https://api.example.test/v1/client/generate_key"
+            )
+        finally:
+            # Restore module-level defaults for the rest of the suite.
+            monkeypatch.delenv("YUTORI_API_BASE_URL")
+            importlib.reload(constants)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -251,6 +251,19 @@ class TestResolveApiKey:
         save_config("yt-stored")
         assert resolve_api_key() == "yt-stored"
 
+    # A trailing newline (e.g. `export YUTORI_API_KEY=$(cat key.txt)`) is an
+    # illegal HTTP header value; the resolved key must come back stripped.
+    def test_param_key_is_stripped(self):
+        assert resolve_api_key("yt-explicit\n") == "yt-explicit"
+
+    def test_env_key_is_stripped(self, monkeypatch):
+        monkeypatch.setenv("YUTORI_API_KEY", " yt-env\n")
+        assert resolve_api_key() == "yt-env"
+
+    def test_stored_key_is_stripped(self):
+        save_config("yt-stored\n")
+        assert resolve_api_key() == "yt-stored"
+
 
 # ---------------------------------------------------------------------------
 # Callback handler
@@ -499,6 +512,47 @@ class TestRunLoginFlow:
                     assert key_name.endswith("-yutori-cli")
                     date_part = key_name[:10]
                     datetime.strptime(date_part, "%Y-%m-%d")
+
+    @patch("yutori.auth.flow.webbrowser.open")
+    @patch("yutori.auth.flow.generate_api_key", return_value="yt-new-key")
+    @patch("yutori.auth.flow.register_user")
+    @patch("yutori.auth.flow.check_registration_status", return_value=False)
+    @patch("yutori.auth.flow.exchange_code_for_token", return_value="jwt123")
+    @patch("yutori.auth.flow.save_config", side_effect=OSError("read-only file system"))
+    def test_save_failure_reports_orphaned_key(
+        self, mock_save, mock_exchange, mock_status, mock_register, mock_gen_key, mock_browser
+    ):
+        # The key exists server-side by the time save_config runs; the error
+        # must say so instead of surfacing a bare OSError.
+        def fake_server_init(self, addr, handler):
+            pass
+
+        with (
+            patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init),
+            patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"),
+            patch("yutori.auth.flow.socketserver.TCPServer.shutdown"),
+            patch("yutori.auth.flow.socketserver.TCPServer.server_close"),
+            patch("yutori.auth.flow.threading.Thread") as mock_thread_cls,
+        ):
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+            original_result = _CallbackResult()
+            with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
+                with patch("yutori.auth.flow.secrets.token_urlsafe", return_value="fixed_state"):
+
+                    def side_effect(*args, **kwargs):
+                        original_result.code = "auth_code"
+                        original_result.state = "fixed_state"
+                        original_result.received.set()
+
+                    mock_thread.start.side_effect = side_effect
+
+                    result = run_login_flow()
+
+        assert result.success is False
+        assert result.api_key == "yt-new-key"
+        assert "an API key was created" in result.error
+        assert "read-only file system" in result.error
 
     @patch("yutori.auth.flow.webbrowser.open")
     @patch("yutori.auth.flow.generate_api_key", return_value="yt-new-key")

--- a/tests/test_bash_scripts.py
+++ b/tests/test_bash_scripts.py
@@ -34,10 +34,6 @@ def _resolve_install_sh() -> Path:
     )
 
 
-def _all_scripts() -> list[Path]:
-    return AUTHORED_SCRIPTS + [_resolve_install_sh()]
-
-
 @pytest.mark.parametrize("script", AUTHORED_SCRIPTS, ids=lambda p: p.name)
 def test_authored_bash_syntax(script: Path) -> None:
     """`bash -n` on every hand-authored script — these must always exist."""

--- a/tests/test_bash_scripts.py
+++ b/tests/test_bash_scripts.py
@@ -289,3 +289,21 @@ def test_full_animation_clears_frame_region_before_handoff() -> None:
         "end of screen) after the animation loop, or leftover frame rows "
         "will bleed through when the Python UI starts printing."
     )
+
+
+def test_frames_render_dir_uses_mktemp_d() -> None:
+    """Regression: the render dir must be mktemp -d-created, not derived from
+    FRAMES_CACHE_FILE — a derived name under shared /tmp can be pre-created
+    (with symlinks inside) by another local user and adopted by `mkdir -p`.
+    """
+    content = INSTALL_TEMPLATE.read_text()
+    assert 'FRAMES_RENDER_DIR="$(mktemp -d' in content
+    assert '"${FRAMES_CACHE_FILE}.rendered.d"' not in content
+
+
+def test_uninstall_confirm_accepts_yes() -> None:
+    """Regression: the prompt offers "[Y/n]", so a typed "yes" must not be
+    treated as a decline by a single-character match.
+    """
+    content = UNINSTALL_SH.read_text()
+    assert "^[Yy]([Ee][Ss])?$" in content

--- a/tests/test_bash_scripts.py
+++ b/tests/test_bash_scripts.py
@@ -57,9 +57,11 @@ def test_authored_shellcheck_clean_if_available(script: Path) -> None:
     """Run shellcheck when available. Informational — non-blocking if absent."""
     if not shutil.which("shellcheck"):
         pytest.skip("shellcheck not installed")
-    # Allow SC2034 (unused color constants in template), SC1091 (sourced files).
+    # Allow SC2034 (unused color constants in template), SC1091 (sourced
+    # files), SC2016 (info-level; flags intentional literal backticks in
+    # single-quoted user-facing messages and grep patterns).
     result = subprocess.run(
-        ["shellcheck", "-e", "SC2034,SC1091", str(script)],
+        ["shellcheck", "-e", "SC2034,SC1091,SC2016", str(script)],
         capture_output=True,
         text=True,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,7 +108,8 @@ def test_browse_run_handles_failed_create_response():
             ["browse", "run", "click the button", "https://example.com"],
         )
 
-    assert result.exit_code == 0
+    # A rejected create must exit non-zero so scripts don't treat it as success.
+    assert result.exit_code == 1
     assert "Browsing task failed to start" in result.stdout
     assert "Rejection Reason: billing_limit_reached" in result.stdout
     client.close.assert_called_once()
@@ -127,7 +128,8 @@ def test_research_run_handles_failed_create_response():
             ["research", "run", "latest AI announcements"],
         )
 
-    assert result.exit_code == 0
+    # A rejected create must exit non-zero so scripts don't treat it as success.
+    assert result.exit_code == 1
     assert "Research task failed to start" in result.stdout
     assert "Rejection Reason" not in result.stdout
     client.close.assert_called_once()
@@ -201,4 +203,146 @@ def test_scouts_list_shows_rejection_reason_column():
 
     assert result.exit_code == 0
     assert "invalid_query" in result.stdout
+    client.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Rich markup safety: API/user strings must render literally, never parse.
+# ---------------------------------------------------------------------------
+
+
+def test_scouts_list_renders_markup_like_queries_literally():
+    client = _make_client_mock()
+    client.scouts.list.return_value = {
+        "scouts": [
+            {
+                "id": "scout-1",
+                "query": "watch [/b] releases",
+                "status": "active",
+                "output_interval": 86400,
+            },
+            {
+                "id": "scout-2",
+                "query": "monitor [beta] pages",
+                "status": "active",
+                "output_interval": 86400,
+            },
+        ]
+    }
+
+    with patch("yutori.cli.commands.scouts.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["scouts", "list"])
+
+    # "[/b]" used to crash the whole listing with MarkupError; "[beta]" used
+    # to be silently deleted by markup parsing.
+    assert result.exit_code == 0
+    assert "[/b]" in result.stdout
+    assert "[beta]" in result.stdout
+
+
+def test_scouts_list_stringifies_non_string_fields_before_escaping():
+    client = _make_client_mock()
+    client.scouts.list.return_value = {
+        "scouts": [
+            {
+                "id": 123,
+                "query": 456,
+                "status": None,
+                "output_interval": 86400,
+                "rejection_reason": {"code": "[/b]"},
+            }
+        ]
+    }
+
+    with patch("yutori.cli.commands.scouts.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["scouts", "list"])
+
+    assert result.exit_code == 0
+    assert "123" in result.stdout
+    assert "456" in result.stdout
+    assert "[/b]" in result.stdout
+
+
+def test_browse_get_renders_markup_like_start_url_literally():
+    client = _make_client_mock()
+    client.browsing.get.return_value = {
+        "task_id": "task-123",
+        "status": "completed",
+        "start_url": "https://example.com/[beta]/page",
+    }
+
+    with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["browse", "get", "task-123"])
+
+    assert result.exit_code == 0
+    assert "[beta]" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Friendly API error handling: no tracebacks for routine failures.
+# ---------------------------------------------------------------------------
+
+
+def test_browse_get_api_error_prints_message_not_traceback():
+    from yutori.exceptions import APIError
+
+    client = _make_client_mock()
+    client.browsing.get.side_effect = APIError("task not found", status_code=404)
+
+    with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["browse", "get", "nope"])
+
+    assert result.exit_code == 1
+    assert "APIError" in result.stdout
+    assert "task not found" in result.stdout
+    assert "Traceback" not in result.stdout
+    client.close.assert_called_once()
+
+
+def test_usage_rejected_key_prints_auth_guidance_not_traceback():
+    from yutori.exceptions import AuthenticationError
+
+    client = _make_client_mock()
+    client.get_usage.side_effect = AuthenticationError("Invalid API key or insufficient permissions (401)")
+
+    with patch("yutori.cli.commands.usage.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["usage"])
+
+    assert result.exit_code == 1
+    # "AuthenticationError" must stay in the output: the installer's
+    # AUTH_FAILURE_MARKERS classify verification failures by grepping it.
+    assert "AuthenticationError" in result.stdout
+    assert "yutori auth login" in result.stdout
+    assert "Traceback" not in result.stdout
+
+
+def test_scouts_list_network_error_prints_message_not_traceback():
+    import httpx
+
+    client = _make_client_mock()
+    client.scouts.list.side_effect = httpx.ConnectError("connection refused")
+
+    with patch("yutori.cli.commands.scouts.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["scouts", "list"])
+
+    assert result.exit_code == 1
+    assert "Network error" in result.stdout
+    assert "Traceback" not in result.stdout
+
+
+def test_usage_renders_stats_from_api_response():
+    from ._usage_fixtures import USAGE_RESPONSE
+
+    client = _make_client_mock()
+    client.get_usage.return_value = USAGE_RESPONSE
+
+    with patch("yutori.cli.commands.usage.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["usage", "--period", "7d"])
+
+    assert result.exit_code == 0
+    client.get_usage.assert_called_once_with(period="7d")
+    assert "Usage Statistics" in result.stdout
+    assert "Active Scouts: 2" in result.stdout
+    assert "Navigator API Rate Limits" in result.stdout
+    assert "Navigator API calls" in result.stdout
     client.close.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -312,7 +312,9 @@ def test_usage_rejected_key_prints_auth_guidance_not_traceback():
     # "AuthenticationError" must stay in the output: the installer's
     # AUTH_FAILURE_MARKERS classify verification failures by grepping it.
     assert "AuthenticationError" in result.stdout
-    assert "yutori auth login" in result.stdout
+    # Normalize: Rich wraps the hint at terminal width. Every variant of the
+    # source-tailored hint mentions 'yutori auth login'.
+    assert "yutori auth login" in " ".join(result.stdout.split())
     assert "Traceback" not in result.stdout
 
 
@@ -346,3 +348,33 @@ def test_usage_renders_stats_from_api_response():
     assert "Navigator API Rate Limits" in result.stdout
     assert "Navigator API calls" in result.stdout
     client.close.assert_called_once()
+
+
+def test_browse_run_missing_task_id_fails():
+    # An empty 2xx body becomes {} at the SDK layer; the CLI must not report
+    # a task that cannot be polled as submitted.
+    client = _make_client_mock()
+    client.browsing.create.return_value = {}
+
+    with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["browse", "run", "do something", "https://example.com"])
+
+    assert result.exit_code == 1
+    assert "returned no task ID" in result.stdout
+
+
+def test_scouts_create_failed_status_exits_nonzero():
+    client = _make_client_mock()
+    client.scouts.create.return_value = {
+        "id": "scout-9",
+        "query": "watch things",
+        "status": "failed",
+        "rejection_reason": "billing_limit_reached",
+    }
+
+    with patch("yutori.cli.commands.scouts.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["scouts", "create", "-q", "watch things"])
+
+    assert result.exit_code == 1
+    assert "Scout creation failed" in result.stdout
+    assert "billing_limit_reached" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,7 +45,7 @@ def test_browse_run_forwards_local_browser_and_auth():
     client = _make_client_mock()
     client.browsing.create.return_value = {"task_id": "task-123", "status": "queued"}
 
-    with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(
             app,
             [
@@ -77,7 +77,7 @@ def test_research_run_basic():
     client = _make_client_mock()
     client.research.create.return_value = {"task_id": "research-123", "status": "queued"}
 
-    with patch("yutori.cli.commands.research.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(
             app,
             ["research", "run", "latest AI announcements", "--timezone", "America/Los_Angeles"],
@@ -102,7 +102,7 @@ def test_browse_run_handles_failed_create_response():
         "rejection_reason": "billing_limit_reached",
     }
 
-    with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(
             app,
             ["browse", "run", "click the button", "https://example.com"],
@@ -122,7 +122,7 @@ def test_research_run_handles_failed_create_response():
         "status": "failed",
     }
 
-    with patch("yutori.cli.commands.research.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(
             app,
             ["research", "run", "latest AI announcements"],
@@ -143,7 +143,7 @@ def test_browse_get_shows_rejection_reason():
         "rejection_reason": "billing_limit_reached",
     }
 
-    with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(app, ["browse", "get", "task-123"])
 
     assert result.exit_code == 0
@@ -159,7 +159,7 @@ def test_research_get_shows_rejection_reason():
         "rejection_reason": "rate_limit_exceeded",
     }
 
-    with patch("yutori.cli.commands.research.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(app, ["research", "get", "research-123"])
 
     assert result.exit_code == 0
@@ -176,7 +176,7 @@ def test_scouts_get_shows_rejection_reason():
         "rejection_reason": "invalid_query",
     }
 
-    with patch("yutori.cli.commands.scouts.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(app, ["scouts", "get", "scout-123"])
 
     assert result.exit_code == 0
@@ -198,7 +198,7 @@ def test_scouts_list_shows_rejection_reason_column():
         ]
     }
 
-    with patch("yutori.cli.commands.scouts.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(app, ["scouts", "list"])
 
     assert result.exit_code == 0
@@ -230,7 +230,7 @@ def test_scouts_list_renders_markup_like_queries_literally():
         ]
     }
 
-    with patch("yutori.cli.commands.scouts.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(app, ["scouts", "list"])
 
     # "[/b]" used to crash the whole listing with MarkupError; "[beta]" used
@@ -254,7 +254,7 @@ def test_scouts_list_stringifies_non_string_fields_before_escaping():
         ]
     }
 
-    with patch("yutori.cli.commands.scouts.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(app, ["scouts", "list"])
 
     assert result.exit_code == 0
@@ -271,7 +271,7 @@ def test_browse_get_renders_markup_like_start_url_literally():
         "start_url": "https://example.com/[beta]/page",
     }
 
-    with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(app, ["browse", "get", "task-123"])
 
     assert result.exit_code == 0
@@ -289,7 +289,7 @@ def test_browse_get_api_error_prints_message_not_traceback():
     client = _make_client_mock()
     client.browsing.get.side_effect = APIError("task not found", status_code=404)
 
-    with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(app, ["browse", "get", "nope"])
 
     assert result.exit_code == 1
@@ -305,7 +305,7 @@ def test_usage_rejected_key_prints_auth_guidance_not_traceback():
     client = _make_client_mock()
     client.get_usage.side_effect = AuthenticationError("Invalid API key or insufficient permissions (401)")
 
-    with patch("yutori.cli.commands.usage.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(app, ["usage"])
 
     assert result.exit_code == 1
@@ -324,7 +324,7 @@ def test_scouts_list_network_error_prints_message_not_traceback():
     client = _make_client_mock()
     client.scouts.list.side_effect = httpx.ConnectError("connection refused")
 
-    with patch("yutori.cli.commands.scouts.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(app, ["scouts", "list"])
 
     assert result.exit_code == 1
@@ -338,7 +338,7 @@ def test_usage_renders_stats_from_api_response():
     client = _make_client_mock()
     client.get_usage.return_value = USAGE_RESPONSE
 
-    with patch("yutori.cli.commands.usage.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(app, ["usage", "--period", "7d"])
 
     assert result.exit_code == 0
@@ -356,7 +356,7 @@ def test_browse_run_missing_task_id_fails():
     client = _make_client_mock()
     client.browsing.create.return_value = {}
 
-    with patch("yutori.cli.commands.browse.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(app, ["browse", "run", "do something", "https://example.com"])
 
     assert result.exit_code == 1
@@ -372,7 +372,7 @@ def test_scouts_create_failed_status_exits_nonzero():
         "rejection_reason": "billing_limit_reached",
     }
 
-    with patch("yutori.cli.commands.scouts.get_authenticated_client", return_value=client):
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
         result = runner.invoke(app, ["scouts", "create", "-q", "watch things"])
 
     assert result.exit_code == 1

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -69,6 +69,11 @@ def test_auth_login_surfaces_backend_error(monkeypatch):
     assert "Creating account..." in result.stdout
     normalized_stdout = " ".join(result.stdout.split())
     assert "Authentication failed (500): backend exploded" in normalized_stdout
+    # The callback server is shut down by the time login fails, so the auth
+    # URL must not be reprinted as a (dead) recovery link; the retry hint
+    # replaces it.
+    assert "https://example.com/auth" not in result.stdout
+    assert "yutori auth login" in normalized_stdout
 
 
 def test_auth_login_ignores_placeholder_env_var(monkeypatch):

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -48,9 +48,7 @@ def test_auth_login_prints_logging_in_message(monkeypatch):
 
 def test_auth_login_surfaces_backend_error(monkeypatch):
     # Generic "backend rejected the login" path — any LoginResult failure
-    # message gets surfaced to the user. This replaces the old test for
-    # /client/register-api unavailability, which the backend no longer
-    # exercises (endpoint has been live since ENG-4003 landed 2026-03).
+    # message gets surfaced to the user.
     monkeypatch.delenv("YUTORI_API_KEY", raising=False)
 
     def fake_run_login_flow(*args, **kwargs):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -14,6 +14,7 @@ def make_response(status_code: int, text: str = "", content: bytes = b"") -> Mag
     response.status_code = status_code
     response.text = text
     response.content = content
+    response.headers = {}
     return response
 
 
@@ -60,3 +61,19 @@ class TestResolveScoutStatusEndpoint:
     def test_empty_string_raises(self):
         with pytest.raises(ValueError, match="Invalid status"):
             resolve_scout_status_endpoint("")
+
+
+class TestHandleResponseNonJson:
+    def test_2xx_non_json_body_raises_api_error(self):
+        # A captive portal / SSO gateway returning 200 text/html must surface
+        # as an SDK error, not a bare JSONDecodeError traceback.
+        response = make_response(200, text="<html>portal</html>", content=b"<html>portal</html>")
+        response.json.side_effect = ValueError("Expecting value: line 1 column 1")
+        with pytest.raises(APIError, match="non-JSON response"):
+            handle_response(response)
+
+    def test_redirect_message_names_the_location(self):
+        response = make_response(301)
+        response.headers = {"location": "https://elsewhere.example/login"}
+        with pytest.raises(APIError, match="elsewhere.example"):
+            handle_response(response)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -34,6 +34,20 @@ class TestHandleResponse:
         with pytest.raises(AuthenticationError, match=r"401"):
             handle_response(make_response(401))
 
+    def test_2xx_non_json_body_raises_api_error(self):
+        # A captive portal / SSO gateway returning 200 text/html must surface
+        # as an SDK error, not a bare JSONDecodeError traceback.
+        response = make_response(200, text="<html>portal</html>", content=b"<html>portal</html>")
+        response.json.side_effect = ValueError("Expecting value: line 1 column 1")
+        with pytest.raises(APIError, match="non-JSON response"):
+            handle_response(response)
+
+    def test_redirect_message_names_the_location(self):
+        response = make_response(301)
+        response.headers = {"location": "https://elsewhere.example/login"}
+        with pytest.raises(APIError, match="elsewhere.example"):
+            handle_response(response)
+
 
 class TestApplyChatExtraBody:
     def test_does_not_mutate_caller_extra_body(self):
@@ -61,19 +75,3 @@ class TestResolveScoutStatusEndpoint:
     def test_empty_string_raises(self):
         with pytest.raises(ValueError, match="Invalid status"):
             resolve_scout_status_endpoint("")
-
-
-class TestHandleResponseNonJson:
-    def test_2xx_non_json_body_raises_api_error(self):
-        # A captive portal / SSO gateway returning 200 text/html must surface
-        # as an SDK error, not a bare JSONDecodeError traceback.
-        response = make_response(200, text="<html>portal</html>", content=b"<html>portal</html>")
-        response.json.side_effect = ValueError("Expecting value: line 1 column 1")
-        with pytest.raises(APIError, match="non-JSON response"):
-            handle_response(response)
-
-    def test_redirect_message_names_the_location(self):
-        response = make_response(301)
-        response.headers = {"location": "https://elsewhere.example/login"}
-        with pytest.raises(APIError, match="elsewhere.example"):
-            handle_response(response)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,8 +1,46 @@
 """Tests for shared HTTP helpers in yutori._http."""
 
+from unittest.mock import MagicMock
+
+import httpx
 import pytest
 
-from yutori._http import resolve_scout_status_endpoint
+from yutori._http import apply_chat_extra_body, handle_response, resolve_scout_status_endpoint
+from yutori.exceptions import APIError, AuthenticationError
+
+
+def make_response(status_code: int, text: str = "", content: bytes = b"") -> MagicMock:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.text = text
+    response.content = content
+    return response
+
+
+class TestHandleResponse:
+    def test_redirect_raises_api_error_instead_of_silent_success(self):
+        # Redirects are never followed, so a 3xx means a misconfigured base
+        # URL; returning {} here would look like a successful empty response.
+        with pytest.raises(APIError) as exc_info:
+            handle_response(make_response(307))
+        assert exc_info.value.status_code == 307
+
+    def test_auth_error_includes_status_and_server_detail(self):
+        with pytest.raises(AuthenticationError, match=r"403.*scout belongs to another user"):
+            handle_response(make_response(403, text="scout belongs to another user"))
+
+    def test_auth_error_without_body_still_readable(self):
+        with pytest.raises(AuthenticationError, match=r"401"):
+            handle_response(make_response(401))
+
+
+class TestApplyChatExtraBody:
+    def test_does_not_mutate_caller_extra_body(self):
+        user_extra = {"trace_id": "trace-123"}
+        kwargs = {"extra_body": user_extra}
+        apply_chat_extra_body(kwargs, tool_set="browser_tools_core", disable_tools=None, json_schema=None)
+        assert user_extra == {"trace_id": "trace-123"}
+        assert kwargs["extra_body"] == {"trace_id": "trace-123", "tool_set": "browser_tools_core"}
 
 
 class TestResolveScoutStatusEndpoint:

--- a/tests/test_install_flow.py
+++ b/tests/test_install_flow.py
@@ -328,6 +328,15 @@ def test_install_flow_exits_nonzero_when_cli_verification_fails():
                 False,
             ),
         ),
+        # Stub the real installs so the test stays hermetic.
+        patch(
+            "yutori.cli.commands.install_flow.maybe_install_mcp_server",
+            return_value=StepResult("MCP server", "success", "ok"),
+        ),
+        patch(
+            "yutori.cli.commands.install_flow.maybe_install_mcp_skills",
+            return_value=StepResult("MCP skills", "success", "ok"),
+        ),
     ):
         result = runner.invoke(app, ["__install_flow"])
 
@@ -364,6 +373,15 @@ def test_install_flow_marks_auth_failure_when_verification_rejects_credentials()
         patch(
             "yutori.cli.commands.install_flow.run_verification",
             return_value=(StepResult("Verification", "failed", "Authentication failed during verification."), True),
+        ),
+        # Stub the real installs so the test stays hermetic.
+        patch(
+            "yutori.cli.commands.install_flow.maybe_install_mcp_server",
+            return_value=StepResult("MCP server", "success", "ok"),
+        ),
+        patch(
+            "yutori.cli.commands.install_flow.maybe_install_mcp_skills",
+            return_value=StepResult("MCP skills", "success", "ok"),
         ),
     ):
         result = runner.invoke(app, ["__install_flow"])
@@ -519,6 +537,15 @@ def test_install_flow_skips_header_when_bootstrap_already_rendered():
             "yutori.cli.commands.install_flow.maybe_authenticate",
             return_value=(StepResult("Auth", "skipped", "skip"), False),
         ),
+        # Stub the real installs so the test stays hermetic.
+        patch(
+            "yutori.cli.commands.install_flow.maybe_install_mcp_server",
+            return_value=StepResult("MCP server", "success", "ok"),
+        ),
+        patch(
+            "yutori.cli.commands.install_flow.maybe_install_mcp_skills",
+            return_value=StepResult("MCP skills", "success", "ok"),
+        ),
     ):
         result = runner.invoke(app, ["__install_flow"], env={"YUTORI_INSTALLER_BOOTSTRAP_SHOWN": "1"})
 
@@ -555,6 +582,15 @@ def test_install_flow_exits_zero_when_verification_fails_for_non_auth_reason():
         patch(
             "yutori.cli.commands.install_flow.run_verification",
             return_value=(StepResult("Verification", "failed", "yutori.com unreachable"), False),
+        ),
+        # Stub the real installs so the test stays hermetic.
+        patch(
+            "yutori.cli.commands.install_flow.maybe_install_mcp_server",
+            return_value=StepResult("MCP server", "success", "ok"),
+        ),
+        patch(
+            "yutori.cli.commands.install_flow.maybe_install_mcp_skills",
+            return_value=StepResult("MCP skills", "success", "ok"),
         ),
     ):
         result = runner.invoke(app, ["__install_flow"])
@@ -1115,9 +1151,6 @@ def test_run_command_catches_generic_oserror_not_just_filenotfound():
 
 
 def test_maybe_install_mcp_skills_runs_noninteractively_without_tty():
-    # Explicit stdin patch keeps us out of the redirected-stdout guard
-    # regardless of how the test runner exposes stdin (pytest defaults to
-    # captured stdin -> isatty=False, but be explicit).
     captured: dict[str, tuple[str, ...]] = {}
 
     def fake_run_command(command, *, env=None, timeout=None, **_kwargs):
@@ -1125,7 +1158,6 @@ def test_maybe_install_mcp_skills_runs_noninteractively_without_tty():
         return _ok_completed_process(tuple(command))
 
     with (
-        patch("yutori.cli.commands.install_flow.sys.stdin.isatty", return_value=False),
         patch("yutori.cli.commands.install_flow.resolve_npx_path", return_value="/usr/local/bin/npx"),
         patch("yutori.cli.commands.install_flow.run_command", side_effect=fake_run_command),
         patch("yutori.cli.commands.install_flow.run_interactive_command") as fake_interactive,
@@ -1140,11 +1172,9 @@ def test_maybe_install_mcp_skills_runs_noninteractively_without_tty():
 
 
 def test_maybe_install_mcp_server_noninteractive_defaults_to_popular_client_set(monkeypatch):
-    # Without YUTORI_INSTALL_CLIENT, in true automation (both streams
-    # non-TTY) install for the small popular default set -- not `--all`
-    # (which writes configs for ~14 clients including ones the user
-    # never installed). Explicit stdin patch guarantees we hit the
-    # automation branch on any test host, not the redirected-stdout guard.
+    # Without YUTORI_INSTALL_CLIENT, non-interactive installs target the
+    # small popular default set -- not `--all` (which writes configs for
+    # ~14 clients including ones the user never installed).
     monkeypatch.delenv("YUTORI_INSTALL_CLIENT", raising=False)
     captured: dict[str, tuple[str, ...]] = {}
 
@@ -1153,7 +1183,6 @@ def test_maybe_install_mcp_server_noninteractive_defaults_to_popular_client_set(
         return _ok_completed_process(tuple(command))
 
     with (
-        patch("yutori.cli.commands.install_flow.sys.stdin.isatty", return_value=False),
         patch("yutori.cli.commands.install_flow.resolve_npx_path", return_value="/opt/npx"),
         patch("yutori.cli.commands.install_flow.run_command", side_effect=fake_run_command),
     ):
@@ -1184,7 +1213,6 @@ def test_maybe_install_mcp_server_noninteractive_scopes_to_yutori_install_client
         return _ok_completed_process(tuple(command))
 
     with (
-        patch("yutori.cli.commands.install_flow.sys.stdin.isatty", return_value=False),
         patch("yutori.cli.commands.install_flow.resolve_npx_path", return_value="/opt/npx"),
         patch("yutori.cli.commands.install_flow.run_command", side_effect=fake_run_command),
     ):
@@ -1212,10 +1240,6 @@ def test_maybe_install_mcp_server_noninteractive_failure_surfaces_captured_outpu
     )
 
     with (
-        # stdin=False puts us in the automation branch where run_command
-        # actually executes; without it we'd hit the redirected-stdout
-        # guard and never reach the failure path under test.
-        patch("yutori.cli.commands.install_flow.sys.stdin.isatty", return_value=False),
         patch("yutori.cli.commands.install_flow.resolve_npx_path", return_value="/opt/npx"),
         patch("yutori.cli.commands.install_flow.run_command", return_value=failure),
     ):
@@ -1228,13 +1252,9 @@ def test_maybe_install_mcp_server_noninteractive_failure_surfaces_captured_outpu
 
 
 def test_maybe_install_mcp_server_noninteractive_skips_when_npx_missing(monkeypatch):
-    # Force automation branch (stdin=False) so the npx-missing skip is
-    # what's actually exercised, not the redirected-stdout guard which
-    # would skip earlier and shadow the npx check.
     monkeypatch.delenv("YUTORI_INSTALL_CLIENT", raising=False)
 
     with (
-        patch("yutori.cli.commands.install_flow.sys.stdin.isatty", return_value=False),
         patch("yutori.cli.commands.install_flow.resolve_npx_path", return_value=None),
         patch("yutori.cli.commands.install_flow.run_command") as fake_run,
     ):
@@ -1247,3 +1267,49 @@ def test_maybe_install_mcp_server_noninteractive_skips_when_npx_missing(monkeypa
     # run -- so the user can copy-paste it directly.
     assert "claude-code" in result.detail  # one of the default agents
     assert "yutori" in result.detail
+
+
+def test_run_verification_ctrl_c_during_poll_returns_cancelled_result(tmp_path: Path):
+    """Ctrl+C lands in the parent-side poll sleep most of the time; it must
+    produce a normal failed-verification result (summary renders, non-auth
+    verification failures exit 0) instead of bubbling to click's Aborted!."""
+    cli_path = tmp_path / "yutori"
+    submission = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="\nBrowsing task submitted.\n  Task ID: task-123\n  Status: queued\n",
+        stderr="",
+    )
+    with (
+        patch("yutori.cli.commands.install_flow.Confirm.ask", return_value=True),
+        patch("yutori.cli.commands.install_flow.run_command", return_value=submission),
+        patch("yutori.cli.commands.install_flow.time.sleep", side_effect=KeyboardInterrupt),
+    ):
+        result, auth_failed = run_verification(Console(), interactive=True, cli_state=_cli_state(cli_path))
+
+    assert auth_failed is False
+    assert result.status == "failed"
+    assert "Cancelled by user" in result.detail
+    assert "task-123" in result.detail
+
+
+def test_run_verification_treats_na_task_id_as_missing(tmp_path: Path):
+    """The CLI prints `Task ID: N/A` when the create response lacks an id;
+    the poller must not run `yutori browse get N/A`."""
+    cli_path = tmp_path / "yutori"
+    submission = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="\nBrowsing task failed to start.\n  Task ID: N/A\n  Status: queued\n",
+        stderr="",
+    )
+    with (
+        patch("yutori.cli.commands.install_flow.Confirm.ask", return_value=True),
+        patch("yutori.cli.commands.install_flow.run_command", return_value=submission) as mock_run,
+    ):
+        result, auth_failed = run_verification(Console(), interactive=True, cli_state=_cli_state(cli_path))
+
+    assert auth_failed is False
+    assert result.status == "failed"
+    # Only the submission command ran — no poll against the "N/A" id.
+    assert len(mock_run.call_args_list) == 1

--- a/tests/test_install_flow.py
+++ b/tests/test_install_flow.py
@@ -1078,6 +1078,7 @@ def test_maybe_repair_path_runs_update_shell_on_consent():
         "  Invalid or missing API key (401)",
         "invalid or missing api key",
         "AuthenticationError: credentials rejected",
+        "Invalid API key or insufficient permissions (401)",
         "HTTP 401 Unauthorized",
         "HTTP 403 Forbidden",
         "Error: 403 Forbidden when accessing resource",
@@ -1313,3 +1314,50 @@ def test_run_verification_treats_na_task_id_as_missing(tmp_path: Path):
     assert result.status == "failed"
     # Only the submission command ran — no poll against the "N/A" id.
     assert len(mock_run.call_args_list) == 1
+
+
+def test_print_prompt_block_renders_markup_tokens_literally():
+    from yutori.cli.commands.install_flow import print_prompt_block
+
+    console = Console(record=True, width=120)
+    # pip routinely emits "[notice]"-style lines that Rich would swallow as
+    # markup; "[/notice]" is closing-tag-shaped and used to raise MarkupError.
+    print_prompt_block(console, "SDK", "pip says [notice] new release [/notice] available")
+    out = console.export_text()
+    assert "[notice]" in out
+    assert "[/notice]" in out
+
+
+def test_summarize_results_survives_markup_shaped_subprocess_output():
+    from yutori.cli.commands.install_flow import summarize_results
+
+    console = Console(record=True, width=120)
+    summarize_results(console, [StepResult("SDK", "failed", "unbalanced [/x] token from pip")])
+    out = console.export_text()
+    assert "[/x]" in out
+
+
+def test_detect_sdk_install_plan_windows_venv_uses_scripts_python(tmp_path: Path, monkeypatch):
+    import os as real_os
+
+    import yutori.cli.commands.install_flow as install_flow_module
+
+    venv_dir = tmp_path / "venv"
+    scripts_dir = venv_dir / "Scripts"
+    scripts_dir.mkdir(parents=True)
+    fake_python = scripts_dir / "python.exe"
+    fake_python.write_text("#!/bin/sh\nexit 0\n")
+    fake_python.chmod(0o755)
+
+    # Patch only install_flow's view of os: setting the real os.name to "nt"
+    # would make pathlib instantiate WindowsPath on a POSIX host.
+    class _NtOsProxy:
+        name = "nt"
+
+        def __getattr__(self, attr):
+            return getattr(real_os, attr)
+
+    monkeypatch.setattr(install_flow_module, "os", _NtOsProxy())
+    plan = detect_sdk_install_plan(cwd=tmp_path, env={"VIRTUAL_ENV": str(venv_dir), "PATH": ""})
+
+    assert plan.command[0] == str(fake_python)

--- a/tests/test_install_flow.py
+++ b/tests/test_install_flow.py
@@ -37,6 +37,31 @@ from yutori.cli.main import app
 runner = CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_mcp_installs():
+    """Safety net: tests in this file must never run real `npx` installs.
+
+    MCP server/skills are the two steps that run unattended without a TTY,
+    so any flow-level test that forgets to stub them hits the npm registry
+    and rewrites ~/.cursor / ~/.codex / ~/.gemini MCP configs. Patching the
+    module attributes covers `install_flow_command` (which resolves them at
+    call time); direct-exercise tests are unaffected because they call the
+    functions through this file's import-time bindings, and tests that need
+    custom behavior layer their own `patch(...)` on top.
+    """
+    with (
+        patch(
+            "yutori.cli.commands.install_flow.maybe_install_mcp_server",
+            return_value=StepResult("MCP server", "success", "ok"),
+        ),
+        patch(
+            "yutori.cli.commands.install_flow.maybe_install_mcp_skills",
+            return_value=StepResult("MCP skills", "success", "ok"),
+        ),
+    ):
+        yield
+
+
 def test_hidden_install_flow_not_in_help():
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
@@ -328,15 +353,6 @@ def test_install_flow_exits_nonzero_when_cli_verification_fails():
                 False,
             ),
         ),
-        # Stub the real installs so the test stays hermetic.
-        patch(
-            "yutori.cli.commands.install_flow.maybe_install_mcp_server",
-            return_value=StepResult("MCP server", "success", "ok"),
-        ),
-        patch(
-            "yutori.cli.commands.install_flow.maybe_install_mcp_skills",
-            return_value=StepResult("MCP skills", "success", "ok"),
-        ),
     ):
         result = runner.invoke(app, ["__install_flow"])
 
@@ -373,15 +389,6 @@ def test_install_flow_marks_auth_failure_when_verification_rejects_credentials()
         patch(
             "yutori.cli.commands.install_flow.run_verification",
             return_value=(StepResult("Verification", "failed", "Authentication failed during verification."), True),
-        ),
-        # Stub the real installs so the test stays hermetic.
-        patch(
-            "yutori.cli.commands.install_flow.maybe_install_mcp_server",
-            return_value=StepResult("MCP server", "success", "ok"),
-        ),
-        patch(
-            "yutori.cli.commands.install_flow.maybe_install_mcp_skills",
-            return_value=StepResult("MCP skills", "success", "ok"),
         ),
     ):
         result = runner.invoke(app, ["__install_flow"])
@@ -537,15 +544,6 @@ def test_install_flow_skips_header_when_bootstrap_already_rendered():
             "yutori.cli.commands.install_flow.maybe_authenticate",
             return_value=(StepResult("Auth", "skipped", "skip"), False),
         ),
-        # Stub the real installs so the test stays hermetic.
-        patch(
-            "yutori.cli.commands.install_flow.maybe_install_mcp_server",
-            return_value=StepResult("MCP server", "success", "ok"),
-        ),
-        patch(
-            "yutori.cli.commands.install_flow.maybe_install_mcp_skills",
-            return_value=StepResult("MCP skills", "success", "ok"),
-        ),
     ):
         result = runner.invoke(app, ["__install_flow"], env={"YUTORI_INSTALLER_BOOTSTRAP_SHOWN": "1"})
 
@@ -582,15 +580,6 @@ def test_install_flow_exits_zero_when_verification_fails_for_non_auth_reason():
         patch(
             "yutori.cli.commands.install_flow.run_verification",
             return_value=(StepResult("Verification", "failed", "yutori.com unreachable"), False),
-        ),
-        # Stub the real installs so the test stays hermetic.
-        patch(
-            "yutori.cli.commands.install_flow.maybe_install_mcp_server",
-            return_value=StepResult("MCP server", "success", "ok"),
-        ),
-        patch(
-            "yutori.cli.commands.install_flow.maybe_install_mcp_skills",
-            return_value=StepResult("MCP skills", "success", "ok"),
         ),
     ):
         result = runner.invoke(app, ["__install_flow"])

--- a/tests/test_n1_compat.py
+++ b/tests/test_n1_compat.py
@@ -44,11 +44,15 @@ def test_compat_imports_forward_and_warn(module_name: str, attribute_name: str) 
 
 
 def test_package_exposes_submodules_as_attributes() -> None:
-    # The pre-rename package imported submodules eagerly, so attribute
-    # access worked right after a plain `import yutori.n1`.
+    # The pre-rename package bound most submodules as attributes; the shim
+    # provides every submodule lazily. Iterate the package's own registry so
+    # an omission from _SUBMODULES fails here.
     module = _fresh_import("yutori.n1")
-    for submodule in ("payload", "images", "loop", "replay", "page_ready", "models"):
+    assert len(module._SUBMODULES) == 13
+    for submodule in sorted(module._SUBMODULES):
         assert getattr(module, submodule).__name__ == f"yutori.n1.{submodule}"
+    # PEP 562 __dir__ keeps lazy submodules discoverable.
+    assert set(module._SUBMODULES) <= set(dir(module))
     with pytest.raises(AttributeError):
         module.does_not_exist
 

--- a/tests/test_n1_compat.py
+++ b/tests/test_n1_compat.py
@@ -45,10 +45,9 @@ def test_compat_imports_forward_and_warn(module_name: str, attribute_name: str) 
 
 def test_package_exposes_submodules_as_attributes() -> None:
     # The pre-rename package bound most submodules as attributes; the shim
-    # provides every submodule lazily. Iterate the package's own registry so
-    # an omission from _SUBMODULES fails here.
+    # provides every submodule lazily. _SUBMODULES is derived from the files
+    # on disk, so iterating it covers any shim that exists.
     module = _fresh_import("yutori.n1")
-    assert len(module._SUBMODULES) == 13
     for submodule in sorted(module._SUBMODULES):
         assert getattr(module, submodule).__name__ == f"yutori.n1.{submodule}"
     # PEP 562 __dir__ keeps lazy submodules discoverable.

--- a/tests/test_n1_compat.py
+++ b/tests/test_n1_compat.py
@@ -42,3 +42,28 @@ def test_compat_imports_forward_and_warn(module_name: str, attribute_name: str) 
     module = _fresh_import(module_name)
     assert hasattr(module, attribute_name)
 
+
+def test_package_exposes_submodules_as_attributes() -> None:
+    # The pre-rename package imported submodules eagerly, so attribute
+    # access worked right after a plain `import yutori.n1`.
+    module = _fresh_import("yutori.n1")
+    for submodule in ("payload", "images", "loop", "replay", "page_ready", "models"):
+        assert getattr(module, submodule).__name__ == f"yutori.n1.{submodule}"
+    with pytest.raises(AttributeError):
+        module.does_not_exist
+
+
+def test_shim_modules_expose_names_outside_dunder_all() -> None:
+    # `__all__` only affects star-imports; direct imports of unexported
+    # names worked from the pre-rename modules and must keep working.
+    module = _fresh_import("yutori.n1.page_ready")
+    assert hasattr(module, "SupportsAsyncPageReady")
+    assert hasattr(module, "logger")
+
+
+def test_shim_modules_preserve_dunder_all() -> None:
+    import yutori.navigator.page_ready as target
+
+    module = _fresh_import("yutori.n1.page_ready")
+    assert module.__all__ == target.__all__
+

--- a/tests/test_navigator_images.py
+++ b/tests/test_navigator_images.py
@@ -1,5 +1,7 @@
 """Tests for yutori.navigator.images."""
 
+from __future__ import annotations
+
 import base64
 import io
 

--- a/tests/test_navigator_payload.py
+++ b/tests/test_navigator_payload.py
@@ -1,5 +1,7 @@
 """Tests for yutori.navigator.payload - payload management utilities."""
 
+from __future__ import annotations
+
 from yutori.navigator.payload import (
     DEFAULT_KEEP_RECENT_SCREENSHOTS,
     DEFAULT_MAX_REQUEST_BYTES,
@@ -223,3 +225,47 @@ class TestTrimmedMessagesToFit:
         assert trimmed_messages is not original_messages
         assert message_has_image(original_messages[0]) is True
         assert any(not message_has_image(message) for message in trimmed_messages[:-1])
+
+
+# ---------------------------------------------------------------------------
+# Multi-image messages (trimming must converge, not strip one image per pass)
+# ---------------------------------------------------------------------------
+
+
+def _multi_image_msg(role: str, urls: list[str]) -> dict:
+    return {
+        "role": role,
+        "content": [{"type": "image_url", "image_url": {"url": url}} for url in urls],
+    }
+
+
+class TestMultiImageTrimming:
+    def test_old_multi_image_message_is_fully_drained(self):
+        big = "B" * 3000
+        messages = [
+            _multi_image_msg("user", [f"data:image/png;base64,{big}{i}" for i in range(3)]),
+            _image_msg("tool", url="data:image/png;base64,recent"),
+        ]
+        target = estimate_messages_size_bytes([messages[1]]) + 200
+
+        size, removed = trim_images_to_fit(messages, max_bytes=target, keep_recent=1)
+
+        assert removed == 3
+        assert size <= target
+        assert message_has_image(messages[0]) is False
+        assert message_has_image(messages[1]) is True
+
+    def test_multi_image_last_message_drains_to_final_screenshot(self):
+        big = "B" * 3000
+        last = _multi_image_msg(
+            "tool",
+            [f"data:image/png;base64,{big}1", f"data:image/png;base64,{big}2", "data:image/png;base64,final"],
+        )
+        messages = [last]
+
+        size, removed = trim_images_to_fit(messages, max_bytes=600, keep_recent=6)
+
+        assert removed == 2
+        assert size <= 600
+        urls = [p["image_url"]["url"] for p in last["content"] if p.get("type") == "image_url"]
+        assert urls == ["data:image/png;base64,final"]

--- a/tests/test_navigator_replay.py
+++ b/tests/test_navigator_replay.py
@@ -230,6 +230,8 @@ def test_generate_visualization_html_escapes_screenshot_url() -> None:
     html = generate_visualization_html("demo-task", messages)
 
     assert "<script>alert(1)</script>" not in html
+    # The URL must survive in escaped form — not merely be dropped from the render.
+    assert "shot.png&quot;&gt;&lt;script&gt;" in html
 
 
 def test_text_only_user_message_keeps_pending_tool_screenshot() -> None:

--- a/tests/test_navigator_replay.py
+++ b/tests/test_navigator_replay.py
@@ -198,3 +198,59 @@ async def test_trajectory_recorder_writes_artifacts(tmp_path) -> None:
     html = recorder.artifact_path("visualization.html").read_text(encoding="utf-8")
     assert "Trajectory Replay" in html
     assert "Raw Request" in html
+
+
+def test_generate_visualization_html_survives_non_object_tool_arguments() -> None:
+    # Valid JSON that isn't an object must not crash the render.
+    messages = [
+        _image_message("user", text="Open the page"),
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "left_click", "arguments": "[1, 2]"}},
+                {"id": "call_2", "type": "function", "function": {"name": "type_text", "arguments": '"hello"'}},
+            ],
+        },
+    ]
+
+    html = generate_visualization_html("demo-task", messages)
+
+    assert "left_click" in html
+    assert "type_text" in html
+
+
+def test_generate_visualization_html_escapes_screenshot_url() -> None:
+    hostile_url = 'https://example.com/shot.png"><script>alert(1)</script>'
+    messages = [
+        _image_message("user", url=hostile_url, text="Open the page"),
+        {"role": "assistant", "content": "Done."},
+    ]
+
+    html = generate_visualization_html("demo-task", messages)
+
+    assert "<script>alert(1)</script>" not in html
+
+
+def test_text_only_user_message_keeps_pending_tool_screenshot() -> None:
+    # A human interjection between the tool screenshot and the assistant's
+    # next step must not blank out the screenshot in the replay.
+    messages = [
+        _image_message("user", text="Open the page"),
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "left_click", "arguments": "{}"}},
+            ],
+        },
+        _image_message("tool", url="data:image/png;base64,toolshot", text="Clicked"),
+        {"role": "user", "content": "Looks good, continue with checkout"},
+        {"role": "assistant", "content": "Proceeding."},
+    ]
+
+    html = generate_visualization_html("demo-task", messages)
+
+    assert "data:image/png;base64,toolshot" in html
+    assert "No screenshot recorded" not in html
+    assert "Looks good, continue with checkout" in html

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -120,11 +120,19 @@ def _write_dependency_stubs(stub_root: Path) -> None:
 def test_built_wheel_includes_packaged_js_assets(tmp_path: Path) -> None:
     dist_dir = tmp_path / "dist"
     dist_dir.mkdir()
-    shutil.rmtree(ROOT / "build", ignore_errors=True)
+
+    # Build from a copy of the source tree so the test never mutates the
+    # repo (a stale ./build dir would otherwise have to be deleted to keep
+    # setuptools from leaking removed files into the wheel).
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    shutil.copytree(ROOT / "yutori", src_dir / "yutori", ignore=shutil.ignore_patterns("__pycache__"))
+    for fname in ("pyproject.toml", "README.md", "LICENSE", "MANIFEST.in"):
+        shutil.copy2(ROOT / fname, src_dir / fname)
 
     subprocess.run(
         [sys.executable, "-m", "build", "--wheel", "--outdir", str(dist_dir)],
-        cwd=ROOT,
+        cwd=src_dir,
         check=True,
     )
 
@@ -148,6 +156,10 @@ def test_built_wheel_includes_packaged_js_assets(tmp_path: Path) -> None:
         """
         from importlib import resources
         from yutori.navigator._assets import load_js_asset
+
+        # PEP 561: without this marker, type checkers ignore every inline
+        # annotation in the installed package.
+        assert resources.files("yutori").joinpath("py.typed").is_file()
         from yutori.navigator.tools import (
             EXECUTE_JS_SCRIPT,
             EXTRACT_ELEMENTS_SCRIPT,

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tarfile
 import textwrap
 import venv
 from pathlib import Path
@@ -117,7 +118,7 @@ def _write_dependency_stubs(stub_root: Path) -> None:
 
 
 @pytest.mark.slow
-def test_built_wheel_includes_packaged_js_assets(tmp_path: Path) -> None:
+def test_built_distributions_include_packaged_assets(tmp_path: Path) -> None:
     dist_dir = tmp_path / "dist"
     dist_dir.mkdir()
 
@@ -127,6 +128,7 @@ def test_built_wheel_includes_packaged_js_assets(tmp_path: Path) -> None:
     src_dir = tmp_path / "src"
     src_dir.mkdir()
     shutil.copytree(ROOT / "yutori", src_dir / "yutori", ignore=shutil.ignore_patterns("__pycache__"))
+    shutil.copytree(ROOT / "tests", src_dir / "tests", ignore=shutil.ignore_patterns("__pycache__", ".pytest_cache"))
     for fname in ("pyproject.toml", "README.md", "LICENSE", "MANIFEST.in"):
         shutil.copy2(ROOT / fname, src_dir / fname)
 
@@ -135,6 +137,27 @@ def test_built_wheel_includes_packaged_js_assets(tmp_path: Path) -> None:
         cwd=src_dir,
         check=True,
     )
+
+    # The sdist must carry a collectable test suite (MANIFEST.in grafts
+    # tests/ — setuptools' default glob ships tests/test_*.py without the
+    # conftest/helpers they import) and the py.typed marker.
+    subprocess.run(
+        [sys.executable, "-m", "build", "--sdist", "--outdir", str(dist_dir)],
+        cwd=src_dir,
+        check=True,
+    )
+    sdists = sorted(dist_dir.glob("yutori-*.tar.gz"))
+    assert sdists, "expected build to produce an sdist"
+    with tarfile.open(sdists[0]) as tar:
+        sdist_names = tar.getnames()
+    sdist_root = sdist_names[0].split("/")[0]
+    for required in (
+        "tests/conftest.py",
+        "tests/__init__.py",
+        "tests/_usage_fixtures.py",
+        "yutori/py.typed",
+    ):
+        assert f"{sdist_root}/{required}" in sdist_names, f"sdist missing {required}"
 
     wheels = sorted(dist_dir.glob("yutori-*.whl"))
     assert wheels, "expected build to produce a wheel"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -132,8 +132,11 @@ def test_built_distributions_include_packaged_assets(tmp_path: Path) -> None:
     for fname in ("pyproject.toml", "README.md", "LICENSE", "MANIFEST.in"):
         shutil.copy2(ROOT / fname, src_dir / fname)
 
+    # One default `python -m build` produces the sdist and then builds the
+    # wheel FROM it — covering the sdist→wheel path with half the build work
+    # of separate --wheel/--sdist invocations.
     subprocess.run(
-        [sys.executable, "-m", "build", "--wheel", "--outdir", str(dist_dir)],
+        [sys.executable, "-m", "build", "--outdir", str(dist_dir)],
         cwd=src_dir,
         check=True,
     )
@@ -141,11 +144,6 @@ def test_built_distributions_include_packaged_assets(tmp_path: Path) -> None:
     # The sdist must carry a collectable test suite (MANIFEST.in grafts
     # tests/ — setuptools' default glob ships tests/test_*.py without the
     # conftest/helpers they import) and the py.typed marker.
-    subprocess.run(
-        [sys.executable, "-m", "build", "--sdist", "--outdir", str(dist_dir)],
-        cwd=src_dir,
-        check=True,
-    )
     sdists = sorted(dist_dir.glob("yutori-*.tar.gz"))
     assert sdists, "expected build to produce an sdist"
     with tarfile.open(sdists[0]) as tar:

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -47,7 +47,9 @@ prompt_confirm() {
         reply="$default_answer"
     fi
 
-    [[ "$reply" =~ ^[Yy]$ ]]
+    # Accept y/Y/yes/Yes/YES — the prompt offers "[Y/n]", so a typed "yes"
+    # must not silently count as a decline.
+    [[ "$reply" =~ ^[Yy]([Ee][Ss])?$ ]]
 }
 
 uv_bin() {

--- a/yutori/__init__.py
+++ b/yutori/__init__.py
@@ -17,4 +17,4 @@ __all__ = [
 try:
     __version__ = version("yutori")
 except PackageNotFoundError:
-    __version__ = "0.1.0"
+    __version__ = "0.0.0+unknown"

--- a/yutori/_async/chat.py
+++ b/yutori/_async/chat.py
@@ -58,9 +58,9 @@ class AsyncChatNamespace:
     """Async namespace for Navigator API operations (pixels-to-actions LLM).
 
     Requests go through the bundled OpenAI client, which retries failures
-    (connection errors, timeouts, 429/5xx) twice by default; pass
-    ``max_retries`` via the OpenAI kwargs to change this. The other SDK
-    namespaces never retry.
+    (connection errors, timeouts, 429/5xx) twice by default; this is not
+    configurable through the SDK surface. The other SDK namespaces never
+    retry.
     """
 
     def __init__(self, base_url: str, api_key: str, timeout: float) -> None:

--- a/yutori/_async/chat.py
+++ b/yutori/_async/chat.py
@@ -55,7 +55,13 @@ class AsyncChatCompletions:
 
 
 class AsyncChatNamespace:
-    """Async namespace for Navigator API operations (pixels-to-actions LLM)."""
+    """Async namespace for Navigator API operations (pixels-to-actions LLM).
+
+    Requests go through the bundled OpenAI client, which retries failures
+    (connection errors, timeouts, 429/5xx) twice by default; pass
+    ``max_retries`` via the OpenAI kwargs to change this. The other SDK
+    namespaces never retry.
+    """
 
     def __init__(self, base_url: str, api_key: str, timeout: float) -> None:
         self._openai_client = AsyncOpenAI(base_url=base_url, api_key=api_key, timeout=timeout)

--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -21,14 +21,26 @@ def build_headers(api_key: str) -> dict[str, str]:
 def handle_response(response: httpx.Response) -> dict[str, Any]:
     """Process HTTP response, raising appropriate errors for failures."""
     if response.status_code in (401, 403):
-        detail = f": {response.text}" if response.text else ""
+        # Truncate: a proxy or gateway can return a full HTML error page here.
+        detail = f": {response.text[:500]}" if response.text else ""
         raise AuthenticationError(
             f"Invalid API key or insufficient permissions ({response.status_code}){detail}"
         )
 
     # Redirects are not followed, so a 3xx here means the base URL does not
     # point directly at the API; treat it as an error rather than empty success.
-    if response.status_code >= 300:
+    if 300 <= response.status_code < 400:
+        location = response.headers.get("location") or "unknown"
+        raise APIError(
+            message=(
+                f"Unexpected redirect to {location} — "
+                "the configured base_url may not point directly at the API."
+            ),
+            status_code=response.status_code,
+            response=response,
+        )
+
+    if response.status_code >= 400:
         raise APIError(
             message=response.text or "Yutori API call failed",
             status_code=response.status_code,
@@ -36,7 +48,16 @@ def handle_response(response: httpx.Response) -> dict[str, Any]:
         )
 
     if response.content:
-        return response.json()
+        # A 2xx non-JSON body (captive portal, SSO gateway, HTML error page)
+        # must surface as an SDK error, not a bare JSONDecodeError.
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise APIError(
+                message=f"API returned a non-JSON response: {response.text[:200]!r}",
+                status_code=response.status_code,
+                response=response,
+            ) from exc
     return {}
 
 

--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -21,9 +21,14 @@ def build_headers(api_key: str) -> dict[str, str]:
 def handle_response(response: httpx.Response) -> dict[str, Any]:
     """Process HTTP response, raising appropriate errors for failures."""
     if response.status_code in (401, 403):
-        raise AuthenticationError("Invalid or missing API key")
+        detail = f": {response.text}" if response.text else ""
+        raise AuthenticationError(
+            f"Invalid API key or insufficient permissions ({response.status_code}){detail}"
+        )
 
-    if response.status_code >= 400:
+    # Redirects are not followed, so a 3xx here means the base URL does not
+    # point directly at the API; treat it as an error rather than empty success.
+    if response.status_code >= 300:
         raise APIError(
             message=response.text or "Yutori API call failed",
             status_code=response.status_code,
@@ -107,13 +112,14 @@ def apply_chat_extra_body(kwargs: dict[str, Any], **fields: Any) -> None:
     """Merge non-None ``fields`` into ``kwargs["extra_body"]`` in place.
 
     Pops any user-provided ``extra_body`` from ``kwargs``, overlays the
-    non-None ``fields`` on top of it, and writes the result back under
-    ``extra_body`` — but only if the merged dict is non-empty. Used by
-    ChatCompletions.create to compose the ``extra_body`` kwarg forwarded
-    to the OpenAI client without letting sync and async implementations
-    drift out of sync.
+    non-None ``fields`` on top of a copy of it, and writes the result back
+    under ``extra_body`` — but only if the merged dict is non-empty. The copy
+    keeps the caller's dict unmodified so it can be safely reused across
+    calls. Used by ChatCompletions.create to compose the ``extra_body`` kwarg
+    forwarded to the OpenAI client without letting sync and async
+    implementations drift out of sync.
     """
-    extra_body = kwargs.pop("extra_body", None) or {}
+    extra_body = dict(kwargs.pop("extra_body", None) or {})
     for key, value in fields.items():
         if value is not None:
             extra_body[key] = value

--- a/yutori/_sync/chat.py
+++ b/yutori/_sync/chat.py
@@ -58,9 +58,9 @@ class ChatNamespace:
     """Namespace for Navigator API operations (pixels-to-actions LLM).
 
     Requests go through the bundled OpenAI client, which retries failures
-    (connection errors, timeouts, 429/5xx) twice by default; pass
-    ``max_retries`` via the OpenAI kwargs to change this. The other SDK
-    namespaces never retry.
+    (connection errors, timeouts, 429/5xx) twice by default; this is not
+    configurable through the SDK surface. The other SDK namespaces never
+    retry.
     """
 
     def __init__(self, base_url: str, api_key: str, timeout: float) -> None:

--- a/yutori/_sync/chat.py
+++ b/yutori/_sync/chat.py
@@ -55,7 +55,13 @@ class ChatCompletions:
 
 
 class ChatNamespace:
-    """Namespace for Navigator API operations (pixels-to-actions LLM)."""
+    """Namespace for Navigator API operations (pixels-to-actions LLM).
+
+    Requests go through the bundled OpenAI client, which retries failures
+    (connection errors, timeouts, 429/5xx) twice by default; pass
+    ``max_retries`` via the OpenAI kwargs to change this. The other SDK
+    namespaces never retry.
+    """
 
     def __init__(self, base_url: str, api_key: str, timeout: float) -> None:
         self._openai_client = OpenAI(base_url=base_url, api_key=api_key, timeout=timeout)

--- a/yutori/auth/constants.py
+++ b/yutori/auth/constants.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 
-from yutori.config import DEFAULT_BASE_URL
+from yutori.config import DEFAULT_BASE_URL, sanitize_base_url
 
 # Clerk OAuth configuration
 DEFAULT_CLERK_INSTANCE_URL = "https://clerk.yutori.com"
@@ -33,6 +33,12 @@ ERROR_STATE_MISMATCH = "Security validation failed (state mismatch). Please try 
 ERROR_AUTH_FAILED = "Authentication failed"
 
 
+# Overridable so a non-production auth stack stays self-consistent: without
+# this, overriding the Clerk URLs above would still mint keys against the
+# production API.
+AUTH_API_BASE_URL = sanitize_base_url(os.environ.get("YUTORI_API_BASE_URL", DEFAULT_BASE_URL))
+
+
 def build_auth_api_url(path: str) -> str:
     """Build API URL for auth endpoints (key generation after OAuth)."""
-    return f"{DEFAULT_BASE_URL}{path}"
+    return f"{AUTH_API_BASE_URL}{path}"

--- a/yutori/auth/credentials.py
+++ b/yutori/auth/credentials.py
@@ -97,7 +97,7 @@ def get_stored_api_key() -> str | None:
         return None
     stored = config.get("api_key")
     if isinstance(stored, str) and _is_real_key(stored):
-        return stored
+        return stored.strip()
     return None
 
 
@@ -111,13 +111,17 @@ def _resolve_api_key_with_source(api_key: str | None = None) -> tuple[str, str] 
     ``"param"``, ``"env_var"``, or ``"config_file"``, or ``None`` if no key
     is found. Callers that only need the key itself should use
     :func:`resolve_api_key`.
+
+    Keys are stripped of surrounding whitespace: a trailing newline (common
+    with ``export YUTORI_API_KEY=$(cat key.txt)``) would otherwise be an
+    illegal HTTP header value and fail every request deep inside httpx.
     """
     if _is_real_key(api_key):
-        return api_key, "param"
+        return api_key.strip(), "param"
 
     env_key = os.environ.get("YUTORI_API_KEY")
     if _is_real_key(env_key):
-        return env_key, "env_var"
+        return env_key.strip(), "env_var"
 
     stored_key = get_stored_api_key()
     if stored_key is not None:

--- a/yutori/auth/credentials.py
+++ b/yutori/auth/credentials.py
@@ -112,9 +112,10 @@ def _resolve_api_key_with_source(api_key: str | None = None) -> tuple[str, str] 
     is found. Callers that only need the key itself should use
     :func:`resolve_api_key`.
 
-    Keys are stripped of surrounding whitespace: a trailing newline (common
-    with ``export YUTORI_API_KEY=$(cat key.txt)``) would otherwise be an
-    illegal HTTP header value and fail every request deep inside httpx.
+    Keys are stripped of surrounding whitespace: a trailing newline (e.g. a
+    key file read verbatim with ``open("key.txt").read()``, or a CI secret
+    decoded with its trailing newline) would otherwise be an illegal HTTP
+    header value and fail every request deep inside httpx.
     """
     if _is_real_key(api_key):
         return api_key.strip(), "param"

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -261,7 +261,10 @@ def run_login_flow(
                 success=False,
                 error=f"Port {REDIRECT_PORT} is already in use. Close other applications and try again.",
             )
-        return LoginResult(success=False, error=str(e))
+        return LoginResult(
+            success=False,
+            error=f"Could not start the local login callback server on {CALLBACK_HOST}:{REDIRECT_PORT}: {e}",
+        )
 
     server_thread = threading.Thread(target=server.serve_forever, daemon=True)
     server_thread.start()
@@ -318,7 +321,8 @@ def run_login_flow(
                 error=(
                     f"Login succeeded and an API key was created, but saving it to "
                     f"{get_config_path()} failed: {e}. Fix the path and run "
-                    f"'yutori auth login' again, or set YUTORI_API_KEY directly."
+                    f"'yutori auth login' again, or set YUTORI_API_KEY to a key from "
+                    f"https://platform.yutori.com/settings."
                 ),
                 auth_url=auth_url,
             )

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -7,6 +7,7 @@ All functions return typed results and never print directly (callers handle pres
 from __future__ import annotations
 
 import base64
+import errno
 import hashlib
 import html
 import http.server
@@ -253,7 +254,9 @@ def run_login_flow(
     try:
         server = _ReusableServer((CALLBACK_HOST, REDIRECT_PORT), _CallbackHandler)
     except OSError as e:
-        if "Address already in use" in str(e):
+        # errno comparison works across platforms and locales, unlike
+        # matching the English "Address already in use" message text.
+        if e.errno == errno.EADDRINUSE:
             return LoginResult(
                 success=False,
                 error=f"Port {REDIRECT_PORT} is already in use. Close other applications and try again.",
@@ -304,7 +307,21 @@ def run_login_flow(
         # always call it regardless of registration_status.
         register_user(jwt)
         api_key = generate_api_key(jwt, key_name=_build_key_name(key_source))
-        save_config(api_key)
+        try:
+            save_config(api_key)
+        except OSError as e:
+            # The key already exists server-side at this point; a generic
+            # error would hide that and leave the user with an orphaned key.
+            return LoginResult(
+                success=False,
+                api_key=api_key,
+                error=(
+                    f"Login succeeded and an API key was created, but saving it to "
+                    f"{get_config_path()} failed: {e}. Fix the path and run "
+                    f"'yutori auth login' again, or set YUTORI_API_KEY directly."
+                ),
+                auth_url=auth_url,
+            )
         return LoginResult(success=True, api_key=api_key, auth_url=auth_url)
     except httpx.HTTPStatusError as e:
         # `e.response.text` decodes with strict error handling and can raise

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -57,20 +57,42 @@ def get_authenticated_client() -> Any:
     return YutoriClient(api_key=api_key)
 
 
+def _auth_recovery_hint() -> str:
+    """Recovery instruction for a rejected key, tailored to where it came from.
+
+    'Run yutori auth login' is wrong advice for an env-var key: login refuses
+    to run while YUTORI_API_KEY is set, and the env var would keep overriding
+    saved credentials anyway. Every variant mentions 'yutori auth login' so
+    the output stays stable for callers grepping it.
+    """
+    from yutori.auth.credentials import _resolve_api_key_with_source
+
+    resolved = _resolve_api_key_with_source()
+    source = resolved[1] if resolved else None
+    if source == "env_var":
+        return (
+            "YUTORI_API_KEY is set but was rejected — update or unset it "
+            "(while set, it overrides 'yutori auth login' credentials)."
+        )
+    if source == "config_file":
+        return "Your saved API key was rejected. Run 'yutori auth logout', then 'yutori auth login'."
+    return "Your API key was rejected. Run 'yutori auth login' to refresh credentials."
+
+
 @contextlib.contextmanager
 def cli_api_errors() -> Iterator[None]:
     """Convert SDK and network errors into friendly messages and exit code 1.
 
     Without this, a rejected key, an unknown task ID, or being offline dumps
-    a multi-screen Typer traceback. The exception class names stay in the
-    output because the installer's AUTH_FAILURE_MARKERS
+    a multi-screen Typer traceback. The AuthenticationError class name stays
+    in the output because the installer's AUTH_FAILURE_MARKERS
     (yutori/cli/commands/install_flow.py) classify failures by grepping it.
     """
     try:
         yield
     except AuthenticationError as exc:
         _console.print(f"[red]AuthenticationError: {escape(str(exc))}[/red]")
-        _console.print("Your API key was rejected. Run 'yutori auth login' to refresh credentials.")
+        _console.print(_auth_recovery_hint())
         raise typer.Exit(1) from exc
     except APIError as exc:
         _console.print(f"[red]APIError: {escape(str(exc))}[/red]")
@@ -162,13 +184,25 @@ def print_creation_result(
 
 
 def print_task_submission_result(console: Console, task_type: str, result: dict[str, Any]) -> bool:
-    """Print a task creation response; returns False when the create failed."""
+    """Print a task creation response; returns False when the create failed.
+
+    A non-failed response without a ``task_id`` is also a failure: the task
+    cannot be polled, so reporting success would strand the user (and any
+    script keying off the exit code) with nothing to do next.
+    """
+    task_id = result.get("task_id")
+    has_task_id = bool(task_id) and str(task_id).strip() not in ("", "N/A")
+    if not has_task_id and result.get("status") != "failed":
+        console.print(f"\n[red]{task_type} task was accepted but the API returned no task ID.[/red]")
+        console.print(f"  Status: {escape(str(result.get('status', 'N/A')))}")
+        print_rejection_reason(console, result)
+        return False
     return print_creation_result(
         console,
         result,
         success_message=f"{task_type} task submitted.",
         failure_message=f"{task_type} task failed to start.",
-        fields=[("Task ID", escape(str(result.get("task_id", "N/A"))))],
+        fields=[("Task ID", escape(str(task_id if has_task_id else "N/A")))],
     )
 
 

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "SECONDS_PER_MINUTE",
     "SECONDS_PER_WEEK",
     "cli_api_errors",
+    "cli_client",
     "format_interval",
     "get_authenticated_client",
     "print_aligned_fields",
@@ -29,6 +30,7 @@ __all__ = [
     "print_task_get_header",
     "print_task_result_output",
     "print_task_submission_result",
+    "safe_str",
 ]
 
 SECONDS_PER_MINUTE = 60
@@ -43,6 +45,17 @@ INTERVAL_PRESETS: dict[str, int] = {
 }
 
 _console = Console()
+
+
+def safe_str(value: Any) -> str:
+    """Stringify and Rich-escape a data value so it renders literally.
+
+    Every value that reaches a markup-enabled print must go through this (or
+    a helper that calls it): API and subprocess strings can carry tokens like
+    ``[beta]`` (silently eaten as markup) or ``[/x]`` (raises MarkupError),
+    and non-string values would crash ``escape`` itself.
+    """
+    return escape(str(value))
 
 
 def get_authenticated_client() -> Any:
@@ -65,10 +78,9 @@ def _auth_recovery_hint() -> str:
     saved credentials anyway. Every variant mentions 'yutori auth login' so
     the output stays stable for callers grepping it.
     """
-    from yutori.auth.credentials import _resolve_api_key_with_source
+    from yutori.auth.flow import get_auth_status
 
-    resolved = _resolve_api_key_with_source()
-    source = resolved[1] if resolved else None
+    source = get_auth_status().source
     if source == "env_var":
         return (
             "YUTORI_API_KEY is set but was rejected — update or unset it "
@@ -91,23 +103,36 @@ def cli_api_errors() -> Iterator[None]:
     try:
         yield
     except AuthenticationError as exc:
-        _console.print(f"[red]AuthenticationError: {escape(str(exc))}[/red]")
+        _console.print(f"[red]AuthenticationError: {safe_str(exc)}[/red]")
         _console.print(_auth_recovery_hint())
         raise typer.Exit(1) from exc
     except APIError as exc:
-        _console.print(f"[red]APIError: {escape(str(exc))}[/red]")
+        _console.print(f"[red]APIError: {safe_str(exc)}[/red]")
         raise typer.Exit(1) from exc
     except httpx.HTTPError as exc:
-        _console.print(f"[red]Network error: {escape(str(exc))}[/red]")
+        _console.print(f"[red]Network error: {safe_str(exc)}[/red]")
         _console.print("Check your connection and try again.")
         raise typer.Exit(1) from exc
+
+
+@contextlib.contextmanager
+def cli_client() -> Iterator[Any]:
+    """Authenticated client with CLI error handling — the one entry point
+    for API-calling commands.
+
+    Bundles :func:`cli_api_errors` with :func:`get_authenticated_client` so a
+    new command cannot accidentally take the client without the friendly
+    error handling (forgetting it regresses to multi-screen tracebacks).
+    """
+    with cli_api_errors(), get_authenticated_client() as client:
+        yield client
 
 
 def print_rejection_reason(console: Console, result: dict[str, Any]) -> None:
     """Print rejection_reason from an API response if present."""
     reason = result.get("rejection_reason")
     if reason:
-        console.print(f"  Rejection Reason: {escape(str(reason))}")
+        console.print(f"  Rejection Reason: {safe_str(reason)}")
 
 
 def print_optional_field(
@@ -115,19 +140,15 @@ def print_optional_field(
     data: dict[str, Any],
     key: str,
     label: str,
-    *,
-    escape_value: bool = False,
 ) -> None:
     """Print ``  {label}: {data[key]}`` only when ``data[key]`` is truthy.
 
-    Set ``escape_value=True`` for user-supplied strings that may contain
-    Rich markup (e.g. ``[red]``) so they render literally.
+    Values render literally (Rich-escaped) — no caller passes markup as data.
     """
     value = data.get(key)
     if not value:
         return
-    rendered = escape(str(value)) if escape_value else value
-    console.print(f"  {label}: {rendered}")
+    console.print(f"  {label}: {safe_str(value)}")
 
 
 def print_aligned_fields(
@@ -149,7 +170,7 @@ def print_aligned_fields(
     label_width = max(min_label_width, *(len(label) for label, _ in fields))
     indent_str = " " * indent
     for label, value in fields:
-        console.print(f"{indent_str}{(label + ':').ljust(label_width + 2)}{value}")
+        console.print(f"{indent_str}{(label + ':').ljust(label_width + 2)}{safe_str(value)}")
 
 
 def print_creation_result(
@@ -166,6 +187,7 @@ def print_creation_result(
     creates do not display a misleading success banner. Each ``(label, value)``
     in ``fields`` is rendered as ``  label: value`` between the header and the
     ``Status`` line, mirroring the existing per-command output ordering.
+    Field values render literally (Rich-escaped) — pass them raw.
 
     Returns False when the response reports a failed status, so callers can
     exit non-zero — scripts must not see a rejected create as success.
@@ -177,8 +199,8 @@ def print_creation_result(
     else:
         console.print(f"\n[green]{success_message}[/green]")
     for label, value in fields or []:
-        console.print(f"  {label}: {value}")
-    console.print(f"  Status: {escape(str(status))}")
+        console.print(f"  {label}: {safe_str(value)}")
+    console.print(f"  Status: {safe_str(status)}")
     print_rejection_reason(console, result)
     return not failed
 
@@ -191,10 +213,10 @@ def print_task_submission_result(console: Console, task_type: str, result: dict[
     script keying off the exit code) with nothing to do next.
     """
     task_id = result.get("task_id")
-    has_task_id = bool(task_id) and str(task_id).strip() not in ("", "N/A")
+    has_task_id = str(task_id or "").strip() not in ("", "N/A")
     if not has_task_id and result.get("status") != "failed":
         console.print(f"\n[red]{task_type} task was accepted but the API returned no task ID.[/red]")
-        console.print(f"  Status: {escape(str(result.get('status', 'N/A')))}")
+        console.print(f"  Status: {safe_str(result.get('status', 'N/A'))}")
         print_rejection_reason(console, result)
         return False
     return print_creation_result(
@@ -202,14 +224,14 @@ def print_task_submission_result(console: Console, task_type: str, result: dict[
         result,
         success_message=f"{task_type} task submitted.",
         failure_message=f"{task_type} task failed to start.",
-        fields=[("Task ID", escape(str(task_id if has_task_id else "N/A")))],
+        fields=[("Task ID", task_id if has_task_id else "N/A")],
     )
 
 
 def print_task_get_header(console: Console, task_type: str, task_id: str, result: dict[str, Any]) -> None:
     """Print the common header for a task-get response: title, status, and rejection reason."""
-    console.print(f"\n[bold]{task_type} Task: {escape(str(result.get('task_id', task_id)))}[/bold]\n")
-    console.print(f"  Status: {escape(str(result.get('status', 'N/A')))}")
+    console.print(f"\n[bold]{task_type} Task: {safe_str(result.get('task_id', task_id))}[/bold]\n")
+    console.print(f"  Status: {safe_str(result.get('status', 'N/A'))}")
     print_rejection_reason(console, result)
 
 

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Any
+import contextlib
+from typing import Any, Iterator
 
+import httpx
 import typer
 from rich.console import Console
 from rich.markup import escape
 
 from yutori.auth.credentials import resolve_api_key
+from yutori.exceptions import APIError, AuthenticationError
 
 __all__ = [
     "INTERVAL_PRESETS",
@@ -16,6 +19,7 @@ __all__ = [
     "SECONDS_PER_HOUR",
     "SECONDS_PER_MINUTE",
     "SECONDS_PER_WEEK",
+    "cli_api_errors",
     "format_interval",
     "get_authenticated_client",
     "print_aligned_fields",
@@ -51,6 +55,30 @@ def get_authenticated_client() -> Any:
         raise typer.Exit(1)
 
     return YutoriClient(api_key=api_key)
+
+
+@contextlib.contextmanager
+def cli_api_errors() -> Iterator[None]:
+    """Convert SDK and network errors into friendly messages and exit code 1.
+
+    Without this, a rejected key, an unknown task ID, or being offline dumps
+    a multi-screen Typer traceback. The exception class names stay in the
+    output because the installer's AUTH_FAILURE_MARKERS
+    (yutori/cli/commands/install_flow.py) classify failures by grepping it.
+    """
+    try:
+        yield
+    except AuthenticationError as exc:
+        _console.print(f"[red]AuthenticationError: {escape(str(exc))}[/red]")
+        _console.print("Your API key was rejected. Run 'yutori auth login' to refresh credentials.")
+        raise typer.Exit(1) from exc
+    except APIError as exc:
+        _console.print(f"[red]APIError: {escape(str(exc))}[/red]")
+        raise typer.Exit(1) from exc
+    except httpx.HTTPError as exc:
+        _console.print(f"[red]Network error: {escape(str(exc))}[/red]")
+        _console.print("Check your connection and try again.")
+        raise typer.Exit(1) from exc
 
 
 def print_rejection_reason(console: Console, result: dict[str, Any]) -> None:
@@ -109,40 +137,45 @@ def print_creation_result(
     success_message: str,
     failure_message: str,
     fields: list[tuple[str, Any]] | None = None,
-) -> None:
+) -> bool:
     """Print a creation response: colored header, optional fields, status, rejection reason.
 
     The header is red on ``status == "failed"`` and green otherwise so failed
     creates do not display a misleading success banner. Each ``(label, value)``
     in ``fields`` is rendered as ``  label: value`` between the header and the
     ``Status`` line, mirroring the existing per-command output ordering.
+
+    Returns False when the response reports a failed status, so callers can
+    exit non-zero — scripts must not see a rejected create as success.
     """
     status = result.get("status", "N/A")
-    if status == "failed":
+    failed = status == "failed"
+    if failed:
         console.print(f"\n[red]{failure_message}[/red]")
     else:
         console.print(f"\n[green]{success_message}[/green]")
     for label, value in fields or []:
         console.print(f"  {label}: {value}")
-    console.print(f"  Status: {status}")
+    console.print(f"  Status: {escape(str(status))}")
     print_rejection_reason(console, result)
+    return not failed
 
 
-def print_task_submission_result(console: Console, task_type: str, result: dict[str, Any]) -> None:
-    """Print a task creation response without implying success on failed creates."""
-    print_creation_result(
+def print_task_submission_result(console: Console, task_type: str, result: dict[str, Any]) -> bool:
+    """Print a task creation response; returns False when the create failed."""
+    return print_creation_result(
         console,
         result,
         success_message=f"{task_type} task submitted.",
         failure_message=f"{task_type} task failed to start.",
-        fields=[("Task ID", result.get("task_id", "N/A"))],
+        fields=[("Task ID", escape(str(result.get("task_id", "N/A"))))],
     )
 
 
 def print_task_get_header(console: Console, task_type: str, task_id: str, result: dict[str, Any]) -> None:
     """Print the common header for a task-get response: title, status, and rejection reason."""
-    console.print(f"\n[bold]{task_type} Task: {result.get('task_id', task_id)}[/bold]\n")
-    console.print(f"  Status: {result.get('status', 'N/A')}")
+    console.print(f"\n[bold]{task_type} Task: {escape(str(result.get('task_id', task_id)))}[/bold]\n")
+    console.print(f"  Status: {escape(str(result.get('status', 'N/A')))}")
     print_rejection_reason(console, result)
 
 

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -6,10 +6,10 @@ import os
 
 import typer
 from rich.console import Console
-from rich.markup import escape
 
 from yutori.auth.credentials import _is_real_key, clear_config, get_stored_api_key, load_config
 from yutori.auth.flow import get_auth_status, run_login_flow
+from yutori.cli.commands import safe_str
 
 app = typer.Typer(help="Manage authentication")
 console = Console()
@@ -49,7 +49,7 @@ def login() -> None:
         console.print("[green]Successfully authenticated![/green]")
         console.print("You can now use the Yutori CLI and SDK.")
     else:
-        console.print(f"\n[red]Authentication failed: {escape(str(result.error))}[/red]")
+        console.print(f"\n[red]Authentication failed: {safe_str(result.error)}[/red]")
         # Don't reprint result.auth_url here: the local callback server is
         # already shut down, so visiting it can no longer complete a login.
         console.print("Run [bold]yutori auth login[/bold] to try again.")

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -50,8 +50,9 @@ def login() -> None:
         console.print("You can now use the Yutori CLI and SDK.")
     else:
         console.print(f"\n[red]Authentication failed: {escape(str(result.error))}[/red]")
-        if result.auth_url:
-            console.print(f"\n[dim]If the browser didn't open, visit:[/dim]\n  {result.auth_url}")
+        # Don't reprint result.auth_url here: the local callback server is
+        # already shut down, so visiting it can no longer complete a login.
+        console.print("Run [bold]yutori auth login[/bold] to try again.")
         raise typer.Exit(1)
 
 

--- a/yutori/cli/commands/browse.py
+++ b/yutori/cli/commands/browse.py
@@ -6,8 +6,7 @@ import typer
 from rich.console import Console
 
 from yutori.cli.commands import (
-    cli_api_errors,
-    get_authenticated_client,
+    cli_client,
     print_optional_field,
     print_task_get_header,
     print_task_result_output,
@@ -28,7 +27,7 @@ def run(
     browser: str = typer.Option(None, "--browser", help="Browser backend: cloud or local"),
 ) -> None:
     """Start a new browsing task."""
-    with cli_api_errors(), get_authenticated_client() as client:
+    with cli_client() as client:
         result = client.browsing.create(
             task=task,
             start_url=start_url,
@@ -47,12 +46,12 @@ def get(
     task_id: str = typer.Argument(help="The browsing task ID"),
 ) -> None:
     """Get the status and result of a browsing task."""
-    with cli_api_errors(), get_authenticated_client() as client:
+    with cli_client() as client:
         result = client.browsing.get(task_id)
 
         print_task_get_header(console, "Browsing", task_id, result)
 
-        print_optional_field(console, result, "start_url", "Start URL", escape_value=True)
+        print_optional_field(console, result, "start_url", "Start URL")
         print_optional_field(console, result, "agent", "Agent")
         print_optional_field(console, result, "created_at", "Created")
 

--- a/yutori/cli/commands/browse.py
+++ b/yutori/cli/commands/browse.py
@@ -6,6 +6,7 @@ import typer
 from rich.console import Console
 
 from yutori.cli.commands import (
+    cli_api_errors,
     get_authenticated_client,
     print_optional_field,
     print_task_get_header,
@@ -27,7 +28,7 @@ def run(
     browser: str = typer.Option(None, "--browser", help="Browser backend: cloud or local"),
 ) -> None:
     """Start a new browsing task."""
-    with get_authenticated_client() as client:
+    with cli_api_errors(), get_authenticated_client() as client:
         result = client.browsing.create(
             task=task,
             start_url=start_url,
@@ -37,7 +38,8 @@ def run(
             browser=browser,
         )
 
-        print_task_submission_result(console, "Browsing", result)
+        if not print_task_submission_result(console, "Browsing", result):
+            raise typer.Exit(1)
 
 
 @app.command()
@@ -45,12 +47,12 @@ def get(
     task_id: str = typer.Argument(help="The browsing task ID"),
 ) -> None:
     """Get the status and result of a browsing task."""
-    with get_authenticated_client() as client:
+    with cli_api_errors(), get_authenticated_client() as client:
         result = client.browsing.get(task_id)
 
         print_task_get_header(console, "Browsing", task_id, result)
 
-        print_optional_field(console, result, "start_url", "Start URL")
+        print_optional_field(console, result, "start_url", "Start URL", escape_value=True)
         print_optional_field(console, result, "agent", "Agent")
         print_optional_field(console, result, "created_at", "Created")
 

--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -32,6 +32,7 @@ from typing import Literal, Mapping, Sequence
 import typer
 from rich import box
 from rich.console import Console
+from rich.markup import escape
 from rich.prompt import Confirm
 from rich.table import Table
 
@@ -60,8 +61,8 @@ MCP_SKILLS_INSTALL_COMMAND = ("npx", "skills", "add", "yutori-ai/yutori-mcp", "-
 # never installed). Set YUTORI_INSTALL_CLIENT=<slug> to override with a
 # single target; see `npx add-mcp list-agents` for the full slug list.
 DEFAULT_NONINTERACTIVE_MCP_CLIENTS = ("claude-code", "codex", "cursor", "gemini-cli")
-# Route matches api-dashboard's /browsing/tasks/[id] page; the Vercel project
-# serves it on platform.yutori.com (production) and platform.dev.yutori.com (dev).
+# Public dashboard page for a browsing task, shown so users can watch the
+# verification task run.
 VERIFICATION_TASK_DASHBOARD_BASE_URL = "https://platform.yutori.com/browsing/tasks"
 
 # Terminal task statuses. Broader than just {succeeded, failed} so the poll
@@ -84,6 +85,7 @@ FINAL_TASK_STATUSES = FINAL_SUCCESS_STATUSES | FINAL_FAILURE_STATUSES
 AUTH_FAILURE_MARKERS = (
     "not authenticated",
     "invalid or missing api key",
+    "invalid api key",
     "authenticationerror",
     "unauthorized",
     "forbidden",
@@ -368,11 +370,14 @@ def render_header(console: Console, *, interactive: bool) -> None:
 
 
 def print_prompt_block(console: Console, title: str, description: str, *, command: Sequence[str] | None = None) -> None:
+    # Descriptions often carry raw subprocess output; escape so tokens like
+    # pip's "[notice]" render literally instead of being parsed as markup
+    # (which deletes them or, for "[/x]"-shaped tokens, raises MarkupError).
     console.print(f"\n[{SLATE_TEXT}]|[/]")
-    console.print(f"[bold {MINT_HIGHLIGHT}]> {title}[/bold {MINT_HIGHLIGHT}]")
-    console.print(f"[{SLATE_TEXT}]| {description}[/]")
+    console.print(f"[bold {MINT_HIGHLIGHT}]> {escape(title)}[/bold {MINT_HIGHLIGHT}]")
+    console.print(f"[{SLATE_TEXT}]| {escape(description)}[/]")
     if command:
-        console.print(f"[{SLATE_TEXT}]| Command: {format_command(command)}[/]")
+        console.print(f"[{SLATE_TEXT}]| Command: {escape(format_command(command))}[/]")
 
 
 def ask_confirm(console: Console, question: str, *, default: bool) -> bool:
@@ -403,7 +408,9 @@ def summarize_results(console: Console, results: Sequence[StepResult]) -> None:
 
     for result in results:
         label, color = STATUS_LABELS[result.status]
-        table.add_row(result.name, f"[{color}]{label}[/{color}]", result.detail)
+        # result.detail routinely carries subprocess output; unescaped markup
+        # tokens in it would crash the summary after the install already ran.
+        table.add_row(escape(result.name), f"[{color}]{label}[/{color}]", escape(result.detail))
 
     console.print("\n")
     console.print(table)
@@ -470,7 +477,10 @@ def detect_sdk_install_plan(cwd: Path | None = None, env: Mapping[str, str] | No
         )
 
     if resolved_env.get("VIRTUAL_ENV"):
-        venv_python = Path(resolved_env["VIRTUAL_ENV"]) / "bin" / "python"
+        if os.name == "nt":
+            venv_python = Path(resolved_env["VIRTUAL_ENV"]) / "Scripts" / "python.exe"
+        else:
+            venv_python = Path(resolved_env["VIRTUAL_ENV"]) / "bin" / "python"
         python_path = (
             str(venv_python)
             if _is_executable(venv_python)
@@ -885,7 +895,9 @@ def run_verification(
         return StepResult("Verification", "failed", detail), auth_failed
 
     task_id = parse_cli_field(submission.stdout, "Task ID")
-    if not task_id:
+    # The CLI prints the literal placeholder "N/A" when the create response
+    # had no task_id; treat it as missing instead of polling `browse get N/A`.
+    if not task_id or task_id == "N/A":
         detail = submission_output or "CLI did not print a task ID for the verification task."
         return StepResult("Verification", "failed", detail), False
 
@@ -893,38 +905,49 @@ def run_verification(
     deadline = time.monotonic() + VERIFICATION_POLL_BUDGET_SECONDS
     status = parse_cli_field(submission.stdout, "Status") or "queued"
     last_output = submission.stdout
-    console.print(f"[{SLATE_TEXT}]| Task: {task_url}[/]")
+    console.print(f"[{SLATE_TEXT}]| Task: {escape(task_url)}[/]")
 
     # Live status line: updates in place so the user sees both the current
     # status and continuous dot-motion confirming the installer is alive
     # during queued/running phases that may last the full 180s poll budget.
-    with console.status(
-        f"[{SLATE_TEXT}]| Status: {status}[/]",
-        spinner="simpleDots",
-        spinner_style=SLATE_TEXT,
-    ) as spinner:
-        while status not in FINAL_TASK_STATUSES:
-            if time.monotonic() >= deadline:
-                detail = (
-                    f"Verification timed out after {VERIFICATION_POLL_BUDGET_SECONDS}s. "
-                    f"View task: {task_url}"
-                )
-                return StepResult("Verification", "failed", detail), False
+    try:
+        with console.status(
+            f"[{SLATE_TEXT}]| Status: {escape(status)}[/]",
+            spinner="simpleDots",
+            spinner_style=SLATE_TEXT,
+        ) as spinner:
+            while status not in FINAL_TASK_STATUSES:
+                if time.monotonic() >= deadline:
+                    detail = (
+                        f"Verification timed out after {VERIFICATION_POLL_BUDGET_SECONDS}s. "
+                        f"View task: {task_url}"
+                    )
+                    return StepResult("Verification", "failed", detail), False
 
-            time.sleep(VERIFICATION_POLL_INTERVAL_SECONDS)
-            poll = run_command((cli_invocation, "browse", "get", task_id))
-            poll_output = collect_process_output(poll)
-            if poll.returncode != 0:
-                auth_failed = looks_like_auth_failure(poll_output)
-                detail = poll_output or describe_completed_process(poll)
-                return StepResult("Verification", "failed", f"{detail} View task: {task_url}"), auth_failed
+                time.sleep(VERIFICATION_POLL_INTERVAL_SECONDS)
+                poll = run_command((cli_invocation, "browse", "get", task_id))
+                poll_output = collect_process_output(poll)
+                if poll.returncode != 0:
+                    auth_failed = looks_like_auth_failure(poll_output)
+                    detail = poll_output or describe_completed_process(poll)
+                    return StepResult("Verification", "failed", f"{detail} View task: {task_url}"), auth_failed
 
-            last_output = poll.stdout
-            status = parse_cli_field(poll.stdout, "Status") or "queued"
-            spinner.update(f"[{SLATE_TEXT}]| Status: {status}[/]")
+                last_output = poll.stdout
+                status = parse_cli_field(poll.stdout, "Status") or "queued"
+                spinner.update(f"[{SLATE_TEXT}]| Status: {escape(status)}[/]")
+    except KeyboardInterrupt:
+        # Most poll wall-time is spent in the parent-side sleep above, where
+        # run_command's KeyboardInterrupt-to-130 mapping can't help. Without
+        # this, Ctrl+C here bubbles to click's "Aborted!" and exits 1 with no
+        # summary — violating the contract that verification failures other
+        # than auth never exit non-zero.
+        return (
+            StepResult("Verification", "failed", f"Cancelled by user. View task: {task_url}"),
+            False,
+        )
 
     summary = _summarize_cli_output(last_output)
-    console.print(f"[{SLATE_TEXT}]| Result: {summary}[/]")
+    console.print(f"[{SLATE_TEXT}]| Result: {escape(summary)}[/]")
     if status in FINAL_SUCCESS_STATUSES:
         return StepResult("Verification", "success", f"Verification succeeded. View task: {task_url}"), False
 

--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -895,8 +895,9 @@ def run_verification(
         return StepResult("Verification", "failed", detail), auth_failed
 
     task_id = parse_cli_field(submission.stdout, "Task ID")
-    # The CLI prints the literal placeholder "N/A" when the create response
-    # had no task_id; treat it as missing instead of polling `browse get N/A`.
+    # Older CLI versions print the literal placeholder "N/A" (and exit 0)
+    # when the create response has no task_id; current CLIs fail before this
+    # point, so this guards against a version-skewed `yutori` on PATH.
     if not task_id or task_id == "N/A":
         detail = submission_output or "CLI did not print a task ID for the verification task."
         return StepResult("Verification", "failed", detail), False

--- a/yutori/cli/commands/research.py
+++ b/yutori/cli/commands/research.py
@@ -6,8 +6,7 @@ import typer
 from rich.console import Console
 
 from yutori.cli.commands import (
-    cli_api_errors,
-    get_authenticated_client,
+    cli_client,
     print_optional_field,
     print_task_get_header,
     print_task_result_output,
@@ -25,7 +24,7 @@ def run(
     location: str = typer.Option(None, "--location", help="e.g., San Francisco, CA, US"),
 ) -> None:
     """Start a new research task."""
-    with cli_api_errors(), get_authenticated_client() as client:
+    with cli_client() as client:
         result = client.research.create(
             query=query,
             user_timezone=timezone,
@@ -41,12 +40,12 @@ def get(
     task_id: str = typer.Argument(help="The research task ID"),
 ) -> None:
     """Get the status and result of a research task."""
-    with cli_api_errors(), get_authenticated_client() as client:
+    with cli_client() as client:
         result = client.research.get(task_id)
 
         print_task_get_header(console, "Research", task_id, result)
 
-        print_optional_field(console, result, "query", "Query", escape_value=True)
+        print_optional_field(console, result, "query", "Query")
         print_optional_field(console, result, "created_at", "Created")
 
         print_task_result_output(console, result)

--- a/yutori/cli/commands/research.py
+++ b/yutori/cli/commands/research.py
@@ -6,6 +6,7 @@ import typer
 from rich.console import Console
 
 from yutori.cli.commands import (
+    cli_api_errors,
     get_authenticated_client,
     print_optional_field,
     print_task_get_header,
@@ -24,14 +25,15 @@ def run(
     location: str = typer.Option(None, "--location", help="e.g., San Francisco, CA, US"),
 ) -> None:
     """Start a new research task."""
-    with get_authenticated_client() as client:
+    with cli_api_errors(), get_authenticated_client() as client:
         result = client.research.create(
             query=query,
             user_timezone=timezone,
             user_location=location,
         )
 
-        print_task_submission_result(console, "Research", result)
+        if not print_task_submission_result(console, "Research", result):
+            raise typer.Exit(1)
 
 
 @app.command()
@@ -39,7 +41,7 @@ def get(
     task_id: str = typer.Argument(help="The research task ID"),
 ) -> None:
     """Get the status and result of a research task."""
-    with get_authenticated_client() as client:
+    with cli_api_errors(), get_authenticated_client() as client:
         result = client.research.get(task_id)
 
         print_task_get_header(console, "Research", task_id, result)

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -4,17 +4,16 @@ from __future__ import annotations
 
 import typer
 from rich.console import Console
-from rich.markup import escape
 from rich.table import Table
 
 from yutori.cli.commands import (
     INTERVAL_PRESETS,
-    cli_api_errors,
+    cli_client,
     format_interval,
-    get_authenticated_client,
     print_creation_result,
     print_optional_field,
     print_rejection_reason,
+    safe_str,
 )
 
 app = typer.Typer(help="Manage scouts")
@@ -27,7 +26,7 @@ def list_scouts(
     status: str = typer.Option(None, help="Filter by status: active, paused, done"),
 ) -> None:
     """List your scouts."""
-    with cli_api_errors(), get_authenticated_client() as client:
+    with cli_client() as client:
         result = client.scouts.list(limit=limit, status=status)
         scouts = result.get("scouts", [])
 
@@ -50,11 +49,11 @@ def list_scouts(
                 query = query[:47] + "..."
 
             table.add_row(
-                escape(str(scout.get("id", ""))),
-                escape(str(query)),
-                escape(str(scout.get("status", "unknown"))),
+                safe_str(scout.get("id", "")),
+                safe_str(query),
+                safe_str(scout.get("status", "unknown")),
                 interval_str,
-                escape(str(scout.get("rejection_reason") or "")),
+                safe_str(scout.get("rejection_reason") or ""),
             )
 
         console.print(table)
@@ -65,12 +64,12 @@ def get(
     scout_id: str = typer.Argument(help="The scout ID"),
 ) -> None:
     """Get details of a specific scout."""
-    with cli_api_errors(), get_authenticated_client() as client:
+    with cli_client() as client:
         scout = client.scouts.get(scout_id)
 
-        console.print(f"\n[bold]Scout: {escape(str(scout.get('id', scout_id)))}[/bold]\n")
-        console.print(f"  Query: {escape(str(scout.get('query', 'N/A')))}")
-        console.print(f"  Status: {escape(str(scout.get('status', 'N/A')))}")
+        console.print(f"\n[bold]Scout: {safe_str(scout.get('id', scout_id))}[/bold]\n")
+        console.print(f"  Query: {safe_str(scout.get('query', 'N/A'))}")
+        console.print(f"  Status: {safe_str(scout.get('status', 'N/A'))}")
         print_rejection_reason(console, scout)
 
         interval_str = format_interval(scout.get("output_interval") or 0)
@@ -94,10 +93,10 @@ def create(
     output_interval = INTERVAL_PRESETS.get(interval.lower())
     if output_interval is None:
         choices = ", ".join(INTERVAL_PRESETS)
-        console.print(f"[red]Invalid interval '{escape(interval)}'. Choose from: {choices}[/red]")
+        console.print(f"[red]Invalid interval '{safe_str(interval)}'. Choose from: {choices}[/red]")
         raise typer.Exit(1)
 
-    with cli_api_errors(), get_authenticated_client() as client:
+    with cli_client() as client:
         result = client.scouts.create(
             query=query,
             output_interval=output_interval,
@@ -110,8 +109,8 @@ def create(
             success_message="Scout created successfully!",
             failure_message="Scout creation failed.",
             fields=[
-                ("ID", escape(str(result.get("id", "N/A")))),
-                ("Query", escape(str(result.get("query", query)))),
+                ("ID", result.get("id", "N/A")),
+                ("Query", result.get("query", query)),
             ],
         )
         if not ok:
@@ -130,6 +129,6 @@ def delete(
             console.print("[yellow]Cancelled.[/yellow]")
             raise typer.Exit(0)
 
-    with cli_api_errors(), get_authenticated_client() as client:
+    with cli_client() as client:
         client.scouts.delete(scout_id)
-        console.print(f"[green]Scout {escape(scout_id)} deleted.[/green]")
+        console.print(f"[green]Scout {safe_str(scout_id)} deleted.[/green]")

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -9,6 +9,7 @@ from rich.table import Table
 
 from yutori.cli.commands import (
     INTERVAL_PRESETS,
+    cli_api_errors,
     format_interval,
     get_authenticated_client,
     print_creation_result,
@@ -26,7 +27,7 @@ def list_scouts(
     status: str = typer.Option(None, help="Filter by status: active, paused, done"),
 ) -> None:
     """List your scouts."""
-    with get_authenticated_client() as client:
+    with cli_api_errors(), get_authenticated_client() as client:
         result = client.scouts.list(limit=limit, status=status)
         scouts = result.get("scouts", [])
 
@@ -44,16 +45,16 @@ def list_scouts(
         for scout in scouts:
             interval_str = format_interval(scout.get("output_interval") or 0, short=True)
 
-            query = scout.get("query", "")
+            query = str(scout.get("query", ""))
             if len(query) > 47:
                 query = query[:47] + "..."
 
             table.add_row(
-                scout.get("id", ""),
-                query,
-                scout.get("status", "unknown"),
+                escape(str(scout.get("id", ""))),
+                escape(str(query)),
+                escape(str(scout.get("status", "unknown"))),
                 interval_str,
-                escape(scout.get("rejection_reason") or ""),
+                escape(str(scout.get("rejection_reason") or "")),
             )
 
         console.print(table)
@@ -64,12 +65,12 @@ def get(
     scout_id: str = typer.Argument(help="The scout ID"),
 ) -> None:
     """Get details of a specific scout."""
-    with get_authenticated_client() as client:
+    with cli_api_errors(), get_authenticated_client() as client:
         scout = client.scouts.get(scout_id)
 
-        console.print(f"\n[bold]Scout: {scout.get('id', scout_id)}[/bold]\n")
-        console.print(f"  Query: {escape(scout.get('query', 'N/A'))}")
-        console.print(f"  Status: {scout.get('status', 'N/A')}")
+        console.print(f"\n[bold]Scout: {escape(str(scout.get('id', scout_id)))}[/bold]\n")
+        console.print(f"  Query: {escape(str(scout.get('query', 'N/A')))}")
+        console.print(f"  Status: {escape(str(scout.get('status', 'N/A')))}")
         print_rejection_reason(console, scout)
 
         interval_str = format_interval(scout.get("output_interval") or 0)
@@ -96,23 +97,25 @@ def create(
         console.print(f"[red]Invalid interval '{escape(interval)}'. Choose from: {choices}[/red]")
         raise typer.Exit(1)
 
-    with get_authenticated_client() as client:
+    with cli_api_errors(), get_authenticated_client() as client:
         result = client.scouts.create(
             query=query,
             output_interval=output_interval,
             user_timezone=timezone,
         )
 
-        print_creation_result(
+        ok = print_creation_result(
             console,
             result,
             success_message="Scout created successfully!",
             failure_message="Scout creation failed.",
             fields=[
-                ("ID", result.get("id", "N/A")),
-                ("Query", escape(result.get("query", query))),
+                ("ID", escape(str(result.get("id", "N/A")))),
+                ("Query", escape(str(result.get("query", query)))),
             ],
         )
+        if not ok:
+            raise typer.Exit(1)
 
 
 @app.command()
@@ -127,6 +130,6 @@ def delete(
             console.print("[yellow]Cancelled.[/yellow]")
             raise typer.Exit(0)
 
-    with get_authenticated_client() as client:
+    with cli_api_errors(), get_authenticated_client() as client:
         client.scouts.delete(scout_id)
-        console.print(f"[green]Scout {scout_id} deleted.[/green]")
+        console.print(f"[green]Scout {escape(scout_id)} deleted.[/green]")

--- a/yutori/cli/commands/usage.py
+++ b/yutori/cli/commands/usage.py
@@ -8,7 +8,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from yutori.cli.commands import cli_api_errors, get_authenticated_client, print_aligned_fields
+from yutori.cli.commands import cli_client, print_aligned_fields, safe_str
 
 app = typer.Typer(help="View usage statistics")
 console = Console()
@@ -59,7 +59,7 @@ def usage(
     if ctx.invoked_subcommand is not None:
         return
 
-    with cli_api_errors(), get_authenticated_client() as client:
+    with cli_client() as client:
         data = client.get_usage(period=period)
 
         console.print("\n[bold]Usage Statistics[/bold]\n")
@@ -70,7 +70,7 @@ def usage(
         active_ids = data.get("active_scout_ids", [])
         if active_ids:
             for sid in active_ids[:5]:
-                console.print(f"    - {sid}")
+                console.print(f"    - {safe_str(sid)}")
             if len(active_ids) > 5:
                 console.print(f"    ... and {len(active_ids) - 5} more")
 
@@ -79,7 +79,7 @@ def usage(
         if rate_limits:
             _print_rate_limits(
                 console,
-                f"\n  [bold]API Rate Limits[/bold] ({rate_limits.get('status', 'unknown')})",
+                f"\n  [bold]API Rate Limits[/bold] ({safe_str(rate_limits.get('status', 'unknown'))})",
                 rate_limits,
                 gate_on_status_available=True,
             )

--- a/yutori/cli/commands/usage.py
+++ b/yutori/cli/commands/usage.py
@@ -8,7 +8,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from yutori.cli.commands import get_authenticated_client, print_aligned_fields
+from yutori.cli.commands import cli_api_errors, get_authenticated_client, print_aligned_fields
 
 app = typer.Typer(help="View usage statistics")
 console = Console()
@@ -59,7 +59,7 @@ def usage(
     if ctx.invoked_subcommand is not None:
         return
 
-    with get_authenticated_client() as client:
+    with cli_api_errors(), get_authenticated_client() as client:
         data = client.get_usage(period=period)
 
         console.print("\n[bold]Usage Statistics[/bold]\n")

--- a/yutori/exceptions.py
+++ b/yutori/exceptions.py
@@ -14,7 +14,7 @@ class AuthenticationError(YutoriSDKError):
 
 
 class APIError(YutoriSDKError):
-    """Raised when the Yutori API returns a non-successful response."""
+    """Raised when the Yutori API returns a non-successful or unusable response."""
 
     def __init__(self, message: str, status_code: int, response: Any | None = None):
         super().__init__(message)

--- a/yutori/n1/__init__.py
+++ b/yutori/n1/__init__.py
@@ -31,10 +31,17 @@ _SUBMODULES = frozenset(
 
 
 def __getattr__(name: str):
-    # The pre-rename package imported its submodules eagerly, so attribute
-    # access like ``yutori.n1.payload`` worked right after ``import
-    # yutori.n1``. Import the shim submodule on demand to keep that working
-    # without emitting thirteen DeprecationWarnings on package import.
+    # The pre-rename package imported most of its submodules eagerly, so
+    # attribute access like ``yutori.n1.payload`` worked right after
+    # ``import yutori.n1``. Import shim submodules on demand to keep that
+    # working (for every submodule) without emitting one DeprecationWarning
+    # per shim on package import.
     if name in _SUBMODULES:
         return importlib.import_module(f".{name}", __name__)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    # PEP 562 companion to __getattr__: keep the lazily-imported submodules
+    # discoverable via dir() / autocomplete, as they were pre-rename.
+    return sorted(set(globals()) | _SUBMODULES)

--- a/yutori/n1/__init__.py
+++ b/yutori/n1/__init__.py
@@ -2,9 +2,39 @@
 
 from __future__ import annotations
 
+import importlib
+
 from ._compat import warn_renamed
 
 warn_renamed(__name__, suffix="Update imports to 'from yutori.navigator import ...'.")
 
 from yutori.navigator import *  # noqa: E402,F401,F403
 from yutori.navigator import __all__  # noqa: E402,F401
+
+_SUBMODULES = frozenset(
+    {
+        "_assets",
+        "content",
+        "context",
+        "coordinates",
+        "hooks",
+        "images",
+        "keys",
+        "loop",
+        "models",
+        "page_ready",
+        "payload",
+        "replay",
+        "stop",
+    }
+)
+
+
+def __getattr__(name: str):
+    # The pre-rename package imported its submodules eagerly, so attribute
+    # access like ``yutori.n1.payload`` worked right after ``import
+    # yutori.n1``. Import the shim submodule on demand to keep that working
+    # without emitting thirteen DeprecationWarnings on package import.
+    if name in _SUBMODULES:
+        return importlib.import_module(f".{name}", __name__)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/yutori/n1/__init__.py
+++ b/yutori/n1/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import pkgutil
 
 from ._compat import warn_renamed
 
@@ -11,22 +12,12 @@ warn_renamed(__name__, suffix="Update imports to 'from yutori.navigator import .
 from yutori.navigator import *  # noqa: E402,F401,F403
 from yutori.navigator import __all__  # noqa: E402,F401
 
+# Shim modules in this package: everything on disk except the _compat
+# helper, so adding or removing a shim file needs no registry edit.
 _SUBMODULES = frozenset(
-    {
-        "_assets",
-        "content",
-        "context",
-        "coordinates",
-        "hooks",
-        "images",
-        "keys",
-        "loop",
-        "models",
-        "page_ready",
-        "payload",
-        "replay",
-        "stop",
-    }
+    module.name
+    for module in pkgutil.iter_modules(__path__)  # noqa: F405 — package __path__, not a star import
+    if module.name != "_compat"
 )
 
 

--- a/yutori/n1/_assets.py
+++ b/yutori/n1/_assets.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ._compat import warn_renamed
+from yutori.navigator import _assets as _target
+
+from ._compat import alias_module_contents, warn_renamed
 
 warn_renamed(__name__)
-
-from yutori.navigator._assets import *  # noqa: E402,F401,F403
+alias_module_contents(globals(), _target)

--- a/yutori/n1/_assets.py
+++ b/yutori/n1/_assets.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from yutori.navigator import _assets as _target
+from ._compat import install_shim
 
-from ._compat import alias_module_contents, warn_renamed
-
-warn_renamed(__name__)
-alias_module_contents(globals(), _target)
+install_shim(globals())

--- a/yutori/n1/_compat.py
+++ b/yutori/n1/_compat.py
@@ -9,12 +9,13 @@ centralizes the warning text and ``stacklevel`` accounting;
 
 from __future__ import annotations
 
+import importlib
 import warnings
 from types import ModuleType
 from typing import Any
 
 
-def warn_renamed(old_name: str, *, suffix: str = "") -> None:
+def warn_renamed(old_name: str, *, suffix: str = "", stacklevel: int = 3) -> None:
     """Emit a DeprecationWarning announcing the ``yutori.n1`` rename.
 
     ``old_name`` is the importing shim's ``__name__`` (e.g.
@@ -25,12 +26,14 @@ def warn_renamed(old_name: str, *, suffix: str = "") -> None:
 
     ``suffix`` is appended after the rename sentence; the package-level
     shim uses it to nudge callers toward updating their imports.
+    ``stacklevel`` defaults to 3 (this helper + the shim module body);
+    :func:`install_shim` passes 4 for its extra frame.
     """
     new_name = old_name.replace("yutori.n1", "yutori.navigator", 1)
     message = f"{old_name} has been renamed to {new_name}."
     if suffix:
         message = f"{message} {suffix}"
-    warnings.warn(message, DeprecationWarning, stacklevel=3)
+    warnings.warn(message, DeprecationWarning, stacklevel=stacklevel)
 
 
 # Attributes that identify the shim module itself and must not be replaced
@@ -60,7 +63,24 @@ def alias_module_contents(shim_globals: dict[str, Any], target: ModuleType) -> N
     which ``__all__`` omits). Copying ``vars(target)`` — including
     ``__all__`` itself, so star-imports from the shim keep the target's
     export list — preserves the original import surface exactly.
+
+    Note the copy semantics: monkeypatching an attribute on the shim module
+    does not affect the ``yutori.navigator`` module (or vice versa) — patch
+    the navigator module directly.
     """
     shim_globals.update(
         {name: value for name, value in vars(target).items() if name not in _MODULE_IDENTITY_ATTRS}
     )
+
+
+def install_shim(shim_globals: dict[str, Any]) -> None:
+    """Set up a ``yutori.n1`` submodule shim: warn, then re-export the target.
+
+    Derives the target module from the shim's own ``__name__`` so the 13
+    shim files cannot drift (a copy-pasted shim aliasing the wrong module
+    is the one realistic editing mistake this prevents).
+    """
+    old_name = shim_globals["__name__"]
+    warn_renamed(old_name, stacklevel=4)
+    target = importlib.import_module(old_name.replace("yutori.n1", "yutori.navigator", 1))
+    alias_module_contents(shim_globals, target)

--- a/yutori/n1/_compat.py
+++ b/yutori/n1/_compat.py
@@ -1,15 +1,17 @@
-"""Internal helper for the yutori.n1 -> yutori.navigator deprecation shims.
+"""Internal helpers for the yutori.n1 -> yutori.navigator deprecation shims.
 
 Each submodule under :mod:`yutori.n1` is a thin compatibility wrapper that
 emits a :class:`DeprecationWarning` at import time and re-exports everything
 from the corresponding ``yutori.navigator`` submodule. :func:`warn_renamed`
-centralizes the warning text and ``stacklevel`` accounting so each shim only
-declares its own name and the star-import.
+centralizes the warning text and ``stacklevel`` accounting;
+:func:`alias_module_contents` does the re-export.
 """
 
 from __future__ import annotations
 
 import warnings
+from types import ModuleType
+from typing import Any
 
 
 def warn_renamed(old_name: str, *, suffix: str = "") -> None:
@@ -29,3 +31,36 @@ def warn_renamed(old_name: str, *, suffix: str = "") -> None:
     if suffix:
         message = f"{message} {suffix}"
     warnings.warn(message, DeprecationWarning, stacklevel=3)
+
+
+# Attributes that identify the shim module itself and must not be replaced
+# by the target's values.
+_MODULE_IDENTITY_ATTRS = frozenset(
+    {
+        "__name__",
+        "__loader__",
+        "__spec__",
+        "__package__",
+        "__file__",
+        "__path__",
+        "__builtins__",
+        "__cached__",
+        "__doc__",
+    }
+)
+
+
+def alias_module_contents(shim_globals: dict[str, Any], target: ModuleType) -> None:
+    """Copy every attribute of ``target`` into a shim module's namespace.
+
+    A bare ``from target import *`` is not enough for a rename shim: it skips
+    underscore-prefixed names and anything excluded by the target's
+    ``__all__``, both of which were importable from the pre-rename
+    ``yutori.n1`` modules (e.g. ``SupportsAsyncPageReady`` in ``page_ready``,
+    which ``__all__`` omits). Copying ``vars(target)`` — including
+    ``__all__`` itself, so star-imports from the shim keep the target's
+    export list — preserves the original import surface exactly.
+    """
+    shim_globals.update(
+        {name: value for name, value in vars(target).items() if name not in _MODULE_IDENTITY_ATTRS}
+    )

--- a/yutori/n1/content.py
+++ b/yutori/n1/content.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ._compat import warn_renamed
+from yutori.navigator import content as _target
+
+from ._compat import alias_module_contents, warn_renamed
 
 warn_renamed(__name__)
-
-from yutori.navigator.content import *  # noqa: E402,F401,F403
+alias_module_contents(globals(), _target)

--- a/yutori/n1/content.py
+++ b/yutori/n1/content.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from yutori.navigator import content as _target
+from ._compat import install_shim
 
-from ._compat import alias_module_contents, warn_renamed
-
-warn_renamed(__name__)
-alias_module_contents(globals(), _target)
+install_shim(globals())

--- a/yutori/n1/context.py
+++ b/yutori/n1/context.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ._compat import warn_renamed
+from yutori.navigator import context as _target
+
+from ._compat import alias_module_contents, warn_renamed
 
 warn_renamed(__name__)
-
-from yutori.navigator.context import *  # noqa: E402,F401,F403
+alias_module_contents(globals(), _target)

--- a/yutori/n1/context.py
+++ b/yutori/n1/context.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from yutori.navigator import context as _target
+from ._compat import install_shim
 
-from ._compat import alias_module_contents, warn_renamed
-
-warn_renamed(__name__)
-alias_module_contents(globals(), _target)
+install_shim(globals())

--- a/yutori/n1/coordinates.py
+++ b/yutori/n1/coordinates.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from yutori.navigator import coordinates as _target
+from ._compat import install_shim
 
-from ._compat import alias_module_contents, warn_renamed
-
-warn_renamed(__name__)
-alias_module_contents(globals(), _target)
+install_shim(globals())

--- a/yutori/n1/coordinates.py
+++ b/yutori/n1/coordinates.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ._compat import warn_renamed
+from yutori.navigator import coordinates as _target
+
+from ._compat import alias_module_contents, warn_renamed
 
 warn_renamed(__name__)
-
-from yutori.navigator.coordinates import *  # noqa: E402,F401,F403
+alias_module_contents(globals(), _target)

--- a/yutori/n1/hooks.py
+++ b/yutori/n1/hooks.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ._compat import warn_renamed
+from yutori.navigator import hooks as _target
+
+from ._compat import alias_module_contents, warn_renamed
 
 warn_renamed(__name__)
-
-from yutori.navigator.hooks import *  # noqa: E402,F401,F403
+alias_module_contents(globals(), _target)

--- a/yutori/n1/hooks.py
+++ b/yutori/n1/hooks.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from yutori.navigator import hooks as _target
+from ._compat import install_shim
 
-from ._compat import alias_module_contents, warn_renamed
-
-warn_renamed(__name__)
-alias_module_contents(globals(), _target)
+install_shim(globals())

--- a/yutori/n1/images.py
+++ b/yutori/n1/images.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ._compat import warn_renamed
+from yutori.navigator import images as _target
+
+from ._compat import alias_module_contents, warn_renamed
 
 warn_renamed(__name__)
-
-from yutori.navigator.images import *  # noqa: E402,F401,F403
+alias_module_contents(globals(), _target)

--- a/yutori/n1/images.py
+++ b/yutori/n1/images.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from yutori.navigator import images as _target
+from ._compat import install_shim
 
-from ._compat import alias_module_contents, warn_renamed
-
-warn_renamed(__name__)
-alias_module_contents(globals(), _target)
+install_shim(globals())

--- a/yutori/n1/keys.py
+++ b/yutori/n1/keys.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ._compat import warn_renamed
+from yutori.navigator import keys as _target
+
+from ._compat import alias_module_contents, warn_renamed
 
 warn_renamed(__name__)
-
-from yutori.navigator.keys import *  # noqa: E402,F401,F403
+alias_module_contents(globals(), _target)

--- a/yutori/n1/keys.py
+++ b/yutori/n1/keys.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from yutori.navigator import keys as _target
+from ._compat import install_shim
 
-from ._compat import alias_module_contents, warn_renamed
-
-warn_renamed(__name__)
-alias_module_contents(globals(), _target)
+install_shim(globals())

--- a/yutori/n1/loop.py
+++ b/yutori/n1/loop.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from yutori.navigator import loop as _target
+from ._compat import install_shim
 
-from ._compat import alias_module_contents, warn_renamed
-
-warn_renamed(__name__)
-alias_module_contents(globals(), _target)
+install_shim(globals())

--- a/yutori/n1/loop.py
+++ b/yutori/n1/loop.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ._compat import warn_renamed
+from yutori.navigator import loop as _target
+
+from ._compat import alias_module_contents, warn_renamed
 
 warn_renamed(__name__)
-
-from yutori.navigator.loop import *  # noqa: E402,F401,F403
+alias_module_contents(globals(), _target)

--- a/yutori/n1/models.py
+++ b/yutori/n1/models.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from yutori.navigator import models as _target
+from ._compat import install_shim
 
-from ._compat import alias_module_contents, warn_renamed
-
-warn_renamed(__name__)
-alias_module_contents(globals(), _target)
+install_shim(globals())

--- a/yutori/n1/models.py
+++ b/yutori/n1/models.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ._compat import warn_renamed
+from yutori.navigator import models as _target
+
+from ._compat import alias_module_contents, warn_renamed
 
 warn_renamed(__name__)
-
-from yutori.navigator.models import *  # noqa: E402,F401,F403
+alias_module_contents(globals(), _target)

--- a/yutori/n1/page_ready.py
+++ b/yutori/n1/page_ready.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from yutori.navigator import page_ready as _target
+from ._compat import install_shim
 
-from ._compat import alias_module_contents, warn_renamed
-
-warn_renamed(__name__)
-alias_module_contents(globals(), _target)
+install_shim(globals())

--- a/yutori/n1/page_ready.py
+++ b/yutori/n1/page_ready.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ._compat import warn_renamed
+from yutori.navigator import page_ready as _target
+
+from ._compat import alias_module_contents, warn_renamed
 
 warn_renamed(__name__)
-
-from yutori.navigator.page_ready import *  # noqa: E402,F401,F403
+alias_module_contents(globals(), _target)

--- a/yutori/n1/payload.py
+++ b/yutori/n1/payload.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from yutori.navigator import payload as _target
+from ._compat import install_shim
 
-from ._compat import alias_module_contents, warn_renamed
-
-warn_renamed(__name__)
-alias_module_contents(globals(), _target)
+install_shim(globals())

--- a/yutori/n1/payload.py
+++ b/yutori/n1/payload.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ._compat import warn_renamed
+from yutori.navigator import payload as _target
+
+from ._compat import alias_module_contents, warn_renamed
 
 warn_renamed(__name__)
-
-from yutori.navigator.payload import *  # noqa: E402,F401,F403
+alias_module_contents(globals(), _target)

--- a/yutori/n1/replay.py
+++ b/yutori/n1/replay.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ._compat import warn_renamed
+from yutori.navigator import replay as _target
+
+from ._compat import alias_module_contents, warn_renamed
 
 warn_renamed(__name__)
-
-from yutori.navigator.replay import *  # noqa: E402,F401,F403
+alias_module_contents(globals(), _target)

--- a/yutori/n1/replay.py
+++ b/yutori/n1/replay.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from yutori.navigator import replay as _target
+from ._compat import install_shim
 
-from ._compat import alias_module_contents, warn_renamed
-
-warn_renamed(__name__)
-alias_module_contents(globals(), _target)
+install_shim(globals())

--- a/yutori/n1/stop.py
+++ b/yutori/n1/stop.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from yutori.navigator import stop as _target
+from ._compat import install_shim
 
-from ._compat import alias_module_contents, warn_renamed
-
-warn_renamed(__name__)
-alias_module_contents(globals(), _target)
+install_shim(globals())

--- a/yutori/n1/stop.py
+++ b/yutori/n1/stop.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ._compat import warn_renamed
+from yutori.navigator import stop as _target
+
+from ._compat import alias_module_contents, warn_renamed
 
 warn_renamed(__name__)
-
-from yutori.navigator.stop import *  # noqa: E402,F401,F403
+alias_module_contents(globals(), _target)

--- a/yutori/navigator/_assets.py
+++ b/yutori/navigator/_assets.py
@@ -9,7 +9,9 @@ from importlib.resources import files
 @lru_cache(maxsize=None)
 def _load_js_resource(package: str, name: str) -> str:
     """Read a bundled ``<package>/js/<name>`` file, stripped of surrounding whitespace."""
-    return files(package).joinpath("js", name).read_text(encoding="utf-8").strip()
+    # Chained single-segment joins: on Python 3.9, zipfile.Path.joinpath
+    # accepts only one argument, so a two-argument join breaks zip imports.
+    return (files(package) / "js" / name).read_text(encoding="utf-8").strip()
 
 
 def load_js_asset(name: str) -> str:

--- a/yutori/navigator/payload.py
+++ b/yutori/navigator/payload.py
@@ -25,10 +25,15 @@ def estimate_messages_size_bytes(messages: list[dict[str, Any]]) -> int:
 
 def message_has_image(message: dict[str, Any]) -> bool:
     """Return True if *message* contains at least one ``image_url`` content block."""
+    return _count_images(message) > 0
+
+
+def _count_images(message: dict[str, Any]) -> int:
+    """Return the number of ``image_url`` content blocks in *message*."""
     content = message.get("content")
     if not isinstance(content, list):
-        return False
-    return any(isinstance(part, dict) and part.get("type") == "image_url" for part in content)
+        return 0
+    return sum(1 for part in content if isinstance(part, dict) and part.get("type") == "image_url")
 
 
 def _strip_one_image(message: dict[str, Any]) -> bool:
@@ -83,7 +88,10 @@ def _strip_until_fits(
             break
         if skip(idx):
             continue
-        if _strip_one_image(messages[idx]):
+        # Drain every image in this message: a message holding several
+        # screenshots would otherwise keep its extras and could leave the
+        # payload over budget no matter how many passes run.
+        while size_bytes > max_bytes and _strip_one_image(messages[idx]):
             removed += 1
             size_bytes = estimate_messages_size_bytes(messages)
     return size_bytes, removed
@@ -130,8 +138,8 @@ def trim_images_to_fit(
     )
 
     # Phase 2: if still over limit, remove from protected set (except the latest)
+    last_idx = image_indices[-1]
     if size_bytes > max_bytes:
-        last_idx = image_indices[-1]
         size_bytes, extra_removed = _strip_until_fits(
             messages,
             image_indices,
@@ -140,6 +148,16 @@ def trim_images_to_fit(
             starting_size=size_bytes,
         )
         removed += extra_removed
+
+    # Phase 3: still over budget — drain extra images from the last message
+    # too. The "very last screenshot is always kept" guarantee protects one
+    # screenshot, not every image that happens to share its message
+    # (_strip_one_image removes the first image, so the final one survives).
+    last_message = messages[last_idx]
+    while size_bytes > max_bytes and _count_images(last_message) > 1:
+        _strip_one_image(last_message)
+        removed += 1
+        size_bytes = estimate_messages_size_bytes(messages)
 
     return size_bytes, removed
 

--- a/yutori/navigator/payload.py
+++ b/yutori/navigator/payload.py
@@ -88,9 +88,10 @@ def _strip_until_fits(
             break
         if skip(idx):
             continue
-        # Drain every image in this message: a message holding several
-        # screenshots would otherwise keep its extras and could leave the
-        # payload over budget no matter how many passes run.
+        # Drain every image in this message: each of the two strip phases
+        # visits a message once, so without the inner loop a message holding
+        # several screenshots would lose at most one image per phase and
+        # could leave the payload over budget.
         while size_bytes > max_bytes and _strip_one_image(messages[idx]):
             removed += 1
             size_bytes = estimate_messages_size_bytes(messages)
@@ -105,8 +106,10 @@ def trim_images_to_fit(
 ) -> tuple[int, int]:
     """Remove old screenshots from *messages* until the payload fits within *max_bytes*.
 
-    The most recent *keep_recent* screenshots are protected from removal (the
-    very last screenshot is always kept). If the payload is already within
+    The most recent *keep_recent* image-bearing messages are protected while
+    removing older screenshots suffices; if the payload is still over the
+    limit, protected screenshots are removed too, oldest first — only the
+    very last screenshot is always kept. If the payload is already within
     limits, no changes are made.
 
     Args:

--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -290,7 +290,13 @@ def _build_steps(
                 user_query = extract_text_content(content) or _stringify_content(content)
             observation = _normalize_observation(content)
             if observation:
-                current_observation = observation
+                if current_observation and not _observation_has_image(observation):
+                    # A text-only interjection (e.g. a user nudge after a tool
+                    # screenshot) augments the pending observation; replacing
+                    # it would drop the screenshot the model actually acted on.
+                    current_observation = current_observation + observation
+                else:
+                    current_observation = observation
             continue
 
         if role != "assistant":
@@ -342,6 +348,11 @@ def _normalize_observation(content: Any) -> list[dict] | None:
         if stripped:
             return [{"type": "text", "text": stripped}]
     return None
+
+
+def _observation_has_image(observation: list[dict]) -> bool:
+    screenshot_url, _ = _extract_observation_parts(observation)
+    return screenshot_url is not None
 
 
 def _extract_observation_parts(observation: list[dict] | None) -> tuple[str | None, list[str]]:
@@ -417,7 +428,11 @@ def _parse_tool_calls(message: dict) -> list[dict[str, Any]]:
         arguments = function.get("arguments") or "{}"
         try:
             parsed_arguments = json.loads(arguments) if isinstance(arguments, str) else dict(arguments)
-        except (TypeError, json.JSONDecodeError):
+        except (TypeError, ValueError):
+            parsed_arguments = {}
+        if not isinstance(parsed_arguments, dict):
+            # Valid JSON that isn't an object (e.g. "[1, 2]") — treat it like
+            # unparseable arguments instead of crashing the render.
             parsed_arguments = {}
         action = {"action_type": function.get("name", "unknown")}
         action.update(parsed_arguments)
@@ -478,7 +493,7 @@ def _render_step(step: dict[str, Any]) -> str:
         (
             f"<div class=\"image-frame\" data-modal-source=\"step-{step['step_num']}\" "
             f"onclick=\"openReplayModal('step-{step['step_num']}')\">"
-            f"<img src=\"{step['screenshot_url']}\" alt=\"Step {step['step_num']} screenshot\">"
+            f"<img src=\"{_escape_html(step['screenshot_url'])}\" alt=\"Step {step['step_num']} screenshot\">"
             f"{markers_html}</div>"
         )
         if step["screenshot_url"]


### PR DESCRIPTION
Fixes every issue from a full-codebase review (Claude Code review with four area subagents, cross-reviewed by Codex — including the two issues Codex found that the original review missed, and one issue Codex found in this PR's own escaping path).

## Highest impact

- **Unit tests executed real \`npx\` installs against \`$HOME\`** — four `__install_flow` tests ran unmocked `npx add-mcp -y -g ...` / `npx skills add ... -g`, rewriting `~/.cursor/mcp.json`, `~/.codex/config.toml`, `~/.gemini/settings.json` on any machine (or CI runner) with `npx`. Now stubbed like their sibling tests; full suite runs in ~4s with zero `$HOME` writes.
- **`py.typed` was missing** despite the `Typing :: Typed` classifier — type checkers ignored every annotation in the installed package. Added and asserted in the wheel-content test.
- **Committed `install.sh` was stale** (`0.7.7` header at `0.7.8`) — and `yutori.com/install.sh` serves this file, so it was live. Regenerated; the pre-commit freshness hook now also triggers on `pyproject.toml`, and new CI enforces it.
- **No CI existed; publishing was ungated** — added a CI workflow (ruff, pytest on 3.9–3.13, wheel-content test, `twine check`, installer freshness + `bash -n`); the publish workflow now runs tests and `twine check` before upload, and the release-asset action is pinned to a commit SHA.

## Behavior changes

- `yutori browse run` / `research run` / `scouts create` now **exit 1 when the API reports `status: failed`** (previously exit 0 — scripts treated rejected tasks as success). Documented in api.md.
- CLI data commands print one-line errors (exit 1) for `AuthenticationError` / `APIError` / network failures instead of multi-screen tracebacks; rejected keys get "Run 'yutori auth login'" guidance. `AUTH_FAILURE_MARKERS` updated in lockstep.
- 401/403 SDK errors include the status code and server response body; 3xx responses raise `APIError` instead of silently returning `{}`.
- API keys are stripped on resolution — a trailing-newline key (e.g. `export YUTORI_API_KEY=$(cat key)`) no longer fails every request deep in httpx.

## Correctness fixes

- **Rich markup injection**: scout queries like `watch [/b] releases` crashed `scouts list` with `MarkupError`; `[beta]`-style tokens were silently deleted; the installer summary could crash *after* a successful install. All user/API/subprocess text rendered through Rich is now escaped (and stringified first — non-string API values also crashed).
- **`yutori.n1` compat shims**: `yutori.n1.payload` attribute access and `from yutori.n1.page_ready import SupportsAsyncPageReady` work again (star-import shims dropped submodule attributes and non-`__all__` names).
- **Payload trimming converges**: a message holding several screenshots could stay over `max_bytes` no matter how many passes ran; trimming now drains multi-image messages (and extra images sharing the last message).
- **Replay robustness**: valid-JSON non-object tool arguments no longer crash HTML generation; screenshot URLs are HTML-escaped; a text-only user interjection no longer blanks the pending tool screenshot.
- `apply_chat_extra_body` no longer mutates the caller's `extra_body` dict; install-flow Ctrl+C during verification polling renders the summary and honors the documented exit-code contract; `Task ID: N/A` is treated as missing instead of polling `browse get N/A`; Windows venvs resolve `Scripts\python.exe`; `EADDRINUSE` detected by errno; failed `save_config` after key generation reports the orphaned key.

## Packaging / installer

- `setuptools>=77` build floor (PEP 639 string `license` fails validation on 67–76).
- `MANIFEST.in` grafts `tests/` so the sdist suite can collect (it shipped `test_*.py` without `conftest.py`/helpers).
- Installer frame-render dir uses `mktemp -d` (predictable `/tmp` path was symlink-clobberable on shared Linux); `uninstall.sh` accepts `yes`, not just `y`.
- `__version__` fallback is `0.0.0+unknown` instead of a plausible-but-wrong `0.1.0`.

## Cleanup

Internal tracker/hostname references removed from comments; stale comments about a removed stdout guard (and their no-op `isatty` patches) removed; examples use the canonical `NAVIGATOR_N1_MODEL`; two test files gained `__future__` imports their PEP 604 annotations needed on 3.9; the packaging test builds from a temp copy instead of deleting the repo's `build/`.

## Verification

- 421 passed, 3 skipped (shellcheck not installed locally) — includes 17 new regression tests pinning these fixes
- `ruff check .` clean; `bash -n` on all installer scripts
- Wheel inspected: `yutori/py.typed` + all 8 JS assets present; sdist inspected: full test suite included; `twine check` PASSED on both
- `install.sh` regeneration verified idempotent; pinned action SHA verified upstream

Not included (needs external setup): OIDC trusted publishing requires configuring the publisher on PyPI first; the workflow keeps the token until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CLI exit-code changes can break scripts that assumed success on rejected creates; auth and HTTP error handling changes affect all API clients, while CI/publish gates reduce the risk of shipping broken releases.
> 
> **Overview**
> This PR bundles review-driven fixes across **CI/publish**, **CLI/SDK behavior**, **packaging**, and **shell installers**, bumping to **0.7.8** with a regenerated **`install.sh`**.
> 
> **Automation:** New **CI** runs ruff, pytest on Python 3.9–3.13, slow wheel/sdist checks, `twine check`, and `install.sh` freshness + `bash -n`. **Publish** now runs tests and metadata validation before upload; the GitHub release action is **pinned to a commit SHA**. Pre-commit also retriggers `install.sh` regen when **`pyproject.toml`** version changes.
> 
> **CLI (breaking for scripts):** `browse run`, `research run`, and `scouts create` **exit 1** on API `status: failed` or missing task ID. Commands use shared **`cli_client`** / **`safe_str`** so API, auth, and network errors print short messages (no tracebacks) and user/API strings don’t break **Rich** markup.
> 
> **SDK/auth:** Keys are **stripped** at resolve time; **401/403** include status and body; **3xx** and **2xx non-JSON** raise **`APIError`** instead of `{}`. OAuth bind errors use **errno**; failed **`save_config`** after key creation reports an **orphaned key**. Auth API base URL respects **`YUTORI_API_BASE_URL`**.
> 
> **Navigator / compat:** Payload trimming **drains multi-image messages**; replay HTML **escapes screenshot URLs** and keeps tool screenshots when a text-only user message follows. **`yutori.n1`** shims use **`install_shim`** / lazy submodules so submodule attributes match pre-rename imports; examples use **`NAVIGATOR_N1_MODEL`**.
> 
> **Packaging/installer:** Ships **`py.typed`**, **`MANIFEST.in`** grafts full **`tests/`**, **`setuptools>=77`**. Installer frame cache uses **`mktemp -d`**; **`uninstall.sh`** accepts **`yes`**. Install-flow tests stub **MCP `npx`** installs; verification handles **Ctrl+C**, **`Task ID: N/A`**, and Windows venv **`Scripts\python.exe`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b1e0ba3174a65e115933836e317205ab245df17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->