### PR TITLE
refactor: extract make_json_response() test helper to dedupe mock-response boilerplate

### DIFF
--- a/tests/_usage_fixtures.py
+++ b/tests/_usage_fixtures.py
@@ -40,11 +40,16 @@ USAGE_RESPONSE = {
 }
 
 
-def make_mock_usage_response(period: str = "24h") -> MagicMock:
-    """Build a mocked 200 OK :class:`httpx.Response` for ``GET /usage``."""
-    data = {**USAGE_RESPONSE, "activity": {**USAGE_RESPONSE["activity"], "period": period}}
+def make_json_response(data: dict, *, status_code: int = 200) -> MagicMock:
+    """Build a mocked :class:`httpx.Response` whose ``.content`` and ``.json()`` both reflect `data`."""
     mock_response = MagicMock(spec=httpx.Response)
-    mock_response.status_code = 200
+    mock_response.status_code = status_code
     mock_response.content = json.dumps(data).encode()
     mock_response.json.return_value = data
     return mock_response
+
+
+def make_mock_usage_response(period: str = "24h") -> MagicMock:
+    """Build a mocked 200 OK :class:`httpx.Response` for ``GET /usage``."""
+    data = {**USAGE_RESPONSE, "activity": {**USAGE_RESPONSE["activity"], "period": period}}
+    return make_json_response(data)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -7,7 +7,7 @@ import pytest
 
 from yutori import APIError, AsyncYutoriClient, AuthenticationError
 
-from ._usage_fixtures import make_mock_usage_response
+from ._usage_fixtures import make_json_response, make_mock_usage_response
 
 
 class TestAsyncYutoriClientInit:
@@ -61,10 +61,7 @@ class TestAsyncYutoriClientGetUsage:
 @pytest.mark.asyncio
 class TestAsyncScoutsNamespace:
     async def test_scouts_list(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"scouts": []}'
-        mock_response.json.return_value = {"scouts": []}
+        mock_response = make_json_response({"scouts": []})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -76,10 +73,7 @@ class TestAsyncScoutsNamespace:
                 assert params["status"] == "active"
 
     async def test_scouts_list_forwards_cursor(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"scouts": []}'
-        mock_response.json.return_value = {"scouts": []}
+        mock_response = make_json_response({"scouts": []})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -89,10 +83,7 @@ class TestAsyncScoutsNamespace:
                 assert "page_size" not in params
 
     async def test_scouts_get(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"id": "scout-123"}'
-        mock_response.json.return_value = {"id": "scout-123"}
+        mock_response = make_json_response({"id": "scout-123"})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -100,10 +91,7 @@ class TestAsyncScoutsNamespace:
                 assert result["id"] == "scout-123"
 
     async def test_scouts_create(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"id": "new-scout"}'
-        mock_response.json.return_value = {"id": "new-scout"}
+        mock_response = make_json_response({"id": "new-scout"})
 
         with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -111,10 +99,7 @@ class TestAsyncScoutsNamespace:
                 assert result["id"] == "new-scout"
 
     async def test_scouts_update_status(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"id": "scout-123", "status": "paused"}'
-        mock_response.json.return_value = {"id": "scout-123", "status": "paused"}
+        mock_response = make_json_response({"id": "scout-123", "status": "paused"})
 
         with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -123,10 +108,7 @@ class TestAsyncScoutsNamespace:
                 assert "/pause" in mock_post.call_args[0][0]
 
     async def test_scouts_update_fields(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"id": "scout-123", "query": "new query"}'
