### PR TITLE
fix(examples): use UTC for memo filename timestamp in navigator_n1_memo

### DIFF
--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -28,7 +28,7 @@ import argparse
 import asyncio
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import cached_property
 
 from _common import (
@@ -81,7 +81,7 @@ class MemoToolSuite:
     def __init__(self, file_path: str | None = None):
         super().__init__()
         if not file_path:
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
             file_path = os.path.join(os.path.dirname(__file__), f"memo_{timestamp}.jsonl")
         self.file_path = file_path
 


### PR DESCRIPTION
## Summary

`MemoToolSuite.__init__` in `examples/navigator_n1_memo.py` built its default memo filename timestamp with naive `datetime.now()`, whereas the SDK library code uses `datetime.now(timezone.utc)` for the **identical** `"%Y%m%d_%H%M%S"` filename-timestamp pattern:

- `yutori/navigator/replay.py:75` — `datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")`
- `yutori/auth/flow.py:154` — `datetime.now(timezone.utc).strftime("%Y-%m-%d")`

This aligns the example with the library's own established convention so it demonstrates timezone-safe usage, and avoids the local-timezone footgun the codebase otherwise consistently avoids.

## Changes

- `from datetime import datetime` → `from datetime import datetime, timezone`
- `datetime.now()` → `datetime.now(timezone.utc)` for the memo filename timestamp

## Testing

- `python -c "ast.parse(...)"` — syntax OK
- `ruff check examples/navigator_n1_memo.py` — all checks passed

Behavior is unchanged aside from the timestamp being UTC; the example still generates a `memo_<timestamp>.jsonl` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQJEAzdKDqMA8kWNpWDsSh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only timestamp change with no impact on auth, data handling, or production paths.
> 
> **Overview**
> When `MemoToolSuite` builds a default `memo_<timestamp>.jsonl` path, it now uses **UTC** for the `%Y%m%d_%H%M%S` segment instead of naive local time.
> 
> The change adds `timezone` to the datetime import and switches `datetime.now()` to `datetime.now(timezone.utc)`, matching the same timestamp pattern used elsewhere (e.g. replay run IDs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a8f887eb117687ac52b25ffb69858cc6e2e5ea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->