### PR TITLE
refactor(examples): extract build_agent_arg_parser() for shared main() arg-parser setup

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -91,6 +91,32 @@ def add_replay_arguments(parser: argparse.ArgumentParser, default_config) -> Non
     parser.add_argument("--replay-id", default=default_config.replay_id, help="Optional replay run id")
 
 
+def build_agent_arg_parser(
+    description: str,
+    default_config: Any,
+    *,
+    api_label: str,
+    include_payload_trim: bool = False,
+) -> argparse.ArgumentParser:
+    """Build the task/model/agent/browser/replay parser shared by the n1 example scripts' ``main()``.
+
+    ``navigator_n1.py``, ``navigator_n1_memo.py``, and ``navigator_n1_custom_tools.py``
+    previously each assembled this same argument list by hand (identical except for
+    ``navigator_n1.py``'s extra payload-trim arguments, toggled here via
+    ``include_payload_trim``). ``navigator_n1_5.py`` adds its own tool-set/json-schema
+    arguments on top of a differently-ordered base set and builds its parser directly.
+    """
+    parser = argparse.ArgumentParser(description=description)
+    add_task_arguments(parser, default_config)
+    add_model_arguments(parser, default_config, api_label=api_label)
+    add_agent_arguments(parser, default_config)
+    add_browser_arguments(parser, default_config)
+    if include_payload_trim:
+        add_payload_trim_arguments(parser, default_config)
+    add_replay_arguments(parser, default_config)
+    return parser
+
+
 def _click_coordinates(
     arguments: dict[str, Any],
     viewport_width: int,

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -21,18 +21,12 @@ Usage:
     uv run python examples/navigator_n1.py --task "List the team member names" --start-url "https://www.yutori.com"
 """
 
-import argparse
 import asyncio
 import json
 
 from _common import (
     BrowserAgentMixin,
-    add_agent_arguments,
-    add_browser_arguments,
-    add_model_arguments,
-    add_payload_trim_arguments,
-    add_replay_arguments,
-    add_task_arguments,
+    build_agent_arg_parser,
     configure_example_logging,
     execute_n1_primitive_action,
     llm_retry,
@@ -260,15 +254,12 @@ async def main():
     configure_example_logging()
 
     default_config = Config()
-    parser = argparse.ArgumentParser(
-        description="Example of using the Yutori Navigator API (Navigator n1) to perform a web browsing task"
+    parser = build_agent_arg_parser(
+        "Example of using the Yutori Navigator API (Navigator n1) to perform a web browsing task",
+        default_config,
+        api_label="Yutori Navigator n1",
+        include_payload_trim=True,
     )
-    add_task_arguments(parser, default_config)
-    add_model_arguments(parser, default_config, api_label="Yutori Navigator n1")
-    add_agent_arguments(parser, default_config)
-    add_browser_arguments(parser, default_config)
-    add_payload_trim_arguments(parser, default_config)
-    add_replay_arguments(parser, default_config)
     args = parser.parse_args()
     config = Config.model_validate(vars(args))
 

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -21,7 +21,6 @@ Usage:
         --start-url "https://www.yutori.com"
 """
 
-import argparse
 import asyncio
 import json
 import re
@@ -29,11 +28,7 @@ from functools import cached_property
 
 from _common import (
     BrowserAgentMixin,
-    add_agent_arguments,
-    add_browser_arguments,
-    add_model_arguments,
-    add_replay_arguments,
-    add_task_arguments,
+    build_agent_arg_parser,
     configure_example_logging,
     execute_n1_primitive_action,
     llm_retry,
@@ -318,14 +313,11 @@ async def main():
     configure_example_logging()
 
     default_config = Config()
-    parser = argparse.ArgumentParser(
-        description="Example of using the Yutori Navigator API (Navigator n1) to perform a web browsing task"
+    parser = build_agent_arg_parser(
+        "Example of using the Yutori Navigator API (Navigator n1) to perform a web browsing task",
+        default_config,
+        api_label="Yutori Navigator n1",
     )
-    add_task_arguments(parser, default_config)
-    add_model_arguments(parser, default_config, api_label="Yutori Navigator n1")
-    add_agent_arguments(parser, default_config)
-    add_browser_arguments(parser, default_config)
-    add_replay_arguments(parser, default_config)
     args = parser.parse_args()
     config = Config.model_validate(vars(args))
 

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -24,7 +24,6 @@ Usage:
         --start-url "https://www.triviaplaza.com/three-letter-computer-terms-quiz/"
 """
 
-import argparse
 import asyncio
 import json
 import os
@@ -33,11 +32,7 @@ from functools import cached_property
 
 from _common import (
     BrowserAgentMixin,
-    add_agent_arguments,
-    add_browser_arguments,
-    add_model_arguments,
-    add_replay_arguments,
-    add_task_arguments,
+    build_agent_arg_parser,
     configure_example_logging,
     execute_n1_primitive_action,
     llm_retry,
@@ -379,14 +374,11 @@ async def main():
     configure_example_logging()
 
     default_config = Config()
-    parser = argparse.ArgumentParser(
-        description="Example of using the Yutori Navigator API (Navigator n1) to perform a web browsing task"
+    parser = build_agent_arg_parser(
+        "Example of using the Yutori Navigator API (Navigator n1) to perform a web browsing task",
+        default_config,
+        api_label="Yutori Navigator n1",
     )
-    add_task_arguments(parser, default_config)
-    add_model_arguments(parser, default_config, api_label="Yutori Navigator n1")
-    add_agent_arguments(parser, default_config)
-    add_browser_arguments(parser, default_config)
-    add_replay_arguments(parser, default_config)
     args = parser.parse_args()
     config = Config.model_validate(vars(args))
 

--- a/tests/test_build_agent_arg_parser.py
+++ b/tests/test_build_agent_arg_parser.py
@@ -1,0 +1,94 @@
+"""Characterization tests for ``examples._common.build_agent_arg_parser``.
+
+Pins the exact argument set/defaults produced before/after extracting this
+parser assembly out of ``navigator_n1.py``, ``navigator_n1_memo.py``, and
+``navigator_n1_custom_tools.py`` (which previously each hand-assembled the
+same task/model/agent/browser/replay argument groups in ``main()``, with
+``navigator_n1.py`` alone also wiring in payload-trim arguments).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+# examples/_common.py pulls in the optional "examples" extra (loguru, openai, tenacity)
+# which isn't installed by the `.[dev]`-only CI test job; skip cleanly rather than
+# erroring on collection when it's unavailable.
+pytest.importorskip("loguru")
+from examples._common import build_agent_arg_parser  # noqa: E402
+
+
+def _default_config(**overrides) -> SimpleNamespace:
+    values = {
+        "task": "default task",
+        "start_url": "https://example.com",
+        "base_url": "https://api.example.com/v1",
+        "model": "some-model",
+        "temperature": 0.3,
+        "max_steps": 100,
+        "viewport_width": 1280,
+        "viewport_height": 800,
+        "max_request_bytes": 9_500_000,
+        "keep_recent_screenshots": 6,
+        "replay_dir": None,
+        "replay_id": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_build_agent_arg_parser_without_payload_trim() -> None:
+    default_config = _default_config()
+
+    parser = build_agent_arg_parser(
+        "Example description",
+        default_config,
+        api_label="Yutori Navigator n1",
+    )
+    args = parser.parse_args([])
+
+    assert vars(args) == {
+        "task": default_config.task,
+        "start_url": default_config.start_url,
+        "base_url": default_config.base_url,
+        "model": default_config.model,
+        "temperature": default_config.temperature,
+        "max_steps": default_config.max_steps,
+        "viewport_width": default_config.viewport_width,
+        "viewport_height": default_config.viewport_height,
+        "headless": False,
+        "replay_dir": default_config.replay_dir,
+        "replay_id": default_config.replay_id,
+    }
+    assert parser.description == "Example description"
+
+
+def test_build_agent_arg_parser_with_payload_trim() -> None:
+    default_config = _default_config()
+
+    parser = build_agent_arg_parser(
+        "Example description",
+        default_config,
+        api_label="Yutori Navigator n1",
+        include_payload_trim=True,
+    )
+    args = parser.parse_args([])
+
+    assert args.max_request_bytes == default_config.max_request_bytes
+    assert args.keep_recent_screenshots == default_config.keep_recent_screenshots
+
+
+def test_build_agent_arg_parser_honors_overrides_via_cli() -> None:
+    default_config = _default_config()
+
+    parser = build_agent_arg_parser(
+        "Example description",
+        default_config,
+        api_label="Yutori Navigator n1",
+    )
+    args = parser.parse_args(["--task", "custom task", "--max-steps", "5"])
+
+    assert args.task == "custom task"
+    assert args.max_steps == 5


### PR DESCRIPTION
## What

`navigator_n1.py`, `navigator_n1_memo.py`, and `navigator_n1_custom_tools.py` each hand-assembled the same `argparse.ArgumentParser` in `main()` — the same description string, and the same `add_task_arguments` / `add_model_arguments` / `add_agent_arguments` / `add_browser_arguments` / `add_replay_arguments` call sequence. `navigator_n1_memo.py` and `navigator_n1_custom_tools.py` had byte-for-byte identical `main()` bodies; `navigator_n1.py` differed only by one extra `add_payload_trim_arguments` call.

Extracted `build_agent_arg_parser(description, default_config, *, api_label, include_payload_trim=False)` into `examples/_common.py`, and had all three `main()` functions delegate to it instead of re-assembling the parser inline.

`navigator_n1_5.py` is untouched — it builds its own parser directly since it has its own non-overlapping tool-set/json-schema arguments layered on a differently-ordered base set (consistent with why it already keeps its own `_predict`/`_format_message_for_log` per the prior `#182` refactor).

## Why this is safe

- Purely mechanical: moves identical/near-identical parser-assembly code into one shared helper; no argument names, defaults, help text, or CLI behavior changed.
- Added `tests/test_build_agent_arg_parser.py` with characterization tests that pin the exact resulting argument set/defaults for both the with- and without-payload-trim cases, plus a check that CLI overrides still work — before relying on the extraction.
- Confirmed via `diff` that `navigator_n1_memo.py`'s and `navigator_n1_custom_tools.py`'s `main()` bodies were identical, and that `navigator_n1.py`'s only delta was the payload-trim call, before touching anything.
- Full test suite green: 519 passed, 3 skipped (up from 516/3 on `main`).
- `ruff check .` clean; all touched files already `ruff format`-clean.
- Contained to 5 files: `examples/_common.py`, the three example scripts, and one new test file. No public API changes.

## Test plan

- [x] `pytest` — 519 passed, 3 skipped
- [x] `ruff check .` — all checks passed
- [x] `ruff format --check` on touched files — already formatted
- [x] Manually diffed old vs. new `main()` bodies for all three scripts to confirm identical argument wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rkm8RXvVSoDyKSZ238KmtS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor in example scripts only; characterization tests guard CLI defaults and flags, with no public API changes.
> 
> **Overview**
> Adds **`build_agent_arg_parser()`** in `examples/_common.py` so the three Navigator n1 example scripts no longer duplicate the same `ArgumentParser` wiring in `main()`.
> 
> **`navigator_n1.py`**, **`navigator_n1_memo.py`**, and **`navigator_n1_custom_tools.py`** now call the helper with the shared description and `api_label`; only **`navigator_n1.py`** passes **`include_payload_trim=True`** so payload-trim flags stay optional for the other two. Unused **`argparse`** imports and per-script **`add_*_arguments`** imports are removed.
> 
> **`tests/test_build_agent_arg_parser.py`** locks in defaults with and without payload trim and checks CLI overrides. **`navigator_n1_5.py`** is unchanged and still builds its own parser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58da91fa3e5aa1254b00e8a808b0a399eb8d95cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->