### PR TITLE
refactor: extract truncate_for_display CLI helper

### DIFF
--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "print_task_result_output",
     "print_task_submission_result",
     "safe_str",
+    "truncate_for_display",
 ]
 
 SECONDS_PER_MINUTE = 60
@@ -48,6 +49,13 @@ INTERVAL_PRESETS: dict[str, int] = {
 }
 
 _console = Console()
+
+
+def truncate_for_display(text: str, max_len: int = 47) -> str:
+    """Truncate ``text`` to ``max_len`` chars, appending ``...`` when truncated."""
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "..."
 
 
 def safe_str(value: Any) -> str:
@@ -273,9 +281,7 @@ def print_task_list(console: Console, task_type: str, result: dict[str, Any]) ->
         for task in tasks:
             # The list endpoint returns the prompt under `query` for both task types
             # (browse create takes it as `task`).
-            query = str(task.get("query", ""))
-            if len(query) > 47:
-                query = query[:47] + "..."
+            query = truncate_for_display(str(task.get("query", "")))
 
             # created_at is an ISO-8601 datetime; show just the YYYY-MM-DD date.
             created = str(task.get("created_at") or "")[:10]

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -14,6 +14,7 @@ from yutori.cli.commands import (
     print_optional_field,
     print_rejection_reason,
     safe_str,
+    truncate_for_display,
 )
 
 app = typer.Typer(help="Manage scouts")
@@ -44,9 +45,7 @@ def list_scouts(
         for scout in scouts:
             interval_str = format_interval(scout.get("output_interval") or 0, short=True)
 
-            query = str(scout.get("query", ""))
-            if len(query) > 47:
-                query = query[:47] + "..."
+            query = truncate_for_display(str(scout.get("query", "")))
 
             table.add_row(
                 safe_str(scout.get("id", "")),


### PR DESCRIPTION
## Summary

- Extract a shared `truncate_for_display(text, max_len=47)` helper into `yutori/cli/commands/__init__.py`
- Replace identical 3-line query-truncation blocks in `print_task_list` (`__init__.py`) and the scout list command (`scouts.py`) with calls to the new helper
- Export the helper in `__all__` so callers can import it alongside `safe_str`, `format_interval`, etc.

## Motivation

The exact same three lines appeared verbatim in two CLI rendering functions:

```python
query = str(obj.get("query", ""))
if len(query) > 47:
    query = query[:47] + "..."
```

Extracting this into a named helper removes the duplication, makes the truncation threshold discoverable/configurable, and follows the existing pattern of shared CLI utilities in `__init__.py` (e.g. `format_interval`, `safe_str`).

## Test plan

- [ ] `yutori scouts list` still shows truncated queries in the table
- [ ] `yutori browse list` / `yutori research list` still show truncated queries
- Strings shorter than 47 chars are returned unchanged; strings of exactly 48+ chars get `...` appended


---
_Generated by [Claude Code](https://claude.ai/code/session_01L9P14Jyx7HPwX3MJwnnSWC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of display string formatting with no API, auth, or data-handling changes.
> 
> **Overview**
> Introduces a shared **`truncate_for_display(text, max_len=47)`** helper in the CLI commands package and exports it from **`__all__`**, alongside utilities like **`safe_str`** and **`format_interval`**.
> 
> **`print_task_list`** (browse/research list) and the **scout list** command now call this helper instead of duplicating the same 47-character query truncation logic. Display behavior for list tables is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713d78eb19fdecbc8219e20c424fa97ddac2db10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->