### PR TITLE
refactor(examples): dedupe primitive-action dispatch in navigator_n1_custom_tools.py

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -115,11 +115,10 @@ async def execute_n1_primitive_action(
     """Execute one of Navigator n1's built-in browser actions on ``page``.
 
     Shared by the n1 example agents that expose the full, unmodified n1
-    action vocabulary (``navigator_n1.py`` and ``navigator_n1_memo.py``);
-    ``navigator_n1_custom_tools.py`` intentionally supports only a trimmed
-    subset for tutorial purposes and ``navigator_n1_5.py`` targets a
-    different model with a different action vocabulary, so neither uses
-    this helper.
+    action vocabulary (``navigator_n1.py``, ``navigator_n1_memo.py``, and
+    ``navigator_n1_custom_tools.py``, which layers its own custom tool on
+    top); ``navigator_n1_5.py`` targets a different model with a different
+    action vocabulary, so it does not use this helper.
 
     Returns True if ``action_name`` was recognized and executed, False
     otherwise -- callers should treat False as "unknown action" (after first

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -25,7 +25,6 @@ import argparse
 import asyncio
 import json
 import re
-import sys
 from functools import cached_property
 
 from _common import (
@@ -36,6 +35,7 @@ from _common import (
     add_replay_arguments,
     add_task_arguments,
     configure_example_logging,
+    execute_n1_primitive_action,
     llm_retry,
     run_example_agent,
 )
@@ -47,7 +47,7 @@ from pydantic import BaseModel, Field
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
-from yutori.navigator import NAVIGATOR_N1_MODEL, denormalize_coordinates
+from yutori.navigator import NAVIGATOR_N1_MODEL
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload  # Optional replay helpers.
 
@@ -310,110 +310,13 @@ class Agent(BrowserAgentMixin):
             return f"[ERROR] Failed to parse arguments: {tool_call.function.arguments}"
 
         try:
-            if action_name == "left_click":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.click(abs_x, abs_y)
-                await asyncio.sleep(0.5)
-
-            elif action_name == "double_click":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.dblclick(abs_x, abs_y)
-                await asyncio.sleep(0.5)
-
-            elif action_name == "right_click":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.click(abs_x, abs_y, button="right")
-                await asyncio.sleep(0.5)
-
-            elif action_name == "triple_click":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.click(abs_x, abs_y, click_count=3)
-                await asyncio.sleep(0.5)
-
-            elif action_name == "type":
-                text = arguments.get("text", "")
-                press_enter = arguments.get("press_enter_after", True)
-                clear_first = arguments.get("clear_before_typing", True)
-
-                if clear_first:
-                    await self._page.keyboard.press("Control+a" if sys.platform != "darwin" else "Meta+a")
-                    await self._page.keyboard.press("Backspace")
-
-                await self._page.keyboard.type(text)
-
-                if press_enter:
-                    await self._page.keyboard.press("Enter")
-                await asyncio.sleep(0.5)
-
-            elif action_name in ("key", "key_press"):
-                key = arguments.get("key") or arguments.get("key_comb", "")
-                key = "+".join("ControlOrMeta" if k == "Meta" else k for k in key.split("+"))
-                await self._page.keyboard.press(key)
-                await asyncio.sleep(0.3)
-
-            elif action_name == "scroll":
-                coords = arguments.get("coordinates") or arguments.get("coordinate", [500, 500])
-                direction = arguments.get("direction", "down")
-                amount = arguments.get("amount", 3)
-
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                scroll_delta = amount * (self.viewport_height * 0.1)
-
-                delta_y = scroll_delta if direction == "down" else (-scroll_delta if direction == "up" else 0)
-                delta_x = scroll_delta if direction == "right" else (-scroll_delta if direction == "left" else 0)
-
-                await self._page.mouse.move(abs_x, abs_y)
-                await self._page.mouse.wheel(delta_x, delta_y)
-                await asyncio.sleep(0.5)
-
-            elif action_name == "hover":
-                coords = arguments.get("coordinates", [0, 0])
-                abs_x, abs_y = denormalize_coordinates(coords, self.viewport_width, self.viewport_height)
-                await self._page.mouse.move(abs_x, abs_y)
-                await asyncio.sleep(0.3)
-
-            elif action_name == "drag":
-                start_coords = arguments.get("start_coordinates") or arguments.get("startCoordinates", [0, 0])
-                end_coords = arguments.get("coordinates") or arguments.get("endCoordinates", [0, 0])
-
-                start_x, start_y = denormalize_coordinates(start_coords, self.viewport_width, self.viewport_height)
-                end_x, end_y = denormalize_coordinates(end_coords, self.viewport_width, self.viewport_height)
-
-                await self._page.mouse.move(start_x, start_y)
-                await self._page.mouse.down()
-                await self._page.mouse.move(end_x, end_y)
-                await self._page.mouse.up()
-                await asyncio.sleep(0.5)
-
-            elif action_name in ("goto", "goto_url"):
-                url = arguments.get("url", "")
-                await self._page.goto(url)
-                await self._page.wait_for_load_state("domcontentloaded")
-                await asyncio.sleep(1)
-
-            elif action_name in ("back", "go_back"):
-                await self._page.go_back()
-                await self._page.wait_for_load_state("domcontentloaded")
-                await asyncio.sleep(0.5)
-
-            elif action_name == "refresh":
-                await self._page.reload()
-                await self._page.wait_for_load_state("domcontentloaded")
-                await asyncio.sleep(1)
-
-            elif action_name == "wait":
-                await asyncio.sleep(5)
-
-            elif action_name == "extract_content_and_links":
+            if action_name == "extract_content_and_links":
                 await self._wait_for_page_ready()
-                result = await self._extract_content_and_links_tool(self._page)
-                return result
+                return await self._extract_content_and_links_tool(self._page)
 
-            else:
+            if not await execute_n1_primitive_action(
+                self._page, action_name, arguments, self.viewport_width, self.viewport_height
+            ):
                 logger.warning(f"Unknown action: {action_name}")
                 return f"[ERROR] Unknown action: {action_name}"
 


### PR DESCRIPTION
## What

`examples/navigator_n1_custom_tools.py`'s `_execute()` reimplemented the entire ~90-line if/elif primitive-action dispatch chain verbatim (`left_click`, `double_click`, `type`, `scroll`, `drag`, `goto`, etc.) instead of delegating to `_common.py`'s `execute_n1_primitive_action()` helper — the same helper `navigator_n1.py` and `navigator_n1_memo.py` already use for the exact same dispatch.

This is the same class of duplication that `tests/test_execute_n1_primitive_action.py`'s docstring says was already fixed for `navigator_n1.py`/`navigator_n1_memo.py` ("previously duplicated the same ~100-line if/elif chain verbatim") — `navigator_n1_custom_tools.py` was simply missed in that earlier pass.

## Fix

- Rewrote `_execute()` to check its one custom action (`extract_content_and_links`) first, then fall through to `execute_n1_primitive_action()` for everything else — the identical pattern `navigator_n1_memo.py` already uses for its own custom tools (`add_question`/`add_options`/`list_records`).
- Removed the now-unused `sys` and `denormalize_coordinates` imports.
- Fixed the stale docstring on `execute_n1_primitive_action()` in `examples/_common.py`, which incorrectly claimed `navigator_n1_custom_tools.py` "intentionally" avoided this helper.

Net: -98 lines, no behavior change (the duplicated branches were functionally identical to the shared helper).

## Why it's safe

- Pure structural dedup — no public API or behavior change. This is example/tutorial code, not SDK surface.
- `tests/test_execute_n1_primitive_action.py` already characterization-tests every branch of the shared `execute_n1_primitive_action()` helper this now delegates to.
- Full test suite green before and after: **512 passed, 3 skipped** (plus the `slow`-marked packaging test, run separately: 1 passed).
- `ruff check` and `ruff format --check` both clean.

## Scope

2 files touched: `examples/navigator_n1_custom_tools.py`, `examples/_common.py` (docstring only).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rq25kujZ3LAGcV5xLhpaED)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only structural dedup with no public API change; behavior is covered by existing tests for execute_n1_primitive_action.
> 
> **Overview**
> **`navigator_n1_custom_tools.py`** no longer inlines the full Navigator n1 primitive-action dispatch (~90 lines of click/type/scroll/goto branches). **`_execute()`** now handles the custom **`extract_content_and_links`** tool first, then delegates everything else to shared **`execute_n1_primitive_action()`** from **`_common.py`**—matching **`navigator_n1_memo.py`**’s pattern. Unused **`sys`** and **`denormalize_coordinates`** imports were dropped.
> 
> The **`execute_n1_primitive_action`** docstring in **`_common.py`** was updated so it no longer says this example “intentionally” avoids the helper; it now lists **`navigator_n1_custom_tools.py`** as a consumer that adds a custom tool on top of the full n1 vocabulary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f660d6d3e565198510b683586f13259bda97fb54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->