### PR TITLE
refactor(tests): extract shared OAuth callback scaffold in test_auth.py

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,6 +7,7 @@ import errno
 import hashlib
 import io
 import json
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
@@ -458,6 +459,38 @@ class TestRegistrationHelpers:
 # ---------------------------------------------------------------------------
 
 
+@contextmanager
+def _successful_oauth_callback():
+    """Patch the local callback server/thread so run_login_flow observes a browser
+    callback that delivers a matching auth code and state, without starting a
+    real server or thread."""
+
+    def fake_server_init(self, addr, handler):
+        pass
+
+    with (
+        patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init),
+        patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"),
+        patch("yutori.auth.flow.socketserver.TCPServer.shutdown"),
+        patch("yutori.auth.flow.socketserver.TCPServer.server_close"),
+        patch("yutori.auth.flow.threading.Thread") as mock_thread_cls,
+    ):
+        mock_thread = MagicMock()
+        mock_thread_cls.return_value = mock_thread
+
+        original_result = _CallbackResult()
+        with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
+            with patch("yutori.auth.flow.secrets.token_urlsafe", return_value="fixed_state"):
+
+                def side_effect(*args, **kwargs):
+                    original_result.code = "auth_code"
+                    original_result.state = "fixed_state"
+                    original_result.received.set()
+
+                mock_thread.start.side_effect = side_effect
+                yield mock_thread
+
+
 class TestRunLoginFlow:
     @patch("yutori.auth.flow.webbrowser.open")
     @patch("yutori.auth.flow.generate_api_key", return_value="yt-new-key")
@@ -467,52 +500,19 @@ class TestRunLoginFlow:
     @patch("yutori.auth.flow.save_config")
     def test_successful_flow(self, mock_save, mock_exchange, mock_status, mock_register, mock_gen_key, mock_browser):
         """Mock the callback result to simulate a successful flow."""
-
-        def fake_server_init(self, addr, handler):
-            pass
-
-        def fake_serve_forever(self):
-            # Simulate the callback happening
-            _CallbackHandler.callback_result.code = "auth_code"
-            _CallbackHandler.callback_result.state = None  # Will be set by run_login_flow
-            _CallbackHandler.callback_result.received.set()
-
-        # We need a more targeted approach: patch the server and thread
-        with (
-            patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init),
-            patch("yutori.auth.flow.socketserver.TCPServer.serve_forever", fake_serve_forever),
-            patch("yutori.auth.flow.socketserver.TCPServer.shutdown"),
-            patch("yutori.auth.flow.socketserver.TCPServer.server_close"),
-            patch("yutori.auth.flow.threading.Thread") as mock_thread_cls,
-        ):
-            mock_thread = MagicMock()
-            mock_thread_cls.return_value = mock_thread
-
-            # Patch the _CallbackResult so we can control the state
-            original_result = _CallbackResult()
-            with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
-                # We need to make the state match — intercept secrets.token_urlsafe
-                with patch("yutori.auth.flow.secrets.token_urlsafe", return_value="fixed_state"):
-                    # Simulate callback setting the right state before received.wait returns
-                    def side_effect(*args, **kwargs):
-                        original_result.code = "auth_code"
-                        original_result.state = "fixed_state"
-                        original_result.received.set()
-
-                    mock_thread.start.side_effect = side_effect
-
-                    result = run_login_flow()
-                    assert result.success is True
-                    assert result.api_key == "yt-new-key"
-                    assert result.auth_url is not None
-                    mock_save.assert_called_once_with("yt-new-key")
-                    mock_register.assert_called_once_with("jwt123")
-                    mock_gen_key.assert_called_once()
-                    assert mock_gen_key.call_args.args[0] == "jwt123"
-                    key_name = mock_gen_key.call_args.kwargs["key_name"]
-                    assert key_name.endswith("-yutori-cli")
-                    date_part = key_name[:10]
-                    datetime.strptime(date_part, "%Y-%m-%d")
+        with _successful_oauth_callback():
+            result = run_login_flow()
+            assert result.success is True
+            assert result.api_key == "yt-new-key"
+            assert result.auth_url is not None
+            mock_save.assert_called_once_with("yt-new-key")
+            mock_register.assert_called_once_with("jwt123")
+            mock_gen_key.assert_called_once()
+            assert mock_gen_key.call_args.args[0] == "jwt123"
+            key_name = mock_gen_key.call_args.kwargs["key_name"]
+            assert key_name.endswith("-yutori-cli")
+            date_part = key_name[:10]
+            datetime.strptime(date_part, "%Y-%m-%d")
 
     @patch("yutori.auth.flow.webbrowser.open")
     @patch("yutori.auth.flow.generate_api_key", return_value="yt-new-key")
@@ -525,30 +525,8 @@ class TestRunLoginFlow:
     ):
         # The key exists server-side by the time save_config runs; the error
         # must say so instead of surfacing a bare OSError.
-        def fake_server_init(self, addr, handler):
-            pass
-
-        with (
-            patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init),
-            patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"),
-            patch("yutori.auth.flow.socketserver.TCPServer.shutdown"),
-            patch("yutori.auth.flow.socketserver.TCPServer.server_close"),
-            patch("yutori.auth.flow.threading.Thread") as mock_thread_cls,
-        ):
-            mock_thread = MagicMock()
-            mock_thread_cls.return_value = mock_thread
-            original_result = _CallbackResult()
-            with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
-                with patch("yutori.auth.flow.secrets.token_urlsafe", return_value="fixed_state"):
-
-                    def side_effect(*args, **kwargs):
-                        original_result.code = "auth_code"
-                        original_result.state = "fixed_state"
-                        original_result.received.set()
-
-                    mock_thread.start.side_effect = side_effect
-
-                    result = run_login_flow()
+        with _successful_oauth_callback():
+            result = run_login_flow()
 
         assert result.success is False
         assert result.api_key == "yt-new-key"
