### PR TITLE
refactor: unify _clip_image_url between examples/_common.py and replay.py

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -14,6 +14,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 from yutori.navigator import aplaywright_screenshot_to_data_url
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder
+from yutori.navigator.replay import _clip_image_url as _clip_image_url_impl
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
 
@@ -149,11 +150,9 @@ class BrowserAgentMixin:
             logger.warning(f"Page did not fully stabilize before continuing: {self._page.url}")
 
     def _clip_image_url(self, url: str, max_len: int = 50) -> str:
-        if url.startswith("data:image"):
-            prefix_end = url.find(",") + 1
-            if prefix_end > 0 and len(url) > prefix_end + max_len:
-                return url[: prefix_end + 20] + "...[clipped]"
-        return url if len(url) <= max_len else url[:max_len] + "..."
+        # Delegates to the canonical implementation in yutori.navigator.replay, passing
+        # this call site's tighter length budget and plain (non-"[clipped]") suffix.
+        return _clip_image_url_impl(url, max_len=max_len, prefix_keep=20, plain_suffix="...")
 
     def _format_message_for_log(self, message: dict) -> dict:
         result = {}

--- a/tests/test_clip_image_url.py
+++ b/tests/test_clip_image_url.py
@@ -1,0 +1,115 @@
+"""Characterization tests pinning the current behavior of the two independent
+``_clip_image_url`` implementations:
+
+- ``examples._common.BrowserAgentMixin._clip_image_url`` (instance method, max_len=50)
+- ``yutori.navigator.replay._clip_image_url`` (module function, max_len=96)
+
+The two are structurally near-identical but differ in constants (max length,
+clip-after-prefix offset, and the suffix used for the "long but not a data
+URL" branch). These tests exist to pin the exact current output of both
+before any attempt to unify them, so a future unification can be checked
+against this file for behavior parity.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from yutori.navigator.replay import _clip_image_url as replay_clip_image_url
+
+# examples/_common.py pulls in the optional "examples" extra (loguru, openai, tenacity)
+# which isn't installed by the `.[dev]`-only CI test job; skip cleanly rather than
+# erroring on collection when it's unavailable.
+pytest.importorskip("loguru")
+from examples._common import BrowserAgentMixin  # noqa: E402
+
+_mixin = BrowserAgentMixin()
+
+
+def _common_clip_image_url(url: str) -> str:
+    return _mixin._clip_image_url(url)
+
+
+class TestExamplesCommonClipImageUrl:
+    """Pins examples._common.BrowserAgentMixin._clip_image_url (max_len=50, offset=20, suffix='...')."""
+
+    def test_short_plain_string_is_unchanged(self) -> None:
+        assert _common_clip_image_url("short") == "short"
+
+    def test_plain_string_at_exact_max_len_is_unchanged(self) -> None:
+        url = "x" * 50
+        assert _common_clip_image_url(url) == url
+
+    def test_plain_string_over_max_len_is_truncated_with_plain_ellipsis(self) -> None:
+        url = "x" * 51
+        assert _common_clip_image_url(url) == "x" * 50 + "..."
+
+    def test_short_data_url_is_unchanged(self) -> None:
+        url = "data:image/png;base64," + "A" * 10
+        assert _common_clip_image_url(url) == url
+
+    def test_long_data_url_is_clipped_after_prefix_with_offset_20(self) -> None:
+        url = "data:image/png;base64," + "A" * 100
+        prefix_end = url.find(",") + 1
+        expected = url[: prefix_end + 20] + "...[clipped]"
+        assert _common_clip_image_url(url) == expected
+        assert expected == "data:image/png;base64,AAAAAAAAAAAAAAAAAAAA...[clipped]"
+
+    def test_data_url_without_comma_falls_back_to_plain_handling(self) -> None:
+        # No comma means prefix_end == 0, so the data-url branch never fires;
+        # the string is short enough to pass through the trailing length check unchanged.
+        url = "data:image;nocomma"
+        assert _common_clip_image_url(url) == url
+
+    def test_long_non_data_url_uses_plain_ellipsis_not_clipped_marker(self) -> None:
+        url = "https://example.com/" + "y" * 90
+        assert _common_clip_image_url(url) == url[:50] + "..."
+
+
+class TestReplayClipImageUrl:
+    """Pins yutori.navigator.replay._clip_image_url (max_len=96, offset=24, suffix='...[clipped]')."""
+
+    def test_short_plain_string_is_unchanged(self) -> None:
+        assert replay_clip_image_url("short") == "short"
+
+    def test_plain_string_at_exact_max_len_is_unchanged(self) -> None:
+        url = "x" * 96
+        assert replay_clip_image_url(url) == url
+
+    def test_plain_string_over_max_len_is_truncated_with_clipped_marker(self) -> None:
+        url = "x" * 97
+        assert replay_clip_image_url(url) == "x" * 96 + "...[clipped]"
+
+    def test_short_data_url_is_unchanged(self) -> None:
+        url = "data:image/png;base64," + "A" * 10
+        assert replay_clip_image_url(url) == url
+
+    def test_long_data_url_is_clipped_after_prefix_with_offset_24(self) -> None:
+        url = "data:image/png;base64," + "A" * 100
+        prefix_end = url.find(",") + 1
+        expected = url[: prefix_end + 24] + "...[clipped]"
+        assert replay_clip_image_url(url) == expected
+        assert expected == "data:image/png;base64,AAAAAAAAAAAAAAAAAAAAAAAA...[clipped]"
+
+    def test_data_url_without_comma_falls_back_to_plain_handling(self) -> None:
+        url = "data:image;nocomma"
+        assert replay_clip_image_url(url) == url
+
+    def test_long_non_data_url_uses_clipped_marker(self) -> None:
+        url = "https://example.com/" + "y" * 90
+        assert replay_clip_image_url(url) == url[:96] + "...[clipped]"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "short",
+        "data:image/png;base64," + "A" * 10,
+        "data:image;nocomma",
+    ],
+)
+def test_both_implementations_agree_below_their_respective_thresholds(url: str) -> None:
+    # Below both max_len thresholds (50 and 96), the two implementations must
+    # produce identical output -- this is the invariant any future unification
+    # needs to preserve exactly, while diverging correctly above the thresholds.
+    assert _common_clip_image_url(url) == replay_clip_image_url(url) == url

--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -690,14 +690,23 @@ def _sanitize_for_replay(value: Any) -> Any:
     return value
 
 
-def _clip_image_url(value: str, *, max_len: int = 96) -> str:
+def _clip_image_url(value: str, *, max_len: int = 96, prefix_keep: int = 24, plain_suffix: str = "...[clipped]") -> str:
+    """Clip a base64 data URL or other long string for display/logging.
+
+    Data URLs are clipped shortly after their comma-delimited prefix so the
+    small, informative prefix survives; other long strings are truncated at
+    ``max_len``. ``prefix_keep`` and ``plain_suffix`` are overridable so
+    callers with different display budgets (e.g. ``examples/_common.py``,
+    which uses a tighter length and a plain "..." for the non-data-URL case)
+    can share this implementation instead of re-deriving it.
+    """
     if value.startswith("data:image"):
         prefix_end = value.find(",") + 1
         if prefix_end > 0 and len(value) > prefix_end + max_len:
-            return value[: prefix_end + 24] + "...[clipped]"
+            return value[: prefix_end + prefix_keep] + "...[clipped]"
     if len(value) <= max_len:
         return value
-    return value[:max_len] + "...[clipped]"
+    return value[:max_len] + plain_suffix
 
 
 def _safe_json_dumps(payload: Any, *, fallback: Any = None) -> str:


### PR DESCRIPTION
## What

`examples/_common.py`'s `BrowserAgentMixin._clip_image_url` and `yutori/navigator/replay.py`'s module-level `_clip_image_url` were two independent implementations of the same "clip a base64 data URL (or other long string) for display/logging" logic. They were structurally near-identical but diverged in three constants: max length (50 vs 96), clip-after-prefix offset (20 vs 24), and the suffix used for the "long but not a data URL" branch (`"..."` vs `"...[clipped]"`). This was flagged in a prior refactor-backlog pass as a "soft candidate" — mechanical-looking but risky to merge blind since there was no test coverage pinning either implementation's exact output.

## Fix

1. Added `tests/test_clip_image_url.py` with characterization tests that pin the *current* exact output of both implementations (short strings, exact-boundary lengths, over-length plain strings, data URLs with/without a comma, etc.), plus a parity test asserting both implementations agree below their respective length thresholds.
2. Parameterized the canonical `yutori/navigator/replay.py::_clip_image_url` with two new keyword-only args, `prefix_keep` (default `24`, preserving current behavior) and `plain_suffix` (default `"...[clipped]"`, preserving current behavior).
3. `examples/_common.py::BrowserAgentMixin._clip_image_url` now delegates to that shared implementation, passing its own existing constants (`max_len=50`, `prefix_keep=20`, `plain_suffix="..."`) instead of re-deriving the algorithm.

## Why this is safe

- No default behavior changed: `replay.py`'s call sites (`_sanitize_for_replay`) don't pass the new kwargs, so they get the exact same defaults as before.
- `examples/_common.py`'s method now produces byte-identical output to before — the new characterization tests assert this for both implementations independently, and all previously-passing assertions (e.g. in `tests/test_navigator_replay.py` around `sanitize_step_payload`/`TrajectoryRecorder`) still pass.
- The new test file imports `examples._common`, which depends on the optional `examples` extra (loguru/openai/tenacity) that the `test` CI job doesn't install (`pip install -e ".[dev]"`); the test module guards that import with `pytest.importorskip("loguru")` so it skips cleanly in that job instead of erroring, while still running (and providing real coverage) in any environment with the `examples` extra installed.
- Full suite passes locally both with and without the `examples` extra installed: `478 passed, 3 skipped` (with extras) / `460 passed, 4 skipped, 1 deselected` (dev-only, matching CI's `test` job). `ruff check .` passes clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01H2QGzBM7YAi9X2d83Pon79)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display/logging-only refactor with defaults preserved and new tests pinning byte-identical behavior for both call sites.
> 
> **Overview**
> **Unifies duplicate image-URL clipping logic** by making `yutori.navigator.replay._clip_image_url` the single implementation and wiring `BrowserAgentMixin._clip_image_url` to call it with the example-specific limits (`max_len=50`, `prefix_keep=20`, `plain_suffix="..."`).
> 
> The replay helper gains optional **`prefix_keep`** and **`plain_suffix`** kwargs (defaults unchanged), so existing replay sanitization behavior stays the same when callers do not pass them.
> 
> Adds **`tests/test_clip_image_url.py`** to lock in prior outputs for both code paths (boundaries, data URLs, long plain strings) and agreement below length thresholds; the examples tests **`pytest.importorskip("loguru")`** so dev-only CI does not fail on the optional examples extra.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bec12acf5f2e5026ace2ef1cd821a15011b5ca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->