### PR TITLE
docs(README): add browse list and research list CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,12 +318,16 @@ yutori scouts get SCOUT_ID
 yutori scouts delete SCOUT_ID
 
 # Browsing
+yutori browse list
+yutori browse list --limit 20 --status succeeded
 yutori browse run "extract all prices" https://example.com/products
 yutori browse run "log in and continue" https://example.com/login --require-auth
 yutori browse run "export dashboard data" https://example.com/dashboard --browser local
 yutori browse get TASK_ID
 
 # Research
+yutori research list
+yutori research list --limit 10 --status running
 yutori research run "latest developments in quantum computing" -tz America/Los_Angeles
 yutori research get TASK_ID
 


### PR DESCRIPTION
## Summary
- Add `yutori browse list` and `yutori research list` CLI examples to README (added in #139 but missing from CLI section)

## Test plan
- [ ] Verify CLI commands match actual implementation in the SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xoe1rtCuBugRRxiPE4gNtM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xoe1rtCuBugRRxiPE4gNtM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> The README **CLI** section now documents **`yutori browse list`** and **`yutori research list`**, including optional **`--limit`** and **`--status`** flags, so terminal usage matches list APIs already described elsewhere in the doc (from #139).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c2e886a74e9f733ca77505fb50b455b09056c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->