### PR TITLE
docs: add APIConnectionError to README error handling example

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,14 @@ asyncio.run(main())
 ## Error Handling
 
 ```python
-from yutori import YutoriClient, APIError, AuthenticationError
+from yutori import YutoriClient, APIError, APIConnectionError, AuthenticationError
 
 try:
     client.get_usage()
 except AuthenticationError as e:
     print(f"Invalid API key: {e}")
+except APIConnectionError as e:
+    print(f"Connection failed: {e}")
 except APIError as e:
     print(f"API error (status {e.status_code}): {e.message}")
 ```


### PR DESCRIPTION
## Summary\n\n- Add `APIConnectionError` to the README error handling example — this exception was added and exported in 0.8.0 (PR #131) but the README snippet only showed `APIError` and `AuthenticationError`\n\nDaily doc-drift fix.\n\n## Test plan\n\n- [x] Documentation-only change, no code affected\n- [x] Verified `APIConnectionError` is exported from `yutori.__init__`

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnBYSTKxmBKJhbykWW9PTF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to README; no runtime or API behavior is modified.
> 
> **Overview**
> Updates the **Error Handling** README snippet so it matches the SDK’s exported exceptions after `APIConnectionError` was added in 0.8.0.
> 
> The import line now includes `APIConnectionError`, and the example adds a dedicated `except APIConnectionError` branch for connection failures, alongside the existing `AuthenticationError` and `APIError` handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5755d1b1ee166a81f1a5e228c2689228d35dd0c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->