### PR TITLE
0.8.0: scouts.update(is_public), APIConnectionError for transport failures, lazy chat namespace

### DIFF
--- a/api.md
+++ b/api.md
@@ -261,7 +261,7 @@ Recurring web-monitoring scouts.
 | `client.scouts.list(*, limit=None, status=None)` | GET | `/v1/scouting/tasks` | `dict` |
 | `client.scouts.get(scout_id)` | GET | `/v1/scouting/tasks/{scout_id}` | `dict` |
 | `client.scouts.create(query, *, output_interval=86400, start_timestamp=None, user_timezone=None, user_location=None, output_schema=None, skip_email=None, webhook_url=None, webhook_format=None, is_public=None)` | POST | `/v1/scouting/tasks` | `dict` |
-| `client.scouts.update(scout_id, *, query=None, status=None, output_interval=None, user_timezone=None, user_location=None, output_schema=None, skip_email=None, webhook_url=None, webhook_format=None)` | PATCH or POST (status endpoints) | `/v1/scouting/tasks/{scout_id}` or `.../pause|resume|done` | `dict` |
+| `client.scouts.update(scout_id, *, query=None, status=None, output_interval=None, user_timezone=None, user_location=None, output_schema=None, skip_email=None, webhook_url=None, webhook_format=None, is_public=None)` | PATCH or POST (status endpoints) | `/v1/scouting/tasks/{scout_id}` or `.../pause|resume|done` | `dict` |
 | `client.scouts.delete(scout_id)` | DELETE | `/v1/scouting/tasks/{scout_id}` | `dict` |
 | `client.scouts.get_updates(scout_id, *, limit=None, cursor=None)` | GET | `/v1/scouting/tasks/{scout_id}/updates` | `dict` |
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.7.9"
+YUTORI_INSTALLER_VERSION="0.8.0"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.7.9"
+version = "0.8.0"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -120,6 +120,18 @@ class TestAsyncScoutsNamespace:
                 result = await client.scouts.update("scout-123", query="new query")
                 assert result["query"] == "new query"
 
+    async def test_scouts_update_is_public(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"id": "scout-123", "is_public": false}'
+        mock_response.json.return_value = {"id": "scout-123", "is_public": False}
+
+        with patch.object(httpx.AsyncClient, "patch", new_callable=AsyncMock, return_value=mock_response) as mock_patch:
+            async with AsyncYutoriClient(api_key="yt-test") as client:
+                await client.scouts.update("scout-123", is_public=False)
+                payload = mock_patch.call_args[1]["json"]
+                assert payload["is_public"] is False
+
     async def test_scouts_update_status_and_fields_raises(self):
         async with AsyncYutoriClient(api_key="yt-test") as client:
             with pytest.raises(ValueError, match="Cannot update status and other fields simultaneously"):
@@ -567,3 +579,22 @@ class TestAsyncErrorHandling:
                 with pytest.raises(APIError) as exc_info:
                     await client.get_usage()
                 assert exc_info.value.status_code == 500
+
+
+class TestAsyncTransportErrorWrapping:
+    async def test_connect_error_wrapped(self):
+        from yutori.exceptions import APIConnectionError
+
+        with patch.object(
+            httpx.AsyncClient, "get", new_callable=AsyncMock, side_effect=httpx.ConnectError("refused")
+        ):
+            async with AsyncYutoriClient(api_key="yt-test") as client:
+                with pytest.raises(APIConnectionError, match="ConnectError.*refused"):
+                    await client.scouts.list()
+
+
+class TestAsyncLazyChatNamespace:
+    async def test_chat_not_built_at_init_and_close_safe(self):
+        async with AsyncYutoriClient(api_key="yt-test") as client:
+            assert client._chat is None
+        assert client._chat is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -166,9 +166,24 @@ class TestScoutsNamespace:
             assert result["query"] == "new query"
             mock_patch.assert_called_once()
 
+    def test_scouts_update_is_public(self, client):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"id": "scout-123", "is_public": false}'
+        mock_response.json.return_value = {"id": "scout-123", "is_public": False}
+
+        with patch.object(httpx.Client, "patch", return_value=mock_response) as mock_patch:
+            client.scouts.update("scout-123", is_public=False)
+            payload = mock_patch.call_args[1]["json"]
+            assert payload["is_public"] is False
+
     def test_scouts_update_status_and_fields_raises(self, client):
         with pytest.raises(ValueError, match="Cannot update status and other fields simultaneously"):
             client.scouts.update("scout-123", status="paused", query="new query")
