### PR TITLE
refactor(examples): build Agent from Config.model_dump() in main()

### DIFF
--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -385,19 +385,9 @@ async def main():
     args = parser.parse_args()
     config = Config.model_validate(vars(args))
 
-    agent = Agent(
-        base_url=config.base_url,
-        model=config.model,
-        temperature=config.temperature,
-        max_steps=config.max_steps,
-        viewport_width=config.viewport_width,
-        viewport_height=config.viewport_height,
-        headless=config.headless,
-        max_request_bytes=config.max_request_bytes,
-        keep_recent_screenshots=config.keep_recent_screenshots,
-        replay_dir=config.replay_dir,
-        replay_id=config.replay_id,
-    )
+    # Config's fields (other than task/start_url, which go to agent.run()) map
+    # 1:1 onto Agent's constructor kwargs by name.
+    agent = Agent(**config.model_dump(exclude={"task", "start_url"}))
 
     result = await agent.run(config.task, config.start_url)
     logger.info(f"Final result: {result or '(No final response from model)'}")

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -719,24 +719,9 @@ async def main():
     args.tool_set = _TOOL_SET_ALIASES.get(args.tool_set, args.tool_set)
     config = Config.model_validate(vars(args))
 
-    agent = Agent(
-        base_url=config.base_url,
-        model=config.model,
-        temperature=config.temperature,
-        tool_set=config.tool_set,
-        disable_tools=config.disable_tools,
-        json_schema=config.json_schema,
-        user_timezone=config.user_timezone,
-        user_location=config.user_location,
-        max_steps=config.max_steps,
-        viewport_width=config.viewport_width,
-        viewport_height=config.viewport_height,
-        headless=config.headless,
-        max_request_bytes=config.max_request_bytes,
-        keep_recent_screenshots=config.keep_recent_screenshots,
-        replay_dir=config.replay_dir,
-        replay_id=config.replay_id,
-    )
+    # Config's fields (other than task/start_url, which go to agent.run()) map
+    # 1:1 onto Agent's constructor kwargs by name.
+    agent = Agent(**config.model_dump(exclude={"task", "start_url"}))
 
     result = await agent.run(config.task, config.start_url)
     logger.info(f"Final result: {result or '(No final response from model)'}")

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -443,17 +443,9 @@ async def main():
     args = parser.parse_args()
     config = Config.model_validate(vars(args))
 
-    agent = Agent(
-        base_url=config.base_url,
-        model=config.model,
-        temperature=config.temperature,
-        max_steps=config.max_steps,
-        viewport_width=config.viewport_width,
-        viewport_height=config.viewport_height,
-        headless=config.headless,
-        replay_dir=config.replay_dir,
-        replay_id=config.replay_id,
-    )
+    # Config's fields (other than task/start_url, which go to agent.run()) map
+    # 1:1 onto Agent's constructor kwargs by name.
+    agent = Agent(**config.model_dump(exclude={"task", "start_url"}))
 
     result = await agent.run(config.task, config.start_url)
     logger.info(f"Final result: {result or '(No final response from model)'}")

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -503,17 +503,9 @@ async def main():
     args = parser.parse_args()
     config = Config.model_validate(vars(args))
 
-    agent = Agent(
-        base_url=config.base_url,
-        model=config.model,
-        temperature=config.temperature,
-        max_steps=config.max_steps,
-        viewport_width=config.viewport_width,
-        viewport_height=config.viewport_height,
-        headless=config.headless,
-        replay_dir=config.replay_dir,
-        replay_id=config.replay_id,
-    )
+    # Config's fields (other than task/start_url, which go to agent.run()) map
+    # 1:1 onto Agent's constructor kwargs by name.
+    agent = Agent(**config.model_dump(exclude={"task", "start_url"}))
 
     result = await agent.run(config.task, config.start_url)
     logger.info(f"Final result: {result or '(No final response from model)'}")


### PR DESCRIPTION
## Summary
- Each of the four navigator example scripts (`navigator_n1.py`, `navigator_n1_5.py`, `navigator_n1_custom_tools.py`, `navigator_n1_memo.py`) manually listed every `Config` field as an `Agent(...)` kwarg in `main()`.
- Verified programmatically that in all four files, `Config`'s fields (minus `task`/`start_url`, which go to `agent.run()`) map 1:1 onto `Agent.__init__`'s parameter names by name.
- Replaced each hand-maintained per-field kwarg list with `Agent(**config.model_dump(exclude={"task", "start_url"}))`, using Pydantic's built-in serialization instead of hand-rolled field enumeration. No behavior change.

## Test plan
- [x] Verified field-name correspondence between `Config` and `Agent.__init__` programmatically for all 4 files before making the change
- [x] Constructed an `Agent` via the new `model_dump()` call for each of the 4 scripts and confirmed no `TypeError`
- [x] Ran each script's `--help` to confirm argparse wiring is unaffected
- [x] `pytest -q` — 488 passed, 3 skipped
- [x] `ruff check examples/` — passing (pre-existing `ruff format` drift in `navigator_n1_5.py` predates this change and is unrelated/out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Un4TpnaZ6dwuh7Ki2BwV2S


---
_Generated by [Claude Code](https://claude.ai/code/session_01Un4TpnaZ6dwuh7Ki2BwV2S)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only refactor with no production logic changes; behavior depends on Config/Agent field name parity, which the PR author verified.
> 
> **Overview**
> In **four** navigator example scripts (`navigator_n1.py`, `navigator_n1_5.py`, `navigator_n1_custom_tools.py`, `navigator_n1_memo.py`), **`main()`** no longer passes each **`Config`** field into **`Agent(...)`** by hand. It now uses **`Agent(**config.model_dump(exclude={"task", "start_url"}))`**, with a short comment that remaining **`Config`** fields align 1:1 with **`Agent`** constructor kwargs while **`task`** and **`start_url`** still go to **`agent.run()`**.
> 
> This is wiring-only in example entrypoints; runtime behavior is intended to stay the same, with less duplication when **`Config`** or **`Agent.__init__`** gains fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ce483182d46ab8388045be8c32a8824df8ef3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->