### PR TITLE
refactor(examples): extract run_example_agent() shared main() tail

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
+from collections.abc import Callable
 from typing import Any, Protocol
 
 from loguru import logger
@@ -87,6 +88,22 @@ def add_replay_arguments(parser: argparse.ArgumentParser, default_config) -> Non
         help="Optional directory for replay artifacts",
     )
     parser.add_argument("--replay-id", default=default_config.replay_id, help="Optional replay run id")
+
+
+class SupportsAgentRun(Protocol):
+    async def run(self, task: str, start_url: str) -> str: ...
+
+
+async def run_example_agent(agent_cls: Callable[..., SupportsAgentRun], config: Any) -> str:
+    """Build ``agent_cls`` from ``config`` and run it -- the shared tail of every example ``main()``.
+
+    Config's fields (other than task/start_url, which go to ``agent.run()``) map 1:1 onto the
+    agent's constructor kwargs by name.
+    """
+    agent = agent_cls(**config.model_dump(exclude={"task", "start_url"}))
+    result = await agent.run(config.task, config.start_url)
+    logger.info(f"Final result: {result or '(No final response from model)'}")
+    return result
 
 
 class SupportsBrowserAgentState(Protocol):

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -36,6 +36,7 @@ from _common import (
     add_task_arguments,
     configure_example_logging,
     llm_retry,
+    run_example_agent,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
@@ -385,12 +386,7 @@ async def main():
     args = parser.parse_args()
     config = Config.model_validate(vars(args))
 
-    # Config's fields (other than task/start_url, which go to agent.run()) map
-    # 1:1 onto Agent's constructor kwargs by name.
-    agent = Agent(**config.model_dump(exclude={"task", "start_url"}))
-
-    result = await agent.run(config.task, config.start_url)
-    logger.info(f"Final result: {result or '(No final response from model)'}")
+    await run_example_agent(Agent, config)
 
 
 if __name__ == "__main__":

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -53,6 +53,7 @@ from _common import (
     add_task_arguments,
     configure_example_logging,
     llm_retry,
+    run_example_agent,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
@@ -719,12 +720,7 @@ async def main():
     args.tool_set = _TOOL_SET_ALIASES.get(args.tool_set, args.tool_set)
     config = Config.model_validate(vars(args))
 
-    # Config's fields (other than task/start_url, which go to agent.run()) map
-    # 1:1 onto Agent's constructor kwargs by name.
-    agent = Agent(**config.model_dump(exclude={"task", "start_url"}))
-
-    result = await agent.run(config.task, config.start_url)
-    logger.info(f"Final result: {result or '(No final response from model)'}")
+    await run_example_agent(Agent, config)
 
 
 if __name__ == "__main__":

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -37,6 +37,7 @@ from _common import (
     add_task_arguments,
     configure_example_logging,
     llm_retry,
+    run_example_agent,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
@@ -443,12 +444,7 @@ async def main():
     args = parser.parse_args()
     config = Config.model_validate(vars(args))
 
-    # Config's fields (other than task/start_url, which go to agent.run()) map
-    # 1:1 onto Agent's constructor kwargs by name.
-    agent = Agent(**config.model_dump(exclude={"task", "start_url"}))
-
-    result = await agent.run(config.task, config.start_url)
-    logger.info(f"Final result: {result or '(No final response from model)'}")
+    await run_example_agent(Agent, config)
 
 
 if __name__ == "__main__":

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -41,6 +41,7 @@ from _common import (
     add_task_arguments,
     configure_example_logging,
     llm_retry,
+    run_example_agent,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
@@ -503,12 +504,7 @@ async def main():
     args = parser.parse_args()
     config = Config.model_validate(vars(args))
 
-    # Config's fields (other than task/start_url, which go to agent.run()) map
-    # 1:1 onto Agent's constructor kwargs by name.
-    agent = Agent(**config.model_dump(exclude={"task", "start_url"}))
-
-    result = await agent.run(config.task, config.start_url)
-    logger.info(f"Final result: {result or '(No final response from model)'}")
+    await run_example_agent(Agent, config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Follow-up to #175, which collapsed each example's hand-listed `Agent(...)` kwargs into `Agent(**config.model_dump(exclude={"task", "start_url"}))`, but left the identical 2-line comment + build/run/log tail duplicated across all 4 examples' `main()` (`navigator_n1.py`, `navigator_n1_5.py`, `navigator_n1_custom_tools.py`, `navigator_n1_memo.py`).
- Extracts that duplicated tail into a new `run_example_agent(agent_cls, config)` async helper (with a `SupportsAgentRun` Protocol for typing) in `examples/_common.py`.
- Each example's `main()` now calls `await run_example_agent(Agent, config)` instead of repeating the build+run+log block.

## Why safe

- Pure extraction: the helper's body is byte-equivalent to what was previously inlined in each `main()` (build `Agent(**config.model_dump(exclude={"task","start_url"}))`, `await agent.run(config.task, config.start_url)`, log the result, return it).
- No behavior change — confirmed no other `examples/*.py` file has the same duplicated block that this diff missed.
- `examples/` scripts have no direct unit tests, but `tests/test_clip_image_url.py` imports from `examples._common`, confirming the module still imports cleanly.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python -m pytest -m "not slow"` — 487 passed, 3 skipped
- [x] `python -c "import ast; ast.parse(...)"` sanity parse on all 5 touched files
- [x] Grepped `examples/*.py` for the old duplicated block/pattern — confirmed only the 4 known files matched and all are now updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nH4v2uk28w39BviUfkTaq

---
_Generated by [Claude Code](https://claude.ai/code/session_019nH4v2uk28w39BviUfkTaq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only mechanical extraction with no intended behavior change; agent loop and library code are untouched.
> 
> **Overview**
> Follow-up to collapsing example `Agent(...)` construction via `config.model_dump`; this PR **deduplicates the identical build/run/log tail** that still lived in each navigator example’s `main()`.
> 
> **`examples/_common.py`** adds a **`SupportsAgentRun`** protocol and async **`run_example_agent(agent_cls, config)`**, which instantiates the agent from config (excluding `task` / `start_url`), runs it, logs the final result, and returns it.
> 
> **Four example scripts** (`navigator_n1.py`, `navigator_n1_5.py`, `navigator_n1_custom_tools.py`, `navigator_n1_memo.py`) now end with **`await run_example_agent(Agent, config)`** instead of inlined copies of the same block and comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73056bb104cffd0c7c0cc116e55462e7b8dcad43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->