### PR TITLE
refactor: consolidate run_interactive_command's triplicate except blocks

### DIFF
--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -296,20 +296,18 @@ def run_interactive_command(
             check=False,
             timeout=timeout,
         )
-    except subprocess.TimeoutExpired as exc:
-        returncode = _synthetic_returncode_for_exception(exc)
-        return subprocess.CompletedProcess(argv, returncode=returncode, stdout=None, stderr=None)
-    except KeyboardInterrupt as exc:
-        # Ctrl+C is forwarded to the child via the shared TTY; once it exits,
-        # the parent's default SIGINT handler raises here. Convert to a
-        # synthetic returncode so callers can render a "Cancelled" row
-        # instead of crashing the installer mid-summary.
-        returncode = _synthetic_returncode_for_exception(exc)
-        return subprocess.CompletedProcess(argv, returncode=returncode, stdout=None, stderr=None)
-    except OSError as exc:
-        # Catches FileNotFoundError, PermissionError, and rarer fork/exec
-        # failures (ENOEXEC, EMFILE, ENOMEM). All map to "could not execute"
-        # from the user's perspective.
+    except (subprocess.TimeoutExpired, KeyboardInterrupt, OSError) as exc:
+        # All three failure modes map to the same synthetic-CompletedProcess
+        # shape, so one shared except body keeps them from drifting apart:
+        #   - TimeoutExpired: the child ran past `timeout`.
+        #   - KeyboardInterrupt: Ctrl+C is forwarded to the child via the
+        #     shared TTY; once it exits, the parent's default SIGINT handler
+        #     raises here.
+        #   - OSError: covers FileNotFoundError, PermissionError, and rarer
+        #     fork/exec failures (ENOEXEC, EMFILE, ENOMEM) — all "could not
+        #     execute" from the user's perspective.
+        # Converting each to a synthetic returncode lets callers render a
+        # status row instead of crashing the installer mid-summary.
         returncode = _synthetic_returncode_for_exception(exc)
         return subprocess.CompletedProcess(argv, returncode=returncode, stdout=None, stderr=None)
 


### PR DESCRIPTION
## What

`run_interactive_command` in `yutori/cli/commands/install_flow.py` had three separate `except` clauses (`subprocess.TimeoutExpired`, `KeyboardInterrupt`, `OSError`) with byte-for-byte identical bodies:

```python
returncode = _synthetic_returncode_for_exception(exc)
return subprocess.CompletedProcess(argv, returncode=returncode, stdout=None, stderr=None)
```

This PR merges them into a single `except (subprocess.TimeoutExpired, KeyboardInterrupt, OSError) as exc:` clause with one consolidated comment explaining all three failure modes.

## Why it's an improvement

- Removes ~14 lines of copy-pasted logic that could silently drift (e.g. a future edit changing the returned `CompletedProcess` shape for one exception type but not the other two).
- `_synthetic_returncode_for_exception` (used here) already documents that it's meant to classify exactly these three exception types together for both `run_command` and `run_interactive_command` — this change makes `run_interactive_command`'s own three branches consistent with that shared intent instead of triplicating it.
- No behavior change: exception matching via a tuple in one `except` clause is equivalent to three separate `except` clauses catching the same types, and `_synthetic_returncode_for_exception` and the returned `CompletedProcess` shape are unchanged.

## Why it's safe

- Single function, single file — no public API or call-site changes.
- Existing dedicated regression tests (`tests/test_install_flow.py::test_run_interactive_command_maps_timeout_to_124`, `..._maps_missing_binary_to_127`, `..._maps_oserror_to_127`, `..._maps_keyboard_interrupt_to_130`) exercise all three exception paths and pass unchanged.
- Full test suite passes locally: `461 passed, 3 skipped`.

## Test plan

- [x] `python -m pytest tests/test_install_flow.py -q` — 79 passed
- [x] `python -m pytest -q` (full suite) — 461 passed, 3 skipped
- [x] `python -m py_compile yutori/cli/commands/install_flow.py`
- [x] `ruff check yutori/cli/commands/install_flow.py` — passed (pre-existing `ruff format` diffs elsewhere in the file predate this change and are unrelated to this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9rz68T1EuT66RbQXYKihc)_