### PR TITLE
refactor(tests): extract _invoke_login helper in test_cli_auth.py

### DIFF
--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -1,13 +1,29 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
-from typer.testing import CliRunner
+from typer.testing import CliRunner, Result
 
 from yutori.auth.types import LoginResult
 from yutori.cli.main import app
 
 runner = CliRunner()
+
+
+def _invoke_login(*, config: dict[str, Any] | None = None, **run_login_flow_kwargs: Any) -> Result:
+    """Invoke ``yutori auth login`` with ``load_config``/``run_login_flow`` patched.
+
+    ``config`` is the stored-config dict returned by ``load_config`` (``None``
+    for "no saved credentials"). ``run_login_flow_kwargs`` are forwarded to
+    ``patch(...)`` for ``run_login_flow`` -- pass ``return_value=...`` or
+    ``side_effect=...`` depending on what the test needs to simulate.
+    """
+    with (
+        patch("yutori.auth.credentials.load_config", return_value=config),
+        patch("yutori.cli.commands.auth.run_login_flow", **run_login_flow_kwargs),
+    ):
+        return runner.invoke(app, ["auth", "login"])
 
 
 def test_auth_login_prints_creating_account_message(monkeypatch):
@@ -17,11 +33,7 @@ def test_auth_login_prints_creating_account_message(monkeypatch):
         kwargs["on_registration_state"]("creating_account")
         return LoginResult(success=True, api_key="yt-key")
 
-    with (
-        patch("yutori.auth.credentials.load_config", return_value=None),
-        patch("yutori.cli.commands.auth.run_login_flow", side_effect=fake_run_login_flow),
-    ):
-        result = runner.invoke(app, ["auth", "login"])
+    result = _invoke_login(side_effect=fake_run_login_flow)
 
     assert result.exit_code == 0
     assert "Creating account..." in result.stdout
@@ -35,11 +47,7 @@ def test_auth_login_prints_logging_in_message(monkeypatch):
         kwargs["on_registration_state"]("logging_in")
         return LoginResult(success=True, api_key="yt-key")
 
-    with (
-        patch("yutori.auth.credentials.load_config", return_value=None),
-        patch("yutori.cli.commands.auth.run_login_flow", side_effect=fake_run_login_flow),
-    ):
-        result = runner.invoke(app, ["auth", "login"])
+    result = _invoke_login(side_effect=fake_run_login_flow)
 
     assert result.exit_code == 0
     assert "Logging in..." in result.stdout
@@ -59,11 +67,7 @@ def test_auth_login_surfaces_backend_error(monkeypatch):
             auth_url="https://example.com/auth",
         )
 
-    with (
-        patch("yutori.auth.credentials.load_config", return_value=None),
-        patch("yutori.cli.commands.auth.run_login_flow", side_effect=fake_run_login_flow),
-    ):
-        result = runner.invoke(app, ["auth", "login"])
+    result = _invoke_login(side_effect=fake_run_login_flow)
 
     assert result.exit_code == 1
     assert "Creating account..." in result.stdout
@@ -79,11 +83,7 @@ def test_auth_login_surfaces_backend_error(monkeypatch):
 def test_auth_login_ignores_placeholder_env_var(monkeypatch):
     monkeypatch.setenv("YUTORI_API_KEY", "YOUR_API_KEY")
 
-    with (
-        patch("yutori.auth.credentials.load_config", return_value=None),
-        patch("yutori.cli.commands.auth.run_login_flow", return_value=LoginResult(success=True, api_key="yt-key")),
-    ):
-        result = runner.invoke(app, ["auth", "login"])
+    result = _invoke_login(return_value=LoginResult(success=True, api_key="yt-key"))
 
     assert result.exit_code == 0
     assert "Successfully authenticated!" in result.stdout
@@ -92,11 +92,10 @@ def test_auth_login_ignores_placeholder_env_var(monkeypatch):
 def test_auth_login_ignores_placeholder_config_key(monkeypatch):
     monkeypatch.delenv("YUTORI_API_KEY", raising=False)
 
-    with (
-        patch("yutori.auth.credentials.load_config", return_value={"api_key": "YOUR_API_KEY"}),
-        patch("yutori.cli.commands.auth.run_login_flow", return_value=LoginResult(success=True, api_key="yt-key")),
-    ):
-        result = runner.invoke(app, ["auth", "login"])
+    result = _invoke_login(
+        config={"api_key": "YOUR_API_KEY"},
+        return_value=LoginResult(success=True, api_key="yt-key"),
+    )
 
     assert result.exit_code == 0
     assert "Successfully authenticated!" in result.stdout


### PR DESCRIPTION
## Summary
- `tests/test_cli_auth.py` had all 5 of its tests repeat an identical `patch("yutori.auth.credentials.load_config", ...)` + `patch("yutori.cli.commands.auth.run_login_flow", ...)` + `runner.invoke(app, ["auth", "login"])` block.
- Extracts `_invoke_login(*, config=None, **run_login_flow_kwargs)` to centralize the double-patch-and-invoke boilerplate, mirroring `_invoke_cli()` in `tests/test_cli.py` (added in #163 for the analogous `get_authenticated_client` pattern) — `test_cli_auth.py` never got the same treatment.
- Removes ~15 lines of duplicated setup across the 5 tests; each test now only supplies what varies (the `run_login_flow` stub/return value and, for 2 tests, a stored `config` dict).

## Why this is safe
- Test-only change, single file, purely mechanical extraction — no production code touched.
- Each test's assertions and patched behavior are unchanged; only the setup boilerplate moved into a shared helper.
- Full test suite passes before and after (462 passed, 4 skipped), and `ruff check`/`ruff format` are clean.

## Test plan
- [x] `pytest tests/test_cli_auth.py -v` — all 5 tests pass
- [x] `pytest -q` (full suite) — 462 passed, 4 skipped
- [x] `ruff check tests/test_cli_auth.py` — clean
- [x] `ruff format --diff tests/test_cli_auth.py` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012c13G2DxwXxZnDqD19eXGm

---
_Generated by [Claude Code](https://claude.ai/code/session_012c13G2DxwXxZnDqD19eXGm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file test refactor with no production code changes; behavior is intended to be identical.
> 
> **Overview**
> **Test-only refactor** in `tests/test_cli_auth.py`: adds `_invoke_login` to centralize patching `load_config` and `run_login_flow` plus invoking `yutori auth login`, following the same pattern as `_invoke_cli` in `test_cli.py`.
> 
> All five auth login tests now call the helper with only what differs (`side_effect`/`return_value` for `run_login_flow`, optional `config` for stored credentials). Assertions and simulated behavior are unchanged; duplicated `with patch(...)` blocks are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8817e6c3112e1c7070d83a8484fab45e1f154e42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->