@@ -572,30 +550,8 @@ class TestRunLoginFlow:
         mock_gen_key,
         mock_browser,
     ):
-        def fake_server_init(self, addr, handler):
-            pass
-
-        with (
-            patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init),
-            patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"),
-            patch("yutori.auth.flow.socketserver.TCPServer.shutdown"),
-            patch("yutori.auth.flow.socketserver.TCPServer.server_close"),
-            patch("yutori.auth.flow.threading.Thread") as mock_thread_cls,
-        ):
-            mock_thread = MagicMock()
-            mock_thread_cls.return_value = mock_thread
-            original_result = _CallbackResult()
-            with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
-                with patch("yutori.auth.flow.secrets.token_urlsafe", return_value="fixed_state"):
-
-                    def side_effect(*args, **kwargs):
-                        original_result.code = "auth_code"
-                        original_result.state = "fixed_state"
-                        original_result.received.set()
-
-                    mock_thread.start.side_effect = side_effect
-
-                    result = run_login_flow(on_registration_state=lambda _: (_ for _ in ()).throw(RuntimeError("boom")))
+        with _successful_oauth_callback():
+            result = run_login_flow(on_registration_state=lambda _: (_ for _ in ()).throw(RuntimeError("boom")))
 
         assert result.success is True
         mock_warning.assert_called_once()
@@ -622,30 +578,8 @@ class TestRunLoginFlow:
         mock_gen_key,
         mock_browser,
     ):
-        def fake_server_init(self, addr, handler):
-            pass
-
-        with (
-            patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init),
-            patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"),
-            patch("yutori.auth.flow.socketserver.TCPServer.shutdown"),
-            patch("yutori.auth.flow.socketserver.TCPServer.server_close"),
-            patch("yutori.auth.flow.threading.Thread") as mock_thread_cls,
-        ):
-            mock_thread = MagicMock()
-            mock_thread_cls.return_value = mock_thread
-            original_result = _CallbackResult()
-            with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
-                with patch("yutori.auth.flow.secrets.token_urlsafe", return_value="fixed_state"):
-
-                    def side_effect(*args, **kwargs):
-                        original_result.code = "auth_code"
-                        original_result.state = "fixed_state"
-                        original_result.received.set()
-
-                    mock_thread.start.side_effect = side_effect
-
-                    result = run_login_flow()
+        with _successful_oauth_callback():
+            result = run_login_flow()
 
         assert result.success is False
         # register_user raises httpx.HTTPStatusError per its docstring; the


### PR DESCRIPTION
## What

`TestRunLoginFlow`'s four success-path tests (`test_successful_flow`, `test_save_failure_reports_orphaned_key`, `test_callback_exception_is_ignored`, `test_register_failure_stops_before_generate_key`) each repeated an identical ~20-line block that:

- patches out the local callback `TCPServer`'s `__init__`/`serve_forever`/`shutdown`/`server_close`
- patches `threading.Thread` with a mock
- constructs a `_CallbackResult` and patches `_CallbackResult` to return it
- patches `secrets.token_urlsafe` to a fixed value
- wires `mock_thread.start.side_effect` to deliver a matching auth code/state

Extracted this into a `_successful_oauth_callback()` contextmanager. Each test now wraps its call to `run_login_flow()` in a 1-2 line `with` block instead of duplicating the scaffold.

As part of the extraction, dropped a vestigial `fake_serve_forever` in `test_successful_flow` that mutated `_CallbackHandler.callback_result` — it was never actually invoked, since `threading.Thread` is fully mocked in that test, so the real `serve_forever` never runs.

## Why this is safe

- Test-only change — no production code touched.
- Pure extract-method: the helper's body is a verbatim relocation of the previously-duplicated block; the per-test decorators, assertions, and mock wiring are untouched.
- All 8 `TestRunLoginFlow` tests pass unchanged, as does the full 77-test suite in `tests/test_auth.py`.
- `ruff check` and `ruff format --check` both pass.

## Test plan

- [x] `python3 -m pytest tests/test_auth.py -v -k TestRunLoginFlow` — 8 passed
- [x] `python3 -m pytest tests/test_auth.py -q` — 77 passed
- [x] `ruff check tests/test_auth.py` / `ruff format --check tests/test_auth.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qu8shrbE61xET3ed7AyZ3M


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qu8shrbE61xET3ed7AyZ3M)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests-only extract-method refactor with no production code changes.
> 
> **Overview**
> **Test-only refactor** in `tests/test_auth.py`: duplicated ~20-line mocks for `run_login_flow`’s local OAuth callback (TCPServer, thread, `_CallbackResult`, fixed state) are moved into a `_successful_oauth_callback()` context manager.
> 
> Four `TestRunLoginFlow` cases—success, save failure, callback exception, register failure—now enter that helper instead of inlining the same patch stack. **`test_successful_flow` no longer defines a custom `fake_serve_forever`** that touched `_CallbackHandler.callback_result`; that path was unused because the thread is fully mocked.
> 
> Per-test decorators and assertions are unchanged; timeout/state-mismatch tests still use their own scaffolding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b27231d80657a1da25f44d84c63e99889be0437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->