### PR TITLE
refactor(navigator): dedupe image-url/text block extraction in replay.py

### DIFF
--- a/tests/test_navigator_replay.py
+++ b/tests/test_navigator_replay.py
@@ -7,6 +7,8 @@ import pytest
 from yutori.navigator.loop import update_trimmed_history
 from yutori.navigator.replay import (
     TrajectoryRecorder,
+    _extract_observation_parts,
+    _extract_tool_result_parts,
     generate_visualization_html,
     make_run_id,
     sanitize_step_payload,
@@ -219,6 +221,95 @@ def test_generate_visualization_html_escapes_screenshot_url() -> None:
     assert "<script>alert(1)</script>" not in html
     # The URL must survive in escaped form — not merely be dropped from the render.
     assert "shot.png&quot;&gt;&lt;script&gt;" in html
+
+
+def test_extract_observation_parts_handles_falsy_observation() -> None:
+    assert _extract_observation_parts(None) == (None, [])
+    assert _extract_observation_parts([]) == (None, [])
+
+
+def test_extract_observation_parts_collects_image_and_text_blocks() -> None:
+    observation = [
+        {"type": "text", "text": "  hello  "},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        {"type": "text", "text": "   "},
+    ]
+
+    url, texts = _extract_observation_parts(observation)
+
+    assert url == "data:image/png;base64,abc"
+    assert texts == ["hello"]
+
+
+def test_extract_observation_parts_last_nonempty_image_url_wins() -> None:
+    observation = [
+        {"type": "image_url", "image_url": {"url": "first"}},
+        {"type": "image_url", "image_url": {"url": ""}},
+        {"type": "image_url", "image_url": {"url": "second"}},
+    ]
+
+    url, _ = _extract_observation_parts(observation)
+
+    assert url == "second"
+
+
+def test_extract_observation_parts_recurses_into_tool_result_content() -> None:
+    observation = [
+        {
+            "type": "tool_result",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "nested-url"}},
+                {"type": "text", "text": "nested text"},
+            ],
+        }
+    ]
+
+    url, texts = _extract_observation_parts(observation)
+
+    assert url == "nested-url"
+    assert texts == ["nested text"]
+
+
+def test_extract_observation_parts_ignores_non_list_tool_result_content() -> None:
+    observation = [{"type": "tool_result", "content": "not-a-list"}]
+
+    url, texts = _extract_observation_parts(observation)
+
+    assert url is None
+    assert texts == []
+
+
+def test_extract_tool_result_parts_handles_base64_image_source() -> None:
+    content = [{"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "xyz"}}]
+
+    url, _ = _extract_tool_result_parts(content)
+
+    assert url == "data:image/jpeg;base64,xyz"
+
+
+def test_extract_tool_result_parts_defaults_media_type_to_png() -> None:
+    content = [{"type": "image", "source": {"type": "base64", "data": "xyz"}}]
+
+    url, _ = _extract_tool_result_parts(content)
+
+    assert url == "data:image/png;base64,xyz"
+
+
+def test_extract_tool_result_parts_ignores_non_base64_image_source() -> None:
+    content = [{"type": "image", "source": {"type": "url", "url": "https://example.com/x.png"}}]
+
+    url, _ = _extract_tool_result_parts(content)
+
+    assert url is None
+
+
+def test_extract_tool_result_parts_skips_non_dict_items() -> None:
+    content = ["not-a-dict", {"type": "text", "text": "keep"}]
+
+    url, texts = _extract_tool_result_parts(content)
+
+    assert url is None
+    assert texts == ["keep"]
 
 
 def test_text_only_user_message_keeps_pending_tool_screenshot() -> None:

--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -360,6 +360,16 @@ def _observation_has_image(observation: list[dict]) -> bool:
     return screenshot_url is not None
 
 
+def _image_url_from_block(block: dict[str, Any]) -> str | None:
+    """Return the ``image_url.url`` field of a content block, if present."""
+    return block.get("image_url", {}).get("url")
+
+
+def _stripped_text_from_block(block: dict[str, Any]) -> str:
+    """Return the stripped ``text`` field of a content block (``""`` if absent)."""
+    return block.get("text", "").strip()
+
+
 def _extract_observation_parts(observation: list[dict] | None) -> tuple[str | None, list[str]]:
     screenshot_url: str | None = None
     text_observations: list[str] = []
@@ -369,9 +379,9 @@ def _extract_observation_parts(observation: list[dict] | None) -> tuple[str | No
     for block in observation:
         block_type = block.get("type")
         if block_type == "image_url":
-            screenshot_url = block.get("image_url", {}).get("url") or screenshot_url
+            screenshot_url = _image_url_from_block(block) or screenshot_url
         elif block_type == "text":
-            text = block.get("text", "").strip()
+            text = _stripped_text_from_block(block)
             if text:
                 text_observations.append(text)
         elif block_type == "tool_result":
@@ -391,14 +401,14 @@ def _extract_tool_result_parts(content: list[Any]) -> tuple[str | None, list[str
             continue
         item_type = item.get("type")
         if item_type == "image_url":
-            screenshot_url = item.get("image_url", {}).get("url") or screenshot_url
+            screenshot_url = _image_url_from_block(item) or screenshot_url
         elif item_type == "image":
             source = item.get("source", {})
             if source.get("type") == "base64":
                 media_type = source.get("media_type", "image/png")
                 screenshot_url = f"data:{media_type};base64,{source.get('data', '')}"
         elif item_type == "text":
-            text = item.get("text", "").strip()
+            text = _stripped_text_from_block(item)
             if text:
                 texts.append(text)
     return screenshot_url, texts


### PR DESCRIPTION
## Issue

`_extract_observation_parts` and `_extract_tool_result_parts` in `yutori/navigator/replay.py` each contained byte-identical inline logic for two of their branches:

- `image_url` branch: `block.get("image_url", {}).get("url") or screenshot_url` — appeared verbatim in both functions.
- `text` branch: `block.get("text", "").strip()` followed by an `if text: <list>.append(text)` — same pattern, different accumulator name.

`_extract_observation_parts` also recurses into `_extract_tool_result_parts` for nested `tool_result` content, so the two functions are tightly coupled already; the duplicated snippets could silently drift apart on a future edit to one but not the other.

## Change

Extracted two tiny private helpers used by both functions:

```python
def _image_url_from_block(block: dict[str, Any]) -> str | None:
    return block.get("image_url", {}).get("url")

def _stripped_text_from_block(block: dict[str, Any]) -> str:
    return block.get("text", "").strip()
```

Each call site becomes a 1-line substitution; control flow and return values are unchanged (`_image_url_from_block(...) or screenshot_url` reproduces the original fallback-to-previous-value behavior exactly).

## Why it's safe

- No behavior or public API change — both functions are module-private (`_`-prefixed) and the diff is a mechanical 1:1 substitution.
- Added characterization tests in `tests/test_navigator_replay.py` (importing the private functions directly, matching the existing `_clip_image_url` test pattern) **before** the refactor, covering branches that had no prior direct test coverage: the `tool_result` recursion path, the base64 `image`-source path (including the default `media_type`), non-base64 image sources, and non-dict items. All new tests pass against the pre-refactor code, then continue to pass unchanged after the extraction.
- Full test suite: `488 passed, 3 skipped`.
- `ruff check .`: all checks passed. `ruff format --diff` and `mypy -p yutori` show the same pre-existing, unrelated findings on `main` (confirmed via `git stash`) — nothing new introduced by this change.

## Test plan

- [x] `pytest -q` — 488 passed, 3 skipped
- [x] `ruff check .` — all checks passed
- [x] Confirmed new characterization tests pass against pre-refactor code (behavior pinned before extraction)
- [x] Confirmed no new `ruff format`/`mypy` findings vs. `main`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BiZYexbRwJ64JUXbAiVwpY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private replay/debug helpers only; refactor is mechanical with new tests pinning existing behavior.
> 
> **Overview**
> **Navigator replay** observation parsing is refactored so shared block handling lives in one place, with tests locking behavior.
> 
> In `yutori/navigator/replay.py`, duplicated inline logic in `_extract_observation_parts` and `_extract_tool_result_parts` is replaced by two private helpers: `_image_url_from_block` and `_stripped_text_from_block`. Call sites still use the same `... or screenshot_url` pattern, so screenshot URL precedence and text stripping are unchanged.
> 
> `tests/test_navigator_replay.py` adds direct tests for those helpers and for paths that were lightly covered before: falsy observations, nested `tool_result` content, base64 `image` sources (including default `media_type`), non-base64 image sources, and non-dict list items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13515891a45629c38d0ce64229f4e69cc6f649a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->