### PR TITLE
Extract _prepare_trimmed_messages() to prevent create_trimmed/acreate_trimmed drift

### DIFF
--- a/yutori/navigator/loop.py
+++ b/yutori/navigator/loop.py
@@ -74,6 +74,16 @@ def update_trimmed_history(
     return request_messages, size_bytes, removed
 
 
+def _prepare_trimmed_messages(
+    messages: list[dict[str, Any]],
+    *,
+    max_bytes: int = DEFAULT_MAX_REQUEST_BYTES,
+    keep_recent: int = DEFAULT_KEEP_RECENT_SCREENSHOTS,
+) -> list[dict[str, Any]]:
+    trimmed_messages, _, _ = trimmed_messages_to_fit(messages, max_bytes=max_bytes, keep_recent=keep_recent)
+    return trimmed_messages
+
+
 def create_trimmed(
     completions: SupportsSyncChatCompletionsCreate,
     messages: list[dict[str, Any]],
@@ -84,13 +94,11 @@ def create_trimmed(
     **kwargs: Any,
 ) -> ChatCompletion:
     """Create a sync chat completion from a trimmed copy of *messages*."""
-
-    trimmed_messages, _, _ = trimmed_messages_to_fit(
-        messages,
-        max_bytes=max_bytes,
-        keep_recent=keep_recent,
+    return completions.create(
+        _prepare_trimmed_messages(messages, max_bytes=max_bytes, keep_recent=keep_recent),
+        model=model,
+        **kwargs,
     )
-    return completions.create(trimmed_messages, model=model, **kwargs)
 
 
 async def acreate_trimmed(
@@ -103,10 +111,8 @@ async def acreate_trimmed(
     **kwargs: Any,
 ) -> ChatCompletion:
     """Create an async chat completion from a trimmed copy of *messages*."""
-
-    trimmed_messages, _, _ = trimmed_messages_to_fit(
-        messages,
-        max_bytes=max_bytes,
-        keep_recent=keep_recent,
+    return await completions.create(
+        _prepare_trimmed_messages(messages, max_bytes=max_bytes, keep_recent=keep_recent),
+        model=model,
+        **kwargs,
     )
-    return await completions.create(trimmed_messages, model=model, **kwargs)


### PR DESCRIPTION
## Summary
- `create_trimmed` and `acreate_trimmed` both called `trimmed_messages_to_fit` with identical arguments and discarded the same return values — if the trim logic ever needs updating, both functions need the same edit
- Extracted the shared trim step into `_prepare_trimmed_messages()`, a private pure function that both callers delegate to
- No behavioral change — identical on-wire messages, same parameters

## Why it's safe
Pure extraction of identical code. Both functions produce the same `trimmed_messages` list as before. No public API changes.

## Test plan
- [ ] Verify `_prepare_trimmed_messages` returns the same list as the previous inline `trimmed_messages_to_fit` call
- [ ] `create_trimmed` and `acreate_trimmed` still pass trimmed messages to `completions.create`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNq3dKtqFdXTXjWjz1W5Gk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with identical trim parameters and outputs; no public API or runtime behavior changes.
> 
> **Overview**
> **Refactors** `create_trimmed` and `acreate_trimmed` in `loop.py` so they no longer each inline the same `trimmed_messages_to_fit` call.
> 
> A new private helper **`_prepare_trimmed_messages`** runs that trim step once (same `max_bytes` / `keep_recent` defaults) and returns only the message list; both completion helpers pass its result to `completions.create`. **No public API or on-wire behavior change**—only deduplication to avoid sync/async drift when trim logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35d7b12810e320d64586943319fe9a382e130f34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->