### PR TITLE
docs: add APIConnectionError to api.md

### DIFF
--- a/api.md
+++ b/api.md
@@ -6,7 +6,7 @@ A dense reference to everything the Yutori Python SDK and CLI expose. The [READM
 
 | Import | Purpose |
 |--------|---------|
-| `yutori` | Clients (`YutoriClient`, `AsyncYutoriClient`) and exceptions (`APIError`, `AuthenticationError`, `YutoriSDKError`) |
+| `yutori` | Clients (`YutoriClient`, `AsyncYutoriClient`) and exceptions (`APIError`, `APIConnectionError`, `AuthenticationError`, `YutoriSDKError`) |
 | `yutori.navigator` | Agent-loop helpers for the Navigator API (Navigator n1 / Navigator n1.5 chat completions) |
 | `yutori.navigator.tools` | Packaged JavaScript reference implementations for the Navigator n1.5 expanded browser tools |
 
@@ -15,13 +15,14 @@ All SDK calls go through `YutoriClient` / `AsyncYutoriClient`. The Navigator hel
 ## Exceptions
 
 ```python
-from yutori import YutoriSDKError, AuthenticationError, APIError
+from yutori import YutoriSDKError, AuthenticationError, APIConnectionError, APIError
 ```
 
 | Exception | Description |
 |-----------|-------------|
 | `YutoriSDKError` | Base class for all Yutori SDK errors. |
 | `AuthenticationError` | Raised on HTTP 401/403 and when no API key can be resolved. |
+| `APIConnectionError` | Raised when the API cannot be reached (connection refused, DNS failure, timeout). |
 | `APIError` | Raised for other non-2xx responses. Attributes: `status_code: int`, `message: str`, `response: httpx.Response \| None`. |
 
 `client.chat` is backed by the OpenAI Python SDK, so HTTP errors from that path surface as `openai.OpenAIError` subclasses (e.g. `openai.APIError`, `openai.RateLimitError`), not wrapped into `yutori` exceptions.
@@ -603,13 +604,15 @@ Optional extras:
 ## Error handling example
 
 ```python
-from yutori import YutoriClient, APIError, AuthenticationError
+from yutori import YutoriClient, APIError, APIConnectionError, AuthenticationError
 
 try:
     client = YutoriClient(api_key="invalid-key")
     client.get_usage()
 except AuthenticationError as e:
     print(f"Invalid API key: {e}")
+except APIConnectionError as e:
+    print(f"Connection failed: {e}")
 except APIError as e:
     print(f"API error (status {e.status_code}): {e.message}")
 ```


### PR DESCRIPTION
## Summary

- Add `APIConnectionError` to package layout table, exceptions import example, exceptions table, and error handling example in `api.md`

## Context

`APIConnectionError` was added as a public exception in v0.8.0 (commit 91b2c21) and the README was updated in PR #132, but `api.md` was not updated to match. Four locations in `api.md` were missing the new exception.

## Test plan

- [ ] Documentation-only change
- [ ] Verify `APIConnectionError` exists in `yutori/__init__.py` `__all__` and `yutori/exceptions.py`

https://claude.ai/code/session_017tT6zLgHsBWT8er2aBf4Bz

---
_Generated by [Claude Code](https://claude.ai/code/session_017tT6zLgHsBWT8er2aBf4Bz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Brings **`api.md`** in line with the public **`APIConnectionError`** exception (already exported from `yutori` since v0.8.0).
> 
> The package layout table, exceptions import snippet, exceptions reference table, and the error-handling example now include **`APIConnectionError`**, with a short note that it is raised when the API cannot be reached (connection refused, DNS failure, timeout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06a6ca3f4b9d4dc3ee023bf25b9c49cdc692630f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->