### PR TITLE
docs: fix stale function names in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@ The examples rely on the SDK's normal credential resolution. They do not expose 
 
 ## navigator_n1.py
 
-A complete browsing agent using the Navigator API with the Navigator n1 model. Launches a local Playwright browser, captures screenshots through `yutori.navigator.aplaywright_screenshot_to_data_url(...)`, converts tool-call coordinates with `yutori.navigator.denormalize_coordinates(...)`, sends them to Navigator n1, and executes predicted actions until the task is complete. The example keeps its own long-lived message history bounded with `estimate_messages_size_bytes(...)` plus `trimmed_messages_to_fit(...)`, then still ends with a standard `client.chat.completions.create(...)` call.
+A complete browsing agent using the Navigator API with the Navigator n1 model. Launches a local Playwright browser, captures screenshots through `yutori.navigator.aplaywright_screenshot_to_data_url(...)`, converts tool-call coordinates with `yutori.navigator.denormalize_coordinates(...)`, sends them to Navigator n1, and executes predicted actions until the task is complete. The example keeps its own long-lived message history bounded with `update_trimmed_history(...)` from `yutori.navigator.loop`, then still ends with a standard `client.chat.completions.create(...)` call.
 
 ```bash
 uv run python examples/navigator_n1.py --task "List the team member names" --start-url "https://www.yutori.com"


### PR DESCRIPTION
## Summary

- Fix stale function names in `examples/README.md`: the `navigator_n1.py` description referenced `estimate_messages_size_bytes(...)` plus `trimmed_messages_to_fit(...)`, but the code actually uses `update_trimmed_history(...)` from `yutori.navigator.loop`

## Test plan

- [x] Verified `examples/navigator_n1.py` imports and calls `update_trimmed_history` (line 49, 193)
- [x] Confirmed the old function names (`estimate_messages_size_bytes`, `trimmed_messages_to_fit`) do not appear anywhere in the examples directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vz7op81bocBxsDV4jjzQdn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vz7op81bocBxsDV4jjzQdn)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Updates the **`navigator_n1.py`** section in **`examples/README.md`** so it matches the example’s real history-trimming API.
> 
> The description no longer mentions **`estimate_messages_size_bytes(...)`** and **`trimmed_messages_to_fit(...)`**. It now documents **`update_trimmed_history(...)`** from **`yutori.navigator.loop`**, which **`examples/navigator_n1.py`** imports and uses before each LLM call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08f30df2d53f1489cc48192c12e2400ed339191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->