### PR TITLE
refactor(cli): extract _slate_line helper for installer step-line markup

### DIFF
--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -47,6 +47,16 @@ MINT_HIGHLIGHT = "#5AE8BD"
 SLATE_TEXT = "#94A3B8"
 ERROR_RED = "#FF5C5C"
 
+
+def _slate_line(text: str) -> str:
+    """Render `text` in the installer's slate-colored ``| `` step-line style.
+
+    Callers are responsible for escaping any dynamic content in `text` before
+    passing it in (see `print_prompt_block` for why).
+    """
+    return f"[{SLATE_TEXT}]| {text}[/]"
+
+
 # Canonical first-task example, mirroring docs.yutori.com.
 VERIFICATION_TASK = "Give me a list of all employees (names and titles) of Yutori."
 VERIFICATION_URL = "https://yutori.com"
@@ -394,7 +404,7 @@ def render_header(console: Console, *, interactive: bool) -> None:
     # from pyproject.toml at build time; here we read from installed
     # package metadata. In a `curl | bash` flow the two match.
     console.print(f"[bold {MINT_HIGHLIGHT}]> Yutori installer v{_yutori_version()}[/bold {MINT_HIGHLIGHT}]")
-    console.print(f"[{SLATE_TEXT}]| {mode}[/]")
+    console.print(_slate_line(mode))
 
 
 def print_prompt_block(console: Console, title: str, description: str, *, command: Sequence[str] | None = None) -> None:
