### PR TITLE
refactor(navigator): extract TrajectoryRecorder text I/O into shared helpers

### DIFF
--- a/tests/test_navigator_replay.py
+++ b/tests/test_navigator_replay.py
@@ -181,6 +181,16 @@ async def test_trajectory_recorder_writes_artifacts(tmp_path) -> None:
     assert "Raw Request" in html
 
 
+@pytest.mark.asyncio
+async def test_trajectory_recorder_load_methods_handle_missing_artifacts(tmp_path) -> None:
+    recorder = TrajectoryRecorder(tmp_path, "run-456")
+
+    assert await recorder.load_json("result.json") is None
+    assert await recorder.load_jsonl("messages.jsonl") == []
+    assert await recorder.load_messages() == []
+    assert await recorder.load_step_payloads() == []
+
+
 def test_generate_visualization_html_survives_non_object_tool_arguments() -> None:
     # Valid JSON that isn't an object must not crash the render.
     messages = [

--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -99,6 +99,18 @@ class TrajectoryRecorder:
 
         return self.item_dir / name
 
+    async def _write_text(self, path: Path, text: str) -> None:
+        """Write *text* to *path* off the event loop thread."""
+
+        await asyncio.to_thread(path.write_text, text, encoding="utf-8")
+
+    async def _read_text_if_exists(self, path: Path) -> str | None:
+        """Read *path* off the event loop thread, or return ``None`` if it is missing."""
+
+        if not path.exists():
+            return None
+        return await asyncio.to_thread(path.read_text, encoding="utf-8")
+
     async def save_json(
         self,
         filename: str,
@@ -109,34 +121,28 @@ class TrajectoryRecorder:
     ) -> None:
         """Write one optional JSON artifact into the replay directory."""
 
-        path = self.artifact_path(filename)
         text = json.dumps(data, indent=indent, default=default or _json_default)
-        await asyncio.to_thread(path.write_text, text, encoding="utf-8")
+        await self._write_text(self.artifact_path(filename), text)
 
     async def load_json(self, filename: str) -> Any | None:
         """Read one optional JSON artifact if it exists."""
 
-        path = self.artifact_path(filename)
-        if not path.exists():
+        text = await self._read_text_if_exists(self.artifact_path(filename))
+        if text is None:
             return None
-        text = await asyncio.to_thread(path.read_text, encoding="utf-8")
         return json.loads(text)
 
     async def save_jsonl(self, filename: str, records: list[Any]) -> None:
         """Write one optional JSONL artifact into the replay directory."""
 
-        path = self.artifact_path(filename)
         lines = [json.dumps(record, default=_json_default) for record in records]
-        await asyncio.to_thread(path.write_text, "\n".join(lines), encoding="utf-8")
+        await self._write_text(self.artifact_path(filename), "\n".join(lines))
 
     async def load_jsonl(self, filename: str) -> list[Any]:
         """Read one optional JSONL artifact if it exists."""
 
-        path = self.artifact_path(filename)
-        if not path.exists():
-            return []
-        text = await asyncio.to_thread(path.read_text, encoding="utf-8")
-        if not text.strip():
+        text = await self._read_text_if_exists(self.artifact_path(filename))
+        if not text or not text.strip():
             return []
         return [json.loads(line) for line in text.splitlines() if line.strip()]
 
@@ -172,7 +178,6 @@ class TrajectoryRecorder:
     ) -> None:
         """Render the optional static HTML replay viewer for one run."""
 
-        path = self.artifact_path("visualization.html")
         html = generate_visualization_html(
             task_id=self.run_id,
             messages=messages,
@@ -181,7 +186,7 @@ class TrajectoryRecorder:
             coord_space_width=coord_space_width,
             coord_space_height=coord_space_height,
         )
-        await asyncio.to_thread(path.write_text, html, encoding="utf-8")
+        await self._write_text(self.artifact_path("visualization.html"), html)
 
 
 def generate_visualization_html(


### PR DESCRIPTION
## What

`TrajectoryRecorder` in `yutori/navigator/replay.py` had the same file-I/O idiom duplicated across five methods:

- `save_json`, `save_jsonl`, and `save_html` each independently wrote:
  ```python
  await asyncio.to_thread(path.write_text, text, encoding="utf-8")
  ```
- `load_json` and `load_jsonl` each independently implemented:
  ```python
  if not path.exists():
      return <default>
  text = await asyncio.to_thread(path.read_text, encoding="utf-8")
  ```

This PR extracts two private helper methods, `_write_text` and `_read_text_if_exists`, and routes all five call sites through them.

## Why

Five near-identical inline implementations of "write text to a path off-thread" and "read text from a path if it exists" is exactly the kind of thing that drifts silently — e.g. one call site could accidentally drop `encoding="utf-8"` or handle a missing file differently, and nothing would flag it. Centralizing the idiom means there's one place to get it right.

## Safety

- **No behavior change.** Every call site passes the same `path`/`text` it did before; `load_jsonl`'s `if not text or not text.strip()` check is equivalent to the original `if not path.exists(): return []` + `if not text.strip(): return []` (missing file now yields `text is None`, which is falsy and short-circuits the same way).
- **Test coverage added first.** The existing `tests/test_navigator_replay.py::test_trajectory_recorder_writes_artifacts` already exercises the write/read-success paths for all five methods. I added `test_trajectory_recorder_load_methods_handle_missing_artifacts`, which characterizes the previously-untested "file doesn't exist" branches (`load_json` → `None`, `load_jsonl`/`load_messages`/`load_step_payloads` → `[]`) *before* refactoring, confirmed it passes against the pre-refactor code, then did the extraction and reran it.
- **Scope.** Touches exactly 2 files (`yutori/navigator/replay.py`, `tests/test_navigator_replay.py`), no public API changes.

## Test plan

- [x] `pytest -m "not slow" -q` → 478 passed, 3 skipped
- [x] `pytest -m slow -q` → 1 passed
- [x] `ruff check .` → all checks passed

🤖 Generated with Claude Code as part of an automated structural-refactor pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UqZLtVkFeQMzMidQiLLB7z)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional local replay/debug code only; behavior-preserving refactor with new characterization tests and no public API changes.
> 
> **Overview**
> **TrajectoryRecorder** replay artifact I/O is consolidated: new private helpers **`_write_text`** and **`_read_text_if_exists`** wrap off-thread UTF-8 reads/writes, and **`save_json`**, **`save_jsonl`**, **`save_html`**, **`load_json`**, and **`load_jsonl`** now call them instead of duplicating **`asyncio.to_thread`** and missing-file checks.
> 
> A new async test asserts that when artifacts are absent, **`load_json`** returns **`None`** and **`load_jsonl`** / **`load_messages`** / **`load_step_payloads`** return empty lists—matching the prior behavior via the shared read helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdbddba160a1533bf3650e300ef1f1678cf0e6e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->