### PR TITLE
refactor: dedupe install_flow's private truncation helper into truncate_for_display

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,9 +5,30 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 from yutori import __version__
+from yutori.cli.commands import truncate_for_display
 from yutori.cli.main import app
 
 runner = CliRunner()
+
+
+def test_truncate_for_display_default_ellipsis_extends_length():
+    # Default mode (used by browse/research/scouts list output) appends "..."
+    # after the max_len-char prefix, so the result can exceed max_len by 3.
+    result = truncate_for_display("a" * 100, 47)
+    assert result == "a" * 47 + "..."
+    assert len(result) == 50
+
+
+def test_truncate_for_display_budget_includes_ellipsis_is_a_hard_cap():
+    # Install-flow summaries need a hard cap: the ellipsis counts against the budget.
+    result = truncate_for_display("a" * 200, 180, budget_includes_ellipsis=True)
+    assert result == "a" * 177 + "..."
+    assert len(result) == 180
+
+
+def test_truncate_for_display_no_truncation_when_within_max_len():
+    assert truncate_for_display("short", 47) == "short"
+    assert truncate_for_display("short", 47, budget_includes_ellipsis=True) == "short"
 
 
 def _make_client_mock() -> MagicMock:

--- a/tests/test_install_flow.py
+++ b/tests/test_install_flow.py
@@ -1326,6 +1326,15 @@ def test_summarize_results_survives_markup_shaped_subprocess_output():
     assert "[/x]" in out
 
 
+def test_truncate_summary_caps_at_summary_max_len():
+    from yutori.cli.commands.install_flow import _SUMMARY_MAX_LEN, _truncate_summary
+
+    result = _truncate_summary("x" * (_SUMMARY_MAX_LEN + 20))
+    assert len(result) == _SUMMARY_MAX_LEN
+    assert result.endswith("...")
+    assert _truncate_summary("short output") == "short output"
+
+
 def test_detect_sdk_install_plan_windows_venv_uses_scripts_python(tmp_path: Path, monkeypatch):
     import os as real_os
 

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -51,10 +51,21 @@ INTERVAL_PRESETS: dict[str, int] = {
 _console = Console()
 
 
-def truncate_for_display(text: str, max_len: int = 47) -> str:
-    """Truncate ``text`` to ``max_len`` chars, appending ``...`` when truncated."""
+def truncate_for_display(text: str, max_len: int = 47, *, budget_includes_ellipsis: bool = False) -> str:
+    """Truncate ``text`` to ``max_len`` chars, appending ``...`` when truncated.
+
+    By default the ``...`` is appended after the ``max_len``-char prefix, so a
+    truncated result can be up to 3 characters longer than ``max_len`` (this
+    matches the table/field truncation used by ``browse``/``research``/``scouts``
+    list output). Pass ``budget_includes_ellipsis=True`` when the caller needs a
+    hard cap — the ellipsis is then counted against the budget, so the result
+    never exceeds ``max_len`` characters (used for the install flow's one-line
+    command-output summaries).
+    """
     if len(text) <= max_len:
         return text
+    if budget_includes_ellipsis:
+        return f"{text[: max_len - 3]}..."
     return text[:max_len] + "..."
 
 

--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -40,6 +40,7 @@ from rich.table import Table
 from yutori.auth.credentials import resolve_api_key
 from yutori.auth.flow import get_auth_status, run_login_flow
 from yutori.auth.types import AuthStatus
+from yutori.cli.commands import truncate_for_display
 
 BRAND_MINT = "#1DCD98"
 MINT_HIGHLIGHT = "#5AE8BD"
@@ -849,9 +850,7 @@ def _truncate_summary(text: str) -> str:
     The trailing ellipsis is included in the budget, so the returned string
     never exceeds ``_SUMMARY_MAX_LEN`` characters.
     """
-    if len(text) <= _SUMMARY_MAX_LEN:
-        return text
-    return f"{text[: _SUMMARY_MAX_LEN - 3]}..."
+    return truncate_for_display(text, _SUMMARY_MAX_LEN, budget_includes_ellipsis=True)
 
 
 def _summarize_cli_output(output: str) -> str:


### PR DESCRIPTION
## What

`yutori/cli/commands/install_flow.py` had a private `_truncate_summary()` helper that reimplemented the same "truncate a string and append `...`" logic that PR #142 already extracted into `truncate_for_display()` in `yutori/cli/commands/__init__.py`. It differed only in one subtle detail: `_truncate_summary` counts the `"..."` against the length budget (hard cap at `_SUMMARY_MAX_LEN`), while `truncate_for_display` appends `"..."` after the `max_len`-char prefix (so the result can be up to 3 chars longer).

This PR adds an opt-in `budget_includes_ellipsis` keyword to `truncate_for_display()` so both call sites share one implementation, and turns `_truncate_summary()` into a one-line delegate:

```python
def _truncate_summary(text: str) -> str:
    return truncate_for_display(text, _SUMMARY_MAX_LEN, budget_includes_ellipsis=True)
```

## Why it's safe

- **No behavior change at either call site.** The default (`budget_includes_ellipsis=False`) preserves the exact existing behavior for `browse.py`/`research.py`/`scouts.py` list output. Passing `budget_includes_ellipsis=True` from `install_flow.py` reproduces the exact prior `_truncate_summary` output byte-for-byte (verified with `x * 200` -> 180-char result ending in `...`, matching the old hard cap).
- **Private, internal-only helpers.** Neither function is part of the SDK's public API surface — no exported symbols or public signatures change.
- **Small, contained diff.** Only 2 source files touched (`yutori/cli/commands/__init__.py`, `yutori/cli/commands/install_flow.py`) plus 2 test files with new regression coverage.
- **Tests added:** `tests/test_cli.py` gets 3 new unit tests for `truncate_for_display`'s two modes; `tests/test_install_flow.py` gets a regression test asserting `_truncate_summary` still hard-caps at `_SUMMARY_MAX_LEN` (180 chars) and passes through short strings unchanged.

## Test plan

- [x] `pytest -q` — 461 passed, 3 skipped (was 457 passed before adding 4 new tests)
- [x] `ruff check .` — clean
- [x] Manual parity check confirming `_truncate_summary` output is byte-identical before/after the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01587HR7Bw83asm2Erry3c8r


---
_Generated by [Claude Code](https://claude.ai/code/session_01587HR7Bw83asm2Erry3c8r)_