### PR TITLE
refactor: extract make_status_response()/make_empty_response() test helpers

### DIFF
--- a/tests/_usage_fixtures.py
+++ b/tests/_usage_fixtures.py
@@ -49,6 +49,26 @@ def make_json_response(data: dict, *, status_code: int = 200) -> MagicMock:
     return mock_response
 
 
+def make_status_response(status_code: int, text: str = "") -> MagicMock:
+    """Build a mocked :class:`httpx.Response` with only ``status_code``/``text`` set.
+
+    Used for error-path tests (401/403/400/500, ...) that only need
+    ``handle_response`` to see a non-2xx status and body text, not a JSON payload.
+    """
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = status_code
+    mock_response.text = text
+    return mock_response
+
+
+def make_empty_response(status_code: int = 200) -> MagicMock:
+    """Build a mocked :class:`httpx.Response` with empty ``.content`` (e.g. a 200 DELETE with no body)."""
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = status_code
+    mock_response.content = b""
+    return mock_response
+
+
 def make_mock_usage_response(period: str = "24h") -> MagicMock:
     """Build a mocked 200 OK :class:`httpx.Response` for ``GET /usage``."""
     data = {**USAGE_RESPONSE, "activity": {**USAGE_RESPONSE["activity"], "period": period}}

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -7,7 +7,7 @@ import pytest
 
 from yutori import APIError, AsyncYutoriClient, AuthenticationError
 
-from ._usage_fixtures import make_json_response, make_mock_usage_response
+from ._usage_fixtures import make_empty_response, make_json_response, make_mock_usage_response, make_status_response
 
 
 class TestAsyncYutoriClientInit:
@@ -130,9 +130,7 @@ class TestAsyncScoutsNamespace:
                 await client.scouts.update("scout-123", status="paused", query="new query")
 
     async def test_scouts_delete(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b""
+        mock_response = make_empty_response()
 
         with patch.object(httpx.AsyncClient, "delete", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-test") as client:
@@ -536,9 +534,7 @@ class TestAsyncChatNamespace:
 @pytest.mark.asyncio
 class TestAsyncErrorHandling:
     async def test_auth_error(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 401
-        mock_response.text = "Unauthorized"
+        mock_response = make_status_response(401, "Unauthorized")
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-invalid") as client:
@@ -546,9 +542,7 @@ class TestAsyncErrorHandling:
                     await client.get_usage()
 
     async def test_auth_error_forbidden(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 403
-        mock_response.text = "Forbidden"
+        mock_response = make_status_response(403, "Forbidden")
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-invalid") as client:
@@ -556,9 +550,7 @@ class TestAsyncErrorHandling:
                     await client.get_usage()
 
     async def test_api_error(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 500
-        mock_response.text = "Server error"
+        mock_response = make_status_response(500, "Server error")
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-test") as client:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,7 @@ import pytest
 
 from yutori import APIError, AuthenticationError, YutoriClient
 
-from ._usage_fixtures import make_json_response, make_mock_usage_response
+from ._usage_fixtures import make_empty_response, make_json_response, make_mock_usage_response, make_status_response
 
 
 class TestYutoriClientInit:
@@ -74,9 +74,7 @@ class TestYutoriClientGetUsage:
             client.close()
 
     def test_get_usage_auth_error(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 401
-        mock_response.text = "Unauthorized"
+        mock_response = make_status_response(401, "Unauthorized")
 
         with patch.object(httpx.Client, "get", return_value=mock_response):
             client = YutoriClient(api_key="yt-invalid")
@@ -85,9 +83,7 @@ class TestYutoriClientGetUsage:
             client.close()
 
     def test_get_usage_forbidden_auth_error(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 403
-        mock_response.text = "Forbidden"
+        mock_response = make_status_response(403, "Forbidden")
 
         with patch.object(httpx.Client, "get", return_value=mock_response):
             client = YutoriClient(api_key="yt-invalid")
@@ -177,9 +173,7 @@ class TestScoutsNamespace:
             client.scouts.update("scout-123", status="paused", is_public=False)
 
     def test_scouts_delete(self, client):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.content = b""
+        mock_response = make_empty_response()
 
         with patch.object(httpx.Client, "delete", return_value=mock_response) as mock_delete:
             result = client.scouts.delete("scout-123")
@@ -584,9 +578,7 @@ class TestChatNamespace:
 
 class TestErrorHandling:
     def test_api_error_on_400(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 400
-        mock_response.text = "Bad request"
+        mock_response = make_status_response(400, "Bad request")
 
         with patch.object(httpx.Client, "get", return_value=mock_response):
             client = YutoriClient(api_key="yt-test")
@@ -596,9 +588,7 @@ class TestErrorHandling:
             client.close()
 
     def test_api_error_on_500(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 500
-        mock_response.text = "Internal server error"
+        mock_response = make_status_response(500, "Internal server error")
 
         with patch.object(httpx.Client, "get", return_value=mock_response):
             client = YutoriClient(api_key="yt-test")


### PR DESCRIPTION
## Summary

- `tests/test_client.py` and `tests/test_async_client.py` each hand-rolled `MagicMock(spec=httpx.Response)` + `status_code` (+ `text`/`content`) boilerplate 7 times total (401/403/400/500 error tests and 200-empty-body delete tests).
- Extracted `make_status_response(status_code, text="")` and `make_empty_response(status_code=200)` into `tests/_usage_fixtures.py`, right next to the existing `make_json_response()` helper (added in #145 for the same reason).
- Replaced all 7 call sites in `test_client.py`/`test_async_client.py`. Purely test scaffolding — no production code touched, no behavior change.

This follows the same pattern as recent refactors in this repo (#145 `make_json_response`, #142 `truncate_for_display`, #144 exception-to-returncode mapping): small, scoped extractions of repeated test/CLI boilerplate.

## Test plan

- [x] `pytest -q` — 457 passed, 3 skipped (full suite, no regressions)
- [x] `ruff check` / `ruff format --check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsYmvythNDX1mc6Fm8LEPt

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsYmvythNDX1mc6Fm8LEPt)_