### PR TITLE
docs(llms.txt): add Navigator API section for coding agents

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -161,7 +161,7 @@ Pass these as keyword args to `client.chat.completions.create(...)`:
 | `json_schema` | JSON Schema dict for structured output. Model returns conforming JSON; accessible as `response.parsed_json`. |
 | `temperature` | Sampling temperature (default 0.3). |
 
-The core action space covers clicks, scroll, type, key press, drag, mouse move/down/up, navigation (`goto_url`, `go_back`, `go_forward`, `refresh`), `wait`, and `hold_key`. Coordinates are in a normalized 1000×1000 space — use `denormalize_coordinates(coords, width, height)` to map to viewport pixels. For the full action reference, see <https://docs.yutori.com/reference/n1-5>.
+The core action space covers clicks, scroll, type, key press, drag, mouse move/down/up, navigation (`goto_url`, `go_back`, `go_forward`, `refresh`), `wait`, and `hold_key`. Coordinates are in a normalized 1000×1000 space — use `denormalize_coordinates(coords, width, height)` to map to viewport pixels. For the full action reference, see <https://docs.yutori.com/reference/n1-5>. For the SDK and CLI reference, see <https://github.com/yutori-ai/yutori-sdk-python/blob/main/api.md>.
 
 For SDK/API integration details, use:
 

--- a/llms.txt
+++ b/llms.txt
@@ -145,34 +145,9 @@ with YutoriClient() as client, sync_playwright() as p:
 
 ### Building an agent loop
 
-The model returns one or more tool calls per turn. For each call:
+In practice you run a loop: execute the returned tool calls on your Playwright `page`, append the results as `tool` messages, capture a fresh screenshot, and call `create()` again until the model returns no tool calls. The `yutori.navigator` subpackage provides helpers for this — screenshot capture, coordinate denormalization (model uses a 1000×1000 space), message trimming, and key mapping.
 
