### PR TITLE
refactor: migrate test_auth.py to shared httpx.Response mock fixtures

### DIFF
--- a/tests/_usage_fixtures.py
+++ b/tests/_usage_fixtures.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 from unittest.mock import MagicMock
 
 import httpx
@@ -40,8 +41,13 @@ USAGE_RESPONSE = {
 }
 
 
-def make_json_response(data: dict, *, status_code: int = 200) -> MagicMock:
-    """Build a mocked :class:`httpx.Response` whose ``.content`` and ``.json()`` both reflect `data`."""
+def make_json_response(data: Any, *, status_code: int = 200) -> MagicMock:
+    """Build a mocked :class:`httpx.Response` whose ``.content`` and ``.json()`` both reflect `data`.
+
+    ``data`` is usually a dict, but any JSON-serializable value works — some
+    callers use this to simulate a 2xx response with a non-dict body (e.g. a
+    backend bug returning a bare list or string).
+    """
     mock_response = MagicMock(spec=httpx.Response)
     mock_response.status_code = status_code
     mock_response.content = json.dumps(data).encode()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -42,6 +42,8 @@ from yutori.auth.flow import (
 )
 from yutori.auth.types import AuthStatus, LoginResult
 
+from ._usage_fixtures import make_json_response, make_status_response
+
 # ---------------------------------------------------------------------------
 # PKCE
 # ---------------------------------------------------------------------------
@@ -349,9 +351,7 @@ class TestCallbackHandler:
 
 class TestTokenExchange:
     def test_exchange_code_for_token_success(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.json.return_value = {"access_token": "jwt_token_123"}
-        mock_response.raise_for_status = MagicMock()
+        mock_response = make_json_response({"access_token": "jwt_token_123"})
 
         with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
             token = exchange_code_for_token("auth_code", "verifier")
@@ -362,7 +362,7 @@ class TestTokenExchange:
             assert call_kwargs[1]["data"]["code_verifier"] == "verifier"
 
     def test_exchange_code_raises_on_error(self):
-        mock_response = MagicMock(spec=httpx.Response)
+        mock_response = make_status_response(401)
         mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
             "401", request=MagicMock(), response=MagicMock(status_code=401)
         )
@@ -374,9 +374,7 @@ class TestTokenExchange:
 
 class TestGenerateApiKey:
     def test_generate_api_key_success(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.json.return_value = {"key": "yt-generated-key"}
-        mock_response.raise_for_status = MagicMock()
+        mock_response = make_json_response({"key": "yt-generated-key"})
 
         with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
             key = generate_api_key("jwt_token", key_name="2026-02-09-yutori-cli")
@@ -386,9 +384,7 @@ class TestGenerateApiKey:
             assert call_kwargs[1]["json"] == {"name": "2026-02-09-yutori-cli"}
 
     def test_generate_api_key_uses_build_auth_api_url(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.json.return_value = {"key": "yt-key"}
-        mock_response.raise_for_status = MagicMock()
+        mock_response = make_json_response({"key": "yt-key"})
 
         with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
             generate_api_key("jwt")
@@ -399,9 +395,7 @@ class TestGenerateApiKey:
 
 class TestRegistrationHelpers:
     def test_check_registration_status_true(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"is_registered": True}
+        mock_response = make_json_response({"is_registered": True})
 
         with patch.object(httpx.Client, "get", return_value=mock_response) as mock_get:
             assert check_registration_status("jwt_token") is True
@@ -416,25 +410,19 @@ class TestRegistrationHelpers:
         # returning `[]` or `"ok"`) must return None, not propagate
         # AttributeError through run_login_flow and fail the whole login.
         for bad_body in ([], "ok", 42, None):
-            mock_response = MagicMock(spec=httpx.Response)
-            mock_response.status_code = 200
-            mock_response.json.return_value = bad_body
+            mock_response = make_json_response(bad_body)
             with patch.object(httpx.Client, "get", return_value=mock_response):
                 assert check_registration_status("jwt_token") is None, (
                     f"non-dict body {bad_body!r} should return None, not raise"
                 )
 
     def test_check_registration_status_returns_none_when_key_missing(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"some_other_field": True}
+        mock_response = make_json_response({"some_other_field": True})
         with patch.object(httpx.Client, "get", return_value=mock_response):
             assert check_registration_status("jwt_token") is None
 
     def test_register_user_posts_cli_source(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.raise_for_status = MagicMock()
+        mock_response = make_status_response(200)
 
         with patch.object(httpx.Client, "post", return_value=mock_response) as mock_post:
             register_user("jwt_token")
@@ -444,8 +432,7 @@ class TestRegistrationHelpers:
             assert "Bearer jwt_token" in call_kwargs[1]["headers"]["Authorization"]
 
     def test_register_user_raises_httpstatuserror_on_bad_status(self):
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 500
+        mock_response = make_status_response(500)
         mock_response.raise_for_status = MagicMock(
             side_effect=httpx.HTTPStatusError("500", request=MagicMock(), response=mock_response)
         )


### PR DESCRIPTION
## Issue

`tests/test_auth.py` had 9 hand-rolled `MagicMock(spec=httpx.Response)` constructions, each manually wiring up `.status_code`, `.json.return_value`, and/or `.raise_for_status` to build a fake HTTP response. This duplicated the `make_json_response()` / `make_status_response()` fixtures in `tests/_usage_fixtures.py`, which `test_client.py`, `test_async_client.py`, and `test_http.py` already use for the exact same purpose (`test_http.py` was migrated to this pattern in #151).

## Change

- Replaced all 9 inline `MagicMock(spec=httpx.Response)` blocks in `test_auth.py` with `make_json_response(...)` / `make_status_response(...)` calls, removing the duplicated boilerplate.
- Widened `make_json_response`'s `data` parameter from `dict` to `Any`: one of the migrated tests (`test_check_registration_status_returns_none_for_non_dict_body`) intentionally exercises non-dict JSON bodies (`[]`, `"ok"`, `42`, `None`) to check a backend-contract-mismatch regression, and the helper's implementation (`json.dumps` + `.json.return_value = data`) already worked fine for any JSON-serializable value — the type hint was just stricter than the actual behavior.

## Why it's safe

- Purely a test-file change; no production code paths are touched.
- Each replacement preserves the exact same mock behavior (same `status_code`, same `.json()` return value, same `raise_for_status` semantics) — verified by diff inspection call-by-call.
- Full test suite passes unchanged: `461 passed, 3 skipped`.
- `ruff check` and `ruff format --check` pass on both changed files.
- Consistent with the existing pattern in this repo (`test_client.py`, `test_async_client.py`, `test_http.py` already use these fixtures) and with prior PRs in this repo doing the same kind of test-fixture consolidation (e.g. #151, #147, #145).

## Test plan

- [x] `pytest tests/test_auth.py -q` — 77 passed
- [x] `pytest -q` (full suite) — 461 passed, 3 skipped
- [x] `ruff check` / `ruff format --check` on changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_01UwNGHh26ksoUEAYZxTviae)_