### PR TITLE
refactor: extract _print_version() to dedupe CLI version output

### DIFF
--- a/yutori/cli/main.py
+++ b/yutori/cli/main.py
@@ -26,12 +26,16 @@ app.add_typer(scouts.app, name="scouts")
 app.add_typer(usage.app, name="usage")
 
 
+def _print_version() -> None:
+    from yutori import __version__
+
+    typer.echo(f"yutori {__version__}")
+
+
 def _version_callback(value: bool) -> None:
     """Handle --version and exit early."""
     if value:
-        from yutori import __version__
-
-        typer.echo(f"yutori {__version__}")
+        _print_version()
         raise typer.Exit()
 
 
@@ -51,9 +55,7 @@ def main(
 @app.command()
 def version() -> None:
     """Show the CLI version."""
-    from yutori import __version__
-
-    typer.echo(f"yutori {__version__}")
+    _print_version()
 
 
 app.command("__install_flow", hidden=True)(install_flow_command)


### PR DESCRIPTION
## Issue

`yutori/cli/main.py` had the exact same two lines — `from yutori import __version__` and `typer.echo(f"yutori {__version__}")` — inlined in both `_version_callback` (handles `yutori --version`) and the `version` subcommand (handles `yutori version`). The two code paths could silently drift (e.g. one gets a format tweak and the other doesn't) with nothing to catch it.

## Improvement

Extracted a small `_print_version()` helper and had both call sites use it. No behavior change — same output, same exit codes.

## Why it's safe

- Pure extraction, no logic change.
- Both existing tests (`test_root_version_option`, `test_version_subcommand` in `tests/test_cli.py`) still assert the exact same output string and pass unmodified.
- Single file touched, `ruff check` / `ruff format --check` clean, full `pytest` suite passes (461 passed, 3 skipped).

## Test plan

- [x] `pytest -q` — 461 passed, 3 skipped
- [x] `ruff check yutori/cli/main.py` / `ruff format --check yutori/cli/main.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMGdx83p9qCSDjpduaDWCD


---
_Generated by [Claude Code](https://claude.ai/code/session_01VMGdx83p9qCSDjpduaDWCD)_