### PR TITLE
feat: list browsing & research tasks (+ cursor pagination on scouts.list)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ print(result)
 
 Common options: `require_auth=True` for login flows, `browser="local"` for Yutori Local, `webhook_url=...` for async completion notifications. Failed tasks may include a `rejection_reason`.
 
+`client.browsing.list()` enumerates your browsing tasks — omit `limit` to get them all, or pass `status` (`running`/`succeeded`/`failed`) and `cursor` to filter and paginate.
+
 ### Structured output
 
 Define the output structure with a JSON Schema dict or a Pydantic model:
@@ -240,6 +242,14 @@ while True:
 ```
 
 Failed tasks may include a `rejection_reason`.
+
+`client.research.list()` enumerates your research tasks — handy for exporting or recovering task IDs from a large batch. Omit `limit` to get them all, or pass `status` / `cursor` to filter and paginate:
+
+```python
+completed = client.research.list(status="succeeded")
+for t in completed["tasks"]:
+    print(t["task_id"], t["created_at"])
+```
 
 ## Scouting API
 

--- a/api.md
+++ b/api.md
@@ -181,8 +181,22 @@ One-time browser automation on Yutori's cloud browser or on Yutori Local.
 
 | Method | HTTP | Endpoint | Returns |
 |--------|------|----------|---------|
+| `client.browsing.list(*, limit=None, status=None, cursor=None)` | GET | `/v1/browsing/tasks` | `dict` |
 | `client.browsing.create(task, start_url, *, max_steps=None, agent=None, require_auth=None, browser=None, output_schema=None, webhook_url=None, webhook_format=None)` | POST | `/v1/browsing/tasks` | `dict` |
 | `client.browsing.get(task_id)` | GET | `/v1/browsing/tasks/{task_id}` | `dict` |
+
+#### `browsing.list`
+
+```python
+tasks = client.browsing.list(limit=20, status="succeeded")
+```
+
+**Parameters:**
+- `limit` (`int`, optional): Max tasks to return. Mapped to the API's `page_size` query param. If omitted, returns all browsing tasks.
+- `status` (`str`, optional): Filter by `"running"`, `"succeeded"`, or `"failed"`.
+- `cursor` (`str`, optional): Pagination cursor from a previous response's `next_cursor`/`prev_cursor`.
+
+**Returns:** Dict with a `tasks` list plus `total`, `filtered_total`, `summary` counts, `has_more`, and `next_cursor`/`prev_cursor`. The list `status` is a lightweight value derived without a live workflow lookup, so `"running"` also covers queued and not-yet-reconciled tasks — call `browsing.get(task_id)` for the authoritative per-task status.
 
 #### `browsing.create`
 
@@ -227,8 +241,22 @@ Deep web research using 100+ MCP tools.
 
 | Method | HTTP | Endpoint | Returns |
 |--------|------|----------|---------|
+| `client.research.list(*, limit=None, status=None, cursor=None)` | GET | `/v1/research/tasks` | `dict` |
 | `client.research.create(query, *, user_timezone=None, user_location=None, output_schema=None, webhook_url=None, webhook_format=None)` | POST | `/v1/research/tasks` | `dict` |
 | `client.research.get(task_id)` | GET | `/v1/research/tasks/{task_id}` | `dict` |
+
+#### `research.list`
+
+```python
+tasks = client.research.list(limit=20, status="succeeded")
+```
+
+**Parameters:**
+- `limit` (`int`, optional): Max tasks to return. Mapped to the API's `page_size` query param. If omitted, returns all research tasks.
+- `status` (`str`, optional): Filter by `"running"`, `"succeeded"`, or `"failed"`.
+- `cursor` (`str`, optional): Pagination cursor from a previous response's `next_cursor`/`prev_cursor`.
+
+**Returns:** Dict with a `tasks` list plus `total`, `filtered_total`, `summary` counts, `has_more`, and `next_cursor`/`prev_cursor`. The list `status` is a lightweight value derived without a live workflow lookup, so `"running"` also covers queued and not-yet-reconciled tasks — call `research.get(task_id)` for the authoritative per-task status.
 
 #### `research.create`
 
@@ -259,7 +287,7 @@ Recurring web-monitoring scouts.
 
 | Method | HTTP | Endpoint | Returns |
 |--------|------|----------|---------|
-| `client.scouts.list(*, limit=None, status=None)` | GET | `/v1/scouting/tasks` | `dict` |
+| `client.scouts.list(*, limit=None, status=None, cursor=None)` | GET | `/v1/scouting/tasks` | `dict` |
 | `client.scouts.get(scout_id)` | GET | `/v1/scouting/tasks/{scout_id}` | `dict` |
 | `client.scouts.create(query, *, output_interval=86400, start_timestamp=None, user_timezone=None, user_location=None, output_schema=None, skip_email=None, webhook_url=None, webhook_format=None, is_public=None)` | POST | `/v1/scouting/tasks` | `dict` |
 | `client.scouts.update(scout_id, *, query=None, status=None, output_interval=None, user_timezone=None, user_location=None, output_schema=None, skip_email=None, webhook_url=None, webhook_format=None, is_public=None)` | PATCH or POST (status endpoints) | `/v1/scouting/tasks/{scout_id}` or `.../pause|resume|done` | `dict` |
@@ -275,6 +303,7 @@ scouts = client.scouts.list(limit=20, status="active")
 **Parameters:**
 - `limit` (`int`, optional): Max scouts to return. Mapped to the API's `page_size` query param.
 - `status` (`str`, optional): `"active"`, `"paused"`, or `"done"`.
+- `cursor` (`str`, optional): Pagination cursor from a previous response's `next_cursor`/`prev_cursor`.
 
 **Returns:** Dict containing `scouts` list and pagination info.
 
@@ -557,6 +586,7 @@ Installed as `yutori` (via the `yutori` script entry point). Run any command wit
 
 | Command | Description |
 |---------|-------------|
+| `yutori browse list [--limit N] [--status running\|succeeded\|failed] [--cursor C]` | List browsing tasks (rich table). If `--limit` is omitted, returns all tasks. |
 | `yutori browse run TASK START_URL [--max-steps N] [--agent NAME] [--require-auth] [--browser cloud\|local]` | Submit a browsing task. Exit code 1 if the API rejects the task (`status: failed`). |
 | `yutori browse get TASK_ID` | Get status and result (truncates output to 2000 chars). |
 
@@ -564,6 +594,7 @@ Installed as `yutori` (via the `yutori` script entry point). Run any command wit
 
 | Command | Description |
 |---------|-------------|
+| `yutori research list [--limit N] [--status running\|succeeded\|failed] [--cursor C]` | List research tasks (rich table). If `--limit` is omitted, returns all tasks. |
 | `yutori research run QUERY [--timezone/-tz TZ] [--location LOC]` | Submit a research task. Exit code 1 if the API rejects the task (`status: failed`). |
 | `yutori research get TASK_ID` | Get status and result (truncates output to 2000 chars). |
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.8.0"
+YUTORI_INSTALLER_VERSION="0.8.1"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.8.0"
+version = "0.8.1"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -75,6 +75,19 @@ class TestAsyncScoutsNamespace:
                 assert "limit" not in params
                 assert params["status"] == "active"
 
+    async def test_scouts_list_forwards_cursor(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"scouts": []}'
+        mock_response.json.return_value = {"scouts": []}
+
+        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
+            async with AsyncYutoriClient(api_key="yt-test") as client:
+                await client.scouts.list(cursor="next-page")
+                params = mock_get.call_args[1]["params"]
+                assert params["cursor"] == "next-page"
+                assert "page_size" not in params
+
     async def test_scouts_get(self):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
@@ -161,6 +174,23 @@ class TestAsyncScoutsNamespace:
 
 @pytest.mark.asyncio
 class TestAsyncBrowsingNamespace:
+    async def test_browsing_list(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"tasks": [], "total": 0}'
+        mock_response.json.return_value = {"tasks": [], "total": 0}
+
+        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
+            async with AsyncYutoriClient(api_key="yt-test") as client:
+                result = await client.browsing.list(limit=20, status="succeeded", cursor="cur-1")
+                assert result == {"tasks": [], "total": 0}
+                assert mock_get.call_args[0][0].endswith("/browsing/tasks")
+                params = mock_get.call_args[1]["params"]
+                assert params["page_size"] == 20
+                assert "limit" not in params
+                assert params["status"] == "succeeded"
+                assert params["cursor"] == "cur-1"
+
     async def test_browsing_create(self):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
@@ -228,6 +258,23 @@ class TestAsyncBrowsingNamespace:
 
 @pytest.mark.asyncio
 class TestAsyncResearchNamespace:
+    async def test_research_list(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"tasks": [], "total": 0}'
+        mock_response.json.return_value = {"tasks": [], "total": 0}
+
+        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
+            async with AsyncYutoriClient(api_key="yt-test") as client:
+                result = await client.research.list(limit=20, status="succeeded", cursor="cur-1")
+                assert result == {"tasks": [], "total": 0}
+                assert mock_get.call_args[0][0].endswith("/research/tasks")
+                params = mock_get.call_args[1]["params"]
+                assert params["page_size"] == 20
+                assert "limit" not in params
+                assert params["status"] == "succeeded"
+                assert params["cursor"] == "cur-1"
+
     async def test_research_create(self):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
@@ -585,9 +632,7 @@ class TestAsyncTransportErrorWrapping:
     async def test_connect_error_wrapped(self):
         from yutori.exceptions import APIConnectionError
 
-        with patch.object(
-            httpx.AsyncClient, "get", new_callable=AsyncMock, side_effect=httpx.ConnectError("refused")
-        ):
+        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, side_effect=httpx.ConnectError("refused")):
             async with AsyncYutoriClient(api_key="yt-test") as client:
                 with pytest.raises(APIConnectionError, match="ConnectError.*refused"):
                     await client.scouts.list()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -245,6 +245,24 @@ def test_research_list_forwards_limit_and_cursor():
     assert "No research tasks found" in result.stdout
 
 
+def test_browse_list_empty_filter_still_shows_summary():
+    # A status filter with no matches should still surface the account totals,
+    # not just a bare "no tasks found".
+    client = _make_client_mock()
+    client.browsing.list.return_value = {
+        "tasks": [],
+        "total": 163,
+        "summary": {"running": 0, "succeeded": 162, "failed": 1},
+    }
+
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["browse", "list", "--status", "running"])
+
+    assert result.exit_code == 0
+    assert "No browsing tasks found" in result.stdout
+    assert "163 total: 0 running, 162 succeeded, 1 failed." in result.stdout
+
+
 def test_browse_list_shows_next_cursor_when_more_results():
     client = _make_client_mock()
     client.browsing.list.return_value = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -206,9 +206,114 @@ def test_scouts_list_shows_rejection_reason_column():
     client.close.assert_called_once()
 
 
+def test_browse_list_renders_tasks_and_summary():
+    client = _make_client_mock()
+    client.browsing.list.return_value = {
+        "tasks": [
+            {
+                "task_id": "task-1",
+                "query": "extract employees",
+                "status": "succeeded",
+                "created_at": "2026-06-25T21:13:08+00:00",
+            }
+        ],
+        "total": 1,
+        "summary": {"running": 0, "succeeded": 1, "failed": 0},
+        "has_more": False,
+    }
+
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["browse", "list", "--status", "succeeded"])
+
+    assert result.exit_code == 0
+    client.browsing.list.assert_called_once_with(limit=None, status="succeeded", cursor=None)
+    assert "task-1" in result.stdout
+    # Assert the full summary line, not just a substring that could appear elsewhere.
+    assert "1 total: 0 running, 1 succeeded, 0 failed." in result.stdout
+    client.close.assert_called_once()
+
+
+def test_research_list_forwards_limit_and_cursor():
+    client = _make_client_mock()
+    client.research.list.return_value = {"tasks": []}
+
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["research", "list", "--limit", "5", "--cursor", "cur-2"])
+
+    assert result.exit_code == 0
+    client.research.list.assert_called_once_with(limit=5, status=None, cursor="cur-2")
+    assert "No research tasks found" in result.stdout
+
+
+def test_browse_list_shows_next_cursor_when_more_results():
+    client = _make_client_mock()
+    client.browsing.list.return_value = {
+        "tasks": [{"task_id": "t1", "query": "q", "status": "running"}],
+        "total": 2,
+        "summary": {"running": 2, "succeeded": 0, "failed": 0},
+        "has_more": True,
+        "next_cursor": "next-cur",
+    }
+
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["browse", "list", "--limit", "1"])
+
+    assert result.exit_code == 0
+    assert "next-cur" in result.stdout
+
+
+def test_browse_list_without_summary_omits_totals_line():
+    # The summary/totals line is gated behind `if summary:`; a response with tasks
+    # but no summary must still render the table without a misleading totals line.
+    client = _make_client_mock()
+    client.browsing.list.return_value = {
+        "tasks": [{"task_id": "task-9", "query": "q", "status": "running"}]
+    }
+
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["browse", "list"])
+
+    assert result.exit_code == 0
+    assert "task-9" in result.stdout
+    assert " total:" not in result.stdout
+
+
 # ---------------------------------------------------------------------------
 # Rich markup safety: API/user strings must render literally, never parse.
 # ---------------------------------------------------------------------------
+
+
+def test_browse_list_renders_markup_like_queries_literally():
+    client = _make_client_mock()
+    client.browsing.list.return_value = {
+        "tasks": [
+            {"task_id": "t1", "query": "watch [/b] page", "status": "running"},
+        ]
+    }
+
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["browse", "list"])
+
+    # "[/b]" used to crash the whole listing with MarkupError.
+    assert result.exit_code == 0
+    assert "[/b]" in result.stdout
+
+
+def test_browse_list_renders_markup_like_cursor_literally():
+    # next_cursor is printed on a markup-enabled console.print line (not a table cell),
+    # so an untrusted cursor containing markup must be escaped, not parsed.
+    client = _make_client_mock()
+    client.browsing.list.return_value = {
+        "tasks": [{"task_id": "t1", "query": "q", "status": "running"}],
+        "has_more": True,
+        "next_cursor": "abc[/b]def",
+    }
+
+    with patch("yutori.cli.commands.get_authenticated_client", return_value=client):
+        result = runner.invoke(app, ["browse", "list", "--limit", "1"])
+
+    assert result.exit_code == 0
+    assert "abc[/b]def" in result.stdout
 
 
 def test_scouts_list_renders_markup_like_queries_literally():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -112,6 +112,18 @@ class TestScoutsNamespace:
             assert "limit" not in params
             assert params["status"] == "active"
 
+    def test_scouts_list_forwards_cursor(self, client):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"scouts": []}'
+        mock_response.json.return_value = {"scouts": []}
+
+        with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
+            client.scouts.list(cursor="next-page")
+            params = mock_get.call_args[1]["params"]
+            assert params["cursor"] == "next-page"
+            assert "page_size" not in params
+
     def test_scouts_get(self, client):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
@@ -207,6 +219,33 @@ class TestScoutsNamespace:
 
 
 class TestBrowsingNamespace:
+    def test_browsing_list(self, client):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"tasks": [], "total": 0}'
+        mock_response.json.return_value = {"tasks": [], "total": 0}
+
+        with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
+            result = client.browsing.list(limit=20, status="succeeded", cursor="cur-1")
+            assert result == {"tasks": [], "total": 0}
+            mock_get.assert_called_once()
+            assert mock_get.call_args[0][0].endswith("/browsing/tasks")
+            params = mock_get.call_args[1]["params"]
+            assert params["page_size"] == 20
+            assert "limit" not in params
+            assert params["status"] == "succeeded"
+            assert params["cursor"] == "cur-1"
+
+    def test_browsing_list_no_args_sends_empty_params(self, client):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"tasks": []}'
+        mock_response.json.return_value = {"tasks": []}
+
+        with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
+            client.browsing.list()
+            assert mock_get.call_args[1]["params"] == {}
+
     def test_browsing_create(self, client):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
@@ -274,6 +313,33 @@ class TestBrowsingNamespace:
 
 
 class TestResearchNamespace:
+    def test_research_list(self, client):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"tasks": [], "total": 0}'
+        mock_response.json.return_value = {"tasks": [], "total": 0}
+
+        with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
+            result = client.research.list(limit=20, status="succeeded", cursor="cur-1")
+            assert result == {"tasks": [], "total": 0}
+            mock_get.assert_called_once()
+            assert mock_get.call_args[0][0].endswith("/research/tasks")
+            params = mock_get.call_args[1]["params"]
+            assert params["page_size"] == 20
+            assert "limit" not in params
+            assert params["status"] == "succeeded"
+            assert params["cursor"] == "cur-1"
+
+    def test_research_list_no_args_sends_empty_params(self, client):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.content = b'{"tasks": []}'
+        mock_response.json.return_value = {"tasks": []}
+
+        with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
+            client.research.list()
+            assert mock_get.call_args[1]["params"] == {}
+
     def test_research_create(self, client):
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200

--- a/yutori/_async/browsing.py
+++ b/yutori/_async/browsing.py
@@ -4,11 +4,40 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._http import _AsyncBaseNamespace, build_payload_with_schema
+from .._http import _AsyncBaseNamespace, build_payload_with_schema, build_query_params
 
 
 class AsyncBrowsingNamespace(_AsyncBaseNamespace):
     """Async namespace for browsing operations (one-time browser automation)."""
+
+    async def list(
+        self,
+        *,
+        limit: int | None = None,
+        status: str | None = None,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """List browsing tasks for the authenticated user.
+
+        Args:
+            limit: Maximum number of tasks to return. If omitted, returns all
+                browsing tasks.
+            status: Filter by status ("running", "succeeded", "failed"). This
+                lightweight status is derived from stored task state without a
+                live workflow lookup, so "running" also covers queued tasks and
+                tasks whose workflow finished but isn't yet reconciled; call
+                ``get(task_id)`` for the authoritative per-task status.
+            cursor: Pagination cursor from a previous response's ``next_cursor``
+                or ``prev_cursor``.
+
+        Returns:
+            Dictionary with a ``tasks`` list plus ``total``, ``filtered_total``,
+            ``summary`` counts, ``has_more``, and ``next_cursor`` / ``prev_cursor``
+            pagination info.
+        """
+        # API pagination parameter is `page_size`; keep `limit` for SDK ergonomics.
+        params = build_query_params(page_size=limit, status=status, cursor=cursor)
+        return await self._request("get", "/browsing/tasks", params=params)
 
     async def create(
         self,

--- a/yutori/_async/research.py
+++ b/yutori/_async/research.py
@@ -4,11 +4,40 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._http import _AsyncBaseNamespace, build_payload_with_schema
+from .._http import _AsyncBaseNamespace, build_payload_with_schema, build_query_params
 
 
 class AsyncResearchNamespace(_AsyncBaseNamespace):
     """Async namespace for research operations (one-time deep web research)."""
+
+    async def list(
+        self,
+        *,
+        limit: int | None = None,
+        status: str | None = None,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """List research tasks for the authenticated user.
+
+        Args:
+            limit: Maximum number of tasks to return. If omitted, returns all
+                research tasks.
+            status: Filter by status ("running", "succeeded", "failed"). This
+                lightweight status is derived from stored task state without a
+                live workflow lookup, so "running" also covers queued tasks and
+                tasks whose workflow finished but isn't yet reconciled; call
+                ``get(task_id)`` for the authoritative per-task status.
+            cursor: Pagination cursor from a previous response's ``next_cursor``
+                or ``prev_cursor``.
+
+        Returns:
+            Dictionary with a ``tasks`` list plus ``total``, ``filtered_total``,
+            ``summary`` counts, ``has_more``, and ``next_cursor`` / ``prev_cursor``
+            pagination info.
+        """
+        # API pagination parameter is `page_size`; keep `limit` for SDK ergonomics.
+        params = build_query_params(page_size=limit, status=status, cursor=cursor)
+        return await self._request("get", "/research/tasks", params=params)
 
     async def create(
         self,

--- a/yutori/_async/scouts.py
+++ b/yutori/_async/scouts.py
@@ -20,18 +20,21 @@ class AsyncScoutsNamespace(_AsyncBaseNamespace):
         *,
         limit: int | None = None,
         status: str | None = None,
+        cursor: str | None = None,
     ) -> dict[str, Any]:
         """List scouts for the authenticated user.
 
         Args:
             limit: Maximum number of scouts to return.
             status: Filter by status ("active", "paused", "done").
+            cursor: Pagination cursor from a previous response's ``next_cursor``
+                or ``prev_cursor``.
 
         Returns:
-            Dictionary containing list of scouts.
+            Dictionary containing list of scouts and pagination info.
         """
         # API pagination parameter is `page_size`; keep `limit` for SDK ergonomics.
-        params = build_query_params(page_size=limit, status=status)
+        params = build_query_params(page_size=limit, status=status, cursor=cursor)
         return await self._request("get", "/scouting/tasks", params=params)
 
     async def get(self, scout_id: str) -> dict[str, Any]:

--- a/yutori/_sync/browsing.py
+++ b/yutori/_sync/browsing.py
@@ -4,11 +4,40 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._http import _SyncBaseNamespace, build_payload_with_schema
+from .._http import _SyncBaseNamespace, build_payload_with_schema, build_query_params
 
 
 class BrowsingNamespace(_SyncBaseNamespace):
     """Namespace for browsing operations (one-time browser automation)."""
+
+    def list(
+        self,
+        *,
+        limit: int | None = None,
+        status: str | None = None,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """List browsing tasks for the authenticated user.
+
+        Args:
+            limit: Maximum number of tasks to return. If omitted, returns all
+                browsing tasks.
+            status: Filter by status ("running", "succeeded", "failed"). This
+                lightweight status is derived from stored task state without a
+                live workflow lookup, so "running" also covers queued tasks and
+                tasks whose workflow finished but isn't yet reconciled; call
+                ``get(task_id)`` for the authoritative per-task status.
+            cursor: Pagination cursor from a previous response's ``next_cursor``
+                or ``prev_cursor``.
+
+        Returns:
+            Dictionary with a ``tasks`` list plus ``total``, ``filtered_total``,
+            ``summary`` counts, ``has_more``, and ``next_cursor`` / ``prev_cursor``
+            pagination info.
+        """
+        # API pagination parameter is `page_size`; keep `limit` for SDK ergonomics.
+        params = build_query_params(page_size=limit, status=status, cursor=cursor)
+        return self._request("get", "/browsing/tasks", params=params)
 
     def create(
         self,

--- a/yutori/_sync/research.py
+++ b/yutori/_sync/research.py
@@ -4,11 +4,40 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._http import _SyncBaseNamespace, build_payload_with_schema
+from .._http import _SyncBaseNamespace, build_payload_with_schema, build_query_params
 
 
 class ResearchNamespace(_SyncBaseNamespace):
     """Namespace for research operations (one-time deep web research)."""
+
+    def list(
+        self,
+        *,
+        limit: int | None = None,
+        status: str | None = None,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """List research tasks for the authenticated user.
+
+        Args:
+            limit: Maximum number of tasks to return. If omitted, returns all
+                research tasks.
+            status: Filter by status ("running", "succeeded", "failed"). This
+                lightweight status is derived from stored task state without a
+                live workflow lookup, so "running" also covers queued tasks and
+                tasks whose workflow finished but isn't yet reconciled; call
+                ``get(task_id)`` for the authoritative per-task status.
+            cursor: Pagination cursor from a previous response's ``next_cursor``
+                or ``prev_cursor``.
+
+        Returns:
+            Dictionary with a ``tasks`` list plus ``total``, ``filtered_total``,
+            ``summary`` counts, ``has_more``, and ``next_cursor`` / ``prev_cursor``
+            pagination info.
+        """
+        # API pagination parameter is `page_size`; keep `limit` for SDK ergonomics.
+        params = build_query_params(page_size=limit, status=status, cursor=cursor)
+        return self._request("get", "/research/tasks", params=params)
 
     def create(
         self,

--- a/yutori/_sync/scouts.py
+++ b/yutori/_sync/scouts.py
@@ -20,18 +20,21 @@ class ScoutsNamespace(_SyncBaseNamespace):
         *,
         limit: int | None = None,
         status: str | None = None,
+        cursor: str | None = None,
     ) -> dict[str, Any]:
         """List scouts for the authenticated user.
 
         Args:
             limit: Maximum number of scouts to return.
             status: Filter by status ("active", "paused", "done").
+            cursor: Pagination cursor from a previous response's ``next_cursor``
+                or ``prev_cursor``.
 
         Returns:
-            Dictionary containing list of scouts.
+            Dictionary containing list of scouts and pagination info.
         """
         # API pagination parameter is `page_size`; keep `limit` for SDK ergonomics.
-        params = build_query_params(page_size=limit, status=status)
+        params = build_query_params(page_size=limit, status=status, cursor=cursor)
         return self._request("get", "/scouting/tasks", params=params)
 
     def get(self, scout_id: str) -> dict[str, Any]:

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -254,42 +254,43 @@ def print_task_list(console: Console, task_type: str, result: dict[str, Any]) ->
     """Render a browsing/research task-list response as a Rich table.
 
     Shared by ``yutori browse list`` and ``yutori research list``: both render
-    the identical task-list response shape, differing only by the title. Below
-    the table it prints status-count totals and a ``--cursor`` hint when more
-    results remain, so the enumerate-all workflow is discoverable from the CLI.
-    Every cell goes through ``safe_str`` so API strings render literally.
+    the identical task-list response shape, differing only by the title. The
+    status-count totals and the ``--cursor`` hint print even when the page is
+    empty, so a status filter with no matches still surfaces the account's
+    totals in other statuses (rather than a bare "no tasks found"). Every cell
+    goes through ``safe_str`` so API strings render literally.
     """
     tasks = result.get("tasks", [])
-    if not tasks:
+
+    if tasks:
+        table = Table(title=f"Your {task_type} Tasks")
+        table.add_column("Task ID", style="cyan", no_wrap=True)
+        table.add_column("Query", max_width=50)
+        table.add_column("Status", style="green")
+        table.add_column("Created")
+        table.add_column("Reason", max_width=32)
+
+        for task in tasks:
+            # The list endpoint returns the prompt under `query` for both task types
+            # (browse create takes it as `task`).
+            query = str(task.get("query", ""))
+            if len(query) > 47:
+                query = query[:47] + "..."
+
+            # created_at is an ISO-8601 datetime; show just the YYYY-MM-DD date.
+            created = str(task.get("created_at") or "")[:10]
+
+            table.add_row(
+                safe_str(task.get("task_id", "")),
+                safe_str(query),
+                safe_str(task.get("status", "unknown")),
+                safe_str(created),
+                safe_str(task.get("rejection_reason") or ""),
+            )
+
+        console.print(table)
+    else:
         console.print(f"[yellow]No {task_type.lower()} tasks found.[/yellow]")
-        return
-
-    table = Table(title=f"Your {task_type} Tasks")
-    table.add_column("Task ID", style="cyan", no_wrap=True)
-    table.add_column("Query", max_width=50)
-    table.add_column("Status", style="green")
-    table.add_column("Created")
-    table.add_column("Reason", max_width=32)
-
-    for task in tasks:
-        # The list endpoint returns the prompt under `query` for both task types
-        # (browse create takes it as `task`).
-        query = str(task.get("query", ""))
-        if len(query) > 47:
-            query = query[:47] + "..."
-
-        # created_at is an ISO-8601 datetime; show just the YYYY-MM-DD date.
-        created = str(task.get("created_at") or "")[:10]
-
-        table.add_row(
-            safe_str(task.get("task_id", "")),
-            safe_str(query),
-            safe_str(task.get("status", "unknown")),
-            safe_str(created),
-            safe_str(task.get("rejection_reason") or ""),
-        )
-
-    console.print(table)
 
     summary = result.get("summary") or {}
     if summary:

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -10,6 +10,7 @@ import httpx
 import typer
 from rich.console import Console
 from rich.markup import escape
+from rich.table import Table
 
 from yutori.auth.credentials import resolve_api_key
 from yutori.exceptions import APIError, AuthenticationError
@@ -29,6 +30,7 @@ __all__ = [
     "print_optional_field",
     "print_rejection_reason",
     "print_task_get_header",
+    "print_task_list",
     "print_task_result_output",
     "print_task_submission_result",
     "safe_str",
@@ -236,9 +238,7 @@ def print_task_get_header(console: Console, task_type: str, task_id: str, result
     print_rejection_reason(console, result)
 
 
-def print_task_result_output(
-    console: Console, result: dict[str, Any], *, max_length: int = 2000
-) -> None:
+def print_task_result_output(console: Console, result: dict[str, Any], *, max_length: int = 2000) -> None:
     """Print the ``result``/``output`` body of a task, truncated to ``max_length`` chars."""
     output = result.get("result") or result.get("output")
     if not output:
@@ -248,6 +248,62 @@ def print_task_result_output(
     if len(text) > max_length:
         text = text[:max_length] + "\n... (truncated)"
     console.print(text, markup=False)
+
+
+def print_task_list(console: Console, task_type: str, result: dict[str, Any]) -> None:
+    """Render a browsing/research task-list response as a Rich table.
+
+    Shared by ``yutori browse list`` and ``yutori research list``: both render
+    the identical task-list response shape, differing only by the title. Below
+    the table it prints status-count totals and a ``--cursor`` hint when more
+    results remain, so the enumerate-all workflow is discoverable from the CLI.
+    Every cell goes through ``safe_str`` so API strings render literally.
+    """
+    tasks = result.get("tasks", [])
+    if not tasks:
+        console.print(f"[yellow]No {task_type.lower()} tasks found.[/yellow]")
+        return
+
+    table = Table(title=f"Your {task_type} Tasks")
+    table.add_column("Task ID", style="cyan", no_wrap=True)
+    table.add_column("Query", max_width=50)
+    table.add_column("Status", style="green")
+    table.add_column("Created")
+    table.add_column("Reason", max_width=32)
+
+    for task in tasks:
+        # The list endpoint returns the prompt under `query` for both task types
+        # (browse create takes it as `task`).
+        query = str(task.get("query", ""))
+        if len(query) > 47:
+            query = query[:47] + "..."
+
+        # created_at is an ISO-8601 datetime; show just the YYYY-MM-DD date.
+        created = str(task.get("created_at") or "")[:10]
+
+        table.add_row(
+            safe_str(task.get("task_id", "")),
+            safe_str(query),
+            safe_str(task.get("status", "unknown")),
+            safe_str(created),
+            safe_str(task.get("rejection_reason") or ""),
+        )
+
+    console.print(table)
+
+    summary = result.get("summary") or {}
+    if summary:
+        total = result.get("total", len(tasks))
+        console.print(
+            f"\n{safe_str(total)} total: "
+            f"{safe_str(summary.get('running', 0))} running, "
+            f"{safe_str(summary.get('succeeded', 0))} succeeded, "
+            f"{safe_str(summary.get('failed', 0))} failed."
+        )
+
+    next_cursor = result.get("next_cursor")
+    if result.get("has_more") and next_cursor:
+        console.print(f"More results available. Re-run with --cursor {safe_str(next_cursor)}")
 
 
 def format_interval(seconds: int, *, short: bool = False) -> str:

--- a/yutori/cli/commands/browse.py
+++ b/yutori/cli/commands/browse.py
@@ -9,12 +9,25 @@ from yutori.cli.commands import (
     cli_client,
     print_optional_field,
     print_task_get_header,
+    print_task_list,
     print_task_result_output,
     print_task_submission_result,
 )
 
 app = typer.Typer(help="Run and manage browsing tasks")
 console = Console()
+
+
+@app.command("list")
+def list_tasks(
+    limit: int = typer.Option(None, help="Maximum number of tasks to return"),
+    status: str = typer.Option(None, help="Filter by status: running, succeeded, failed"),
+    cursor: str = typer.Option(None, help="Pagination cursor from a previous response"),
+) -> None:
+    """List your browsing tasks."""
+    with cli_client() as client:
+        result = client.browsing.list(limit=limit, status=status, cursor=cursor)
+        print_task_list(console, "Browsing", result)
 
 
 @app.command()

--- a/yutori/cli/commands/research.py
+++ b/yutori/cli/commands/research.py
@@ -9,12 +9,25 @@ from yutori.cli.commands import (
     cli_client,
     print_optional_field,
     print_task_get_header,
+    print_task_list,
     print_task_result_output,
     print_task_submission_result,
 )
 
 app = typer.Typer(help="Run and manage research tasks")
 console = Console()
+
+
+@app.command("list")
+def list_tasks(
+    limit: int = typer.Option(None, help="Maximum number of tasks to return"),
+    status: str = typer.Option(None, help="Filter by status: running, succeeded, failed"),
+    cursor: str = typer.Option(None, help="Pagination cursor from a previous response"),
+) -> None:
+    """List your research tasks."""
+    with cli_client() as client:
+        result = client.research.list(limit=limit, status=status, cursor=cursor)
+        print_task_list(console, "Research", result)
 
 
 @app.command()


### PR DESCRIPTION
## What

Adds client support for the new developer task-list endpoints, so callers can enumerate and recover their one-time task IDs. Previously browsing/research only exposed `create()` and `get(task_id)` — there was no way to list your own tasks.

| Method | Endpoint |
|---|---|
| `client.browsing.list(*, limit=None, status=None, cursor=None)` | `GET /v1/browsing/tasks` |
| `client.research.list(*, limit=None, status=None, cursor=None)` | `GET /v1/research/tasks` |

- Available on both `YutoriClient` and `AsyncYutoriClient`.
- `status` filters by `running` / `succeeded` / `failed`; `cursor` drives keyset pagination (`next_cursor` / `prev_cursor`); omit `limit` to return all tasks.
- `cursor` added to `scouts.list()` too, so all three list methods expose the same pagination.
- CLI: `yutori browse list` and `yutori research list` (paginated rich tables) via a shared `print_task_list` helper.

## Use case

Recovering task IDs after a local data loss — `client.research.list()` enumerates every task, and round-tripping a `task_id` back through `research.get()` re-ingests the results.

```python
for t in client.research.list(status="succeeded")["tasks"]:
    print(t["task_id"], t["created_at"])
```

## Tests & docs

- Sync, async, and CLI tests; full suite green, ruff clean.
- `api.md` and `README.md` updated with the new methods and CLI commands.
- Verified end-to-end against the production API (list shape + list→get round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only list endpoints and CLI output; no changes to create/get auth or mutation paths, with broad test coverage.
> 
> **Overview**
> Adds **read-only task enumeration** for one-time browsing and research work: `client.browsing.list()` and `client.research.list()` on sync and async clients, calling `GET /v1/browsing/tasks` and `GET /v1/research/tasks` with optional `limit` (mapped to `page_size`), `status`, and `cursor` pagination.
> 
> **`scouts.list()`** now accepts the same **`cursor`** parameter so all three list methods share consistent pagination.
> 
> The CLI gains **`yutori browse list`** and **`yutori research list`**, both using a shared **`print_task_list`** helper (Rich table, account summary counts even when a filter returns no rows, `--cursor` hint when `has_more` is true, and **`safe_str`** on API strings to avoid Rich markup crashes).
> 
> Docs (`README.md`, `api.md`) and release version (**0.8.1** in `pyproject.toml` / `install.sh`) are updated; sync, async, and CLI tests cover query forwarding and listing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 287e5e38e18d24e80edd61b0f690c4641e23dd4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->