### PR TITLE
refactor: dedupe _format_message_for_log into BrowserAgentMixin

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -104,11 +104,16 @@ class BrowserAgentMixin:
     Every ``examples/navigator_*.py`` script defines its own ``Agent`` class
     because the action-execution logic differs meaningfully per Navigator
     version (that divergence is the point of having separate examples).
-    These six methods, however, are identical boilerplate across all of
+    These methods, however, are identical boilerplate across all of
     them -- launching/closing the browser, taking a screenshot, waiting for
-    page readiness, clipping image URLs for log output, and persisting
-    optional replay artifacts -- so they live here once instead of being
-    copy-pasted into every script.
+    page readiness, clipping image URLs for log output, formatting messages
+    for log output, and persisting optional replay artifacts -- so they live
+    here once instead of being copy-pasted into every script.
+
+    ``navigator_n1_5.py`` defines its own ``_format_message_for_log`` (a
+    differently-styled but behaviorally-equivalent implementation) and so
+    overrides this mixin's version via normal MRO -- it is intentionally not
+    part of this mechanical extraction.
     """
 
     async def _init_browser(self: SupportsBrowserAgentState, playwright) -> None:
@@ -141,6 +146,24 @@ class BrowserAgentMixin:
             if prefix_end > 0 and len(url) > prefix_end + max_len:
                 return url[: prefix_end + 20] + "...[clipped]"
         return url if len(url) <= max_len else url[:max_len] + "..."
+
+    def _format_message_for_log(self, message: dict) -> dict:
+        result = {}
+        for key, value in message.items():
+            if key == "content" and isinstance(value, list):
+                clipped_content = []
+                for item in value:
+                    if isinstance(item, dict) and item.get("type") == "image_url":
+                        clipped_item = dict(item)
+                        if "image_url" in clipped_item and "url" in clipped_item["image_url"]:
+                            clipped_item["image_url"] = {"url": self._clip_image_url(clipped_item["image_url"]["url"])}
+                        clipped_content.append(clipped_item)
+                    else:
+                        clipped_content.append(item)
+                result[key] = clipped_content
+            else:
+                result[key] = value
+        return result
 
     async def _persist_replay(self: SupportsBrowserAgentState) -> None:
         # Replay persistence is best-effort and not part of the agent loop itself.

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -189,24 +189,6 @@ class Agent(BrowserAgentMixin):
 
         return final_response
 
-    def _format_message_for_log(self, message: dict) -> dict:
-        result = {}
-        for key, value in message.items():
-            if key == "content" and isinstance(value, list):
-                clipped_content = []
-                for item in value:
-                    if isinstance(item, dict) and item.get("type") == "image_url":
-                        clipped_item = dict(item)
-                        if "image_url" in clipped_item and "url" in clipped_item["image_url"]:
-                            clipped_item["image_url"] = {"url": self._clip_image_url(clipped_item["image_url"]["url"])}
-                        clipped_content.append(clipped_item)
-                    else:
-                        clipped_content.append(item)
-                result[key] = clipped_content
-            else:
-                result[key] = value
-        return result
-
     @retry(
         retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
         stop=stop_after_attempt(3),

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -250,24 +250,6 @@ class Agent(BrowserAgentMixin):
 
         return final_response
 
-    def _format_message_for_log(self, message: dict) -> dict:
-        result = {}
-        for key, value in message.items():
-            if key == "content" and isinstance(value, list):
-                clipped_content = []
-                for item in value:
-                    if isinstance(item, dict) and item.get("type") == "image_url":
-                        clipped_item = dict(item)
-                        if "image_url" in clipped_item and "url" in clipped_item["image_url"]:
-                            clipped_item["image_url"] = {"url": self._clip_image_url(clipped_item["image_url"]["url"])}
-                        clipped_content.append(clipped_item)
-                    else:
-                        clipped_content.append(item)
-                result[key] = clipped_content
-            else:
-                result[key] = value
-        return result
-
     @retry(
         retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
         stop=stop_after_attempt(3),

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -300,24 +300,6 @@ class Agent(BrowserAgentMixin):
 
         return final_response
 
-    def _format_message_for_log(self, message: dict) -> dict:
-        result = {}
-        for key, value in message.items():
-            if key == "content" and isinstance(value, list):
-                clipped_content = []
-                for item in value:
-                    if isinstance(item, dict) and item.get("type") == "image_url":
-                        clipped_item = dict(item)
-                        if "image_url" in clipped_item and "url" in clipped_item["image_url"]:
-                            clipped_item["image_url"] = {"url": self._clip_image_url(clipped_item["image_url"]["url"])}
-                        clipped_content.append(clipped_item)
-                    else:
-                        clipped_content.append(item)
-                result[key] = clipped_content
-            else:
-                result[key] = value
-        return result
-
     @retry(
         retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
         stop=stop_after_attempt(3),


### PR DESCRIPTION
## Structural issue

PR #155 extracted six identical Playwright/replay-plumbing methods from the four `examples/navigator_*.py` scripts into a new `BrowserAgentMixin` in `examples/_common.py`, but deliberately left `_format_message_for_log` out, noting that `navigator_n1_5.py`'s implementation "uses a different (functionally-equivalent but not byte-identical) coding style than the other three."

Re-checking that claim: `navigator_n1.py`, `navigator_n1_custom_tools.py`, and `navigator_n1_memo.py` all define **byte-for-byte identical** copies of `_format_message_for_log` (~17 lines each, verified with `diff`). Only `navigator_n1_5.py` differs. So three of the four copies were exactly the kind of copy-paste boilerplate #155 was extracting — they just got missed because the fourth file's version isn't identical.

## Fix

Moved the shared 17-line implementation into `BrowserAgentMixin` (right after the existing `_clip_image_url`, which it calls). `navigator_n1.py`, `navigator_n1_custom_tools.py`, and `navigator_n1_memo.py` now inherit it from the mixin instead of redefining it. `navigator_n1_5.py` is untouched — its own differently-styled `_format_message_for_log` method continues to override the mixin's version via normal Python MRO (a subclass's own method always wins over an inherited one), so its behavior is unaffected either way.

## Why this is safe

- No behavior change: the method body moved verbatim; only its location changed for the three files that used it identically.
- Verified via direct instantiation that MRO resolves as intended:
  - `navigator_n1.Agent._format_message_for_log` → `BrowserAgentMixin._format_message_for_log`
  - `navigator_n1_custom_tools.Agent._format_message_for_log` → `BrowserAgentMixin._format_message_for_log`
  - `navigator_n1_memo.Agent._format_message_for_log` → `BrowserAgentMixin._format_message_for_log`
  - `navigator_n1_5.Agent._format_message_for_log` → `Agent._format_message_for_log` (its own, unaffected)
- Verified the mixin's method still clips image URLs correctly with a direct call (image URL over the length threshold gets `...[clipped]` appended, non-image content passes through unchanged).
- All four scripts still run `--help` cleanly (import wiring intact).
- `ruff check` / `ruff format --check` pass on all changed files.
- Full test suite: 460 passed, 3 skipped, 1 deselected (slow) — unchanged from before this PR.

Net diff: +27/-58 across `examples/_common.py` and three example scripts (4 files total).

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01CQHxJkDXEZbvEaKCuyth7z)_