### PR TITLE
refactor: extract BrowserAgentMixin to dedupe example agent boilerplate

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import sys
+from typing import Any, Protocol
 
 from loguru import logger
 from openai import APIConnectionError, APITimeoutError, InternalServerError, RateLimitError
+
+from yutori.navigator import aplaywright_screenshot_to_data_url
+from yutori.navigator.page_ready import PageReadyChecker
+from yutori.navigator.replay import TrajectoryRecorder
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
@@ -72,3 +78,77 @@ def add_replay_arguments(parser: argparse.ArgumentParser, default_config) -> Non
         help="Optional directory for replay artifacts",
     )
     parser.add_argument("--replay-id", default=default_config.replay_id, help="Optional replay run id")
+
+
+class SupportsBrowserAgentState(Protocol):
+    """Instance attributes :class:`BrowserAgentMixin` methods expect from ``self``.
+
+    Each example ``Agent.__init__`` sets these before the browser lifecycle
+    or replay-persistence methods below are called.
+    """
+
+    headless: bool
+    viewport_width: int
+    viewport_height: int
+    _browser: Any
+    _page: Any
+    _page_ready_checker: PageReadyChecker
+    _replay: TrajectoryRecorder | None
+    _messages: list
+    _step_payloads: list[dict]
+
+
+class BrowserAgentMixin:
+    """Playwright lifecycle, screenshot, and replay-persistence helpers shared by the example agents.
+
+    Every ``examples/navigator_*.py`` script defines its own ``Agent`` class
+    because the action-execution logic differs meaningfully per Navigator
+    version (that divergence is the point of having separate examples).
+    These six methods, however, are identical boilerplate across all of
+    them -- launching/closing the browser, taking a screenshot, waiting for
+    page readiness, clipping image URLs for log output, and persisting
+    optional replay artifacts -- so they live here once instead of being
+    copy-pasted into every script.
+    """
+
+    async def _init_browser(self: SupportsBrowserAgentState, playwright) -> None:
+        self._browser = await playwright.chromium.launch(headless=self.headless)
+        context = await self._browser.new_context(
+            viewport={"width": self.viewport_width, "height": self.viewport_height}
+        )
+        self._page = await context.new_page()
+        await asyncio.sleep(1)
+
+    async def _close_browser(self: SupportsBrowserAgentState) -> None:
+        if self._browser:
+            await self._browser.close()
+            self._browser = None
+
+    async def _take_screenshot(self: SupportsBrowserAgentState) -> str:
+        await self._wait_for_page_ready(fast_mode=True)
+        return await aplaywright_screenshot_to_data_url(
+            self._page,
+            resize_to=(self.viewport_width, self.viewport_height),
+        )
+
+    async def _wait_for_page_ready(self: SupportsBrowserAgentState, fast_mode: bool = False) -> None:
+        if not await self._page_ready_checker.wait_until_ready(self._page, fast_mode=fast_mode):
+            logger.warning(f"Page did not fully stabilize before continuing: {self._page.url}")
+
+    def _clip_image_url(self, url: str, max_len: int = 50) -> str:
+        if url.startswith("data:image"):
+            prefix_end = url.find(",") + 1
+            if prefix_end > 0 and len(url) > prefix_end + max_len:
+                return url[: prefix_end + 20] + "...[clipped]"
+        return url if len(url) <= max_len else url[:max_len] + "..."
+
+    async def _persist_replay(self: SupportsBrowserAgentState) -> None:
+        # Replay persistence is best-effort and not part of the agent loop itself.
+        if self._replay is None:
+            return
+        try:
+            await self._replay.save_messages(self._messages)
+            await self._replay.save_step_payloads(self._step_payloads)
+            await self._replay.save_html(self._messages, step_payloads=self._step_payloads)
+        except Exception:
+            logger.opt(exception=True).warning("Failed to write replay artifacts")

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -28,6 +28,7 @@ import sys
 
 from _common import (
     RETRYABLE_EXCEPTIONS,
+    BrowserAgentMixin,
     add_agent_arguments,
     add_browser_arguments,
     add_model_arguments,
@@ -45,11 +46,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
-from yutori.navigator import (
-    NAVIGATOR_N1_MODEL,
-    aplaywright_screenshot_to_data_url,
-    denormalize_coordinates,
-)
+from yutori.navigator import NAVIGATOR_N1_MODEL, denormalize_coordinates
 from yutori.navigator.loop import update_trimmed_history
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload  # Optional replay helpers.
@@ -77,7 +74,7 @@ class Config(BaseModel):
     replay_id: str | None = None
 
 
-class Agent:
+class Agent(BrowserAgentMixin):
     def __init__(
         self,
         base_url: str = DEFAULT_BASE_URL,
@@ -191,37 +188,6 @@ class Agent:
                 await self._close_browser()
 
         return final_response
-
-    async def _init_browser(self, playwright) -> None:
-        self._browser = await playwright.chromium.launch(headless=self.headless)
-        context = await self._browser.new_context(
-            viewport={"width": self.viewport_width, "height": self.viewport_height}
-        )
-        self._page = await context.new_page()
-        await asyncio.sleep(1)
-
-    async def _close_browser(self) -> None:
-        if self._browser:
-            await self._browser.close()
-            self._browser = None
-
-    async def _take_screenshot(self) -> str:
-        await self._wait_for_page_ready(fast_mode=True)
-        return await aplaywright_screenshot_to_data_url(
-            self._page,
-            resize_to=(self.viewport_width, self.viewport_height),
-        )
-
-    async def _wait_for_page_ready(self, fast_mode: bool = False) -> None:
-        if not await self._page_ready_checker.wait_until_ready(self._page, fast_mode=fast_mode):
-            logger.warning(f"Page did not fully stabilize before continuing: {self._page.url}")
-
-    def _clip_image_url(self, url: str, max_len: int = 50) -> str:
-        if url.startswith("data:image"):
-            prefix_end = url.find(",") + 1
-            if prefix_end > 0 and len(url) > prefix_end + max_len:
-                return url[: prefix_end + 20] + "...[clipped]"
-        return url if len(url) <= max_len else url[:max_len] + "..."
 
     def _format_message_for_log(self, message: dict) -> dict:
         result = {}
@@ -425,17 +391,6 @@ class Agent:
         except Exception as e:
             logger.error(f"Error executing {action_name}: {e}")
             return f"[ERROR] Error executing {action_name}: {e}"
-
-    async def _persist_replay(self) -> None:
-        # Replay persistence is best-effort and not part of the agent loop itself.
-        if self._replay is None:
-            return
-        try:
-            await self._replay.save_messages(self._messages)
-            await self._replay.save_step_payloads(self._step_payloads)
-            await self._replay.save_html(self._messages, step_payloads=self._step_payloads)
-        except Exception:
-            logger.opt(exception=True).warning("Failed to write replay artifacts")
 
 
 async def main():

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -45,6 +45,7 @@ import json
 
 from _common import (
     RETRYABLE_EXCEPTIONS,
+    BrowserAgentMixin,
     add_agent_arguments,
     add_browser_arguments,
     add_model_arguments,
@@ -66,7 +67,6 @@ from yutori.navigator import (
     NAVIGATOR_N1_5_MODEL,
     TOOL_SET_CORE,
     TOOL_SET_EXPANDED,
-    aplaywright_screenshot_to_data_url,
     denormalize_coordinates,
     format_stop_and_summarize,
     format_task_with_context,
@@ -120,7 +120,7 @@ class Config(BaseModel):
     replay_id: str | None = None
 
 
-class Agent:
+class Agent(BrowserAgentMixin):
     def __init__(
         self,
         base_url: str = DEFAULT_BASE_URL,
@@ -261,37 +261,6 @@ class Agent:
                 await self._close_browser()
 
         return final_response
-
-    async def _init_browser(self, playwright) -> None:
-        self._browser = await playwright.chromium.launch(headless=self.headless)
-        context = await self._browser.new_context(
-            viewport={"width": self.viewport_width, "height": self.viewport_height}
-        )
-        self._page = await context.new_page()
-        await asyncio.sleep(1)
-
-    async def _close_browser(self) -> None:
-        if self._browser:
-            await self._browser.close()
-            self._browser = None
-
-    async def _take_screenshot(self) -> str:
-        await self._wait_for_page_ready(fast_mode=True)
-        return await aplaywright_screenshot_to_data_url(
-            self._page,
-            resize_to=(self.viewport_width, self.viewport_height),
-        )
-
-    async def _wait_for_page_ready(self, fast_mode: bool = False) -> None:
-        if not await self._page_ready_checker.wait_until_ready(self._page, fast_mode=fast_mode):
-            logger.warning(f"Page did not fully stabilize before continuing: {self._page.url}")
-
-    def _clip_image_url(self, url: str, max_len: int = 50) -> str:
-        if url.startswith("data:image"):
-            prefix_end = url.find(",") + 1
-            if prefix_end > 0 and len(url) > prefix_end + max_len:
-                return url[: prefix_end + 20] + "...[clipped]"
-        return url if len(url) <= max_len else url[:max_len] + "..."
 
     def _format_message_for_log(self, message: dict) -> dict:
         content = message.get("content")
@@ -706,17 +675,6 @@ class Agent:
         except Exception as e:
             logger.error(f"Error executing {action_name}: {e}")
             return f"[ERROR] Error executing {action_name}: {e}"
-
-    async def _persist_replay(self) -> None:
-        # Replay persistence is best-effort and not part of the agent loop itself.
-        if self._replay is None:
-            return
-        try:
-            await self._replay.save_messages(self._messages)
-            await self._replay.save_step_payloads(self._step_payloads)
-            await self._replay.save_html(self._messages, step_payloads=self._step_payloads)
-        except Exception:
-            logger.opt(exception=True).warning("Failed to write replay artifacts")
 
 
 async def main():

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -30,6 +30,7 @@ from functools import cached_property
 
 from _common import (
     RETRYABLE_EXCEPTIONS,
+    BrowserAgentMixin,
     add_agent_arguments,
     add_browser_arguments,
     add_model_arguments,
@@ -46,7 +47,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
-from yutori.navigator import NAVIGATOR_N1_MODEL, aplaywright_screenshot_to_data_url, denormalize_coordinates
+from yutori.navigator import NAVIGATOR_N1_MODEL, denormalize_coordinates
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload  # Optional replay helpers.
 
@@ -137,7 +138,7 @@ class ExtractContentAndLinksTool:
         return result
 
 
-class Agent:
+class Agent(BrowserAgentMixin):
     def __init__(
         self,
         base_url: str = DEFAULT_BASE_URL,
@@ -248,37 +249,6 @@ class Agent:
                 await self._close_browser()
 
         return final_response
-
-    async def _init_browser(self, playwright) -> None:
-        self._browser = await playwright.chromium.launch(headless=self.headless)
-        context = await self._browser.new_context(
-            viewport={"width": self.viewport_width, "height": self.viewport_height}
-        )
-        self._page = await context.new_page()
-        await asyncio.sleep(1)
-
-    async def _close_browser(self) -> None:
-        if self._browser:
-            await self._browser.close()
-            self._browser = None
-
-    async def _take_screenshot(self) -> str:
-        await self._wait_for_page_ready(fast_mode=True)
-        return await aplaywright_screenshot_to_data_url(
-            self._page,
-            resize_to=(self.viewport_width, self.viewport_height),
-        )
-
-    async def _wait_for_page_ready(self, fast_mode: bool = False) -> None:
-        if not await self._page_ready_checker.wait_until_ready(self._page, fast_mode=fast_mode):
-            logger.warning(f"Page did not fully stabilize before continuing: {self._page.url}")
-
-    def _clip_image_url(self, url: str, max_len: int = 50) -> str:
-        if url.startswith("data:image"):
-            prefix_end = url.find(",") + 1
-            if prefix_end > 0 and len(url) > prefix_end + max_len:
-                return url[: prefix_end + 20] + "...[clipped]"
-        return url if len(url) <= max_len else url[:max_len] + "..."
 
     def _format_message_for_log(self, message: dict) -> dict:
         result = {}
@@ -480,17 +450,6 @@ class Agent:
         except Exception as e:
             logger.error(f"Error executing {action_name}: {e}")
             return f"[ERROR] Error executing {action_name}: {e}"
-
-    async def _persist_replay(self) -> None:
-        # Replay persistence is best-effort and not part of the agent loop itself.
-        if self._replay is None:
-            return
-        try:
-            await self._replay.save_messages(self._messages)
-            await self._replay.save_step_payloads(self._step_payloads)
-            await self._replay.save_html(self._messages, step_payloads=self._step_payloads)
-        except Exception:
-            logger.opt(exception=True).warning("Failed to write replay artifacts")
 
 
 async def main():

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -34,6 +34,7 @@ from functools import cached_property
 
 from _common import (
     RETRYABLE_EXCEPTIONS,
+    BrowserAgentMixin,
     add_agent_arguments,
     add_browser_arguments,
     add_model_arguments,
@@ -50,7 +51,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
-from yutori.navigator import NAVIGATOR_N1_MODEL, aplaywright_screenshot_to_data_url, denormalize_coordinates
+from yutori.navigator import NAVIGATOR_N1_MODEL, denormalize_coordinates
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload  # Optional replay helpers.
 
@@ -183,7 +184,7 @@ class MemoToolSuite:
         return f"Memo file path: {self.file_path}\nRecords:\n{content}"
 
 
-class Agent:
+class Agent(BrowserAgentMixin):
     def __init__(
         self,
         base_url: str = DEFAULT_BASE_URL,
@@ -298,37 +299,6 @@ class Agent:
                 await self._close_browser()
 
         return final_response
-
-    async def _init_browser(self, playwright) -> None:
-        self._browser = await playwright.chromium.launch(headless=self.headless)
-        context = await self._browser.new_context(
-            viewport={"width": self.viewport_width, "height": self.viewport_height}
-        )
-        self._page = await context.new_page()
-        await asyncio.sleep(1)
-
-    async def _close_browser(self) -> None:
-        if self._browser:
-            await self._browser.close()
-            self._browser = None
-
-    async def _take_screenshot(self) -> str:
-        await self._wait_for_page_ready(fast_mode=True)
-        return await aplaywright_screenshot_to_data_url(
-            self._page,
-            resize_to=(self.viewport_width, self.viewport_height),
-        )
-
-    async def _wait_for_page_ready(self, fast_mode: bool = False) -> None:
-        if not await self._page_ready_checker.wait_until_ready(self._page, fast_mode=fast_mode):
-            logger.warning(f"Page did not fully stabilize before continuing: {self._page.url}")
-
-    def _clip_image_url(self, url: str, max_len: int = 50) -> str:
-        if url.startswith("data:image"):
-            prefix_end = url.find(",") + 1
-            if prefix_end > 0 and len(url) > prefix_end + max_len:
-                return url[: prefix_end + 20] + "...[clipped]"
-        return url if len(url) <= max_len else url[:max_len] + "..."
 
     def _format_message_for_log(self, message: dict) -> dict:
         result = {}
@@ -540,17 +510,6 @@ class Agent:
             return False, f"[ERROR] Error executing {action_name}: {e}"
 
         return False, None
-
-    async def _persist_replay(self) -> None:
-        # Replay persistence is best-effort and not part of the agent loop itself.
-        if self._replay is None:
-            return
-        try:
-            await self._replay.save_messages(self._messages)
-            await self._replay.save_step_payloads(self._step_payloads)
-            await self._replay.save_html(self._messages, step_payloads=self._step_payloads)
-        except Exception:
-            logger.opt(exception=True).warning("Failed to write replay artifacts")
 
 
 async def main():


### PR DESCRIPTION
## Structural issue

All four `examples/navigator_*.py` scripts (`navigator_n1.py`, `navigator_n1_5.py`, `navigator_n1_custom_tools.py`, `navigator_n1_memo.py`) define their own `Agent` class, and six of those methods were **byte-for-byte identical** copy-paste across all four files:

- `_init_browser`
- `_close_browser`
- `_take_screenshot`
- `_wait_for_page_ready`
- `_clip_image_url`
- `_persist_replay`

That's ~40 lines of pure Playwright/replay plumbing duplicated per file (~150 lines total across the four scripts). This is distinct from the intentional per-script duplication in the action-execution logic (`_execute`), which genuinely differs across Navigator n1 vs n1.5's action space and is the whole reason these are separate examples rather than one parameterized script.

## Fix

Added a `BrowserAgentMixin` class to `examples/_common.py` (which already holds the shared argparse helpers used by all four scripts) containing the six identical methods, and had each example's `Agent` class inherit from it instead of redefining them.

I deliberately left `_format_message_for_log` alone even though it appears in all four files, because `navigator_n1_5.py`'s implementation uses a different (functionally-equivalent but not byte-identical) coding style than the other three — consolidating it would require verifying behavioral equivalence rather than a pure mechanical extraction, so it's out of scope for this change.

## Why this is safe

- No behavior change — the six extracted methods are moved verbatim into the mixin; only their location changed.
- Verified all four `Agent` classes retain the six methods with correctly-bound instance state (browser handle, page, page-ready checker, replay recorder, messages, step payloads) via direct instantiation + `hasattr`/MRO checks.
- Verified all four scripts still run `--help` cleanly (argparse wiring untouched).
- `ruff check .` passes.
- Full test suite: 460 passed, 3 skipped, 1 slow (also passed when run explicitly) — unchanged from before this PR.

Net diff: +91/-180 across `examples/_common.py` and the four example scripts (5 files total).


---
_Generated by [Claude Code](https://claude.ai/code/session_014ZZ5LT8vmL6JKb4AxToAvB)_