### PR TITLE
cleanup: drop redundant .keys() in dict iteration

### DIFF
--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -633,7 +633,7 @@ def _format_action_details(action: dict[str, Any]) -> str:
             details.append(f"{key}={_format_value(action[key])}")
             seen.add(key)
 
-    for key in sorted(action.keys()):
+    for key in sorted(action):
         if key in seen:
             continue
         details.append(f"{key}={_format_value(action[key])}")


### PR DESCRIPTION
## Summary

- `replay.py:636`: `sorted(action.keys())` → `sorted(action)` — iterating a dict directly yields its keys, making `.keys()` redundant

cc @dhruvbatra (recent author)

## Test plan

- [ ] No behavior change — `sorted(dict)` and `sorted(dict.keys())` produce identical results


---
_Generated by [Claude Code](https://claude.ai/code/session_01H3BeGtknpkr548Rhb7zQVx)_