### PR TITLE
refactor(tests): extract mocked OpenAI/AsyncOpenAI client helpers

### DIFF
--- a/tests/_client_fixtures.py
+++ b/tests/_client_fixtures.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from openai.types.chat import ChatCompletion
 
 # Mirrors the current server dual-emit: both navigator_* and n1_* keys
@@ -109,3 +112,32 @@ def make_mock_chat_completion(
         model=model,
         object="chat.completion",
     )
+
+
+@contextmanager
+def mocked_sync_openai_client(mock_completion: ChatCompletion) -> Iterator[MagicMock]:
+    """Patch ``yutori._sync.chat.OpenAI`` so ``chat.completions.create()`` returns `mock_completion`.
+
+    Yields the mocked OpenAI client instance so callers can assert on
+    ``mock_openai_client.chat.completions.create.call_args``.
+    """
+    with patch("yutori._sync.chat.OpenAI") as MockOpenAI:
+        mock_openai_client = MagicMock()
+        mock_openai_client.chat.completions.create.return_value = mock_completion
+        MockOpenAI.return_value = mock_openai_client
+        yield mock_openai_client
+
+
+@contextmanager
+def mocked_async_openai_client(mock_completion: ChatCompletion) -> Iterator[MagicMock]:
+    """Patch ``yutori._async.chat.AsyncOpenAI`` so ``chat.completions.create()`` returns `mock_completion`.
+
+    Yields the mocked AsyncOpenAI client instance so callers can assert on
+    ``mock_openai_client.chat.completions.create.call_args``.
+    """
+    with patch("yutori._async.chat.AsyncOpenAI") as MockAsyncOpenAI:
+        mock_openai_client = MagicMock()
+        mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+        mock_openai_client.close = AsyncMock()
+        MockAsyncOpenAI.return_value = mock_openai_client
+        yield mock_openai_client

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,6 +1,6 @@
 """Tests for the async AsyncYutoriClient."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -12,6 +12,7 @@ from ._client_fixtures import (
     make_mock_chat_completion,
     make_mock_usage_response,
     make_status_response,
+    mocked_async_openai_client,
 )
 
 
@@ -338,12 +339,7 @@ class TestAsyncChatNamespace:
     async def test_chat_completions(self):
         mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
 
-        with patch("yutori._async.chat.AsyncOpenAI") as MockAsyncOpenAI:
-            mock_openai_client = MagicMock()
-            mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_completion)
-            mock_openai_client.close = AsyncMock()
-            MockAsyncOpenAI.return_value = mock_openai_client
-
+        with mocked_async_openai_client(mock_completion):
             async with AsyncYutoriClient(api_key="yt-test") as client:
                 result = await client.chat.completions.create(
                     messages=[{"role": "user", "content": "Click login"}],
@@ -361,12 +357,7 @@ class TestAsyncChatNamespace:
         }
         mock_completion = make_mock_chat_completion(content='{"status":"ok"}', model="n1.5-latest")
 
-        with patch("yutori._async.chat.AsyncOpenAI") as MockAsyncOpenAI:
-            mock_openai_client = MagicMock()
-            mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_completion)
-            mock_openai_client.close = AsyncMock()
-            MockAsyncOpenAI.return_value = mock_openai_client
-
+        with mocked_async_openai_client(mock_completion) as mock_openai_client:
             async with AsyncYutoriClient(api_key="yt-test") as client:
                 result = await client.chat.completions.create(
                     messages=[{"role": "user", "content": "Reply with JSON."}],
@@ -412,12 +403,7 @@ class TestAsyncChatNamespace:
         ]
         original_snapshot = deepcopy(original_messages)
 
-        with patch("yutori._async.chat.AsyncOpenAI") as MockAsyncOpenAI:
-            mock_openai_client = MagicMock()
-            mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_completion)
-            mock_openai_client.close = AsyncMock()
-            MockAsyncOpenAI.return_value = mock_openai_client
-
+        with mocked_async_openai_client(mock_completion) as mock_openai_client:
             async with AsyncYutoriClient(api_key="yt-test") as client:
                 result = await acreate_trimmed(
                     client.chat.completions,
@@ -458,12 +444,7 @@ class TestAsyncChatNamespace:
         original_snapshot = deepcopy(original_messages)
         trimmed_messages, _, _ = trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)
 
-        with patch("yutori._async.chat.AsyncOpenAI") as MockAsyncOpenAI:
-            mock_openai_client = MagicMock()
-            mock_openai_client.chat.completions.create = AsyncMock(return_value=mock_completion)
-            mock_openai_client.close = AsyncMock()
-            MockAsyncOpenAI.return_value = mock_openai_client
-
+        with mocked_async_openai_client(mock_completion) as mock_openai_client:
             async with AsyncYutoriClient(api_key="yt-test") as client:
                 result = await client.chat.completions.create(
                     model="n1-latest",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 """Tests for the sync YutoriClient."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -12,6 +12,7 @@ from ._client_fixtures import (
     make_mock_chat_completion,
     make_mock_usage_response,
     make_status_response,
