### PR TITLE
Move CI actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install ruff
@@ -23,8 +23,8 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"
@@ -35,8 +35,8 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install -e ".[dev]" twine
@@ -50,7 +50,7 @@ jobs:
   install-sh:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Verify install.sh matches template + assets + version
         run: bash scripts/check_install_sh_fresh.sh
       - name: Syntax-check shell scripts

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -10,9 +10,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -54,7 +54,7 @@ jobs:
         # Pinned to a commit SHA: this third-party action runs with
         # contents:write and uploads the curl|sh installer artifact, so a
         # mutable tag would be a supply-chain risk.
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: |
             install.sh


### PR DESCRIPTION
GitHub forces actions onto Node 24 starting **2026-06-16** (and removes Node 20 from runners 2026-09-16). The v0.7.9 publish run's annotations flagged all three actions we use as Node 20.

- `actions/checkout` v4 → v5 (`using: node24`, verified)
- `actions/setup-python` v5 → v6 (`using: node24`, verified)
- `softprops/action-gh-release` SHA re-pinned `v2.6.2` → `v3.0.0` (`b430933...`) — its release notes confirm v3.0.0 is a runtime-only change (Node 20 → 24) with no input changes; our usage (`files:`) is unaffected. Still pinned by commit SHA since it runs with `contents: write`.

The CI jobs on this PR exercise checkout/setup-python at the new versions; the gh-release pin gets exercised on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency bumps with no application code changes; publish still gates on tests and keeps the gh-release action SHA-pinned.
> 
> **Overview**
> Updates CI and PyPI publish workflows so they run on GitHub’s upcoming **Node 24** action runtimes instead of Node 20.
> 
> In **`ci.yml`**, every job that used **`actions/checkout@v4`** and **`actions/setup-python@v5`** now uses **`@v5`** and **`@v6`** respectively (lint, test matrix, package, and install-sh). The **`install-sh`** job only bumps checkout; it never used setup-python.
> 
> In **`publish_to_pypi.yml`**, checkout and setup-python get the same version bumps. The release asset upload step re-pins **`softprops/action-gh-release`** from the v2.6.2 commit to **`v3.0.0`** (`b430933…`), still by full SHA because that action has **`contents: write`**. Workflow inputs (e.g. **`files:`**) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47b00d0392c68d34b83ee0f1a41254ded744897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->