### PR TITLE
refactor(auth): dedupe registration-state message text between auth.py and install_flow.py

### DIFF
--- a/tests/test_install_flow.py
+++ b/tests/test_install_flow.py
@@ -622,6 +622,46 @@ def test_maybe_authenticate_noninteractive_skips_without_calling_flow():
     mock_flow.assert_not_called()
 
 
+def test_maybe_authenticate_prints_creating_account_message():
+    # Characterizes the on_registration_state callback wired up inside
+    # maybe_authenticate, which shares its message text with
+    # yutori/cli/commands/auth.py::_print_registration_state via
+    # yutori.auth.types.REGISTRATION_STATE_MESSAGES.
+    def fake_run_login_flow(*args, **kwargs):
+        kwargs["on_registration_state"]("creating_account")
+        return LoginResult(success=True, api_key="yt-new-key")
+
+    console = Console(record=True, width=120)
+    with (
+        patch("yutori.cli.commands.install_flow.resolve_api_key", return_value=None),
+        patch("yutori.cli.commands.install_flow.Confirm.ask", return_value=True),
+        patch("yutori.cli.commands.install_flow.run_login_flow", side_effect=fake_run_login_flow),
+    ):
+        result, authenticated = maybe_authenticate(console, interactive=True)
+
+    assert authenticated is True
+    assert result.status == "success"
+    assert "Creating account..." in console.export_text()
+
+
+def test_maybe_authenticate_prints_logging_in_message():
+    def fake_run_login_flow(*args, **kwargs):
+        kwargs["on_registration_state"]("logging_in")
+        return LoginResult(success=True, api_key="yt-existing-key")
+
+    console = Console(record=True, width=120)
+    with (
+        patch("yutori.cli.commands.install_flow.resolve_api_key", return_value=None),
+        patch("yutori.cli.commands.install_flow.Confirm.ask", return_value=True),
+        patch("yutori.cli.commands.install_flow.run_login_flow", side_effect=fake_run_login_flow),
+    ):
+        result, authenticated = maybe_authenticate(console, interactive=True)
+
+    assert authenticated is True
+    assert result.status == "success"
+    assert "Logging in..." in console.export_text()
+
+
 # ---------------------------------------------------------------------------
 # inspect_cli_install direct tests
 # ---------------------------------------------------------------------------

--- a/yutori/auth/types.py
+++ b/yutori/auth/types.py
@@ -3,6 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
+
+RegistrationState = Literal["creating_account", "logging_in"]
+
+# Shared by yutori/cli/commands/auth.py and yutori/cli/commands/install_flow.py,
+# the two ``on_registration_state`` callbacks passed to ``run_login_flow``, so
+# the wording can't drift out of sync between the two entrypoints.
+REGISTRATION_STATE_MESSAGES: dict[RegistrationState, str] = {
+    "creating_account": "Creating account...",
+    "logging_in": "Logging in...",
+}
 
 
 @dataclass

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -9,6 +9,7 @@ from rich.console import Console
 
 from yutori.auth.credentials import _is_real_key, clear_config, get_stored_api_key, load_config
 from yutori.auth.flow import get_auth_status, run_login_flow
+from yutori.auth.types import REGISTRATION_STATE_MESSAGES
 from yutori.cli.commands import safe_str
 
 app = typer.Typer(help="Manage authentication")
@@ -16,10 +17,9 @@ console = Console()
 
 
 def _print_registration_state(state: str) -> None:
-    if state == "creating_account":
-        console.print("[dim]Creating account...[/dim]")
-    else:
-        console.print("[dim]Logging in...[/dim]")
+    # Unrecognized states fall back to "Logging in..." (matches prior behavior).
+    message = REGISTRATION_STATE_MESSAGES.get(state, REGISTRATION_STATE_MESSAGES["logging_in"])  # type: ignore[arg-type]
+    console.print(f"[dim]{message}[/dim]")
 
 
 @app.command()

--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -39,7 +39,7 @@ from rich.table import Table
 
 from yutori.auth.credentials import resolve_api_key
 from yutori.auth.flow import get_auth_status, run_login_flow
-from yutori.auth.types import AuthStatus
+from yutori.auth.types import REGISTRATION_STATE_MESSAGES, AuthStatus
 from yutori.cli.commands import truncate_for_display
 
 BRAND_MINT = "#1DCD98"