+    mocked_sync_openai_client,
 )
 
 
@@ -380,11 +381,7 @@ class TestChatNamespace:
     def test_chat_completions(self):
         mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
 
-        with patch("yutori._sync.chat.OpenAI") as MockOpenAI:
-            mock_openai_client = MagicMock()
-            mock_openai_client.chat.completions.create.return_value = mock_completion
-            MockOpenAI.return_value = mock_openai_client
-
+        with mocked_sync_openai_client(mock_completion) as mock_openai_client:
             client = YutoriClient(api_key="yt-test")
             result = client.chat.completions.create(
                 messages=[{"role": "user", "content": "Click login"}],
@@ -407,11 +404,7 @@ class TestChatNamespace:
         }
         mock_completion = make_mock_chat_completion(content='{"status":"ok"}', model="n1.5-latest")
 
-        with patch("yutori._sync.chat.OpenAI") as MockOpenAI:
-            mock_openai_client = MagicMock()
-            mock_openai_client.chat.completions.create.return_value = mock_completion
-            MockOpenAI.return_value = mock_openai_client
-
+        with mocked_sync_openai_client(mock_completion) as mock_openai_client:
             client = YutoriClient(api_key="yt-test")
             result = client.chat.completions.create(
                 messages=[{"role": "user", "content": "Reply with JSON."}],
@@ -457,11 +450,7 @@ class TestChatNamespace:
         ]
         original_snapshot = deepcopy(original_messages)
 
-        with patch("yutori._sync.chat.OpenAI") as MockOpenAI:
-            mock_openai_client = MagicMock()
-            mock_openai_client.chat.completions.create.return_value = mock_completion
-            MockOpenAI.return_value = mock_openai_client
-
+        with mocked_sync_openai_client(mock_completion) as mock_openai_client:
             client = YutoriClient(api_key="yt-test")
             result = create_trimmed(
                 client.chat.completions,
@@ -503,11 +492,7 @@ class TestChatNamespace:
         original_snapshot = deepcopy(original_messages)
         trimmed_messages, _, _ = trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)
 
-        with patch("yutori._sync.chat.OpenAI") as MockOpenAI:
-            mock_openai_client = MagicMock()
-            mock_openai_client.chat.completions.create.return_value = mock_completion
-            MockOpenAI.return_value = mock_openai_client
-
+        with mocked_sync_openai_client(mock_completion) as mock_openai_client:
             client = YutoriClient(api_key="yt-test")
             result = client.chat.completions.create(
                 model="n1-latest",


### PR DESCRIPTION
## Pattern

`TestChatNamespace` in `tests/test_client.py` and `TestAsyncChatNamespace` in `tests/test_async_client.py` each hand-rolled the same 4-line patch-and-wire block in 4 tests per file:

```python
with patch("yutori._sync.chat.OpenAI") as MockOpenAI:
    mock_openai_client = MagicMock()
    mock_openai_client.chat.completions.create.return_value = mock_completion
    MockOpenAI.return_value = mock_openai_client
```

(and the analogous `AsyncMock`/`AsyncOpenAI` version in the async file). Only `mock_completion` and the subsequent call differed each time — the patch/mock-wiring itself was byte-for-byte identical across all 8 occurrences.

## Fix

Extracted two small context managers, `mocked_sync_openai_client` and `mocked_async_openai_client`, into `tests/_client_fixtures.py` (alongside the existing `make_mock_chat_completion` helper), and updated all 8 call sites to use them. Each test now reads as `with mocked_sync_openai_client(mock_completion) as mock_openai_client:` instead of the repeated 4-line block.

No behavior change — purely structural.

## Test plan

- [x] `pytest tests/` — 478 passed, 3 skipped (unchanged from before this change)
- [x] `ruff check` / `ruff format --check` on all three touched files pass

cc @dhruvbatra — this repo's been swept thoroughly this week (#142, #163–#167); this is a small pattern in `test_client.py`/`test_async_client.py` that those passes hadn't touched yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015ePPJeoiutK9Y1JC31W4M1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test fixtures and client test files; no SDK or API code is modified.
> 
> **Overview**
> **Test-only refactor:** repeated inline `patch` + `MagicMock` wiring for Navigator chat tests is consolidated into shared helpers in `tests/_client_fixtures.py`.
> 
> Adds **`mocked_sync_openai_client`** and **`mocked_async_openai_client`** context managers that patch `yutori._sync.chat.OpenAI` and `yutori._async.chat.AsyncOpenAI`, stub `chat.completions.create` (with `AsyncMock` + `close` on the async path), and yield the mock client for `call_args` assertions. **`TestChatNamespace`** and **`TestAsyncChatNamespace`** (eight tests total) now use these helpers instead of duplicated four-line blocks; unused `MagicMock` imports are dropped from the test modules.
> 
> No production or runtime behavior change—structure and readability only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 283d7ff962ae9de47c63d72345f0435c78851f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->