### PR TITLE
refactor(examples): extract shared n1 primitive-action dispatch

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -12,7 +12,7 @@ from loguru import logger
 from openai import APIConnectionError, APITimeoutError, InternalServerError, RateLimitError
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from yutori.navigator import aplaywright_screenshot_to_data_url
+from yutori.navigator import aplaywright_screenshot_to_data_url, denormalize_coordinates
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder
 from yutori.navigator.replay import _clip_image_url as _clip_image_url_impl
@@ -88,6 +88,132 @@ def add_replay_arguments(parser: argparse.ArgumentParser, default_config) -> Non
         help="Optional directory for replay artifacts",
     )
     parser.add_argument("--replay-id", default=default_config.replay_id, help="Optional replay run id")
+
+
+async def execute_n1_primitive_action(
+    page: Any,
+    action_name: str,
+    arguments: dict[str, Any],
+    viewport_width: int,
+    viewport_height: int,
+) -> bool:
+    """Execute one of Navigator n1's built-in browser actions on ``page``.
+
+    Shared by the n1 example agents that expose the full, unmodified n1
+    action vocabulary (``navigator_n1.py`` and ``navigator_n1_memo.py``);
+    ``navigator_n1_custom_tools.py`` intentionally supports only a trimmed
+    subset for tutorial purposes and ``navigator_n1_5.py`` targets a
+    different model with a different action vocabulary, so neither uses
+    this helper.
+
+    Returns True if ``action_name`` was recognized and executed, False
+    otherwise -- callers should treat False as "unknown action" (after first
+    checking their own custom tool names, if any). Exceptions raised by
+    Playwright calls propagate to the caller, which already wraps action
+    execution in its own try/except.
+    """
+    if action_name == "left_click":
+        coords = arguments.get("coordinates", [0, 0])
+        abs_x, abs_y = denormalize_coordinates(coords, viewport_width, viewport_height)
+        await page.mouse.click(abs_x, abs_y)
+        await asyncio.sleep(0.5)
+
+    elif action_name == "double_click":
+        coords = arguments.get("coordinates", [0, 0])
+        abs_x, abs_y = denormalize_coordinates(coords, viewport_width, viewport_height)
+        await page.mouse.dblclick(abs_x, abs_y)
+        await asyncio.sleep(0.5)
+
+    elif action_name == "right_click":
+        coords = arguments.get("coordinates", [0, 0])
+        abs_x, abs_y = denormalize_coordinates(coords, viewport_width, viewport_height)
+        await page.mouse.click(abs_x, abs_y, button="right")
+        await asyncio.sleep(0.5)
+
+    elif action_name == "triple_click":
+        coords = arguments.get("coordinates", [0, 0])
+        abs_x, abs_y = denormalize_coordinates(coords, viewport_width, viewport_height)
+        await page.mouse.click(abs_x, abs_y, click_count=3)
+        await asyncio.sleep(0.5)
+
+    elif action_name == "type":
+        text = arguments.get("text", "")
+        press_enter = arguments.get("press_enter_after", True)
+        clear_first = arguments.get("clear_before_typing", True)
+
+        if clear_first:
+            await page.keyboard.press("Control+a" if sys.platform != "darwin" else "Meta+a")
+            await page.keyboard.press("Backspace")
+
+        await page.keyboard.type(text)
+
+        if press_enter:
+            await page.keyboard.press("Enter")
+        await asyncio.sleep(0.5)
+
+    elif action_name in ("key", "key_press"):
+        key = arguments.get("key") or arguments.get("key_comb", "")
+        key = "+".join("ControlOrMeta" if k == "Meta" else k for k in key.split("+"))
+        await page.keyboard.press(key)
+        await asyncio.sleep(0.3)
+
+    elif action_name == "scroll":
+        coords = arguments.get("coordinates") or arguments.get("coordinate", [500, 500])
+        direction = arguments.get("direction", "down")
+        amount = arguments.get("amount", 3)
+
+        abs_x, abs_y = denormalize_coordinates(coords, viewport_width, viewport_height)
+        scroll_delta = amount * (viewport_height * 0.1)
+
+        delta_y = scroll_delta if direction == "down" else (-scroll_delta if direction == "up" else 0)
+        delta_x = scroll_delta if direction == "right" else (-scroll_delta if direction == "left" else 0)
+
+        await page.mouse.move(abs_x, abs_y)
+        await page.mouse.wheel(delta_x, delta_y)
+        await asyncio.sleep(0.5)
+
+    elif action_name == "hover":
+        coords = arguments.get("coordinates", [0, 0])
+        abs_x, abs_y = denormalize_coordinates(coords, viewport_width, viewport_height)
+        await page.mouse.move(abs_x, abs_y)
+        await asyncio.sleep(0.3)
+
+    elif action_name == "drag":
+        start_coords = arguments.get("start_coordinates") or arguments.get("startCoordinates", [0, 0])
+        end_coords = arguments.get("coordinates") or arguments.get("endCoordinates", [0, 0])
+
+        start_x, start_y = denormalize_coordinates(start_coords, viewport_width, viewport_height)
+        end_x, end_y = denormalize_coordinates(end_coords, viewport_width, viewport_height)
+
+        await page.mouse.move(start_x, start_y)
+        await page.mouse.down()
+        await page.mouse.move(end_x, end_y)
+        await page.mouse.up()
+        await asyncio.sleep(0.5)
+
+    elif action_name in ("goto", "goto_url"):
+        url = arguments.get("url", "")
+        await page.goto(url)
+        await page.wait_for_load_state("domcontentloaded")
+        await asyncio.sleep(1)
+
+    elif action_name in ("back", "go_back"):
+        await page.go_back()
+        await page.wait_for_load_state("domcontentloaded")
+        await asyncio.sleep(0.5)
+
+    elif action_name == "refresh":
+        await page.reload()
+        await page.wait_for_load_state("domcontentloaded")
+        await asyncio.sleep(1)
+
+    elif action_name == "wait":
+        await asyncio.sleep(5)
+
+    else:
+        return False
+
+    return True
 
 
 class SupportsAgentRun(Protocol):

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -24,7 +24,6 @@ Usage:
 import argparse
 import asyncio
 import json
