### PR TITLE
Import abstract base classes from collections.abc instead of typing

### DIFF
--- a/yutori/_async/chat.py
+++ b/yutori/_async/chat.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam

--- a/yutori/_sync/chat.py
+++ b/yutori/_sync/chat.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from openai import OpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -17,8 +17,9 @@ import socketserver
 import sys
 import threading
 import webbrowser
+from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import Any, Callable
+from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import contextlib
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 import httpx
 import typer

--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -24,10 +24,11 @@ import shutil
 import subprocess
 import sys
 import time
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Literal, Mapping, Sequence
+from typing import Literal
 
 import typer
 from rich import box

--- a/yutori/navigator/coordinates.py
+++ b/yutori/navigator/coordinates.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from typing import Sequence
+from collections.abc import Sequence
 
 NAVIGATOR_COORDINATE_SCALE = 1000
 

--- a/yutori/navigator/loop.py
+++ b/yutori/navigator/loop.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import copy
-from typing import Any, Iterable, Protocol
+from collections.abc import Iterable
+from typing import Any, Protocol
 
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 

--- a/yutori/navigator/payload.py
+++ b/yutori/navigator/payload.py
@@ -11,8 +11,9 @@ Adapted from the n1-brightdata project (https://github.com/meirk-brd/n1-brightda
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from copy import deepcopy
-from typing import Any, Callable
+from typing import Any
 
 DEFAULT_MAX_REQUEST_BYTES = 9_500_000
 DEFAULT_KEEP_RECENT_SCREENSHOTS = 6


### PR DESCRIPTION
## Summary

`Callable`, `Iterable`, `Iterator`, `Mapping`, and `Sequence` have been deprecated as `typing` aliases since Python 3.9 (PEP 585), with the canonical home being `collections.abc`. This PR moves those imports to `collections.abc` across the SDK.

Files updated:
- `yutori/_async/chat.py` — `Iterable`
- `yutori/_sync/chat.py` — `Iterable`
- `yutori/navigator/loop.py` — `Iterable`
- `yutori/navigator/payload.py` — `Callable`
- `yutori/navigator/coordinates.py` — `Sequence`
- `yutori/cli/commands/__init__.py` — `Iterator`
- `yutori/cli/commands/install_flow.py` — `Mapping`, `Sequence`
- `yutori/auth/flow.py` — `Callable`

## Safety

- Import-only, behavior-preserving change.
- PEP 585 makes the `collections.abc` forms subscriptable at runtime since Python 3.9, matching the package's `requires-python = ">=3.9"`. The change is therefore safe across the full 3.9–3.13 CI matrix, regardless of whether a module uses `from __future__ import annotations`.
- `ruff check .` passes (including import-order rule `I`).
- Verified the edited modules parse and `coordinates.py` runs correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Gttj2hC9K3D8KfzchL1sQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only, behavior-preserving change aligned with the package’s Python ≥3.9 support; no logic or API surface changes.
> 
> **Overview**
> Updates type-only imports to follow **PEP 585**: abstract collection types that were deprecated on `typing` since Python 3.9 now come from **`collections.abc`** instead.
> 
> Touched areas include sync/async **chat** completions (`Iterable`), **Navigator** helpers (`Iterable`, `Callable`, `Sequence`), **OAuth login** (`Callable`), and **CLI** install/error helpers (`Iterator`, `Mapping`, `Sequence`). Annotations and call sites are unchanged; only import lines were split or rewired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 926aa28c5207da4d76ba458e0c45636f5dfbeb1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->