+
+    def test_scouts_update_status_and_is_public_raises(self, client):
+        with pytest.raises(ValueError, match="Cannot update status and other fields simultaneously"):
+            client.scouts.update("scout-123", status="paused", is_public=False)
 
     def test_scouts_delete(self, client):
         mock_response = MagicMock(spec=httpx.Response)
@@ -592,3 +607,34 @@ class TestErrorHandling:
                 client.get_usage()
             assert exc_info.value.status_code == 500
             client.close()
+
+
+class TestTransportErrorWrapping:
+    """httpx transport errors are wrapped in APIConnectionError with a
+    never-blank message (some httpx errors stringify to "")."""
+
+    def test_connect_error_wrapped(self, client):
+        from yutori.exceptions import APIConnectionError
+
+        with patch.object(httpx.Client, "get", side_effect=httpx.ConnectError("refused")):
+            with pytest.raises(APIConnectionError, match="ConnectError.*refused"):
+                client.scouts.list()
+
+    def test_blank_timeout_still_has_message(self, client):
+        from yutori.exceptions import APIConnectionError
+
+        with patch.object(httpx.Client, "get", side_effect=httpx.ReadTimeout("")):
+            with pytest.raises(APIConnectionError, match="ReadTimeout"):
+                client.scouts.list()
+
+
+class TestLazyChatNamespace:
+    """The chat namespace (and its OpenAI client) is only built on first use."""
+
+    def test_chat_not_built_at_init(self, client):
+        assert client._chat is None
+
+    def test_close_without_chat_use(self, client):
+        with patch.object(httpx.Client, "close"):
+            client.close()
+        assert client._chat is None

--- a/yutori/__init__.py
+++ b/yutori/__init__.py
@@ -4,7 +4,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 from .async_client import AsyncYutoriClient
 from .client import YutoriClient
-from .exceptions import APIError, AuthenticationError, YutoriSDKError
+from .exceptions import APIConnectionError, APIError, AuthenticationError, YutoriSDKError
 
 __all__ = [
     "YutoriClient",
@@ -12,6 +12,7 @@ __all__ = [
     "YutoriSDKError",
     "AuthenticationError",
     "APIError",
+    "APIConnectionError",
 ]
 
 try:

--- a/yutori/_async/scouts.py
+++ b/yutori/_async/scouts.py
@@ -104,6 +104,7 @@ class AsyncScoutsNamespace(_AsyncBaseNamespace):
         skip_email: bool | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
+        is_public: bool | None = None,
     ) -> dict[str, Any]:
         """Update an existing scout.
 
@@ -120,6 +121,7 @@ class AsyncScoutsNamespace(_AsyncBaseNamespace):
             skip_email: Updated email notification setting.
             webhook_url: Updated webhook URL.
             webhook_format: Updated webhook format.
+            is_public: Updated public visibility setting.
 
         Returns:
             Dictionary containing updated scout details.
@@ -136,6 +138,7 @@ class AsyncScoutsNamespace(_AsyncBaseNamespace):
             skip_email=skip_email,
             webhook_url=webhook_url,
             webhook_format=webhook_format,
+            is_public=is_public,
         )
 
         method, path, json = prepare_scout_update(scout_id, status, payload)

--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -7,7 +7,7 @@ from typing import Any
 import httpx
 
 from ._schema import resolve_output_schema
-from .exceptions import APIError, AuthenticationError
+from .exceptions import APIConnectionError, APIError, AuthenticationError
 
 
 def build_headers(api_key: str) -> dict[str, str]:
@@ -148,6 +148,19 @@ def apply_chat_extra_body(kwargs: dict[str, Any], **fields: Any) -> None:
         kwargs["extra_body"] = extra_body
 
 
+def _to_connection_error(exc: httpx.HTTPError) -> APIConnectionError:
+    """Build an APIConnectionError with a never-blank message.
+
+    Some httpx errors (e.g. ReadTimeout) stringify to "", so the exception
+    type name is always included.
+    """
+    message = f"Network error calling the Yutori API ({type(exc).__name__})"
+    detail = str(exc)
+    if detail:
+        message = f"{message}: {detail}"
+    return APIConnectionError(message)
+
+
 class _BaseNamespace:
     """Shared base for SDK namespace classes (sync and async).
 