-1. **Execute** the action on your Playwright `page` (click at the denormalized coordinates, type text, scroll, etc.).
-2. **Append** the result as a `{"role": "tool", "tool_call_id": tc.id, "content": [...]}` message.
-3. **Capture** a fresh screenshot and append it to the last user message as an `image_url` part.
-4. **Call** `create()` again with the updated message list.
-
-Stop when the model returns no tool calls (task done) or you hit a step limit. Use `format_stop_and_summarize(task)` to request a final summary when stopping early.
-
-```python
-from yutori.navigator import (
-    playwright_screenshot_to_data_url,
-    denormalize_coordinates,
-    format_task_with_context,
-    format_stop_and_summarize,
-    trimmed_messages_to_fit,
-    map_key_to_playwright,
-)
-
-# Coordinates come back in a normalized 1000×1000 space —
-# map them to your viewport before clicking:
-abs_x, abs_y = denormalize_coordinates([500, 250], width=1280, height=800)
-
-# Trim old screenshots to stay under the API size limit:
-messages, _size, _removed = trimmed_messages_to_fit(
-    messages, max_bytes=9_500_000, keep_recent=6,
-)
-```
+For a complete working agent loop with retries, structured output, and expanded tools, see [`examples/navigator_n1_5.py`](https://github.com/yutori-ai/yutori-sdk-python/blob/main/examples/navigator_n1_5.py).
 
 ### Navigator n1.5 parameters
 
@@ -186,52 +161,7 @@ Pass these as keyword args to `client.chat.completions.create(...)`:
 | `json_schema` | JSON Schema dict for structured output. Model returns conforming JSON; accessible as `response.parsed_json`. |
 | `temperature` | Sampling temperature (default 0.3). |
 
-### `yutori.navigator` helpers
-
-| Helper | Purpose |
-|--------|---------|
-| `playwright_screenshot_to_data_url(page)` / `aplaywright_screenshot_to_data_url(page)` | Capture a Playwright screenshot as a Navigator-optimized WebP data URL (sync / async). |
-| `denormalize_coordinates(coords, width, height)` | Map the model's 1000×1000 coordinate space to viewport pixels. |
-| `format_task_with_context(task, user_timezone=..., user_location=...)` | Append location, timezone, and current date to a task message. |
-| `format_stop_and_summarize(task)` | Produce a "stop and summarize" user message for early termination. |
-| `trimmed_messages_to_fit(messages, max_bytes, keep_recent)` | Drop older screenshots to stay under the API size limit. |
-| `map_key_to_playwright(key)` / `map_keys_individual(keys)` | Convert n1.5 lowercase key names (`ctrl+c`, `enter`) to Playwright format. |
-| `yutori.navigator.tools` | Reference JS implementations for the expanded tools (`extract_elements`, `find`, `set_element_value`, `execute_js`) plus `evaluate_tool_script(page, SCRIPT, *args)`. |
-
-### Core action space
-
-The default tool set (`browser_tools_core-20260403`) exposes 18 coordinate-based tools:
-
-| Action | Key args |
-|--------|----------|
-| `left_click` / `double_click` / `triple_click` / `middle_click` / `right_click` | `coordinates` `[x, y]` (1000×1000 space), optional `ref`, `modifier` |
-| `scroll` | `coordinates`, `direction` (`down`/`up`/`left`/`right`), `amount` (1 unit ≈ 10% screen) |
-| `type` | `text` |
-| `key_press` | `key` (lowercase: `ctrl+c`, `enter`, `down down down enter`) |
-| `drag` | `start_coordinates`, `coordinates` |
-| `mouse_move` / `mouse_down` / `mouse_up` | `coordinates`, optional `ref` |
-| `goto_url` | `url` |
-| `go_back` / `go_forward` / `refresh` / `wait` | — (optional `duration` for `wait`) |
-| `hold_key` | `key`, optional `duration` (seconds) |
-
-### Expanded tools
-
-Switch to `tool_set="browser_tools_expanded-20260403"` to add DOM-based tools. These are executed by evaluating bundled JavaScript against the page via `evaluate_tool_script` from `yutori.navigator.tools`:
-
-| Action | Purpose |
-|--------|---------|
-| `extract_elements` | Extract a structured ARIA-snapshot of the page's elements (returns `pageContent` with `ref` handles). |
-| `find` | Search the page for elements matching text (returns `matches` with `ref` handles). |
-| `set_element_value` | Set an input/textarea/select value directly by `ref`. |
-| `execute_js` | Run arbitrary JavaScript against the page and return the serialized result. |
-
-Refs from `extract_elements`/`find` can be passed as the `ref` arg to click/scroll actions — the model uses them as stable element handles.
-
-### Complete examples and reference
-
-- **Full agent loop**: [`examples/navigator_n1_5.py`](https://github.com/yutori-ai/yutori-sdk-python/blob/main/examples/navigator_n1_5.py) — complete n1.5 loop with retries, replay logging, structured output, expanded tools, and page-ready detection.
-- **SDK and CLI reference**: https://github.com/yutori-ai/yutori-sdk-python/blob/main/api.md
-- **Navigator n1.5 API reference**: https://docs.yutori.com/reference/n1-5 — full action space, key names, and parameter details.
+The core action space covers clicks, scroll, type, key press, drag, mouse move/down/up, navigation (`goto_url`, `go_back`, `go_forward`, `refresh`), `wait`, and `hold_key`. Coordinates are in a normalized 1000×1000 space — use `denormalize_coordinates(coords, width, height)` to map to viewport pixels. For the full action reference, see <https://docs.yutori.com/reference/n1-5>.
 
 For SDK/API integration details, use:
 

--- a/llms.txt
+++ b/llms.txt
@@ -161,7 +161,7 @@ Pass these as keyword args to `client.chat.completions.create(...)`:
 | `json_schema` | JSON Schema dict for structured output. Model returns conforming JSON; accessible as `response.parsed_json`. |
 | `temperature` | Sampling temperature (default 0.3). |
 
-The core action space covers clicks, scroll, type, key press, drag, mouse move/down/up, navigation (`goto_url`, `go_back`, `go_forward`, `refresh`), `wait`, and `hold_key`. Coordinates are in a normalized 1000×1000 space — use `denormalize_coordinates(coords, width, height)` to map to viewport pixels. For the full action reference, see <https://docs.yutori.com/reference/n1-5>. For the SDK and CLI reference, see <https://github.com/yutori-ai/yutori-sdk-python/blob/main/api.md>.
+The core action space covers clicks, scroll, type, key press, drag, mouse move/down/up, navigation (`goto_url`, `go_back`, `go_forward`, `refresh`), `wait`, and `hold_key`. Coordinates are in a normalized 1000×1000 space — use `denormalize_coordinates(coords, width, height)` to map to viewport pixels. For the full action reference, see <https://docs.yutori.com/reference/n1-5>. For the SDK and CLI reference, see the link at the bottom of this file.
 
 For SDK/API integration details, use:
 

--- a/llms.txt
+++ b/llms.txt
@@ -105,6 +105,132 @@ yutori scouts create -q "Tell me about the latest news, product updates, press r
 
 If they decline, skip the Scout demo and end with a recap of Research + Browsing.
 
+## Navigator API
+
+Navigator is Yutori's computer-use model (model id `n1.5-latest`). It is an **OpenAI Chat Completions-compatible endpoint**: you send a screenshot of a web page plus a task instruction, and the model returns **browser actions** as tool calls (`left_click`, `type`, `scroll`, `goto_url`, …). You execute those actions in your own browser (e.g. Playwright), append the results, capture a fresh screenshot, and call again — an **agent loop** — until the model returns a text response with no tool calls.
+
+There is no `yutori` CLI command for Navigator; it is called from Python via `client.chat.completions.create(...)`, which is a drop-in OpenAI-compatible client.
+
+### Minimal single call
+
+```python
+from yutori import YutoriClient
+from yutori.navigator import playwright_screenshot_to_data_url
+from playwright.sync_api import sync_playwright
+
+with YutoriClient() as client, sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page()
+    page.goto("https://www.yutori.com")
+
+    image_url = playwright_screenshot_to_data_url(page)
+
+    response = client.chat.completions.create(
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "List the team member names."},
+                    {"type": "image_url", "image_url": {"url": image_url}},
+                ],
+            }
+        ],
+    )
+
+    message = response.choices[0].message
+    print(message.content)            # model's reasoning / final answer
+    for tc in message.tool_calls or []:
+        print(tc.function.name, tc.function.arguments)
+```
+
+### Building an agent loop
+
+The model returns one or more tool calls per turn. For each call:
+
+1. **Execute** the action on your Playwright `page` (click at the denormalized coordinates, type text, scroll, etc.).
+2. **Append** the result as a `{"role": "tool", "tool_call_id": tc.id, "content": [...]}` message.
+3. **Capture** a fresh screenshot and append it to the last user message as an `image_url` part.
+4. **Call** `create()` again with the updated message list.
+
+Stop when the model returns no tool calls (task done) or you hit a step limit. Use `format_stop_and_summarize(task)` to request a final summary when stopping early.
+
+```python
+from yutori.navigator import (
+    playwright_screenshot_to_data_url,
+    denormalize_coordinates,
+    format_task_with_context,
+    format_stop_and_summarize,
+    trimmed_messages_to_fit,
+    map_key_to_playwright,
+)
+
+# Coordinates come back in a normalized 1000×1000 space —
+# map them to your viewport before clicking:
+abs_x, abs_y = denormalize_coordinates([500, 250], width=1280, height=800)
+
+# Trim old screenshots to stay under the API size limit:
+messages = trimmed_messages_to_fit(messages, max_bytes=9_500_000, keep_recent=6)
+```
+
+### Navigator n1.5 parameters
+
+Pass these as keyword args to `client.chat.completions.create(...)`:
+
+| Parameter | Purpose |
+|-----------|---------|
+| `model` | `"n1.5-latest"` (default) or a dated version like `"n1.5-20260428"`. |
+| `tool_set` | Built-in tool set: `"browser_tools_core-20260403"` (default — 18 coordinate-based tools) or `"browser_tools_expanded-20260403"` (adds `extract_elements`, `find`, `set_element_value`, `execute_js`). |
+| `disable_tools` | Remove specific tools by name, e.g. `["hold_key", "drag"]`. |
+| `json_schema` | JSON Schema dict for structured output. Model returns conforming JSON; accessible as `response.parsed_json`. |
+| `temperature` | Sampling temperature (default 0.3). |
+
+### `yutori.navigator` helpers
+
+| Helper | Purpose |
+|--------|---------|
+| `playwright_screenshot_to_data_url(page)` / `aplaywright_screenshot_to_data_url(page)` | Capture a Playwright screenshot as a Navigator-optimized WebP data URL (sync / async). |
+| `denormalize_coordinates(coords, width, height)` | Map the model's 1000×1000 coordinate space to viewport pixels. |
+| `format_task_with_context(task, user_timezone=..., user_location=...)` | Append location, timezone, and current date to a task message. |
+| `format_stop_and_summarize(task)` | Produce a "stop and summarize" user message for early termination. |
+| `trimmed_messages_to_fit(messages, max_bytes, keep_recent)` | Drop older screenshots to stay under the API size limit. |
+| `map_key_to_playwright(key)` / `map_keys_individual(keys)` | Convert n1.5 lowercase key names (`ctrl+c`, `enter`) to Playwright format. |
+| `yutori.navigator.tools` | Reference JS implementations for the expanded tools (`extract_elements`, `find`, `set_element_value`, `execute_js`) plus `evaluate_tool_script(page, SCRIPT, *args)`. |
+
+### Core action space
+
+The default tool set (`browser_tools_core-20260403`) exposes 18 coordinate-based tools:
+
+| Action | Key args |
+|--------|----------|
+| `left_click` / `double_click` / `triple_click` / `middle_click` / `right_click` | `coordinates` `[x, y]` (1000×1000 space), optional `ref`, `modifier` |
+| `scroll` | `coordinates`, `direction` (`down`/`up`/`left`/`right`), `amount` (1 unit ≈ 10% screen) |
+| `type` | `text` |
+| `key_press` | `key` (lowercase: `ctrl+c`, `enter`, `down down down enter`) |
+| `drag` | `start_coordinates`, `coordinates` |
+| `mouse_move` / `mouse_down` / `mouse_up` | `coordinates`, optional `ref` |
+| `goto_url` | `url` |
+| `go_back` / `go_forward` / `refresh` / `wait` | — (optional `duration` for `wait`) |
+| `hold_key` | `key`, optional `duration` (seconds) |
+
+### Expanded tools
+
+Switch to `tool_set="browser_tools_expanded-20260403"` to add DOM-based tools. These are executed by evaluating bundled JavaScript against the page via `evaluate_tool_script` from `yutori.navigator.tools`:
+
+| Action | Purpose |
+|--------|---------|
+| `extract_elements` | Extract a structured ARIA-snapshot of the page's elements (returns `pageContent` with `ref` handles). |
+| `find` | Search the page for elements matching text (returns `matches` with `ref` handles). |
+| `set_element_value` | Set an input/textarea/select value directly by `ref`. |
+| `execute_js` | Run arbitrary JavaScript against the page and return the serialized result. |
+
+Refs from `extract_elements`/`find` can be passed as the `ref` arg to click/scroll actions — the model uses them as stable element handles.
+
+### Complete examples and reference
+
+- **Full agent loop**: [`examples/navigator_n1_5.py`](https://github.com/yutori-ai/yutori-sdk-python/blob/main/examples/navigator_n1_5.py) — complete n1.5 loop with retries, replay logging, structured output, expanded tools, and page-ready detection.
+- **SDK and CLI reference**: https://github.com/yutori-ai/yutori-sdk-python/blob/main/api.md
+- **Navigator n1.5 API reference**: https://docs.yutori.com/reference/n1-5 — full action space, key names, and parameter details.
+
 For SDK/API integration details, use:
 
 - Python SDK and CLI reference: https://github.com/yutori-ai/yutori-sdk-python/blob/main/api.md

--- a/llms.txt
+++ b/llms.txt
@@ -169,7 +169,9 @@ from yutori.navigator import (
 abs_x, abs_y = denormalize_coordinates([500, 250], width=1280, height=800)
 
 # Trim old screenshots to stay under the API size limit:
-messages = trimmed_messages_to_fit(messages, max_bytes=9_500_000, keep_recent=6)
+messages, _size, _removed = trimmed_messages_to_fit(
+    messages, max_bytes=9_500_000, keep_recent=6,
+)
 ```
 
 ### Navigator n1.5 parameters


### PR DESCRIPTION
## Summary

The `llms.txt` quickstart told coding agents how to install Yutori, run Scout/Research/Browsing demos, and use the SDK for those APIs — but it had **no instructions for calling Navigator**, our computer-use model API. A coding agent following this file would not know Navigator exists or how to use it.

## Changes

Add a `## Navigator API` section to `llms.txt` covering:

- **What Navigator is**: OpenAI Chat Completions-compatible endpoint, model id `n1.5-latest`, screenshot-in → browser actions out
- **Minimal single call**: complete sync Python example with Playwright + `YutoriClient`
- **Agent loop instructions**: the 4-step execute/append/screenshot/repeat pattern, with code showing coordinate denormalization and message trimming
- **n1.5 parameters table**: `model`, `tool_set`, `disable_tools`, `json_schema`, `temperature`
- **`yutori.navigator` helpers table**: all SDK helpers with their purposes
- **Core action space table**: all 18 coordinate-based tools with key args
- **Expanded tools section**: the 4 DOM-based tools (`extract_elements`, `find`, `set_element_value`, `execute_js`) and how refs work
- **Links**: to `examples/navigator_n1_5.py` and the n1.5 API reference docs

## Verification

Content is sourced from the Navigator n1.5 API reference (`docs/reference/n1-5.mdx`), the SDK `yutori/navigator/` module, and `examples/navigator_n1_5.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to llms.txt; no runtime, auth, or API behavior changes.
> 
> **Overview**
> Adds a **`## Navigator API`** section to `llms.txt` so agents following the quickstart learn how to call **Navigator** (`n1.5-latest`), not just Scout, Research, and Browsing.
> 
> The new content explains that Navigator is an **OpenAI Chat Completions–compatible** screenshot-in / browser-actions-out API with **no CLI**—use **`YutoriClient().chat.completions.create(...)`** from Python. It includes a **minimal Playwright + screenshot** example, a short **agent loop** description (execute tool calls, append `tool` messages, re-screenshot, repeat), and a **parameters** table (`model`, `tool_set`, `disable_tools`, `json_schema`, `temperature`) plus notes on **1000×1000 coordinates** and **`denormalize_coordinates`**. It points to **`examples/navigator_n1_5.py`** and the **n1.5 API reference**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 523395bd926d607311fbeda4a5ddd24c9d4af46f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->