### PR TITLE
refactor(tests): extract _tool_call/_tool_call_message helpers in test_navigator_replay.py

### DIFF
--- a/tests/test_navigator_replay.py
+++ b/tests/test_navigator_replay.py
@@ -21,6 +21,14 @@ def _image_message(role: str, *, url: str = "data:image/png;base64,abc", text: s
     return {"role": role, "content": content}
 
 
+def _tool_call(name: str, arguments: str, *, call_id: str = "call_1") -> dict:
+    return {"id": call_id, "type": "function", "function": {"name": name, "arguments": arguments}}
+
+
+def _tool_call_message(*calls: dict, content: object = None) -> dict:
+    return {"role": "assistant", "content": content, "tool_calls": list(calls)}
+
+
 class FakeResult:
     score = 1.0
 
@@ -90,17 +98,10 @@ def test_sanitize_step_payload_clips_images_before_storage() -> None:
 def test_generate_visualization_html_includes_steps_and_result() -> None:
     messages = [
         _image_message("user", text="Open the page"),
-        {
-            "role": "assistant",
-            "content": [{"type": "text", "text": "Click the main CTA"}],
-            "tool_calls": [
-                {
-                    "id": "call_1",
-                    "type": "function",
-                    "function": {"name": "left_click", "arguments": '{"coordinates":[250,500]}'},
-                }
-            ],
-        },
+        _tool_call_message(
+            _tool_call("left_click", '{"coordinates":[250,500]}'),
+            content=[{"type": "text", "text": "Click the main CTA"}],
+        ),
         _image_message("tool", text="Clicked button"),
         {"role": "assistant", "content": "The CTA is now open."},
     ]
@@ -121,17 +122,7 @@ def test_generate_visualization_html_renders_raw_request_and_response_json() -> 
     large_url = "data:image/png;base64," + ("A" * 400)
     messages = [
         _image_message("user", url=large_url, text="Inspect page"),
-        {
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [
-                {
-                    "id": "call_1",
-                    "type": "function",
-                    "function": {"name": "left_click", "arguments": '{"coordinates":[100,200]}'},
-                }
-            ],
-        },
+        _tool_call_message(_tool_call("left_click", '{"coordinates":[100,200]}')),
     ]
     step_payloads = [
         {
@@ -160,17 +151,7 @@ async def test_trajectory_recorder_writes_artifacts(tmp_path) -> None:
     recorder = TrajectoryRecorder(tmp_path, "run-123")
     messages = [
         _image_message("user", text="Inspect page"),
-        {
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [
-                {
-                    "id": "call_1",
-                    "type": "function",
-                    "function": {"name": "left_click", "arguments": '{"coordinates":[100,200]}'},
-                }
-            ],
-        },
+        _tool_call_message(_tool_call("left_click", '{"coordinates":[100,200]}')),
     ]
     large_url = "data:image/png;base64," + ("A" * 400)
     step_payloads = [
@@ -204,14 +185,10 @@ def test_generate_visualization_html_survives_non_object_tool_arguments() -> Non
     # Valid JSON that isn't an object must not crash the render.
     messages = [
         _image_message("user", text="Open the page"),
-        {
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [
-                {"id": "call_1", "type": "function", "function": {"name": "left_click", "arguments": "[1, 2]"}},
-                {"id": "call_2", "type": "function", "function": {"name": "type_text", "arguments": '"hello"'}},
-            ],
-        },
+        _tool_call_message(
+            _tool_call("left_click", "[1, 2]"),
+            _tool_call("type_text", '"hello"', call_id="call_2"),
+        ),
     ]
 
     html = generate_visualization_html("demo-task", messages)
@@ -239,13 +216,7 @@ def test_text_only_user_message_keeps_pending_tool_screenshot() -> None:
     # next step must not blank out the screenshot in the replay.
     messages = [
         _image_message("user", text="Open the page"),
-        {
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [
-                {"id": "call_1", "type": "function", "function": {"name": "left_click", "arguments": "{}"}},
-            ],
-        },
+        _tool_call_message(_tool_call("left_click", "{}")),
         _image_message("tool", url="data:image/png;base64,toolshot", text="Clicked"),
         {"role": "user", "content": "Looks good, continue with checkout"},
         {"role": "assistant", "content": "Proceeding."},


### PR DESCRIPTION
## What

`tests/test_navigator_replay.py` had five tests that each hand-rolled the same OpenAI-style assistant `tool_calls` message dict literal:

```python
{
    "role": "assistant",
    "content": None,
    "tool_calls": [
        {
            "id": "call_1",
            "type": "function",
            "function": {"name": "left_click", "arguments": '{"coordinates":[100,200]}'},
        }
    ],
},
```

This PR extracts two small helpers, following the same pattern already used by `_image_message` in the same file:

```python
def _tool_call(name: str, arguments: str, *, call_id: str = "call_1") -> dict:
    return {"id": call_id, "type": "function", "function": {"name": name, "arguments": arguments}}


def _tool_call_message(*calls: dict, content: object = None) -> dict:
    return {"role": "assistant", "content": content, "tool_calls": list(calls)}
```

and updates all five call sites (including the multi-tool-call case in `test_generate_visualization_html_survives_non_object_tool_arguments`) to use them.

## Why

The repeated 8–10 line dict literal obscured what actually varied between tests (tool name, arguments, call id, content) behind identical id/type/function boilerplate. The helpers make each test read as its actual intent instead of re-deriving the OpenAI tool-call shape every time, and remove one more place where a future change to that shape (e.g. an added field) would need to be edited in five spots instead of one.

## Why it's safe

- Test-only change — no production code, no public API surface touched.
- Single file (`tests/test_navigator_replay.py`).
- Each call site was translated mechanically; the resulting dicts are byte-for-byte identical to what was there before (verified by inspection and by all assertions still passing).
- Full test suite passes: `pytest -q` → 478 passed, 3 skipped (pre-existing skips unrelated to this change).
- `ruff check` and `ruff format --check` pass on the changed file.

## Test plan

- [x] `pytest tests/test_navigator_replay.py -v` — 10/10 passed
- [x] `pytest -q` (full suite) — 478 passed, 3 skipped
- [x] `ruff check tests/test_navigator_replay.py` — clean
- [x] `ruff format --check tests/test_navigator_replay.py` — already formatted


---
_Generated by [Claude Code](https://claude.ai/code/session_01U7TgzVBkSAtUZzXbbgkWSA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single test file only; mechanical replacement with no production or API changes.
> 
> **Overview**
> **Test-only refactor** in `tests/test_navigator_replay.py`: adds `_tool_call` and `_tool_call_message` helpers (same style as existing `_image_message`) and uses them in five tests that previously inlined OpenAI-style assistant messages with `tool_calls`.
> 
> Behavior is unchanged—the helpers build the same dict shapes (including optional `content`, custom `call_id`, and multiple calls per message). Tests should read more clearly about tool name, arguments, and content instead of repeating id/type/function boilerplate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee356193f65b22d6cd8699ea72dac0e3702f4ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->