@@ -187,10 +200,13 @@ class _SyncBaseNamespace(_BaseNamespace):
         json: Any = None,
     ) -> dict[str, Any]:
         http_method = getattr(self._client, method)
-        response = http_method(
-            f"{self._base_url}{path}",
-            **self._request_kwargs(params, json),
-        )
+        try:
+            response = http_method(
+                f"{self._base_url}{path}",
+                **self._request_kwargs(params, json),
+            )
+        except httpx.HTTPError as exc:
+            raise _to_connection_error(exc) from exc
         return handle_response(response)
 
 
@@ -206,8 +222,11 @@ class _AsyncBaseNamespace(_BaseNamespace):
         json: Any = None,
     ) -> dict[str, Any]:
         http_method = getattr(self._client, method)
-        response = await http_method(
-            f"{self._base_url}{path}",
-            **self._request_kwargs(params, json),
-        )
+        try:
+            response = await http_method(
+                f"{self._base_url}{path}",
+                **self._request_kwargs(params, json),
+            )
+        except httpx.HTTPError as exc:
+            raise _to_connection_error(exc) from exc
         return handle_response(response)

--- a/yutori/_sync/scouts.py
+++ b/yutori/_sync/scouts.py
@@ -104,6 +104,7 @@ class ScoutsNamespace(_SyncBaseNamespace):
         skip_email: bool | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
+        is_public: bool | None = None,
     ) -> dict[str, Any]:
         """Update an existing scout.
 
@@ -120,6 +121,7 @@ class ScoutsNamespace(_SyncBaseNamespace):
             skip_email: Updated email notification setting.
             webhook_url: Updated webhook URL.
             webhook_format: Updated webhook format.
+            is_public: Updated public visibility setting.
 
         Returns:
             Dictionary containing updated scout details.
@@ -136,6 +138,7 @@ class ScoutsNamespace(_SyncBaseNamespace):
             skip_email=skip_email,
             webhook_url=webhook_url,
             webhook_format=webhook_format,
+            is_public=is_public,
         )
 
         method, path, json = prepare_scout_update(scout_id, status, payload)

--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -65,7 +65,8 @@ class AsyncYutoriClient(_AsyncBaseNamespace):
         self.scouts = AsyncScoutsNamespace(self._client, self._base_url, self._api_key)
         self.browsing = AsyncBrowsingNamespace(self._client, self._base_url, self._api_key)
         self.research = AsyncResearchNamespace(self._client, self._base_url, self._api_key)
-        self.chat = AsyncChatNamespace(self._base_url, self._api_key, timeout)
+        self._timeout = timeout
+        self._chat: AsyncChatNamespace | None = None
 
     async def get_usage(self, *, period: str | None = None) -> dict[str, Any]:
         """Get usage statistics for your API key.
@@ -84,10 +85,27 @@ class AsyncYutoriClient(_AsyncBaseNamespace):
         """
         return await self._request("get", "/usage", params=build_query_params(period=period))
 
+    @property
+    def chat(self) -> AsyncChatNamespace:
+        """Chat completions namespace, constructed lazily on first use.
+
+        Building it eagerly would pay the AsyncOpenAI client construction
+        cost (its own HTTP client and SSL context) on every
+        AsyncYutoriClient, even for callers that never use chat completions.
+        """
+        if self._chat is None:
+            self._chat = AsyncChatNamespace(self._base_url, self._api_key, self._timeout)
+        return self._chat
+
     async def close(self) -> None:
         """Release the underlying HTTP client resources."""
-        await self._client.aclose()
-        await self.chat.close()
+        try:
+            await self._client.aclose()
+        finally:
+            # Close the chat client (if ever built) even if the HTTP client
+            # close fails.
+            if self._chat is not None:
+                await self._chat.close()
 
     async def __aenter__(self) -> AsyncYutoriClient:
         return self

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -55,7 +55,8 @@ class YutoriClient(_SyncBaseNamespace):
         self.scouts = ScoutsNamespace(self._client, self._base_url, self._api_key)
         self.browsing = BrowsingNamespace(self._client, self._base_url, self._api_key)
         self.research = ResearchNamespace(self._client, self._base_url, self._api_key)
-        self.chat = ChatNamespace(self._base_url, self._api_key, timeout)
+        self._timeout = timeout
+        self._chat: ChatNamespace | None = None
 
     def get_usage(self, *, period: str | None = None) -> dict[str, Any]:
         """Get usage statistics for your API key.