@@ -403,9 +413,9 @@ def print_prompt_block(console: Console, title: str, description: str, *, comman
     # (which deletes them or, for "[/x]"-shaped tokens, raises MarkupError).
     console.print(f"\n[{SLATE_TEXT}]|[/]")
     console.print(f"[bold {MINT_HIGHLIGHT}]> {escape(title)}[/bold {MINT_HIGHLIGHT}]")
-    console.print(f"[{SLATE_TEXT}]| {escape(description)}[/]")
+    console.print(_slate_line(escape(description)))
     if command:
-        console.print(f"[{SLATE_TEXT}]| Command: {escape(format_command(command))}[/]")
+        console.print(_slate_line(f"Command: {escape(format_command(command))}"))
 
 
 def ask_confirm(console: Console, question: str, *, default: bool) -> bool:
@@ -607,7 +617,7 @@ def maybe_install_sdk(
     # simpleDots fits the `| `-prefixed aesthetic; the default "dots" spinner
     # renders as a rotating braille block that reads as a "box" on some terminals.
     with console.status(
-        f"[{SLATE_TEXT}]| Running {format_command(plan.command)}[/]",
+        _slate_line(f"Running {format_command(plan.command)}"),
         spinner="simpleDots",
         spinner_style=SLATE_TEXT,
     ):
@@ -789,11 +799,9 @@ def maybe_authenticate(console: Console, *, interactive: bool) -> tuple[StepResu
     if not resolve_api_key():
         if not interactive:
             print_prompt_block(console, "Authentication", "No interactive terminal detected.")
-            console.print(f"[{SLATE_TEXT}]| Skipping auth. To finish setting up:[/]")
-            console.print(f"[{SLATE_TEXT}]|   - Run `yutori auth login` on a machine with a browser[/]")
-            console.print(
-                f"[{SLATE_TEXT}]|   - Or set YUTORI_API_KEY (get one at https://platform.yutori.com/settings)[/]"
-            )
+            console.print(_slate_line("Skipping auth. To finish setting up:"))
+            console.print(_slate_line("  - Run `yutori auth login` on a machine with a browser"))
+            console.print(_slate_line("  - Or set YUTORI_API_KEY (get one at https://platform.yutori.com/settings)"))
             return (
                 StepResult(
                     "Auth",
@@ -814,13 +822,13 @@ def maybe_authenticate(console: Console, *, interactive: bool) -> tuple[StepResu
 
         def on_registration_state(state: str) -> None:
             message = messages.get(state, state)  # type: ignore[arg-type]
-            console.print(f"[{SLATE_TEXT}]| {message}[/]")
+            console.print(_slate_line(message))
 
         result = run_login_flow(on_registration_state=on_registration_state)
         if not result.success:
             # The callback server has already been torn down, so reprinting
             # auth_url here would be misleading — it can't produce a credential.
-            console.print(f"[{SLATE_TEXT}]| Run `yutori auth login` again from a terminal to retry.[/]")
+            console.print(_slate_line("Run `yutori auth login` again from a terminal to retry."))
             return StepResult("Auth", "failed", str(result.error or "Authentication failed.")), False
 
         return StepResult("Auth", "success", "Authenticated and saved credentials."), True
@@ -932,14 +940,14 @@ def run_verification(
     deadline = time.monotonic() + VERIFICATION_POLL_BUDGET_SECONDS
     status = parse_cli_field(submission.stdout, "Status") or "queued"
     last_output = submission.stdout
-    console.print(f"[{SLATE_TEXT}]| Task: {escape(task_url)}[/]")
+    console.print(_slate_line(f"Task: {escape(task_url)}"))
 
     # Live status line: updates in place so the user sees both the current
     # status and continuous dot-motion confirming the installer is alive
     # during queued/running phases that may last the full 180s poll budget.
     try:
         with console.status(
-            f"[{SLATE_TEXT}]| Status: {escape(status)}[/]",
+            _slate_line(f"Status: {escape(status)}"),
             spinner="simpleDots",
             spinner_style=SLATE_TEXT,
         ) as spinner:
@@ -961,7 +969,7 @@ def run_verification(
 
                 last_output = poll.stdout
                 status = parse_cli_field(poll.stdout, "Status") or "queued"
-                spinner.update(f"[{SLATE_TEXT}]| Status: {escape(status)}[/]")
+                spinner.update(_slate_line(f"Status: {escape(status)}"))
     except KeyboardInterrupt:
         # Most poll wall-time is spent in the parent-side sleep above, where
         # run_command's KeyboardInterrupt-to-130 mapping can't help. Without
@@ -974,7 +982,7 @@ def run_verification(
         )
 
     summary = _summarize_cli_output(last_output)
-    console.print(f"[{SLATE_TEXT}]| Result: {escape(summary)}[/]")
+    console.print(_slate_line(f"Result: {escape(summary)}"))
     if status in FINAL_SUCCESS_STATUSES:
         return StepResult("Verification", "success", f"Verification succeeded. View task: {task_url}"), False
 


### PR DESCRIPTION
## Issue

`yutori/cli/commands/install_flow.py` (the hidden `yutori __install_flow` installer) hand-inlines the same Rich markup template — `f"[{SLATE_TEXT}]| {text}[/]"`, the slate-colored `| `-prefixed step-line style used throughout the installer's output — at 13 separate call sites across `console.print(...)`, `console.status(...)`, and `spinner.update(...)`.

This file already centralizes other repeated style tokens (`STATUS_LABELS`, `_manual_retry_hint`, `_synthetic_returncode_for_exception`), so this one template was the remaining outlier from earlier refactor passes.

## Improvement

Extracted a single helper:

```python
def _slate_line(text: str) -> str:
    """Render `text` in the installer's slate-colored ``| `` step-line style.

    Callers are responsible for escaping any dynamic content in `text` before
    passing it in (see `print_prompt_block` for why).
    """
    return f"[{SLATE_TEXT}]| {text}[/]"
```

All 13 call sites that exactly matched the `f"[{SLATE_TEXT}]| {text}[/]"` shape now call `_slate_line(...)` instead. Two call sites were deliberately left as-is because they don't fit the template:
- `f"\n[{SLATE_TEXT}]|[/]"` — a bare separator with no text (using the helper here would add a stray space before `[/]`, changing the rendered output).
- `f"[{SLATE_TEXT}]|[/] {question}"` in `ask_confirm` — the question text sits *outside* the colored span, a different structure entirely.

## Why it's safe

- **Purely mechanical, behavior-preserving**: each replaced call site produces byte-identical markup output (verified by diffing the f-string expansion at every site before editing).
- **Single file, no API surface touched**: `install_flow.py` is a hidden CLI subcommand invoked only by `install.sh`; nothing public changes.
- **No tests assert on the raw markup internals** (confirmed no `SLATE_TEXT` references in `tests/test_install_flow.py`), so this is a pure internal cleanup.
- **Reduces the chance of a recurring escaping bug**: the file has existing comments noting past bugs from forgetting `escape()` on dynamic content interpolated into markup-enabled `console.print` calls; centralizing the template through one function makes it easier to audit escaping at a glance.
- Full test suite passes (`pytest -q`): 478 passed, 3 skipped — same as on `main` (the one pre-existing failure, `test_built_distributions_include_packaged_assets`, fails identically on `main` due to a missing `build` module in this sandbox, unrelated to this change).
- `ruff check` passes with no findings on the modified file.

## Test plan

- [x] `pytest tests/test_install_flow.py -q` — 79 passed
- [x] `pytest -q` (full suite) — 478 passed, 3 skipped, 1 pre-existing unrelated failure (confirmed identical on `main`)
- [x] `ruff check yutori/cli/commands/install_flow.py` — all checks passed
- [x] Manual diff review confirming byte-identical markup output at every changed call site


---
_Generated by [Claude Code](https://claude.ai/code/session_01PFgxKQh2rGG7qQA9aHXPqs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal markup refactor in a hidden CLI subcommand with no intended output change; two non-matching call sites were left untouched on purpose.
> 
> **Overview**
> Introduces **`_slate_line(text)`** in `install_flow.py` as the single place that builds the installer’s slate-colored `| ` Rich markup (`[{SLATE_TEXT}]| {text}[/]`).
> 
> **Thirteen** call sites that duplicated that f-string—header mode line, prompt descriptions/commands, SDK/auth/verification status and prints, and `console.status` / `spinner.update`—now call the helper instead. **Two** patterns stay inline: the bare `\n[{SLATE_TEXT}]|[/]` separator (would add an extra space if routed through the helper) and **`ask_confirm`**, where the question text sits outside the colored span.
> 
> Callers still **`escape()`** dynamic content before passing it in; the helper’s docstring calls that out. No behavior or public API change—markup output is intended to stay byte-identical at each migrated site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d86be03079a9c46dd2bdc12e2db325d0d2c4955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->