### PR TITLE
refactor: extract make_mock_chat_completion() test helper to dedupe ChatCompletion boilerplate

### DIFF
--- a/tests/_usage_fixtures.py
+++ b/tests/_usage_fixtures.py
@@ -1,12 +1,15 @@
-"""Shared usage-endpoint response fixtures for sync/async client tests."""
+"""Shared response fixtures for sync/async client tests."""
 
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import httpx
+
+if TYPE_CHECKING:
+    from openai.types.chat import ChatCompletion
 
 # Mirrors the current server dual-emit: both navigator_* and n1_* keys
 # are present with equal values (n1_* is the deprecated alias).
@@ -77,3 +80,32 @@ def make_mock_usage_response(period: str = "24h") -> MagicMock:
     """Build a mocked 200 OK :class:`httpx.Response` for ``GET /usage``."""
     data = {**USAGE_RESPONSE, "activity": {**USAGE_RESPONSE["activity"], "period": period}}
     return make_json_response(data)
+
+
+def make_mock_chat_completion(
+    *, content: str = "click", model: str = "n1-latest", completion_id: str = "chatcmpl-123"
+) -> ChatCompletion:
+    """Build a minimal :class:`openai.types.chat.ChatCompletion` for mocking chat.completions.create.
+
+    Every Navigator chat-completions test only cares about ``choices[0].message.content``
+    (and sometimes ``model``); the rest of the ChatCompletion fields are fixed
+    boilerplate required by the pydantic model. Centralizing them here keeps the
+    sync/async client test suites from re-declaring the same
+    ChatCompletion/Choice/ChatCompletionMessage construction in every test.
+    """
+    from openai.types.chat import ChatCompletion, ChatCompletionMessage
+    from openai.types.chat.chat_completion import Choice
+
+    return ChatCompletion(
+        id=completion_id,
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content=content),
+            )
+        ],
+        created=1234567890,
+        model=model,
+        object="chat.completion",
+    )

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -7,7 +7,12 @@ import pytest
 
 from yutori import APIError, AsyncYutoriClient, AuthenticationError
 
-from ._usage_fixtures import make_json_response, make_mock_usage_response, make_status_response
+from ._usage_fixtures import (
+    make_json_response,
+    make_mock_chat_completion,
+    make_mock_usage_response,
+    make_status_response,
+)
 
 
 class TestAsyncYutoriClientInit:
@@ -331,22 +336,7 @@ class TestAsyncPydanticSchemaIntegration:
 @pytest.mark.asyncio
 class TestAsyncChatNamespace:
     async def test_chat_completions(self):
-        from openai.types.chat import ChatCompletion, ChatCompletionMessage
-        from openai.types.chat.chat_completion import Choice
-
-        mock_completion = ChatCompletion(
-            id="chatcmpl-123",
-            choices=[
-                Choice(
-                    finish_reason="stop",
-                    index=0,
-                    message=ChatCompletionMessage(role="assistant", content="click"),
-                )
-            ],
-            created=1234567890,
-            model="n1-latest",
-            object="chat.completion",
-        )
+        mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
 
         with patch("yutori._async.chat.AsyncOpenAI") as MockAsyncOpenAI:
             mock_openai_client = MagicMock()
@@ -361,9 +351,6 @@ class TestAsyncChatNamespace:
                 assert result.choices[0].message.content == "click"
 
     async def test_chat_completions_n1_5_forwards_extra_body_options(self):
-        from openai.types.chat import ChatCompletion, ChatCompletionMessage
-        from openai.types.chat.chat_completion import Choice
-
         from yutori.navigator import TOOL_SET_CORE
 
         json_schema = {
@@ -372,19 +359,7 @@ class TestAsyncChatNamespace:
             "required": ["status"],
             "additionalProperties": False,
         }