-        mock_response.json.return_value = {"id": "scout-123", "query": "new query"}
+        mock_response = make_json_response({"id": "scout-123", "query": "new query"})
 
         with patch.object(httpx.AsyncClient, "patch", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -134,10 +116,7 @@ class TestAsyncScoutsNamespace:
                 assert result["query"] == "new query"
 
     async def test_scouts_update_is_public(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"id": "scout-123", "is_public": false}'
-        mock_response.json.return_value = {"id": "scout-123", "is_public": False}
+        mock_response = make_json_response({"id": "scout-123", "is_public": False})
 
         with patch.object(httpx.AsyncClient, "patch", new_callable=AsyncMock, return_value=mock_response) as mock_patch:
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -161,10 +140,7 @@ class TestAsyncScoutsNamespace:
                 assert result == {}
 
     async def test_scouts_get_updates(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"updates": []}'
-        mock_response.json.return_value = {"updates": []}
+        mock_response = make_json_response({"updates": []})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -175,10 +151,7 @@ class TestAsyncScoutsNamespace:
 @pytest.mark.asyncio
 class TestAsyncBrowsingNamespace:
     async def test_browsing_list(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"tasks": [], "total": 0}'
-        mock_response.json.return_value = {"tasks": [], "total": 0}
+        mock_response = make_json_response({"tasks": [], "total": 0})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -192,10 +165,7 @@ class TestAsyncBrowsingNamespace:
                 assert params["cursor"] == "cur-1"
 
     async def test_browsing_create(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "task-123"}'
-        mock_response.json.return_value = {"task_id": "task-123"}
+        mock_response = make_json_response({"task_id": "task-123"})
 
         with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -206,10 +176,7 @@ class TestAsyncBrowsingNamespace:
                 assert result["task_id"] == "task-123"
 
     async def test_browsing_create_with_local_browser_and_auth(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "task-456"}'
-        mock_response.json.return_value = {"task_id": "task-456"}
+        mock_response = make_json_response({"task_id": "task-456"})
 
         with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -227,10 +194,7 @@ class TestAsyncBrowsingNamespace:
                 assert payload["webhook_format"] == "zapier"
 
     async def test_browsing_get(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "task-123", "status": "succeeded"}'
-        mock_response.json.return_value = {"task_id": "task-123", "status": "succeeded"}
+        mock_response = make_json_response({"task_id": "task-123", "status": "succeeded"})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -238,16 +202,13 @@ class TestAsyncBrowsingNamespace:
                 assert result["status"] == "succeeded"
 
     async def test_browsing_get_with_rejection_reason(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = (
-            b'{"task_id": "task-123", "status": "failed", "rejection_reason": "billing_limit_reached"}'
+        mock_response = make_json_response(
+            {
+                "task_id": "task-123",
+                "status": "failed",
+                "rejection_reason": "billing_limit_reached",
+            }
         )
-        mock_response.json.return_value = {
-            "task_id": "task-123",
-            "status": "failed",
-            "rejection_reason": "billing_limit_reached",
-        }
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -259,10 +220,7 @@ class TestAsyncBrowsingNamespace:
 @pytest.mark.asyncio
 class TestAsyncResearchNamespace:
     async def test_research_list(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"tasks": [], "total": 0}'
-        mock_response.json.return_value = {"tasks": [], "total": 0}
+        mock_response = make_json_response({"tasks": [], "total": 0})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -276,10 +234,7 @@ class TestAsyncResearchNamespace:
                 assert params["cursor"] == "cur-1"
 
     async def test_research_create(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "research-123"}'
-        mock_response.json.return_value = {"task_id": "research-123"}
+        mock_response = make_json_response({"task_id": "research-123"})
 
         with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -287,10 +242,7 @@ class TestAsyncResearchNamespace:
                 assert result["task_id"] == "research-123"
 
     async def test_research_get(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "research-123", "status": "succeeded"}'
-        mock_response.json.return_value = {"task_id": "research-123", "status": "succeeded"}
+        mock_response = make_json_response({"task_id": "research-123", "status": "succeeded"})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -298,16 +250,13 @@ class TestAsyncResearchNamespace:
                 assert result["status"] == "succeeded"
 
     async def test_research_get_with_rejection_reason(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = (
-            b'{"task_id": "research-123", "status": "failed", "rejection_reason": "rate_limit_exceeded"}'
+        mock_response = make_json_response(
+            {
+                "task_id": "research-123",
+                "status": "failed",
+                "rejection_reason": "rate_limit_exceeded",
+            }
         )
-        mock_response.json.return_value = {
-            "task_id": "research-123",
-            "status": "failed",
-            "rejection_reason": "rate_limit_exceeded",
-        }
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -322,11 +271,7 @@ class TestAsyncPydanticSchemaIntegration:
 
     @staticmethod
     def _make_mock_response():
-        mock = MagicMock(spec=httpx.Response)
-        mock.status_code = 200
-        mock.content = b'{"task_id": "t-1"}'
-        mock.json.return_value = {"task_id": "t-1"}
-        return mock
+        return make_json_response({"task_id": "t-1"})
 
     class _FakeModel:
         @classmethod
@@ -361,9 +306,7 @@ class TestAsyncPydanticSchemaIntegration:
                 assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
     async def test_scouts_create_with_model_class(self):
-        mock = self._make_mock_response()
-        mock.content = b'{"id": "s-1"}'
-        mock.json.return_value = {"id": "s-1"}
+        mock = make_json_response({"id": "s-1"})
         with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock) as mock_post:
             async with AsyncYutoriClient(api_key="yt-test") as client:
                 await client.scouts.create(query="q", output_schema=self._FakeModel)
@@ -371,9 +314,7 @@ class TestAsyncPydanticSchemaIntegration:
                 assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
     async def test_scouts_update_with_model_class(self):
-        mock = self._make_mock_response()
-        mock.content = b'{"id": "s-1"}'
-        mock.json.return_value = {"id": "s-1"}
+        mock = make_json_response({"id": "s-1"})
         with patch.object(httpx.AsyncClient, "patch", new_callable=AsyncMock, return_value=mock) as mock_patch:
             async with AsyncYutoriClient(api_key="yt-test") as client:
                 await client.scouts.update("s-1", output_schema=self._FakeModel)
@@ -381,9 +322,7 @@ class TestAsyncPydanticSchemaIntegration:
                 assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
     async def test_scouts_update_with_model_instance(self):
-        mock = self._make_mock_response()
-        mock.content = b'{"id": "s-1"}'
-        mock.json.return_value = {"id": "s-1"}
+        mock = make_json_response({"id": "s-1"})
         with patch.object(httpx.AsyncClient, "patch", new_callable=AsyncMock, return_value=mock) as mock_patch:
             async with AsyncYutoriClient(api_key="yt-test") as client:
                 await client.scouts.update("s-1", output_schema=self._FakeModel())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,7 @@ import pytest
 
 from yutori import APIError, AuthenticationError, YutoriClient
 
-from ._usage_fixtures import make_mock_usage_response
+from ._usage_fixtures import make_json_response, make_mock_usage_response
 
 
 class TestYutoriClientInit:
@@ -98,10 +98,7 @@ class TestYutoriClientGetUsage:
 
 class TestScoutsNamespace:
     def test_scouts_list(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"scouts": []}'
-        mock_response.json.return_value = {"scouts": []}
+        mock_response = make_json_response({"scouts": []})
 
         with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
             result = client.scouts.list(limit=10, status="active")
@@ -113,10 +110,7 @@ class TestScoutsNamespace:
             assert params["status"] == "active"
 
     def test_scouts_list_forwards_cursor(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"scouts": []}'
-        mock_response.json.return_value = {"scouts": []}
+        mock_response = make_json_response({"scouts": []})
 
         with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
             client.scouts.list(cursor="next-page")
@@ -125,10 +119,7 @@ class TestScoutsNamespace:
             assert "page_size" not in params
 
     def test_scouts_get(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"id": "scout-123", "query": "test"}'
-        mock_response.json.return_value = {"id": "scout-123", "query": "test"}
+        mock_response = make_json_response({"id": "scout-123", "query": "test"})
 
         with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
             result = client.scouts.get("scout-123")
@@ -136,10 +127,7 @@ class TestScoutsNamespace:
             mock_get.assert_called_once()
 
     def test_scouts_create(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"id": "new-scout", "query": "Monitor site"}'
-        mock_response.json.return_value = {"id": "new-scout", "query": "Monitor site"}
+        mock_response = make_json_response({"id": "new-scout", "query": "Monitor site"})
 
         with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
             result = client.scouts.create(
@@ -156,10 +144,7 @@ class TestScoutsNamespace:
             assert payload["webhook_url"] == "https://webhook.test"
 
     def test_scouts_update_status(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"id": "scout-123", "status": "paused"}'
-        mock_response.json.return_value = {"id": "scout-123", "status": "paused"}
+        mock_response = make_json_response({"id": "scout-123", "status": "paused"})
 
         with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
             result = client.scouts.update("scout-123", status="paused")
@@ -168,10 +153,7 @@ class TestScoutsNamespace:
             assert "/pause" in mock_post.call_args[0][0]
 
     def test_scouts_update_fields(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"id": "scout-123", "query": "new query"}'
-        mock_response.json.return_value = {"id": "scout-123", "query": "new query"}
+        mock_response = make_json_response({"id": "scout-123", "query": "new query"})
 
         with patch.object(httpx.Client, "patch", return_value=mock_response) as mock_patch:
             result = client.scouts.update("scout-123", query="new query")
@@ -179,10 +161,7 @@ class TestScoutsNamespace:
             mock_patch.assert_called_once()
 
     def test_scouts_update_is_public(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"id": "scout-123", "is_public": false}'
-        mock_response.json.return_value = {"id": "scout-123", "is_public": False}
+        mock_response = make_json_response({"id": "scout-123", "is_public": False})
 
         with patch.object(httpx.Client, "patch", return_value=mock_response) as mock_patch:
             client.scouts.update("scout-123", is_public=False)
@@ -208,10 +187,7 @@ class TestScoutsNamespace:
             mock_delete.assert_called_once()
 
     def test_scouts_get_updates(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"updates": [], "cursor": null}'
-        mock_response.json.return_value = {"updates": [], "cursor": None}
+        mock_response = make_json_response({"updates": [], "cursor": None})
 
         with patch.object(httpx.Client, "get", return_value=mock_response):
             result = client.scouts.get_updates("scout-123", limit=5)
@@ -220,10 +196,7 @@ class TestScoutsNamespace:
 
 class TestBrowsingNamespace:
     def test_browsing_list(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"tasks": [], "total": 0}'
-        mock_response.json.return_value = {"tasks": [], "total": 0}
+        mock_response = make_json_response({"tasks": [], "total": 0})
 
         with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
             result = client.browsing.list(limit=20, status="succeeded", cursor="cur-1")
@@ -237,20 +210,14 @@ class TestBrowsingNamespace:
             assert params["cursor"] == "cur-1"
 
     def test_browsing_list_no_args_sends_empty_params(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"tasks": []}'
-        mock_response.json.return_value = {"tasks": []}
+        mock_response = make_json_response({"tasks": []})
 
         with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
             client.browsing.list()
             assert mock_get.call_args[1]["params"] == {}
 
     def test_browsing_create(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "task-123", "status": "queued"}'
-        mock_response.json.return_value = {"task_id": "task-123", "status": "queued"}
+        mock_response = make_json_response({"task_id": "task-123", "status": "queued"})
 
         with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
             result = client.browsing.create(
@@ -265,10 +232,7 @@ class TestBrowsingNamespace:
             assert payload["max_steps"] == 10
 
     def test_browsing_create_with_local_browser_and_auth(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "task-456", "status": "queued"}'
-        mock_response.json.return_value = {"task_id": "task-456", "status": "queued"}
+        mock_response = make_json_response({"task_id": "task-456", "status": "queued"})
 
         with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
             result = client.browsing.create(
@@ -285,26 +249,20 @@ class TestBrowsingNamespace:
             assert payload["webhook_format"] == "zapier"
 
     def test_browsing_get(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "task-123", "status": "succeeded"}'
-        mock_response.json.return_value = {"task_id": "task-123", "status": "succeeded"}
+        mock_response = make_json_response({"task_id": "task-123", "status": "succeeded"})
 
         with patch.object(httpx.Client, "get", return_value=mock_response):
             result = client.browsing.get("task-123")
             assert result["status"] == "succeeded"
 
     def test_browsing_get_with_rejection_reason(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = (
-            b'{"task_id": "task-123", "status": "failed", "rejection_reason": "billing_limit_reached"}'
+        mock_response = make_json_response(
+            {
+                "task_id": "task-123",
+                "status": "failed",
+                "rejection_reason": "billing_limit_reached",
+            }
         )
-        mock_response.json.return_value = {
-            "task_id": "task-123",
-            "status": "failed",
-            "rejection_reason": "billing_limit_reached",
-        }
 
         with patch.object(httpx.Client, "get", return_value=mock_response):
             result = client.browsing.get("task-123")
@@ -314,10 +272,7 @@ class TestBrowsingNamespace:
 
 class TestResearchNamespace:
     def test_research_list(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"tasks": [], "total": 0}'
-        mock_response.json.return_value = {"tasks": [], "total": 0}
+        mock_response = make_json_response({"tasks": [], "total": 0})
 
         with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
             result = client.research.list(limit=20, status="succeeded", cursor="cur-1")
@@ -331,20 +286,14 @@ class TestResearchNamespace:
             assert params["cursor"] == "cur-1"
 
     def test_research_list_no_args_sends_empty_params(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"tasks": []}'
-        mock_response.json.return_value = {"tasks": []}
+        mock_response = make_json_response({"tasks": []})
 
         with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
             client.research.list()
             assert mock_get.call_args[1]["params"] == {}
 
     def test_research_create(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "research-123", "status": "queued"}'
-        mock_response.json.return_value = {"task_id": "research-123", "status": "queued"}
+        mock_response = make_json_response({"task_id": "research-123", "status": "queued"})
 
         with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
             result = client.research.create(
@@ -356,26 +305,20 @@ class TestResearchNamespace:
             assert payload["query"] == "Find AI startup funding"
 
     def test_research_get(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b'{"task_id": "research-123", "status": "succeeded"}'
-        mock_response.json.return_value = {"task_id": "research-123", "status": "succeeded"}
+        mock_response = make_json_response({"task_id": "research-123", "status": "succeeded"})
 
         with patch.object(httpx.Client, "get", return_value=mock_response):
             result = client.research.get("research-123")
             assert result["status"] == "succeeded"
 
     def test_research_get_with_rejection_reason(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = (
-            b'{"task_id": "research-123", "status": "failed", "rejection_reason": "rate_limit_exceeded"}'
+        mock_response = make_json_response(
+            {
+                "task_id": "research-123",
+                "status": "failed",
+                "rejection_reason": "rate_limit_exceeded",
+            }
         )
-        mock_response.json.return_value = {
-            "task_id": "research-123",
-            "status": "failed",
-            "rejection_reason": "rate_limit_exceeded",
-        }
 
         with patch.object(httpx.Client, "get", return_value=mock_response):
             result = client.research.get("research-123")
@@ -387,11 +330,7 @@ class TestPydanticSchemaIntegration:
     """Test that Pydantic models are resolved to JSON schema dicts in payloads."""
 
     def _make_mock_response(self):
-        mock = MagicMock(spec=httpx.Response)
-        mock.status_code = 200
-        mock.content = b'{"task_id": "t-1"}'
-        mock.json.return_value = {"task_id": "t-1"}
-        return mock
+        return make_json_response({"task_id": "t-1"})
 
     class _FakeModel:
         @classmethod
@@ -417,27 +356,21 @@ class TestPydanticSchemaIntegration:
             assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
     def test_scouts_create_with_model_class(self, client):
-        mock = self._make_mock_response()
-        mock.content = b'{"id": "s-1"}'
-        mock.json.return_value = {"id": "s-1"}
+        mock = make_json_response({"id": "s-1"})
         with patch.object(httpx.Client, "post", return_value=mock) as mock_post:
             client.scouts.create(query="q", output_schema=self._FakeModel)
             payload = mock_post.call_args[1]["json"]
             assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
     def test_scouts_update_with_model_class(self, client):
-        mock = self._make_mock_response()
-        mock.content = b'{"id": "s-1"}'
-        mock.json.return_value = {"id": "s-1"}
+        mock = make_json_response({"id": "s-1"})
         with patch.object(httpx.Client, "patch", return_value=mock) as mock_patch:
             client.scouts.update("s-1", output_schema=self._FakeModel)
             payload = mock_patch.call_args[1]["json"]
             assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
     def test_scouts_update_with_model_instance(self, client):
-        mock = self._make_mock_response()
-        mock.content = b'{"id": "s-1"}'
-        mock.json.return_value = {"id": "s-1"}
+        mock = make_json_response({"id": "s-1"})
         with patch.object(httpx.Client, "patch", return_value=mock) as mock_patch:
             client.scouts.update("s-1", output_schema=self._FakeModel())
             payload = mock_patch.call_args[1]["json"]


### PR DESCRIPTION
## What

`tests/test_client.py` and `tests/test_async_client.py` independently rebuilt the same 4-line mock-response scaffolding by hand at ~30 call sites:

```python
mock_response = MagicMock(spec=httpx.Response)
mock_response.status_code = 200
mock_response.content = b'{"scouts": []}'
mock_response.json.return_value = {"scouts": []}
```

`tests/_usage_fixtures.py` had already implemented this exact pattern (`json.dumps(data).encode()` + `.json.return_value`) for the `/usage` endpoint via `make_mock_usage_response()`, and `tests/test_http.py` has its own local `make_response()` helper for the same shape — the pattern just hadn't been generalized and reused across the other two test files.

This PR generalizes `_usage_fixtures.py`'s inline mock-building into a reusable helper:

```python
def make_json_response(data: dict, *, status_code: int = 200) -> MagicMock:
    """Build a mocked httpx.Response whose .content and .json() both reflect `data`."""
```

and reuses it at every call site in `test_client.py` / `test_async_client.py` that mocks a 200 JSON response, including the per-class `_make_mock_response()` helpers in the Pydantic schema integration test classes (which now just delegate to it). `make_mock_usage_response()` is rewritten in terms of the new helper too.

Call sites that mock non-JSON responses (text-only error bodies like 401/403/500, or empty-content deletes) are intentionally left untouched — they don't fit this pattern.

## Why

Pure duplication cleanup: ~30 identical 4-line blocks collapse to 1-line calls, and the codebase now has one canonical way to build a mocked JSON response instead of three ad-hoc variants (`test_http.py`'s local helper is a different, distinct case with `text`/`headers` fields and is left as-is).

## Why it's safe

- Test-only change — no production code (`yutori/`) touched.
- Behavior-preserving: `json.dumps(data).encode()` is byte-for-byte equivalent to the literal `b'{"key": "value"}'` strings it replaces (all replaced dict shapes are plain JSON-serializable types — strings, ints, bools, `None`, lists).
- Verified via the full test suite before and after: `456 passed, 3 skipped, 1 deselected` (unchanged).
- `ruff check` and `ruff format --check` pass clean on all three touched files.

## Scope

3 files: `tests/_usage_fixtures.py`, `tests/test_client.py`, `tests/test_async_client.py`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01C2CRpnBvo3Lgu7KGEQKXzW)_