### PR TITLE
refactor(tests): extract _patched_callback_server() for OAuth callback scaffold

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -460,10 +460,14 @@ class TestRegistrationHelpers:
 
 
 @contextmanager
-def _successful_oauth_callback():
-    """Patch the local callback server/thread so run_login_flow observes a browser
-    callback that delivers a matching auth code and state, without starting a
-    real server or thread."""
+def _patched_callback_server():
+    """Patch the local OAuth callback server/thread machinery (TCPServer, its
+    background Thread, and the browser launch) so tests can drive
+    run_login_flow's callback delivery without starting a real server or thread.
+
+    Yields (mock_thread, original_result) so callers can script how/whether the
+    callback delivers a code, state, and the `received` signal.
+    """
 
     def fake_server_init(self, addr, handler):
         pass
@@ -473,6 +477,7 @@ def _successful_oauth_callback():
         patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"),
         patch("yutori.auth.flow.socketserver.TCPServer.shutdown"),
         patch("yutori.auth.flow.socketserver.TCPServer.server_close"),
+        patch("yutori.auth.flow.webbrowser.open"),
         patch("yutori.auth.flow.threading.Thread") as mock_thread_cls,
     ):
         mock_thread = MagicMock()
@@ -480,15 +485,25 @@ def _successful_oauth_callback():
 
         original_result = _CallbackResult()
         with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
-            with patch("yutori.auth.flow.secrets.token_urlsafe", return_value="fixed_state"):
+            yield mock_thread, original_result
 
-                def side_effect(*args, **kwargs):
-                    original_result.code = "auth_code"
-                    original_result.state = "fixed_state"
-                    original_result.received.set()
 
-                mock_thread.start.side_effect = side_effect
-                yield mock_thread
+@contextmanager
+def _successful_oauth_callback():
+    """Patch the local callback server/thread so run_login_flow observes a browser
+    callback that delivers a matching auth code and state, without starting a
+    real server or thread."""
+
+    with _patched_callback_server() as (mock_thread, original_result):
+        with patch("yutori.auth.flow.secrets.token_urlsafe", return_value="fixed_state"):
+
+            def side_effect(*args, **kwargs):
+                original_result.code = "auth_code"
+                original_result.state = "fixed_state"
+                original_result.received.set()
+
+            mock_thread.start.side_effect = side_effect
+            yield mock_thread
 
 
 class TestRunLoginFlow:
@@ -610,59 +625,29 @@ class TestRunLoginFlow:
             assert "Permission denied" in result.error
 
     def test_timeout(self):
-        def fake_server_init(self, addr, handler):
-            pass
-
-        with (
-            patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init),
-            patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"),
-            patch("yutori.auth.flow.socketserver.TCPServer.shutdown"),
-            patch("yutori.auth.flow.socketserver.TCPServer.server_close"),
-            patch("yutori.auth.flow.webbrowser.open"),
-            patch("yutori.auth.flow.threading.Thread") as mock_thread_cls,
-        ):
-            mock_thread = MagicMock()
-            mock_thread_cls.return_value = mock_thread
-
-            original_result = _CallbackResult()
-            with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
-                # Don't set received, so wait() returns False after timeout=0
-                with patch.object(original_result.received, "wait", return_value=False):
-                    result = run_login_flow()
-                    assert result.success is False
-                    assert "timed out" in result.error.lower()
-                    assert result.auth_url is not None
+        with _patched_callback_server() as (_, original_result):
+            # Don't set received, so wait() returns False after timeout=0
+            with patch.object(original_result.received, "wait", return_value=False):
+                result = run_login_flow()
+                assert result.success is False
+                assert "timed out" in result.error.lower()
+                assert result.auth_url is not None
 
     def test_state_mismatch(self):
-        def fake_server_init(self, addr, handler):
-            pass
+        with _patched_callback_server() as (mock_thread, original_result):
+            with patch("yutori.auth.flow.secrets.token_urlsafe", return_value="expected_state"):
 
-        with (
-            patch("yutori.auth.flow.socketserver.TCPServer.__init__", fake_server_init),
-            patch("yutori.auth.flow.socketserver.TCPServer.serve_forever"),
-            patch("yutori.auth.flow.socketserver.TCPServer.shutdown"),
-            patch("yutori.auth.flow.socketserver.TCPServer.server_close"),
-            patch("yutori.auth.flow.webbrowser.open"),
-            patch("yutori.auth.flow.threading.Thread") as mock_thread_cls,
-        ):
-            mock_thread = MagicMock()
-            mock_thread_cls.return_value = mock_thread
+                def side_effect(*args, **kwargs):
+                    original_result.code = "auth_code"
+                    original_result.state = "wrong_state"
+                    original_result.received.set()
 
-            original_result = _CallbackResult()
-            with patch("yutori.auth.flow._CallbackResult", return_value=original_result):
-                with patch("yutori.auth.flow.secrets.token_urlsafe", return_value="expected_state"):
+                mock_thread.start.side_effect = side_effect
 
-                    def side_effect(*args, **kwargs):
-                        original_result.code = "auth_code"
-                        original_result.state = "wrong_state"
-                        original_result.received.set()
-
-                    mock_thread.start.side_effect = side_effect
-
-                    result = run_login_flow()
-                    assert result.success is False
-                    assert "state mismatch" in result.error.lower()
-                    assert result.auth_url is not None
+                result = run_login_flow()
+                assert result.success is False
+                assert "state mismatch" in result.error.lower()
+                assert result.auth_url is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `test_timeout` and `test_state_mismatch` in `TestRunLoginFlow` (`tests/test_auth.py`) hand-rolled the same "patch the local OAuth callback server" scaffold that `_successful_oauth_callback()` already exists to avoid — leftover from the earlier extraction in #165, since these two tests need custom callback-delivery behavior (timeout never signals `received`; state mismatch delivers a mismatched `state`).
- Extracted the low-level `TCPServer`/`Thread` patch block into a new `_patched_callback_server()` context manager that yields the mock thread; `_successful_oauth_callback()` now wraps it, adding only the `_CallbackResult`/`secrets.token_urlsafe`/success side effect.
- `test_timeout` and `test_state_mismatch` now call `_patched_callback_server()` directly instead of redeclaring `fake_server_init` and the four patches.
- No behavior change, one file touched, ~15 duplicated lines removed.

## Test plan
- [x] `uv run pytest tests/test_auth.py -k RunLoginFlow -v` — 8 passed
- [x] `uv run pytest -q` (full suite) — 488 passed, 3 skipped (matches pre-change baseline)
- [x] `ruff check tests/test_auth.py` / `ruff format --check tests/test_auth.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171mJWHAuH9BzKsMMkcD4Fu


---
_Generated by [Claude Code](https://claude.ai/code/session_0171mJWHAuH9BzKsMMkcD4Fu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test helpers in one file with no production code touched; behavior is intended to stay the same.
> 
> **Overview**
> Extracts shared OAuth callback mocking in `tests/test_auth.py` into a new **`_patched_callback_server()`** context manager that patches `TCPServer`, the background `Thread`, **`webbrowser.open`**, and yields `(mock_thread, original_result)` for custom callback scripts.
> 
> **`_successful_oauth_callback()`** now delegates to that helper and only adds the success path (fixed state + matching code on thread start). **`test_timeout`** and **`test_state_mismatch`** use **`_patched_callback_server()`** directly instead of duplicating the patch block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 265f55a30517b19f6bd1948ce4c217f728c057fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->