### PR TITLE
refactor(examples): extract _click_coordinates() for repeated coord-resolution

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -90,6 +90,21 @@ def add_replay_arguments(parser: argparse.ArgumentParser, default_config) -> Non
     parser.add_argument("--replay-id", default=default_config.replay_id, help="Optional replay run id")
 
 
+def _click_coordinates(
+    arguments: dict[str, Any],
+    viewport_width: int,
+    viewport_height: int,
+) -> tuple[int, int]:
+    """Resolve the ``coordinates`` argument (default ``[0, 0]``) to absolute pixel coordinates.
+
+    Shared by the pointer actions in :func:`execute_n1_primitive_action` (the click
+    variants and hover) that all read the same ``coordinates`` argument and denormalize
+    it the same way.
+    """
+    coords = arguments.get("coordinates", [0, 0])
+    return denormalize_coordinates(coords, viewport_width, viewport_height)
+
+
 async def execute_n1_primitive_action(
     page: Any,
     action_name: str,
@@ -113,26 +128,22 @@ async def execute_n1_primitive_action(
     execution in its own try/except.
     """
     if action_name == "left_click":
-        coords = arguments.get("coordinates", [0, 0])
-        abs_x, abs_y = denormalize_coordinates(coords, viewport_width, viewport_height)
+        abs_x, abs_y = _click_coordinates(arguments, viewport_width, viewport_height)
         await page.mouse.click(abs_x, abs_y)
         await asyncio.sleep(0.5)
 
     elif action_name == "double_click":
-        coords = arguments.get("coordinates", [0, 0])
-        abs_x, abs_y = denormalize_coordinates(coords, viewport_width, viewport_height)
+        abs_x, abs_y = _click_coordinates(arguments, viewport_width, viewport_height)
         await page.mouse.dblclick(abs_x, abs_y)
         await asyncio.sleep(0.5)
 
     elif action_name == "right_click":
-        coords = arguments.get("coordinates", [0, 0])
-        abs_x, abs_y = denormalize_coordinates(coords, viewport_width, viewport_height)
+        abs_x, abs_y = _click_coordinates(arguments, viewport_width, viewport_height)
         await page.mouse.click(abs_x, abs_y, button="right")
         await asyncio.sleep(0.5)
 
     elif action_name == "triple_click":
-        coords = arguments.get("coordinates", [0, 0])
-        abs_x, abs_y = denormalize_coordinates(coords, viewport_width, viewport_height)
+        abs_x, abs_y = _click_coordinates(arguments, viewport_width, viewport_height)
         await page.mouse.click(abs_x, abs_y, click_count=3)
         await asyncio.sleep(0.5)
 
@@ -173,8 +184,7 @@ async def execute_n1_primitive_action(
         await asyncio.sleep(0.5)
 
     elif action_name == "hover":
-        coords = arguments.get("coordinates", [0, 0])
-        abs_x, abs_y = denormalize_coordinates(coords, viewport_width, viewport_height)
+        abs_x, abs_y = _click_coordinates(arguments, viewport_width, viewport_height)
         await page.mouse.move(abs_x, abs_y)
         await asyncio.sleep(0.3)
 


### PR DESCRIPTION
## Issue

In `examples/_common.py::execute_n1_primitive_action()` (extracted in #177), five of the dispatch branches — `left_click`, `double_click`, `right_click`, `triple_click`, and `hover` — each repeated the identical two-line pattern:

```python
coords = arguments.get("coordinates", [0, 0])
abs_x, abs_y = denormalize_coordinates(coords, viewport_width, viewport_height)
```

before doing their own Playwright call. `scroll` and `drag` were intentionally left untouched since they resolve coordinates from different keys, fallbacks, and defaults — unifying those would not be a clear behavior-preserving simplification.

## Change

Extracted the shared two-line pattern into a small helper:

```python
def _click_coordinates(arguments, viewport_width, viewport_height) -> tuple[int, int]:
    coords = arguments.get("coordinates", [0, 0])
    return denormalize_coordinates(coords, viewport_width, viewport_height)
```

Each of the five branches now calls `_click_coordinates(...)` instead of re-deriving `abs_x`/`abs_y` inline. No behavior change: every branch still computes and passes the exact same `(abs_x, abs_y)` to the exact same Playwright call it did before.

## Why this is safe

- Purely mechanical extraction — same inputs, same computation, same outputs, same call sites.
- `tests/test_execute_n1_primitive_action.py` already has characterization tests (added in #177) pinning the exact Playwright calls and denormalized coordinates for every one of these branches, including `left_click`'s default-to-origin case and the `hover` case. Full suite is green after the change: **512 passed, 3 skipped**.
- `ruff check` is clean. (`ruff format --check` flags 12 pre-existing files unrelated to this change — confirmed via `git stash` that they're unformatted on `main` too, likely a local ruff version mismatch vs. CI's pin; `examples/_common.py` is not among them.)
- Single file touched (`examples/_common.py`), no public API surface change — this is example code, not part of the importable `yutori` package's public interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Afjbwj25GDxdSEa9Emz44S)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor in example-only code with existing characterization tests; no public API or behavior change intended.
> 
> **Overview**
> In **`examples/_common.py`**, the five pointer branches in **`execute_n1_primitive_action`** (`left_click`, `double_click`, `right_click`, `triple_click`, and `hover`) no longer each inline the same **`coordinates` → denormalize** logic; they call a new private helper **`_click_coordinates`**.
> 
> **`scroll`** and **`drag`** are unchanged and still resolve coordinates from their own argument keys and defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a902bbbfe47c091c8f0af4bf2e7af0fac3c4fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->