### PR TITLE
refactor: extract shared exception-to-returncode mapping in install_flow

### DIFF
--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -184,6 +184,27 @@ def _resolve_env(env: Mapping[str, str] | None) -> Mapping[str, str]:
     return env or os.environ
 
 
+def _synthetic_returncode_for_exception(exc: BaseException) -> int:
+    """Map a caught subprocess-launch exception to a synthetic returncode.
+
+    Shared by ``run_command`` and ``run_interactive_command``, which must
+    classify the same three failure modes (timeout, Ctrl+C, exec failure)
+    into the same module-level ``RETURNCODE_*`` constants. Centralizing the
+    mapping keeps the two call sites' comments from having to cross-reference
+    each other to describe why the catches match.
+
+    Only ``subprocess.TimeoutExpired``, ``KeyboardInterrupt``, and ``OSError``
+    (covering ``FileNotFoundError``, ``PermissionError``, and rarer fork/exec
+    failures like ENOEXEC, EMFILE, ENOMEM) are recognized; callers must not
+    pass any other exception type.
+    """
+    if isinstance(exc, subprocess.TimeoutExpired):
+        return RETURNCODE_TIMEOUT
+    if isinstance(exc, KeyboardInterrupt):
+        return RETURNCODE_CANCELLED
+    return RETURNCODE_EXEC_FAILED
+
+
 def run_command(
     command: Sequence[str],
     *,
@@ -217,18 +238,18 @@ def run_command(
         partial_stderr = _coerce_output_text(exc.stderr)
         return subprocess.CompletedProcess(
             argv,
-            returncode=RETURNCODE_TIMEOUT,
+            returncode=_synthetic_returncode_for_exception(exc),
             stdout=partial_stdout,
             stderr=f"{partial_stderr}\nTimed out after {timeout}s waiting for {format_command(argv)}.",
         )
-    except KeyboardInterrupt:
+    except KeyboardInterrupt as exc:
         # Mirror run_interactive_command: Ctrl+C during a long npx run
         # (no-TTY MCP/skills install can take ~minutes on first network
         # fetch) should yield a "Cancelled" status row instead of
         # aborting the installer before the summary table prints.
         return subprocess.CompletedProcess(
             argv,
-            returncode=RETURNCODE_CANCELLED,
+            returncode=_synthetic_returncode_for_exception(exc),
             stdout="",
             stderr=f"Cancelled by user while running {argv[0]!r}.",
         )
@@ -240,7 +261,7 @@ def run_command(
         # path would have folded into the status table.
         return subprocess.CompletedProcess(
             argv,
-            returncode=RETURNCODE_EXEC_FAILED,
+            returncode=_synthetic_returncode_for_exception(exc),
             stdout="",
             stderr=f"Could not execute {argv[0]!r}: {exc}",
         )
@@ -274,19 +295,22 @@ def run_interactive_command(
             check=False,
             timeout=timeout,
         )
-    except subprocess.TimeoutExpired:
-        return subprocess.CompletedProcess(argv, returncode=RETURNCODE_TIMEOUT, stdout=None, stderr=None)
-    except KeyboardInterrupt:
+    except subprocess.TimeoutExpired as exc:
+        returncode = _synthetic_returncode_for_exception(exc)
+        return subprocess.CompletedProcess(argv, returncode=returncode, stdout=None, stderr=None)
+    except KeyboardInterrupt as exc:
         # Ctrl+C is forwarded to the child via the shared TTY; once it exits,
         # the parent's default SIGINT handler raises here. Convert to a
         # synthetic returncode so callers can render a "Cancelled" row
         # instead of crashing the installer mid-summary.
-        return subprocess.CompletedProcess(argv, returncode=RETURNCODE_CANCELLED, stdout=None, stderr=None)
-    except OSError:
+        returncode = _synthetic_returncode_for_exception(exc)
+        return subprocess.CompletedProcess(argv, returncode=returncode, stdout=None, stderr=None)
+    except OSError as exc:
         # Catches FileNotFoundError, PermissionError, and rarer fork/exec
         # failures (ENOEXEC, EMFILE, ENOMEM). All map to "could not execute"
         # from the user's perspective.
-        return subprocess.CompletedProcess(argv, returncode=RETURNCODE_EXEC_FAILED, stdout=None, stderr=None)
+        returncode = _synthetic_returncode_for_exception(exc)
+        return subprocess.CompletedProcess(argv, returncode=returncode, stdout=None, stderr=None)
 
 
 def describe_completed_process(result: subprocess.CompletedProcess[str], *, max_lines: int = 8) -> str:


### PR DESCRIPTION
## What

`run_command` and `run_interactive_command` in `yutori/cli/commands/install_flow.py` each caught the same three exceptions (`subprocess.TimeoutExpired`, `KeyboardInterrupt`, `OSError`) from a `subprocess.run(...)` call and mapped them to the same synthetic `RETURNCODE_*` constants (`RETURNCODE_TIMEOUT`, `RETURNCODE_CANCELLED`, `RETURNCODE_EXEC_FAILED`). The two functions' comments literally cross-referenced each other ("Mirror run_interactive_command...", "Matches run_interactive_command's catch...") to explain why the catches had to stay in sync — a maintainer-acknowledged duplication/drift risk.

This extracts the shared classification into `_synthetic_returncode_for_exception(exc) -> int`, called from both functions' `except` blocks. Each function still builds its own `CompletedProcess` independently, since that part genuinely differs: `run_command` captures real stdout/stderr text (including partial output on timeout), while `run_interactive_command` inherits the terminal's stdio and always returns `None` for both streams.

## Why this is safe

- Single file touched (`yutori/cli/commands/install_flow.py`), which is an internal, non-public CLI implementation module (`install_flow_command` is registered as a hidden Typer subcommand, `__install_flow` / `__install_ui`, never a public SDK API).
- No behavior change: the returncode produced for each exception type, and every stdout/stderr value, is identical before and after — verifiable directly from the diff.
- Existing tests in `tests/test_install_flow.py` that directly exercise this mapping (`test_run_command_catches_keyboardinterrupt_and_returns_cancelled`, `test_run_command_catches_generic_oserror_not_just_filenotfound`, `test_run_interactive_command_maps_timeout_to_124`, `test_run_interactive_command_maps_missing_binary_to_127`, `test_run_interactive_command_maps_oserror_to_127`, `test_run_interactive_command_maps_keyboard_interrupt_to_130`) all pass unchanged.
- Full test suite passes: `456 passed, 3 skipped, 1 deselected`.
- `ruff check` passes with no new lint findings.

## Scope note

This is an hourly automated structural-refactor pass over `yutori-sdk-python`. Per the standing backlog (`yutori-ai/yutori` `.claude/REFACTOR.md`, `## yutori-sdk-python` section), the sync/async duplication between `yutori/_sync/` and `yutori/_async/` is explicitly out of scope for a single PR (flagged as needing a larger code-gen/shared-base-class approach) — this change does not touch that split. I audited the rest of the package (auth flow, credentials, exceptions, HTTP helpers, CLI commands, navigator/n1 modules) and found it already thoroughly consolidated from prior refactor passes; this was the one remaining narrow, low-risk, high-confidence duplication.

## Test plan

- [x] `pytest tests/test_install_flow.py -v` — 78 passed
- [x] `pytest -q -m "not slow"` (full suite) — 456 passed, 3 skipped, 1 deselected
- [x] `ruff check yutori/cli/commands/install_flow.py` — all checks passed

🤖 Generated with automated structural-refactor pass

https://claude.ai/code/session_01Lv1wx3dZcZp1oWrdeY7z2B


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lv1wx3dZcZp1oWrdeY7z2B)_