-import sys
 
 from _common import (
     BrowserAgentMixin,
@@ -35,6 +34,7 @@ from _common import (
     add_replay_arguments,
     add_task_arguments,
     configure_example_logging,
+    execute_n1_primitive_action,
     llm_retry,
     run_example_agent,
 )
@@ -46,7 +46,7 @@ from pydantic import BaseModel, Field
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
-from yutori.navigator import NAVIGATOR_N1_MODEL, denormalize_coordinates
+from yutori.navigator import NAVIGATOR_N1_MODEL
 from yutori.navigator.loop import update_trimmed_history
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload  # Optional replay helpers.
@@ -256,105 +256,9 @@ class Agent(BrowserAgentMixin):
             return f"[ERROR] Failed to parse arguments: {tool_call.function.arguments}"
 
         try:
-            if action_name == "left_click":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.click(abs_x, abs_y)
-                await asyncio.sleep(0.5)
-
-            elif action_name == "double_click":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.dblclick(abs_x, abs_y)
-                await asyncio.sleep(0.5)
-
-            elif action_name == "right_click":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.click(abs_x, abs_y, button="right")
-                await asyncio.sleep(0.5)
-
-            elif action_name == "triple_click":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.click(abs_x, abs_y, click_count=3)
-                await asyncio.sleep(0.5)
-
-            elif action_name == "type":
-                text = arguments.get("text", "")
-                press_enter = arguments.get("press_enter_after", True)
-                clear_first = arguments.get("clear_before_typing", True)
-
-                if clear_first:
-                    await self._page.keyboard.press("Control+a" if sys.platform != "darwin" else "Meta+a")
-                    await self._page.keyboard.press("Backspace")
-
-                await self._page.keyboard.type(text)
-
-                if press_enter:
-                    await self._page.keyboard.press("Enter")
-                await asyncio.sleep(0.5)
-
-            elif action_name in ("key", "key_press"):
-                key = arguments.get("key") or arguments.get("key_comb", "")
-                key = "+".join("ControlOrMeta" if k == "Meta" else k for k in key.split("+"))
-                await self._page.keyboard.press(key)
-                await asyncio.sleep(0.3)
-
-            elif action_name == "scroll":
-                coords = arguments.get("coordinates") or arguments.get("coordinate", [500, 500])
-                direction = arguments.get("direction", "down")
-                amount = arguments.get("amount", 3)
-
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                scroll_delta = amount * (self.viewport_height * 0.1)
-
-                delta_y = scroll_delta if direction == "down" else (-scroll_delta if direction == "up" else 0)
-                delta_x = scroll_delta if direction == "right" else (-scroll_delta if direction == "left" else 0)
-
-                await self._page.mouse.move(abs_x, abs_y)
-                await self._page.mouse.wheel(delta_x, delta_y)
-                await asyncio.sleep(0.5)
-
-            elif action_name == "hover":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.move(abs_x, abs_y)
-                await asyncio.sleep(0.3)
-
-            elif action_name == "drag":
-                start_coords = arguments.get("start_coordinates") or arguments.get("startCoordinates", [0, 0])
-                end_coords = arguments.get("coordinates") or arguments.get("endCoordinates", [0, 0])
-
-                start_x, start_y = denormalize_coordinates(start_coords, self.viewport_width, self.viewport_height)
-                end_x, end_y = denormalize_coordinates(end_coords, self.viewport_width, self.viewport_height)
-
-                await self._page.mouse.move(start_x, start_y)
-                await self._page.mouse.down()
-                await self._page.mouse.move(end_x, end_y)
-                await self._page.mouse.up()
-                await asyncio.sleep(0.5)
-
-            elif action_name in ("goto", "goto_url"):
-                url = arguments.get("url", "")
-                await self._page.goto(url)
-                await self._page.wait_for_load_state("domcontentloaded")
-                await asyncio.sleep(1)
-
-            elif action_name in ("back", "go_back"):
-                await self._page.go_back()
-                await self._page.wait_for_load_state("domcontentloaded")
-                await asyncio.sleep(0.5)
-
-            elif action_name == "refresh":
-                await self._page.reload()
-                await self._page.wait_for_load_state("domcontentloaded")
-                await asyncio.sleep(1)
-
-            elif action_name == "wait":
-                await asyncio.sleep(5)
-
-            else:
+            if not await execute_n1_primitive_action(
+                self._page, action_name, arguments, self.viewport_width, self.viewport_height
+            ):
                 logger.warning(f"Unknown action: {action_name}")
                 return f"[ERROR] Unknown action: {action_name}"
 

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -28,7 +28,6 @@ import argparse
 import asyncio
 import json
 import os
-import sys
 from datetime import datetime
 from functools import cached_property
 
@@ -40,6 +39,7 @@ from _common import (
     add_replay_arguments,
     add_task_arguments,
     configure_example_logging,
+    execute_n1_primitive_action,
     llm_retry,
     run_example_agent,
 )
@@ -51,7 +51,7 @@ from pydantic import BaseModel, Field
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
-from yutori.navigator import NAVIGATOR_N1_MODEL, denormalize_coordinates
+from yutori.navigator import NAVIGATOR_N1_MODEL
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload  # Optional replay helpers.
 
@@ -361,105 +361,7 @@ class Agent(BrowserAgentMixin):
             return False, f"[ERROR] Failed to parse arguments: {tool_call.function.arguments}"
 
         try:
-            if action_name == "left_click":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.click(abs_x, abs_y)
-                await asyncio.sleep(0.5)
-
-            elif action_name == "double_click":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.dblclick(abs_x, abs_y)
-                await asyncio.sleep(0.5)
-
-            elif action_name == "right_click":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.click(abs_x, abs_y, button="right")
-                await asyncio.sleep(0.5)
-
-            elif action_name == "triple_click":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.click(abs_x, abs_y, click_count=3)
-                await asyncio.sleep(0.5)
-
-            elif action_name == "type":
-                text = arguments.get("text", "")
-                press_enter = arguments.get("press_enter_after", True)
-                clear_first = arguments.get("clear_before_typing", True)
-
-                if clear_first:
-                    await self._page.keyboard.press("Control+a" if sys.platform != "darwin" else "Meta+a")
-                    await self._page.keyboard.press("Backspace")
-
-                await self._page.keyboard.type(text)
-
-                if press_enter:
-                    await self._page.keyboard.press("Enter")
-                await asyncio.sleep(0.5)
-
-            elif action_name in ("key", "key_press"):
-                key = arguments.get("key") or arguments.get("key_comb", "")
-                key = "+".join("ControlOrMeta" if k == "Meta" else k for k in key.split("+"))
-                await self._page.keyboard.press(key)
-                await asyncio.sleep(0.3)
-
-            elif action_name == "scroll":
-                coords = arguments.get("coordinates") or arguments.get("coordinate", [500, 500])
-                direction = arguments.get("direction", "down")
-                amount = arguments.get("amount", 3)
-
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                scroll_delta = amount * (self.viewport_height * 0.1)
-
-                delta_y = scroll_delta if direction == "down" else (-scroll_delta if direction == "up" else 0)
-                delta_x = scroll_delta if direction == "right" else (-scroll_delta if direction == "left" else 0)
-
-                await self._page.mouse.move(abs_x, abs_y)
-                await self._page.mouse.wheel(delta_x, delta_y)
-                await asyncio.sleep(0.5)
-
-            elif action_name == "hover":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.move(abs_x, abs_y)
-                await asyncio.sleep(0.3)
-
-            elif action_name == "drag":
-                start_coords = arguments.get("start_coordinates") or arguments.get("startCoordinates", [0, 0])
-                end_coords = arguments.get("coordinates") or arguments.get("endCoordinates", [0, 0])
-
-                start_x, start_y = denormalize_coordinates(start_coords, self.viewport_width, self.viewport_height)
-                end_x, end_y = denormalize_coordinates(end_coords, self.viewport_width, self.viewport_height)
-
-                await self._page.mouse.move(start_x, start_y)
-                await self._page.mouse.down()
-                await self._page.mouse.move(end_x, end_y)
-                await self._page.mouse.up()
-                await asyncio.sleep(0.5)
-
-            elif action_name in ("goto", "goto_url"):
-                url = arguments.get("url", "")
-                await self._page.goto(url)
-                await self._page.wait_for_load_state("domcontentloaded")
-                await asyncio.sleep(1)
-
-            elif action_name in ("back", "go_back"):
-                await self._page.go_back()
-                await self._page.wait_for_load_state("domcontentloaded")
-                await asyncio.sleep(0.5)
-
-            elif action_name == "refresh":
-                await self._page.reload()
-                await self._page.wait_for_load_state("domcontentloaded")
-                await asyncio.sleep(1)
-
-            elif action_name == "wait":
-                await asyncio.sleep(5)
-
-            elif action_name == "add_question":
+            if action_name == "add_question":
                 result = await self._memo_tool_suite.add_question(**arguments)
                 return False, result
 
@@ -471,7 +373,9 @@ class Agent(BrowserAgentMixin):
                 result = await self._memo_tool_suite.list_records()
                 return True, result
 
-            else:
+            if not await execute_n1_primitive_action(
+                self._page, action_name, arguments, self.viewport_width, self.viewport_height
+            ):
                 logger.warning(f"Unknown action: {action_name}")
                 return False, f"[ERROR] Unknown action: {action_name}"
 

--- a/tests/test_execute_n1_primitive_action.py
+++ b/tests/test_execute_n1_primitive_action.py
@@ -1,0 +1,217 @@
+"""Characterization tests for ``examples._common.execute_n1_primitive_action``.
+
+Pins the exact Playwright calls and denormalized coordinates for each of
+Navigator n1's browser primitives before/after extracting this dispatch out
+of ``navigator_n1.py`` and ``navigator_n1_memo.py`` (which previously
+duplicated the same ~100-line if/elif chain verbatim).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+pytest.importorskip("loguru")
+from examples._common import execute_n1_primitive_action  # noqa: E402
+from yutori.navigator import denormalize_coordinates  # noqa: E402
+
+VIEWPORT_WIDTH = 1280
+VIEWPORT_HEIGHT = 800
+
+
+def make_page() -> MagicMock:
+    page = MagicMock()
+    page.mouse = MagicMock()
+    page.mouse.click = AsyncMock()
+    page.mouse.dblclick = AsyncMock()
+    page.mouse.move = AsyncMock()
+    page.mouse.wheel = AsyncMock()
+    page.mouse.down = AsyncMock()
+    page.mouse.up = AsyncMock()
+    page.keyboard = MagicMock()
+    page.keyboard.press = AsyncMock()
+    page.keyboard.type = AsyncMock()
+    page.goto = AsyncMock()
+    page.wait_for_load_state = AsyncMock()
+    page.go_back = AsyncMock()
+    page.reload = AsyncMock()
+    return page
+
+
+async def run_action(action_name: str, arguments: dict) -> tuple[bool, MagicMock]:
+    page = make_page()
+    handled = await execute_n1_primitive_action(page, action_name, arguments, VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+    return handled, page
+
+
+class TestClickActions:
+    async def test_left_click(self):
+        handled, page = await run_action("left_click", {"coordinates": [500, 500]})
+        assert handled is True
+        abs_x, abs_y = denormalize_coordinates([500, 500], VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+        page.mouse.click.assert_awaited_once_with(abs_x, abs_y)
+
+    async def test_left_click_defaults_to_origin(self):
+        handled, page = await run_action("left_click", {})
+        assert handled is True
+        abs_x, abs_y = denormalize_coordinates([0, 0], VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+        page.mouse.click.assert_awaited_once_with(abs_x, abs_y)
+
+    async def test_double_click(self):
+        handled, page = await run_action("double_click", {"coordinates": [100, 200]})
+        assert handled is True
+        abs_x, abs_y = denormalize_coordinates([100, 200], VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+        page.mouse.dblclick.assert_awaited_once_with(abs_x, abs_y)
+
+    async def test_right_click(self):
+        handled, page = await run_action("right_click", {"coordinates": [100, 200]})
+        assert handled is True
+        abs_x, abs_y = denormalize_coordinates([100, 200], VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+        page.mouse.click.assert_awaited_once_with(abs_x, abs_y, button="right")
+
+    async def test_triple_click(self):
+        handled, page = await run_action("triple_click", {"coordinates": [100, 200]})
+        assert handled is True
+        abs_x, abs_y = denormalize_coordinates([100, 200], VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+        page.mouse.click.assert_awaited_once_with(abs_x, abs_y, click_count=3)
+
+
+class TestTypeAction:
+    async def test_type_clears_and_presses_enter_by_default(self):
+        handled, page = await run_action("type", {"text": "hello"})
+        assert handled is True
+        page.keyboard.type.assert_awaited_once_with("hello")
+        # Clear-before-typing + trailing Enter both default to True.
+        assert call("Backspace") in page.keyboard.press.await_args_list
+        assert call("Enter") in page.keyboard.press.await_args_list
+
+    async def test_type_can_skip_clear_and_enter(self):
+        handled, page = await run_action(
+            "type", {"text": "hello", "press_enter_after": False, "clear_before_typing": False}
+        )
+        assert handled is True
+        page.keyboard.type.assert_awaited_once_with("hello")
+        page.keyboard.press.assert_not_awaited()
+
+    async def test_type_defaults_to_empty_text(self):
+        handled, page = await run_action("type", {})
+        assert handled is True
+        page.keyboard.type.assert_awaited_once_with("")
+
+
+class TestKeyActions:
+    async def test_key_press_by_key_field(self):
+        handled, page = await run_action("key_press", {"key": "Enter"})
+        assert handled is True
+        page.keyboard.press.assert_awaited_once_with("Enter")
+
+    async def test_key_press_by_legacy_key_comb_field(self):
+        handled, page = await run_action("key", {"key_comb": "Control+c"})
+        assert handled is True
+        page.keyboard.press.assert_awaited_once_with("Control+c")
+
+    async def test_key_press_translates_meta_to_control_or_meta(self):
+        handled, page = await run_action("key_press", {"key": "Meta+a"})
+        assert handled is True
+        page.keyboard.press.assert_awaited_once_with("ControlOrMeta+a")
+
+
+class TestScrollAction:
+    async def test_scroll_down_default(self):
+        handled, page = await run_action("scroll", {})
+        assert handled is True
+        abs_x, abs_y = denormalize_coordinates([500, 500], VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+        page.mouse.move.assert_awaited_once_with(abs_x, abs_y)
+        expected_delta = 3 * (VIEWPORT_HEIGHT * 0.1)
+        page.mouse.wheel.assert_awaited_once_with(0, expected_delta)
+
+    async def test_scroll_up_negates_delta_y(self):
+        handled, page = await run_action("scroll", {"direction": "up", "amount": 2})
+        assert handled is True
+        expected_delta = -(2 * (VIEWPORT_HEIGHT * 0.1))
+        page.mouse.wheel.assert_awaited_once_with(0, expected_delta)
+
+    async def test_scroll_right_sets_delta_x(self):
+        handled, page = await run_action("scroll", {"direction": "right", "amount": 1})
+        assert handled is True
+        expected_delta = 1 * (VIEWPORT_HEIGHT * 0.1)
+        page.mouse.wheel.assert_awaited_once_with(expected_delta, 0)
+
+    async def test_scroll_accepts_legacy_coordinate_singular_key(self):
+        handled, page = await run_action("scroll", {"coordinate": [10, 20]})
+        assert handled is True
+        abs_x, abs_y = denormalize_coordinates([10, 20], VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+        page.mouse.move.assert_awaited_once_with(abs_x, abs_y)
+
+
+class TestHoverAction:
+    async def test_hover(self):
+        handled, page = await run_action("hover", {"coordinates": [50, 60]})
+        assert handled is True
+        abs_x, abs_y = denormalize_coordinates([50, 60], VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+        page.mouse.move.assert_awaited_once_with(abs_x, abs_y)
+
+
+class TestDragAction:
+    async def test_drag_moves_down_and_up(self):
+        handled, page = await run_action("drag", {"start_coordinates": [10, 10], "coordinates": [200, 200]})
+        assert handled is True
+        start_x, start_y = denormalize_coordinates([10, 10], VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+        end_x, end_y = denormalize_coordinates([200, 200], VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+        assert page.mouse.move.await_args_list == [call(start_x, start_y), call(end_x, end_y)]
+        page.mouse.down.assert_awaited_once_with()
+        page.mouse.up.assert_awaited_once_with()
+
+    async def test_drag_accepts_legacy_camelcase_keys(self):
+        handled, page = await run_action("drag", {"startCoordinates": [1, 1], "endCoordinates": [2, 2]})
+        assert handled is True
+        start_x, start_y = denormalize_coordinates([1, 1], VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+        end_x, end_y = denormalize_coordinates([2, 2], VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+        assert page.mouse.move.await_args_list == [call(start_x, start_y), call(end_x, end_y)]
+
+
+class TestNavigationActions:
+    async def test_goto(self):
+        handled, page = await run_action("goto", {"url": "https://example.com"})
+        assert handled is True
+        page.goto.assert_awaited_once_with("https://example.com")
+        page.wait_for_load_state.assert_awaited_once_with("domcontentloaded")
+
+    async def test_goto_url_alias(self):
+        handled, page = await run_action("goto_url", {"url": "https://example.com"})
+        assert handled is True
+        page.goto.assert_awaited_once_with("https://example.com")
+
+    async def test_back(self):
+        handled, page = await run_action("back", {})
+        assert handled is True
+        page.go_back.assert_awaited_once_with()
+
+    async def test_go_back_alias(self):
+        handled, page = await run_action("go_back", {})
+        assert handled is True
+        page.go_back.assert_awaited_once_with()
+
+    async def test_refresh(self):
+        handled, page = await run_action("refresh", {})
+        assert handled is True
+        page.reload.assert_awaited_once_with()
+
+
+class TestWaitAction:
+    async def test_wait_does_not_touch_the_page(self):
+        handled, page = await run_action("wait", {})
+        assert handled is True
+        page.mouse.assert_not_called()
+        page.keyboard.assert_not_called()
+        page.goto.assert_not_awaited()
+
+
+class TestUnknownAction:
+    async def test_unknown_action_returns_false_and_touches_nothing(self):
+        handled, page = await run_action("teleport", {})
+        assert handled is False
+        page.mouse.assert_not_called()
+        page.keyboard.assert_not_called()
+        page.goto.assert_not_awaited()


### PR DESCRIPTION
## What

`examples/navigator_n1.py` and `examples/navigator_n1_memo.py` both duplicated the same ~100-line if/elif chain dispatching Navigator n1's browser primitives (`left_click`, `double_click`, `right_click`, `triple_click`, `type`, `key`/`key_press`, `scroll`, `hover`, `drag`, `goto`/`goto_url`, `back`/`go_back`, `refresh`, `wait`) byte-for-byte — both scripts target the same full n1 action vocabulary (`NAVIGATOR_N1_MODEL`).

This extracts the dispatch into a new `execute_n1_primitive_action(page, action_name, arguments, viewport_width, viewport_height) -> bool` helper in `examples/_common.py`. It returns `True`/`False` for "handled"/"unrecognized" so each caller keeps its own error message and post-action wait logic exactly as before.

`navigator_n1_memo.py`'s `_execute` now checks its own custom tool names (`add_question`/`add_options`/`list_records`) first, then falls back to the shared primitive dispatch. Action-name sets between the two are disjoint, so this reorder has no behavioral effect.

## What was deliberately left alone

- `examples/navigator_n1_custom_tools.py` intentionally supports only a trimmed subset of the n1 action vocabulary for tutorial brevity (no `key_press`, `goto`, `back`) — left untouched to avoid changing its pedagogical scope. Noted in the new helper's docstring.
- `examples/navigator_n1_5.py` targets a different model (`NAVIGATOR_N1_5_MODEL`) with a genuinely different action vocabulary — not a duplicate, so not touched.
- `examples/` is not part of the published `yutori` package (`[tool.setuptools.packages.find] include = ["yutori*"]`), so this has no effect on the SDK's public API surface.

## Testing

- Added `tests/test_execute_n1_primitive_action.py` as a characterization test (mocked Playwright `Page`) pinning the exact Playwright calls, denormalized coordinates, and branch behavior for every action and the unknown-action fallback, since no test previously covered this dispatch logic.
- Full suite green: **512 passed, 3 skipped** (up from 487 passed pre-change; +25 new tests), plus the `slow` wheel-content test passes.
- `ruff check .` and `ruff format --check` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECCfuSyBqavaVnVb9YzFJJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only refactor with no published SDK API changes; behavior is locked by new characterization tests.
> 
> **Overview**
> **Deduplicates** the duplicated Navigator n1 browser-tool dispatch (~100-line `if/elif` chains) from `navigator_n1.py` and `navigator_n1_memo.py` into a shared **`execute_n1_primitive_action`** helper in `examples/_common.py`.
> 
> Both example agents now call that helper from `_execute` and treat **`False`** as an unknown action, keeping their existing error handling and post-action page-ready waits. **`navigator_n1_memo.py`** still handles memo tools (`add_question`, `add_options`, `list_records`) first, then delegates everything else to the shared primitive dispatch.
> 
> Adds **`tests/test_execute_n1_primitive_action.py`** as mocked Playwright characterization tests so each action’s Playwright calls, coordinate denormalization, and unknown-action behavior stay pinned after the move.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2676d33afb75f7f16a0d6b7bb961ba0ad114ad10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->