@@ -131,7 +131,7 @@ RETURNCODE_EXEC_FAILED = 127  # POSIX "command not found"
 RETURNCODE_CANCELLED = 130  # POSIX SIGINT (128 + 2)
 
 StepStatus = Literal["success", "skipped", "failed"]
-RegistrationState = Literal["creating_account", "logging_in"]
+# RegistrationState is imported from yutori.auth.types, shared with yutori/cli/commands/auth.py.
 
 STATUS_LABELS: dict[StepStatus, tuple[str, str]] = {
     "success": ("OK", BRAND_MINT),
@@ -815,13 +815,8 @@ def maybe_authenticate(console: Console, *, interactive: bool) -> tuple[StepResu
         if not ask_confirm(console, "Log in to Yutori now?", default=True):
             return StepResult("Auth", "skipped", "Authentication was skipped."), False
 
-        messages: dict[RegistrationState, str] = {
-            "creating_account": "Creating account...",
-            "logging_in": "Logging in...",
-        }
-
         def on_registration_state(state: str) -> None:
-            message = messages.get(state, state)  # type: ignore[arg-type]
+            message = REGISTRATION_STATE_MESSAGES.get(state, state)  # type: ignore[arg-type]
             console.print(_slate_line(message))
 
         result = run_login_flow(on_registration_state=on_registration_state)


### PR DESCRIPTION
## Issue

`yutori/cli/commands/auth.py::_print_registration_state` and the `on_registration_state` callback inside `yutori/cli/commands/install_flow.py::maybe_authenticate` each independently hand-roll the same state→message mapping:

- `"creating_account"` → `"Creating account..."`
- `"logging_in"` → `"Logging in..."`

Both are passed as the `on_registration_state` callback into `run_login_flow()` (`yutori/auth/flow.py`). The two implementations only differed in Rich-markup styling; the actual wording was copy-pasted with no shared source of truth, so a copy change would need to be made in two places (and `tests/test_cli_auth.py` already hardcodes both strings independently for the `auth.py` side).

## Fix

Extracted `REGISTRATION_STATE_MESSAGES: dict[RegistrationState, str]` into `yutori/auth/types.py` — moving the existing `RegistrationState` Literal there from `install_flow.py`, since both call sites already import from `yutori.auth.types` (`AuthStatus`, `LoginResult`). Each call site keeps its own markup/fallback wrapping around the shared strings:

- `auth.py::_print_registration_state` still falls back to `"Logging in..."` for any unrecognized state (matches its original `if/else`).
- `install_flow.py`'s callback still falls back to the raw `state` string for any unrecognized value (matches its original `messages.get(state, state)`).

No public API or printed-text change — same strings, same fallback behavior, in both places.

## Why it's safe

- Purely internal: `RegistrationState`/`REGISTRATION_STATE_MESSAGES` were never part of the package's public surface (`install_flow.py` is an internal, non-public module per its own docstring; `auth.py`'s helper was already private/prefixed `_print_registration_state`).
- `run_login_flow`'s public signature (`on_registration_state: Callable[[str], None] | None`) is untouched.
- Added two characterization tests (`test_maybe_authenticate_prints_creating_account_message`, `test_maybe_authenticate_prints_logging_in_message`) for the `install_flow.py` registration-state print path, which no prior test exercised (existing `maybe_authenticate` tests only assert on return values, never on printed console output).
- Full test suite green: 473 passed, 7 skipped (up from 471/7 with the two new tests). `ruff check .` clean.
- Touches 4 files total: `yutori/auth/types.py`, `yutori/cli/commands/auth.py`, `yutori/cli/commands/install_flow.py`, `tests/test_install_flow.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fwnmhj1LhHzF1iBCQ8U5fU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no API or user-facing text changes; only adds test coverage for install-flow auth messaging.
> 
> **Overview**
> **Centralizes** browser-login progress copy so `yutori auth login` and the install flow’s `maybe_authenticate` step cannot drift.
> 
> Adds `RegistrationState` and `REGISTRATION_STATE_MESSAGES` in `yutori/auth/types.py`, then wires both `on_registration_state` callbacks to that map. **User-visible strings and fallbacks stay the same**: `auth.py` still defaults unknown states to “Logging in...”, while `install_flow.py` still prints the raw state when it is not in the map; only Rich vs slate step-line styling differs per entrypoint.
> 
> Adds two characterization tests on `maybe_authenticate` that assert “Creating account...” and “Logging in...” appear in recorded console output when `run_login_flow` invokes the callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add607b67384376f825e8d0b089b9b56e1ed7349. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->