### PR TITLE
refactor(examples): dedupe identical _predict() across n1 example agents

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -10,6 +10,7 @@ from typing import Any, Protocol
 
 from loguru import logger
 from openai import APIConnectionError, APITimeoutError, InternalServerError, RateLimitError
+from openai.types.chat import ChatCompletion
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori.navigator import aplaywright_screenshot_to_data_url, denormalize_coordinates
@@ -256,7 +257,10 @@ class SupportsBrowserAgentState(Protocol):
     _page_ready_checker: PageReadyChecker
     _replay: TrajectoryRecorder | None
     _messages: list
+    _message_index: int
     _step_payloads: list[dict]
+
+    async def _call_llm_with_retries(self) -> ChatCompletion: ...
 
 
 class BrowserAgentMixin:
@@ -268,13 +272,15 @@ class BrowserAgentMixin:
     These methods, however, are identical boilerplate across all of
     them -- launching/closing the browser, taking a screenshot, waiting for
     page readiness, clipping image URLs for log output, formatting messages
-    for log output, and persisting optional replay artifacts -- so they live
+    for log output, building the next model request from the latest
+    screenshot, and persisting optional replay artifacts -- so they live
     here once instead of being copy-pasted into every script.
 
-    ``navigator_n1_5.py`` defines its own ``_format_message_for_log`` (a
-    differently-styled but behaviorally-equivalent implementation) and so
-    overrides this mixin's version via normal MRO -- it is intentionally not
-    part of this mechanical extraction.
+    ``navigator_n1_5.py`` defines its own ``_format_message_for_log`` and
+    ``_predict`` (differently-styled/shaped implementations, since it targets
+    a different model with a different action vocabulary) and so overrides
+    this mixin's versions via normal MRO -- it is intentionally not part of
+    this mechanical extraction.
     """
 
     async def _init_browser(self: SupportsBrowserAgentState, playwright) -> None:
@@ -300,6 +306,26 @@ class BrowserAgentMixin:
     async def _wait_for_page_ready(self: SupportsBrowserAgentState, fast_mode: bool = False) -> None:
         if not await self._page_ready_checker.wait_until_ready(self._page, fast_mode=fast_mode):
             logger.warning(f"Page did not fully stabilize before continuing: {self._page.url}")
+
+    async def _predict(self: SupportsBrowserAgentState) -> ChatCompletion:
+        screenshot_url = await self._take_screenshot()
+        current_url = self._page.url
+
+        last_content = self._messages[-1]["content"]
+        if len(last_content) == 0:
+            last_content.append({"type": "text", "text": f"Current URL: {current_url}"})
+        last_content.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": screenshot_url, "detail": "high"},
+            }
+        )
+
+        for i in range(self._message_index, len(self._messages)):
+            logger.info(f"Message: {self._format_message_for_log(self._messages[i])}")
+
+        response = await self._call_llm_with_retries()
+        return response.choices[0].message
 
     def _clip_image_url(self, url: str, max_len: int = 50) -> str:
         # Delegates to the canonical implementation in yutori.navigator.replay, passing

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -226,25 +226,7 @@ class Agent(BrowserAgentMixin):
         )
         return response
 
-    async def _predict(self) -> ChatCompletion:
-        screenshot_url = await self._take_screenshot()
-        current_url = self._page.url
-
-        last_content = self._messages[-1]["content"]
-        if len(last_content) == 0:
-            last_content.append({"type": "text", "text": f"Current URL: {current_url}"})
-        last_content.append(
-            {
-                "type": "image_url",
-                "image_url": {"url": screenshot_url, "detail": "high"},
-            }
-        )
-
-        for i in range(self._message_index, len(self._messages)):
-            logger.info(f"Message: {self._format_message_for_log(self._messages[i])}")
-
-        response = await self._call_llm_with_retries()
-        return response.choices[0].message
+    # _predict() is inherited from BrowserAgentMixin (identical across the n1 examples).
 
     async def _execute(self, tool_call: ChatCompletionMessageToolCall) -> str | None:
         action_name = tool_call.function.name

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -280,25 +280,7 @@ class Agent(BrowserAgentMixin):
         )
         return response
 
-    async def _predict(self) -> ChatCompletion:
-        screenshot_url = await self._take_screenshot()
-        current_url = self._page.url
-
-        last_content = self._messages[-1]["content"]
-        if len(last_content) == 0:
-            last_content.append({"type": "text", "text": f"Current URL: {current_url}"})
-        last_content.append(
-            {
-                "type": "image_url",
-                "image_url": {"url": screenshot_url, "detail": "high"},
-            }
-        )
-
-        for i in range(self._message_index, len(self._messages)):
-            logger.info(f"Message: {self._format_message_for_log(self._messages[i])}")
-
-        response = await self._call_llm_with_retries()
-        return response.choices[0].message
+    # _predict() is inherited from BrowserAgentMixin (identical across the n1 examples).
 
     async def _execute(self, tool_call: ChatCompletionMessageToolCall) -> str | None:
         action_name = tool_call.function.name

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -330,25 +330,7 @@ class Agent(BrowserAgentMixin):
         )
         return response
 
-    async def _predict(self) -> ChatCompletion:
-        screenshot_url = await self._take_screenshot()
-        current_url = self._page.url
-
-        last_content = self._messages[-1]["content"]
-        if len(last_content) == 0:
-            last_content.append({"type": "text", "text": f"Current URL: {current_url}"})
-        last_content.append(
-            {
-                "type": "image_url",
-                "image_url": {"url": screenshot_url, "detail": "high"},
-            }
-        )
-
-        for i in range(self._message_index, len(self._messages)):
-            logger.info(f"Message: {self._format_message_for_log(self._messages[i])}")
-
-        response = await self._call_llm_with_retries()
-        return response.choices[0].message
+    # _predict() is inherited from BrowserAgentMixin (identical across the n1 examples).
 
     async def _execute(self, tool_call: ChatCompletionMessageToolCall) -> tuple[bool, str | None]:
         # Returns (should_exit, result)

--- a/tests/test_predict_mixin.py
+++ b/tests/test_predict_mixin.py
@@ -1,0 +1,77 @@
+"""Characterization tests for ``examples._common.BrowserAgentMixin._predict``.
+
+Pins the exact message-building behavior of ``_predict`` before/after
+extracting it out of ``navigator_n1.py``, ``navigator_n1_custom_tools.py``,
+and ``navigator_n1_memo.py`` (which previously each carried a byte-for-byte
+identical copy of this method). ``navigator_n1_5.py`` defines its own,
+differently-shaped ``_predict`` and is out of scope here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# examples/_common.py pulls in the optional "examples" extra (loguru, openai, tenacity)
+# which isn't installed by the `.[dev]`-only CI test job; skip cleanly rather than
+# erroring on collection when it's unavailable.
+pytest.importorskip("loguru")
+from examples._common import BrowserAgentMixin  # noqa: E402
+
+
+def _make_agent(*, content: list, message_index: int = 0) -> BrowserAgentMixin:
+    agent = BrowserAgentMixin()
+    agent._page = MagicMock(url="https://example.com/current")
+    agent._messages = [{"role": "user", "content": content}]
+    agent._message_index = message_index
+    agent._take_screenshot = AsyncMock(return_value="data:image/png;base64,AAAA")
+
+    response = MagicMock()
+    response.choices = [MagicMock(message="assistant-message")]
+    agent._call_llm_with_retries = AsyncMock(return_value=response)
+    return agent
+
+
+async def test_predict_inserts_current_url_when_content_is_empty() -> None:
+    agent = _make_agent(content=[])
+
+    message = await agent._predict()
+
+    assert message == "assistant-message"
+    content = agent._messages[-1]["content"]
+    assert content[0] == {"type": "text", "text": "Current URL: https://example.com/current"}
+    assert content[1] == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,AAAA", "detail": "high"},
+    }
+    agent._call_llm_with_retries.assert_awaited_once()
+
+
+async def test_predict_skips_current_url_when_content_is_nonempty() -> None:
+    agent = _make_agent(content=[{"type": "text", "text": "existing"}])
+
+    await agent._predict()
+
+    content = agent._messages[-1]["content"]
+    # No "Current URL: ..." entry is inserted -- only the screenshot is appended.
+    assert content == [
+        {"type": "text", "text": "existing"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA", "detail": "high"}},
+    ]
+
+
+async def test_predict_logs_only_messages_from_message_index_onward() -> None:
+    agent = _make_agent(content=[], message_index=0)
+    agent._messages = [
+        {"role": "user", "content": [{"type": "text", "text": "already logged"}]},
+        {"role": "user", "content": []},
+    ]
+    agent._message_index = 1
+    logged: list[dict] = []
+    agent._format_message_for_log = MagicMock(side_effect=lambda m: logged.append(m) or m)
+
+    await agent._predict()
+
+    # Only the message at/after _message_index is formatted for logging.
+    assert logged == [agent._messages[1]]


### PR DESCRIPTION
## What

`navigator_n1.py`, `navigator_n1_custom_tools.py`, and `navigator_n1_memo.py` each carried a byte-for-byte identical `_predict()` method: take a screenshot, insert a "Current URL: ..." text block on the first turn, append the screenshot as an `image_url` block, log any new messages since `_message_index`, then call the model.

Moved `_predict()` into `BrowserAgentMixin` in `examples/_common.py`, alongside the other lifecycle helpers already shared there (`_init_browser`, `_close_browser`, `_take_screenshot`, `_wait_for_page_ready`, `_format_message_for_log`, `_persist_replay`). Each of the three example files now inherits it instead of redefining it; a one-line comment marks where it used to live.

`navigator_n1_5.py` keeps its own, differently-shaped `_predict()` (targets a different model with a different action vocabulary) and is untouched — the mixin docstring is updated to call this out explicitly, matching the existing precedent for `_format_message_for_log`.

Also widened `SupportsBrowserAgentState` (the `Protocol` describing the attributes/methods `BrowserAgentMixin` expects from `self`) with `_message_index: int` and an abstract `_call_llm_with_retries()` method, since `_predict()` now depends on both from the mixin's perspective.

## Why

Pure mechanical dedup in a package that's already had many similar extractions land (see git history: `BrowserAgentMixin` itself, `execute_n1_primitive_action`, `run_example_agent`, etc.). No test previously exercised this code path (verified via `grep`), so I added `tests/test_predict_mixin.py` to characterize it — current-URL insertion, screenshot appending, and message-index-scoped logging — following the repo's existing characterization-test convention (e.g. `tests/test_clip_image_url.py`, `tests/test_execute_n1_primitive_action.py`).

## Verification

- Confirmed via `diff` that all three removed `_predict()` methods were byte-for-byte identical before this change.
- `pytest`: 516 passed, 3 skipped (up from 513 passed/3 skipped on `main`, i.e. exactly the 3 new tests added, zero regressions).
- `ruff check .`: clean.
- No behavior/API change — this is a pure code move plus new test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfiZMdXh6u5rXGaVMn3Xge)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor in example scripts only, with new characterization tests and no intended behavior change.
> 
> **Overview**
> Consolidates the duplicated **`_predict()`** loop from **`navigator_n1.py`**, **`navigator_n1_custom_tools.py`**, and **`navigator_n1_memo.py`** into **`BrowserAgentMixin`** in **`examples/_common.py`**. Those scripts now inherit the shared implementation (screenshot → optional “Current URL” text on empty content → append high-detail image → log messages from **`_message_index`** → LLM call).
> 
> **`SupportsBrowserAgentState`** now documents **`_message_index`** and an abstract **`_call_llm_with_retries()`**, which the mixin relies on. **`navigator_n1_5.py`** is unchanged and still overrides **`_predict`** for its different model/message shape.
> 
> Adds **`tests/test_predict_mixin.py`** to lock in URL insertion, screenshot appending, and index-scoped logging (skipped when the examples extra isn’t installed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95641597cc1e06b54e7d05fc61619d1fc3186ae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->