-        mock_completion = ChatCompletion(
-            id="chatcmpl-123",
-            choices=[
-                Choice(
-                    finish_reason="stop",
-                    index=0,
-                    message=ChatCompletionMessage(role="assistant", content='{"status":"ok"}'),
-                )
-            ],
-            created=1234567890,
-            model="n1.5-latest",
-            object="chat.completion",
-        )
+        mock_completion = make_mock_chat_completion(content='{"status":"ok"}', model="n1.5-latest")
 
         with patch("yutori._async.chat.AsyncOpenAI") as MockAsyncOpenAI:
             mock_openai_client = MagicMock()
@@ -415,25 +390,10 @@ class TestAsyncChatNamespace:
     async def test_n1_helper_acreate_trimmed_public_helper_uses_trimmed_copy(self):
         from copy import deepcopy
 
-        from openai.types.chat import ChatCompletion, ChatCompletionMessage
-        from openai.types.chat.chat_completion import Choice
-
         from yutori.navigator import acreate_trimmed
         from yutori.navigator.payload import trimmed_messages_to_fit
 
-        mock_completion = ChatCompletion(
-            id="chatcmpl-123",
-            choices=[
-                Choice(
-                    finish_reason="stop",
-                    index=0,
-                    message=ChatCompletionMessage(role="assistant", content="click"),
-                )
-            ],
-            created=1234567890,
-            model="n1-latest",
-            object="chat.completion",
-        )
+        mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
         original_messages = [
             {
                 "role": "user",
@@ -476,24 +436,9 @@ class TestAsyncChatNamespace:
     async def test_n1_payload_helper_supports_standard_async_create_pattern(self):
         from copy import deepcopy
 
-        from openai.types.chat import ChatCompletion, ChatCompletionMessage
-        from openai.types.chat.chat_completion import Choice
-
         from yutori.navigator import trimmed_messages_to_fit
 
-        mock_completion = ChatCompletion(
-            id="chatcmpl-123",
-            choices=[
-                Choice(
-                    finish_reason="stop",
-                    index=0,
-                    message=ChatCompletionMessage(role="assistant", content="click"),
-                )
-            ],
-            created=1234567890,
-            model="n1-latest",
-            object="chat.completion",
-        )
+        mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
         original_messages = [
             {
                 "role": "user",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,12 @@ import pytest
 
 from yutori import APIError, AuthenticationError, YutoriClient
 
-from ._usage_fixtures import make_json_response, make_mock_usage_response, make_status_response
+from ._usage_fixtures import (
+    make_json_response,
+    make_mock_chat_completion,
+    make_mock_usage_response,
+    make_status_response,
+)
 
 
 class TestYutoriClientInit:
@@ -373,22 +378,7 @@ class TestPydanticSchemaIntegration:
 
 class TestChatNamespace:
     def test_chat_completions(self):
-        from openai.types.chat import ChatCompletion, ChatCompletionMessage
-        from openai.types.chat.chat_completion import Choice
-
-        mock_completion = ChatCompletion(
-            id="chatcmpl-123",
-            choices=[
-                Choice(
-                    finish_reason="stop",
-                    index=0,
-                    message=ChatCompletionMessage(role="assistant", content="click"),
-                )
-            ],
-            created=1234567890,
-            model="n1-latest",
-            object="chat.completion",
-        )
+        mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
 
         with patch("yutori._sync.chat.OpenAI") as MockOpenAI:
             mock_openai_client = MagicMock()
@@ -407,9 +397,6 @@ class TestChatNamespace:
             client.close()
 
     def test_chat_completions_n1_5_forwards_extra_body_options(self):
-        from openai.types.chat import ChatCompletion, ChatCompletionMessage
-        from openai.types.chat.chat_completion import Choice
-
         from yutori.navigator import TOOL_SET_CORE
 
         json_schema = {
@@ -418,19 +405,7 @@ class TestChatNamespace:
             "required": ["status"],
             "additionalProperties": False,
         }
-        mock_completion = ChatCompletion(
-            id="chatcmpl-123",
-            choices=[
-                Choice(
-                    finish_reason="stop",
-                    index=0,
-                    message=ChatCompletionMessage(role="assistant", content='{"status":"ok"}'),
-                )
-            ],
-            created=1234567890,
-            model="n1.5-latest",
-            object="chat.completion",
-        )
+        mock_completion = make_mock_chat_completion(content='{"status":"ok"}', model="n1.5-latest")
 
         with patch("yutori._sync.chat.OpenAI") as MockOpenAI:
             mock_openai_client = MagicMock()
@@ -460,25 +435,10 @@ class TestChatNamespace:
     def test_n1_helper_create_trimmed_public_helper_uses_trimmed_copy(self):
         from copy import deepcopy
 
-        from openai.types.chat import ChatCompletion, ChatCompletionMessage
-        from openai.types.chat.chat_completion import Choice
-
         from yutori.navigator import create_trimmed
         from yutori.navigator.payload import trimmed_messages_to_fit
 
-        mock_completion = ChatCompletion(
-            id="chatcmpl-123",
-            choices=[
-                Choice(
-                    finish_reason="stop",
-                    index=0,
-                    message=ChatCompletionMessage(role="assistant", content="click"),
-                )
-            ],
-            created=1234567890,
-            model="n1-latest",
-            object="chat.completion",
-        )
+        mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
         original_messages = [
             {
                 "role": "user",
@@ -521,24 +481,9 @@ class TestChatNamespace:
     def test_n1_payload_helper_supports_standard_create_pattern(self):
         from copy import deepcopy
 
-        from openai.types.chat import ChatCompletion, ChatCompletionMessage
-        from openai.types.chat.chat_completion import Choice
-
         from yutori.navigator import trimmed_messages_to_fit
 
-        mock_completion = ChatCompletion(
-            id="chatcmpl-123",
-            choices=[
-                Choice(
-                    finish_reason="stop",
-                    index=0,
-                    message=ChatCompletionMessage(role="assistant", content="click"),
-                )
-            ],
-            created=1234567890,
-            model="n1-latest",
-            object="chat.completion",
-        )
+        mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
         original_messages = [
             {
                 "role": "user",


### PR DESCRIPTION
## What

`TestChatNamespace` (tests/test_client.py) and `TestAsyncChatNamespace` (tests/test_async_client.py) each hand-built the same `ChatCompletion(id=..., choices=[Choice(finish_reason="stop", index=0, message=ChatCompletionMessage(role="assistant", content=...))], created=1234567890, model=..., object="chat.completion")` boilerplate in 4 tests per file (8 near-identical blocks total), varying only the `content` string and `model`.

This PR extracts that into a single `make_mock_chat_completion(*, content=..., model=..., completion_id=...)` helper in `tests/_usage_fixtures.py`, alongside the existing `make_json_response`/`make_status_response` shared fixtures (added in #145/#147/#151/#152).

## Why

Same category of cleanup as the recent `make_json_response`/`make_status_response`/`_completed_process` extractions: repeated fixture construction across sync/async test twins is exactly the kind of thing that drifts when one copy gets updated (e.g. a new required `ChatCompletion` field) and the other doesn't. Centralizing it removes ~80 lines of duplicated boilerplate and leaves each test focused on what it's actually asserting.

## Why it's safe

- No production code changed — this is test-only.
- No behavior change: the helper produces byte-for-byte the same `ChatCompletion` objects the inlined code built before.
- Verified: `ruff check .` and `ruff format --check` pass on the touched files, and the full test suite (`pytest -m "not slow"`) passes: 460 passed, 3 skipped (pre-existing, unrelated).

## Test plan

- [x] `ruff check tests/_usage_fixtures.py tests/test_client.py tests/test_async_client.py`
- [x] `ruff format --check` on touched files
- [x] `pytest -m "not slow"` — 460 passed, 3 skipped, 0 failed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_012wjLtHwPEnTZizvmkcRZrV)_