### PR TITLE
refactor: dedupe _use_tmp_config fixture across test_auth.py test classes

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -131,6 +131,24 @@ class TestBuildKeyName:
         assert key_name == "2026-02-09-yutori-mcp"
 
 
+def _redirect_config_path(tmp_path, monkeypatch, *, patch_flow: bool = False, clear_env: bool = False):
+    """Redirect ``get_config_path()`` to a temp path and return it.
+
+    Always patches ``yutori.auth.credentials.get_config_path``. Pass
+    ``patch_flow=True`` to also patch the separate import in ``flow.py``, and
+    ``clear_env=True`` to delete ``YUTORI_API_KEY`` so it can't leak into the
+    test from the surrounding environment.
+    """
+    config_path = tmp_path / ".yutori" / "config.json"
+    monkeypatch.setattr("yutori.auth.credentials.get_config_path", lambda: config_path)
+    if patch_flow:
+        # Also patch the import in flow.py which imports _get_config_path
+        monkeypatch.setattr("yutori.auth.flow.get_config_path", lambda: config_path)
+    if clear_env:
+        monkeypatch.delenv("YUTORI_API_KEY", raising=False)
+    return config_path
+
+
 # ---------------------------------------------------------------------------
 # Credentials: save / load / clear / resolve
 # ---------------------------------------------------------------------------
@@ -140,12 +158,8 @@ class TestCredentials:
     @pytest.fixture(autouse=True)
     def _use_tmp_config(self, tmp_path, monkeypatch):
         """Redirect config path to a temp directory for all credential tests."""
-        config_path = tmp_path / ".yutori" / "config.json"
-        monkeypatch.setattr("yutori.auth.credentials.get_config_path", lambda: config_path)
-        # Also patch the import in flow.py which imports _get_config_path
-        monkeypatch.setattr("yutori.auth.flow.get_config_path", lambda: config_path)
-        self.config_path = config_path
-        self.config_dir = config_path.parent
+        self.config_path = _redirect_config_path(tmp_path, monkeypatch, patch_flow=True)
+        self.config_dir = self.config_path.parent
 
     def test_save_and_load_round_trip(self):
         save_config("yt-test-key-12345")
@@ -206,10 +220,7 @@ class TestCredentials:
 class TestResolveApiKey:
     @pytest.fixture(autouse=True)
     def _use_tmp_config(self, tmp_path, monkeypatch):
-        config_path = tmp_path / ".yutori" / "config.json"
-        monkeypatch.setattr("yutori.auth.credentials.get_config_path", lambda: config_path)
-        self.config_path = config_path
-        monkeypatch.delenv("YUTORI_API_KEY", raising=False)
+        self.config_path = _redirect_config_path(tmp_path, monkeypatch, clear_env=True)
 
     def test_explicit_param_wins(self, monkeypatch):
         monkeypatch.setenv("YUTORI_API_KEY", "yt-env")
@@ -728,11 +739,7 @@ class TestRunLoginFlow:
 class TestGetAuthStatus:
     @pytest.fixture(autouse=True)
     def _use_tmp_config(self, tmp_path, monkeypatch):
-        config_path = tmp_path / ".yutori" / "config.json"
-        monkeypatch.setattr("yutori.auth.credentials.get_config_path", lambda: config_path)
-        monkeypatch.setattr("yutori.auth.flow.get_config_path", lambda: config_path)
-        monkeypatch.delenv("YUTORI_API_KEY", raising=False)
-        self.config_path = config_path
+        self.config_path = _redirect_config_path(tmp_path, monkeypatch, patch_flow=True, clear_env=True)
 
     def test_authenticated_from_config_file(self):
         save_config("yt-test-key-12345")


### PR DESCRIPTION
## What

`tests/test_auth.py` had three test classes (`TestCredentials`, `TestResolveApiKey`, `TestGetAuthStatus`) each defining a near-identical autouse `_use_tmp_config` fixture that redirects `get_config_path()` to a temp path, with slightly different combinations of:

- patching `yutori.auth.credentials.get_config_path`
- also patching `yutori.auth.flow.get_config_path` (needed by tests that exercise `flow.py`)
- clearing `YUTORI_API_KEY` from the environment (needed by tests that check env-var precedence)

This PR extracts a single module-level helper, `_redirect_config_path(tmp_path, monkeypatch, *, patch_flow=False, clear_env=False)`, and has each of the three fixtures call it with the flags it needs. Each fixture body shrinks to a one-liner.

## Why this is safe

- Test-only change, single file, no production code touched.
- Behavior-preserving: each fixture still ends up patching exactly the same targets and clearing the same env var it did before — only the plumbing is shared, the effective behavior per test class is identical (verified by re-reading each class's assertions to confirm none relied on the difference between "unpatched" and "patched but resulting in the same value").
- Full test suite passes locally: `pytest -q -m "not slow"` → 460 passed, 3 skipped, 1 deselected.
- `ruff check` and `ruff format --check` both pass on the changed file.

## Context

Found during a fresh look for the recurring automated structural-refactor cronjob for this repo. Per the shared cross-repo refactor backlog (`yutori-ai/yutori`'s `.claude/REFACTOR.md`), this package has already had most obvious duplication extracted in prior runs (payload building, CLI interval formatting, browsing/research namespace migration, n1 deprecation shims, CLI truncation helpers, several test-helper extractions). This fixture duplication in `test_auth.py` was a small remaining pocket that hadn't been touched yet.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RZ1DNw8JaxcjJdMKRzSBNr)_