### PR TITLE
refactor: migrate test_http.py to shared make_status_response fixture

### DIFF
--- a/tests/_usage_fixtures.py
+++ b/tests/_usage_fixtures.py
@@ -49,15 +49,21 @@ def make_json_response(data: dict, *, status_code: int = 200) -> MagicMock:
     return mock_response
 
 
-def make_status_response(status_code: int, text: str = "") -> MagicMock:
-    """Build a mocked :class:`httpx.Response` with only ``status_code``/``text`` set.
+def make_status_response(
+    status_code: int, text: str = "", *, content: bytes = b"", headers: dict | None = None
+) -> MagicMock:
+    """Build a mocked :class:`httpx.Response` with ``status_code``/``text`` set.
 
     Used for error-path tests (401/403/400/500, ...) that only need
     ``handle_response`` to see a non-2xx status and body text, not a JSON payload.
+    ``content``/``headers`` are only needed by callers exercising the redirect
+    (3xx) or 2xx-non-JSON-body paths of ``handle_response``.
     """
     mock_response = MagicMock(spec=httpx.Response)
     mock_response.status_code = status_code
     mock_response.text = text
+    mock_response.content = content
+    mock_response.headers = headers if headers is not None else {}
     return mock_response
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,21 +1,11 @@
 """Tests for shared HTTP helpers in yutori._http."""
 
-from unittest.mock import MagicMock
-
-import httpx
 import pytest
 
 from yutori._http import apply_chat_extra_body, handle_response, resolve_scout_status_endpoint
 from yutori.exceptions import APIError, AuthenticationError
 
-
-def make_response(status_code: int, text: str = "", content: bytes = b"") -> MagicMock:
-    response = MagicMock(spec=httpx.Response)
-    response.status_code = status_code
-    response.text = text
-    response.content = content
-    response.headers = {}
-    return response
+from ._usage_fixtures import make_status_response as make_response
 
 
 class TestHandleResponse:
@@ -43,8 +33,7 @@ class TestHandleResponse:
             handle_response(response)
 
     def test_redirect_message_names_the_location(self):
-        response = make_response(301)
-        response.headers = {"location": "https://elsewhere.example/login"}
+        response = make_response(301, headers={"location": "https://elsewhere.example/login"})
         with pytest.raises(APIError, match="elsewhere.example"):
             handle_response(response)
 


### PR DESCRIPTION
## What

`tests/test_http.py` defined its own local mock-`httpx.Response` builder (`make_response`) instead of using the shared `make_status_response` fixture that PRs #145/#147 already extracted into `tests/_usage_fixtures.py` for `test_client.py`/`test_async_client.py` — same mechanism, one missed instance.

## Why this is an improvement

Two independent copies of the same mock-builder pattern can silently drift (e.g. one gets a bugfix or a new kwarg the other doesn't). Consolidating onto the single shared fixture removes that risk and continues an already-established pattern in this repo rather than introducing a new one.

## Changes

- Generalized `make_status_response()` in `tests/_usage_fixtures.py` with optional `content: bytes = b""` and `headers: dict | None = None` keyword-only params (both default to the values `test_http.py`'s local builder used), so it now also covers the redirect (3xx) and 2xx-non-JSON-body test cases that `test_http.py` needs.
- Deleted the local `make_response()` in `tests/test_http.py`; it now imports `make_status_response` (aliased as `make_response` to keep the diff minimal at call sites) from `._usage_fixtures`.

## Why this is safe

- Test-only change — no production code or public API touched.
- The new `content`/`headers` params are additive and keyword-only; existing callers in `test_client.py`/`test_async_client.py` (which never pass them) get the same behavior as before (verified: `handle_response`'s 401/403/400/500 paths never read `.content` or `.headers`).
- All 100 tests across `tests/test_http.py`, `tests/test_client.py`, and `tests/test_async_client.py` pass unchanged.
- `ruff format --check` and `ruff check` both pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYAxNpPhhGuah2YHQ2uELp)_