@@ -74,10 +75,27 @@ class YutoriClient(_SyncBaseNamespace):
         """
         return self._request("get", "/usage", params=build_query_params(period=period))
 
+    @property
+    def chat(self) -> ChatNamespace:
+        """Chat completions namespace, constructed lazily on first use.
+
+        Building it eagerly would pay the OpenAI client construction cost
+        (its own HTTP client and SSL context) on every YutoriClient, even
+        for callers that never use chat completions.
+        """
+        if self._chat is None:
+            self._chat = ChatNamespace(self._base_url, self._api_key, self._timeout)
+        return self._chat
+
     def close(self) -> None:
         """Release the underlying HTTP client resources."""
-        self._client.close()
-        self.chat.close()
+        try:
+            self._client.close()
+        finally:
+            # Close the chat client (if ever built) even if the HTTP client
+            # close fails.
+            if self._chat is not None:
+                self._chat.close()
 
     def __enter__(self) -> YutoriClient:
         return self

--- a/yutori/exceptions.py
+++ b/yutori/exceptions.py
@@ -13,6 +13,10 @@ class AuthenticationError(YutoriSDKError):
     """Raised when an API key is missing or rejected by the server."""
 
 
+class APIConnectionError(YutoriSDKError):
+    """Raised when the Yutori API cannot be reached (connection or timeout failure)."""
+
+
 class APIError(YutoriSDKError):
     """Raised when the Yutori API returns a non-successful or unusable response."""
 


### PR DESCRIPTION
## Changes

**`scouts.update(is_public=...)`** — the developer API's PATCH already accepts `is_public`, but neither client exposed it on `update()` (only `create()`), so visibility couldn't be changed after creation through the SDK; yutori-mcp's `edit_scout` hit a `TypeError`. Added to both sync and async namespaces through the shared payload builder. Verified live against production: an `is_public` edit round-trips correctly.

**`APIConnectionError` for transport failures** — `handle_response` already wraps auth failures, redirects, status errors, and non-JSON bodies, but httpx transport errors (timeouts, DNS/connect failures) escaped `_request` raw — and some (e.g. `ReadTimeout`) stringify to `""`, giving callers a blank error. Both `_request` chokepoints now raise `APIConnectionError` with a message that always names the underlying httpx exception type. Exported from the package root.

**Lazy `chat` namespace** — the chat namespace eagerly built an OpenAI client (its own HTTP client + SSL context) in every client `__init__` — measured at roughly half the construction cost — even for callers that never use chat completions (yutori-mcp builds a client per tool call). Now constructed on first attribute access; `close()` releases it inside `try/finally` so an HTTP-client close failure can't leak it.

**Version → 0.8.0.**

## Tests

442 passed, 3 skipped. New coverage: `is_public` wire payload (sync + async, including `False` surviving the None-filter), status mutual-exclusion with `is_public`, transport-error wrapping (sync + async, including blank-stringifying timeout), lazy-chat construction and close-without-use.

## Release ordering

yutori-mcp pins `yutori>=0.8.0` and consumes all three changes (`is_public` edit, `APIConnectionError` mapping, per-call client cost). Sequence: **deploy yutori-ai/yutori#10031 → publish this as 0.8.0 → release yutori-mcp**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK API and error-type changes with tests; no auth or server logic changes, though callers may need to catch APIConnectionError for network failures.
> 
> **Overview**
> **Release 0.8.0** bumps package and installer version strings; API docs now list `is_public` on `scouts.update`.
> 
> **Scout visibility:** Sync and async `scouts.update()` accept **`is_public`**, wired through the shared payload builder so PATCH can change public/private after create (including `False`, which is not dropped as `None`). Combining `status` with `is_public` still raises the existing mutual-exclusion `ValueError`.
> 
> **Transport errors:** Shared sync/async `_request` paths catch `httpx.HTTPError` and raise exported **`APIConnectionError`** with a message that always includes the httpx exception type (avoids blank messages from errors like `ReadTimeout("")`).
> 
> **Client lifecycle:** `YutoriClient` / `AsyncYutoriClient` defer building the **`chat`** namespace (OpenAI client) until first access; `close()` uses `try/finally` so a built chat client is released even if the main HTTP client close fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba91ec671e100c4f3da3e9450395d141c21c2c9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->