### PR TITLE
refactor(tests): extract require_examples_extra() for the loguru importorskip guard

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,3 +11,14 @@ def client():
     client = YutoriClient(api_key="yt-test")
     yield client
     client.close()
+
+
+def require_examples_extra() -> None:
+    """Skip collection of the calling test module if the "examples" extra isn't installed.
+
+    examples/_common.py pulls in the optional "examples" extra (loguru, openai, tenacity)
+    which isn't installed by the `.[dev]`-only CI test job; skip cleanly rather than
+    erroring on collection when it's unavailable. Call this before importing anything
+    from ``examples`` at module level.
+    """
+    pytest.importorskip("loguru")

--- a/tests/test_build_agent_arg_parser.py
+++ b/tests/test_build_agent_arg_parser.py
@@ -11,12 +11,9 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-import pytest
+from .conftest import require_examples_extra
 
-# examples/_common.py pulls in the optional "examples" extra (loguru, openai, tenacity)
-# which isn't installed by the `.[dev]`-only CI test job; skip cleanly rather than
-# erroring on collection when it's unavailable.
-pytest.importorskip("loguru")
+require_examples_extra()
 from examples._common import build_agent_arg_parser  # noqa: E402
 
 

--- a/tests/test_clip_image_url.py
+++ b/tests/test_clip_image_url.py
@@ -17,10 +17,9 @@ import pytest
 
 from yutori.navigator.replay import _clip_image_url as replay_clip_image_url
 
-# examples/_common.py pulls in the optional "examples" extra (loguru, openai, tenacity)
-# which isn't installed by the `.[dev]`-only CI test job; skip cleanly rather than
-# erroring on collection when it's unavailable.
-pytest.importorskip("loguru")
+from .conftest import require_examples_extra
+
+require_examples_extra()
 from examples._common import BrowserAgentMixin  # noqa: E402
 
 _mixin = BrowserAgentMixin()

--- a/tests/test_execute_n1_primitive_action.py
+++ b/tests/test_execute_n1_primitive_action.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, call
 
-import pytest
+from .conftest import require_examples_extra
 
-pytest.importorskip("loguru")
+require_examples_extra()
 from examples._common import execute_n1_primitive_action  # noqa: E402
 from yutori.navigator import denormalize_coordinates  # noqa: E402
 

--- a/tests/test_predict_mixin.py
+++ b/tests/test_predict_mixin.py
@@ -11,12 +11,9 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
+from .conftest import require_examples_extra
 
-# examples/_common.py pulls in the optional "examples" extra (loguru, openai, tenacity)
-# which isn't installed by the `.[dev]`-only CI test job; skip cleanly rather than
-# erroring on collection when it's unavailable.
-pytest.importorskip("loguru")
+require_examples_extra()
 from examples._common import BrowserAgentMixin  # noqa: E402
 
 


### PR DESCRIPTION
## Issue

Four characterization test modules each hand-rolled the same guard before importing from `examples._common` (which needs the optional `examples` extra — loguru, openai, tenacity — not installed by the `.[dev]`-only CI test job):

```python
# examples/_common.py pulls in the optional "examples" extra (loguru, openai, tenacity)
# which isn't installed by the `.[dev]`-only CI test job; skip cleanly rather than
# erroring on collection when it's unavailable.
pytest.importorskip("loguru")
from examples._common import ...  # noqa: E402
```

- `tests/test_build_agent_arg_parser.py`
- `tests/test_clip_image_url.py`
- `tests/test_execute_n1_primitive_action.py` (missing the comment, but same guard)
- `tests/test_predict_mixin.py`

Three copies of the identical explanatory comment plus the `pytest.importorskip("loguru")` call, each with its own now-unnecessary `import pytest` (three of the four files only used `pytest` for this one guard).

## Fix

Extracted a single `require_examples_extra()` helper into `tests/conftest.py`:

```python
def require_examples_extra() -> None:
    """Skip collection of the calling test module if the "examples" extra isn't installed.
    ...
    """
    pytest.importorskip("loguru")
```

All four modules now do:

```python
from .conftest import require_examples_extra

require_examples_extra()
from examples._common import ...  # noqa: E402
```

`tests/test_clip_image_url.py` keeps its `import pytest` since it still uses `@pytest.mark.parametrize` elsewhere; the other three drop their now-unused `import pytest`.

## Why it's safe

- `pytest.importorskip` works correctly when called from inside a wrapper function — verified empirically with a throwaway test module before touching the real files (module-level skip still fires).
- No behavior change: this only reorganizes an import-time skip guard, not any runtime logic.
- Verified full suite green **both with and without** the `examples` extra installed:
  - With `examples` extra: 521 passed, 3 skipped (matches `main`).
  - Without `examples` extra (CI's `.[dev]`-only job): 473 passed, 7 skipped (matches `main` — the same 4 modules skip cleanly).
- `ruff check .` clean. `ruff format --check .` flags the same 12 pre-existing files as on `main` (confirmed via `git stash`) — none of the 5 files this PR touches are among them.
- Contained to 5 files: `tests/conftest.py` + the 4 test modules. No public API/package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhoNwxKzo3wDDHJ3KMjWjC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only import/collection skip refactor with no runtime or public API changes.
> 
> **Overview**
> Centralizes the repeated **optional `examples` extra** guard used before importing `examples._common` into **`require_examples_extra()`** in `tests/conftest.py` (still `pytest.importorskip("loguru")`, with the CI skip rationale in one docstring).
> 
> Four characterization modules now call that helper instead of duplicating inline `importorskip` and comments; three of them drop a **`pytest` import** that existed only for the guard. **`test_clip_image_url.py`** keeps `import pytest` for `@pytest.mark.parametrize`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6087978c126b62a1d63a3a067440ead02349fcad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->