### PR TITLE
Remove make_empty_response, now redundant with make_status_response

### DIFF
--- a/tests/_usage_fixtures.py
+++ b/tests/_usage_fixtures.py
@@ -73,14 +73,6 @@ def make_status_response(
     return mock_response
 
 
-def make_empty_response(status_code: int = 200) -> MagicMock:
-    """Build a mocked :class:`httpx.Response` with empty ``.content`` (e.g. a 200 DELETE with no body)."""
-    mock_response = MagicMock(spec=httpx.Response)
-    mock_response.status_code = status_code
-    mock_response.content = b""
-    return mock_response
-
-
 def make_mock_usage_response(period: str = "24h") -> MagicMock:
     """Build a mocked 200 OK :class:`httpx.Response` for ``GET /usage``."""
     data = {**USAGE_RESPONSE, "activity": {**USAGE_RESPONSE["activity"], "period": period}}

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -7,7 +7,7 @@ import pytest
 
 from yutori import APIError, AsyncYutoriClient, AuthenticationError
 
-from ._usage_fixtures import make_empty_response, make_json_response, make_mock_usage_response, make_status_response
+from ._usage_fixtures import make_json_response, make_mock_usage_response, make_status_response
 
 
 class TestAsyncYutoriClientInit:
@@ -130,7 +130,7 @@ class TestAsyncScoutsNamespace:
                 await client.scouts.update("scout-123", status="paused", query="new query")
 
     async def test_scouts_delete(self):
-        mock_response = make_empty_response()
+        mock_response = make_status_response(200)
 
         with patch.object(httpx.AsyncClient, "delete", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-test") as client:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,7 @@ import pytest
 
 from yutori import APIError, AuthenticationError, YutoriClient
 
-from ._usage_fixtures import make_empty_response, make_json_response, make_mock_usage_response, make_status_response
+from ._usage_fixtures import make_json_response, make_mock_usage_response, make_status_response
 
 
 class TestYutoriClientInit:
@@ -173,7 +173,7 @@ class TestScoutsNamespace:
             client.scouts.update("scout-123", status="paused", is_public=False)
 
     def test_scouts_delete(self, client):
-        mock_response = make_empty_response()
+        mock_response = make_status_response(200)
 
         with patch.object(httpx.Client, "delete", return_value=mock_response) as mock_delete:
             result = client.scouts.delete("scout-123")


### PR DESCRIPTION
## Summary

Daily cleanup pass over yesterday's merged commits surfaced a same-day duplication that no single PR's reviewer would have caught: PR #147 added `make_empty_response()` for empty-body response mocks, and PR #151 (four commits later, same day) generalized `make_status_response()` to accept `content: bytes` and `headers: dict | None` kwargs. Once both landed, `make_status_response(200)` produces a mock that's behaviorally identical to `make_empty_response()` at its two call sites — `handle_response()` only checks `.content` truthiness on the 2xx path, and both mocks set `content=b""`.

- Removed `make_empty_response()` from `tests/_usage_fixtures.py`
- Updated the two call sites (`tests/test_client.py::test_scouts_delete`, `tests/test_async_client.py::test_scouts_delete`) to use `make_status_response(200)`
- Updated the corresponding imports

No behavior change — pure test-fixture dedup.

## Test plan
- [x] `python -m pytest tests/test_client.py tests/test_async_client.py -q` — 89 passed

cc @dhruvbatra — sole author of both PR #147 and #151, the two commits whose combination created this duplication.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpYmefpRt557BRwptTDJtk)_