### PR TITLE
refactor(examples): extract shared llm_retry decorator

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -9,12 +9,20 @@ from typing import Any, Protocol
 
 from loguru import logger
 from openai import APIConnectionError, APITimeoutError, InternalServerError, RateLimitError
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori.navigator import aplaywright_screenshot_to_data_url
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
+
+llm_retry = retry(
+    retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    reraise=True,
+)
 
 _LOG_FORMAT = (
     "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -27,7 +27,6 @@ import json
 import sys
 
 from _common import (
-    RETRYABLE_EXCEPTIONS,
     BrowserAgentMixin,
     add_agent_arguments,
     add_browser_arguments,
@@ -36,13 +35,13 @@ from _common import (
     add_replay_arguments,
     add_task_arguments,
     configure_example_logging,
+    llm_retry,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
 from playwright.async_api import Browser, Page, async_playwright
 from pydantic import BaseModel, Field
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
@@ -189,12 +188,7 @@ class Agent(BrowserAgentMixin):
 
         return final_response
 
-    @retry(
-        retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        reraise=True,
-    )
+    @llm_retry
     async def _call_llm_with_retries(self) -> ChatCompletion:
         self._request_messages, size_bytes, removed = update_trimmed_history(
             self._messages,

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -44,7 +44,6 @@ import asyncio
 import json
 
 from _common import (
-    RETRYABLE_EXCEPTIONS,
     BrowserAgentMixin,
     add_agent_arguments,
     add_browser_arguments,
@@ -53,13 +52,13 @@ from _common import (
     add_replay_arguments,
     add_task_arguments,
     configure_example_logging,
+    llm_retry,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
 from playwright.async_api import Browser, Page, async_playwright
 from pydantic import BaseModel, Field
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
@@ -278,12 +277,7 @@ class Agent(BrowserAgentMixin):
                 clipped_content.append(item)
         return {**message, "content": clipped_content}
 
-    @retry(
-        retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        reraise=True,
-    )
+    @llm_retry
     async def _call_llm_with_retries(self) -> ChatCompletion:
         self._request_messages, size_bytes, removed = update_trimmed_history(
             self._messages,

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -29,7 +29,6 @@ import sys
 from functools import cached_property
 
 from _common import (
-    RETRYABLE_EXCEPTIONS,
     BrowserAgentMixin,
     add_agent_arguments,
     add_browser_arguments,
@@ -37,13 +36,13 @@ from _common import (
     add_replay_arguments,
     add_task_arguments,
     configure_example_logging,
+    llm_retry,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
 from playwright.async_api import Browser, Page, async_playwright
 from pydantic import BaseModel, Field
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
@@ -250,12 +249,7 @@ class Agent(BrowserAgentMixin):
 
         return final_response
 
-    @retry(
-        retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        reraise=True,
-    )
+    @llm_retry
     async def _call_llm_with_retries(self) -> ChatCompletion:
         # This copy is only for replay output; the request itself just uses the same fields directly.
         request_payload = {

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -33,7 +33,6 @@ from datetime import datetime
 from functools import cached_property
 
 from _common import (
-    RETRYABLE_EXCEPTIONS,
     BrowserAgentMixin,
     add_agent_arguments,
     add_browser_arguments,
@@ -41,13 +40,13 @@ from _common import (
     add_replay_arguments,
     add_task_arguments,
     configure_example_logging,
+    llm_retry,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
 from playwright.async_api import Browser, Page, async_playwright
 from pydantic import BaseModel, Field
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
@@ -300,12 +299,7 @@ class Agent(BrowserAgentMixin):
 
         return final_response
 
-    @retry(
-        retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=1, max=10),
-        reraise=True,
-    )
+    @llm_retry
     async def _call_llm_with_retries(self) -> ChatCompletion:
         # This copy is only for replay output; the request itself just uses the same fields directly.
         request_payload = {


### PR DESCRIPTION
## What

`examples/navigator_n1.py`, `navigator_n1_5.py`, `navigator_n1_custom_tools.py`, and `navigator_n1_memo.py` each defined the identical 5-line tenacity `@retry(...)` configuration decorating their `_call_llm_with_retries` method:

```python
@retry(
    retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
    stop=stop_after_attempt(3),
    wait=wait_exponential(multiplier=1, min=1, max=10),
    reraise=True,
)
```

`RETRYABLE_EXCEPTIONS` was already shared via `examples/_common.py`, but the retry policy built from it wasn't.

## Why

Extracted `llm_retry` into `examples/_common.py` next to `RETRYABLE_EXCEPTIONS`. Each example now does `@llm_retry` instead of repeating the retry/stop/wait/reraise config.

## Why this is safe

- Byte-for-byte identical decorator across all 4 sites — pure mechanical extraction, same `Retrying` configuration applied to the same methods.
- Verified no remaining references to the now-unused per-file `tenacity` imports.
- All 5 touched files parse cleanly (`ast.parse`).
- `ruff check` passes; `ruff format --check` flags pre-existing formatting drift in `navigator_n1_5.py` that exists on `main` too (confirmed via `git stash`) — unrelated to this diff, not touched by it.
- No test suite exercises these example scripts directly (confirmed via grep), so there's nothing to run beyond static verification.

## Scope

5 files touched (1 helper + 4 call sites), 16 insertions / 32 deletions. No behavior change.

🤖 Generated by the hourly automated refactor cronjob.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01AX2cYgVBmx6NFfXkGnXQgw)_