### PR TITLE
refactor(examples): extract shared Agent init/run bookkeeping into BrowserAgentMixin

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -15,7 +15,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 
 from yutori.navigator import aplaywright_screenshot_to_data_url, denormalize_coordinates
 from yutori.navigator.page_ready import PageReadyChecker
-from yutori.navigator.replay import TrajectoryRecorder
+from yutori.navigator.replay import TrajectoryRecorder, make_run_id
 from yutori.navigator.replay import _clip_image_url as _clip_image_url_impl
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
@@ -278,12 +278,16 @@ class SupportsBrowserAgentState(Protocol):
     headless: bool
     viewport_width: int
     viewport_height: int
+    replay_dir: str | None
+    replay_id: str | None
+    _client: Any
     _browser: Any
     _page: Any
     _page_ready_checker: PageReadyChecker
     _replay: TrajectoryRecorder | None
     _messages: list
     _message_index: int
+    _step_count: int
     _step_payloads: list[dict]
 
     async def _call_llm_with_retries(self) -> ChatCompletion: ...
@@ -307,7 +311,76 @@ class BrowserAgentMixin:
     a different model with a different action vocabulary) and so overrides
     this mixin's versions via normal MRO -- it is intentionally not part of
     this mechanical extraction.
+
+    ``_init_agent_state`` and ``_start_run`` cover the ``__init__``/``run()``
+    bookkeeping that was also duplicated verbatim across all four scripts
+    (browser handles, the ``PageReadyChecker``, and per-run message/replay
+    setup); every ``Agent.__init__``/``run()`` still has its own model- and
+    tool-specific setup around these calls.
     """
+
+    def _init_agent_state(self: SupportsBrowserAgentState) -> None:
+        """Initialize the browser/replay/message bookkeeping shared by every example ``Agent.__init__``.
+
+        Each script's ``__init__`` set this same block of instance state --
+        browser/page handles, the ``PageReadyChecker``, and replay/message
+        bookkeeping -- verbatim after assigning its own constructor kwargs.
+        ``navigator_n1.py`` and ``navigator_n1_5.py`` additionally set
+        ``self._request_messages = None`` for payload trimming right after
+        calling this; that attribute isn't part of the shared state since
+        ``navigator_n1_custom_tools.py``/``navigator_n1_memo.py`` never read it.
+        """
+        self._client = None
+        self._browser = None
+        self._page = None
+        self._page_ready_checker = PageReadyChecker(
+            timeout=30,
+            initial_wait=2.0,
+            wait_after_ready=1.0,
+            replace_native_select_dropdown=True,
+            disable_new_tabs=True,
+            disable_printing=True,
+        )
+        # Replay bookkeeping is optional and only used when writing local artifacts.
+        self._replay = None
+        self._messages = []
+        # Stored only so the replay viewer can show raw request/response JSON per step.
+        self._step_payloads = []
+        self._step_count = 0
+
+    def _start_run(
+        self: SupportsBrowserAgentState,
+        task: str,
+        start_url: str,
+        *,
+        replay_prefix: str,
+    ) -> None:
+        """Reset per-run message/replay state and log the run header -- the shared prologue of every example ``run()``.
+
+        Resets message/step bookkeeping for a fresh run and starts a replay
+        recorder when ``self.replay_dir`` is set. ``replay_prefix`` is the
+        ``make_run_id`` prefix each script previously hardcoded inline
+        (``"n1"``, ``"n1_custom"``, ``"navigator_memo"``, ``"navigator_1_5"``).
+        ``navigator_n1_5.py`` calls this after reformatting ``task`` with
+        timezone/location context, so it logs and labels the replay with the
+        reformatted task, matching its existing behavior. Callers that reset
+        additional per-run state (``navigator_n1.py`` and ``navigator_n1_5.py``
+        also clear ``self._request_messages``) do so themselves.
+        """
+        logger.info(f"Task: {task}")
+        logger.info(f"Starting URL: {start_url}")
+
+        self._messages = [{"role": "user", "content": [{"type": "text", "text": task}]}]
+        self._message_index = 0
+        self._step_count = 0
+        self._step_payloads = []
+        self._replay = None
+
+        # Replay output is opt-in; the loop still works without any of this.
+        if self.replay_dir:
+            replay_id = self.replay_id or make_run_id(prefix=replay_prefix, label=task)
+            self._replay = TrajectoryRecorder(self.replay_dir, replay_id)
+            logger.info(f"Replay artifacts: {self._replay.item_dir}")
 
     async def _init_browser(self: SupportsBrowserAgentState, playwright) -> None:
         self._browser = await playwright.chromium.launch(headless=self.headless)

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -35,15 +35,14 @@ from _common import (
 from loguru import logger
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from playwright.async_api import Browser, Page, async_playwright
+from playwright.async_api import async_playwright
 from pydantic import BaseModel, Field
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
 from yutori.navigator.loop import update_trimmed_history
-from yutori.navigator.page_ready import PageReadyChecker
-from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload  # Optional replay helpers.
+from yutori.navigator.replay import sanitize_step_payload  # Optional replay helpers.
 
 
 class Config(BaseModel):
@@ -95,42 +94,14 @@ class Agent(BrowserAgentMixin):
         self.replay_dir = replay_dir
         self.replay_id = replay_id
 
-        self._client: AsyncYutoriClient | None = None
-        self._browser: Browser | None = None
-        self._page: Page | None = None
-        self._page_ready_checker = PageReadyChecker(
-            timeout=30,
-            initial_wait=2.0,
-            wait_after_ready=1.0,
-            replace_native_select_dropdown=True,
-            disable_new_tabs=True,
-            disable_printing=True,
-        )
-        # Replay bookkeeping is optional and only used when writing local artifacts.
-        self._replay: TrajectoryRecorder | None = None
-        self._messages: list = []
+        self._init_agent_state()
         self._request_messages: list | None = None
-        # Stored only so the replay viewer can show raw request/response JSON per step.
-        self._step_payloads: list[dict] = []
-        self._step_count = 0
 
     async def run(self, task: str, start_url: str) -> str:
-        logger.info(f"Task: {task}")
-        logger.info(f"Starting URL: {start_url}")
-
-        self._messages = [{"role": "user", "content": [{"type": "text", "text": task}]}]
-        self._message_index = 0
-        self._step_count = 0
+        self._start_run(task, start_url, replay_prefix="n1")
         self._request_messages = None
-        self._step_payloads = []
-        self._replay = None
 
         final_response = ""
-        # Replay output is opt-in; the loop still works without any of this.
-        if self.replay_dir:
-            replay_id = self.replay_id or make_run_id(prefix="n1", label=task)
-            self._replay = TrajectoryRecorder(self.replay_dir, replay_id)
-            logger.info(f"Replay artifacts: {self._replay.item_dir}")
 
         async with (
             AsyncYutoriClient(base_url=self.base_url) as client,

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -58,7 +58,7 @@ from _common import (
 from loguru import logger
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from playwright.async_api import Browser, Page, async_playwright
+from playwright.async_api import async_playwright
 from pydantic import BaseModel, Field
 
 from yutori import AsyncYutoriClient
@@ -74,8 +74,7 @@ from yutori.navigator import (
     map_keys_individual,
 )
 from yutori.navigator.loop import update_trimmed_history
-from yutori.navigator.page_ready import PageReadyChecker
-from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload  # Optional replay helpers.
+from yutori.navigator.replay import sanitize_step_payload  # Optional replay helpers.
 from yutori.navigator.tools import (
     EXECUTE_JS_SCRIPT,
     EXTRACT_ELEMENTS_SCRIPT,
@@ -157,24 +156,8 @@ class Agent(BrowserAgentMixin):
         self.replay_dir = replay_dir
         self.replay_id = replay_id
 
-        self._client: AsyncYutoriClient | None = None
-        self._browser: Browser | None = None
-        self._page: Page | None = None
-        self._page_ready_checker = PageReadyChecker(
-            timeout=30,
-            initial_wait=2.0,
-            wait_after_ready=1.0,
-            replace_native_select_dropdown=True,
-            disable_new_tabs=True,
-            disable_printing=True,
-        )
-        # Replay bookkeeping is optional and only used when writing local artifacts.
-        self._replay: TrajectoryRecorder | None = None
-        self._messages: list = []
+        self._init_agent_state()
         self._request_messages: list | None = None
-        # Stored only so the replay viewer can show raw request/response JSON per step.
-        self._step_payloads: list[dict] = []
-        self._step_count = 0
 
     async def run(self, task: str, start_url: str) -> str:
         # Keep original task for stop-and-summarize; format with context for the model
@@ -185,22 +168,10 @@ class Agent(BrowserAgentMixin):
             user_location=self.user_location,
         )
 
-        logger.info(f"Task: {task}")
-        logger.info(f"Starting URL: {start_url}")
-
-        self._messages = [{"role": "user", "content": [{"type": "text", "text": task}]}]
-        self._message_index = 0
-        self._step_count = 0
+        self._start_run(task, start_url, replay_prefix="navigator_1_5")
         self._request_messages = None
-        self._step_payloads = []
-        self._replay = None
 
         final_response = ""
-        # Replay output is opt-in; the loop still works without any of this.
-        if self.replay_dir:
-            replay_id = self.replay_id or make_run_id(prefix="navigator_1_5", label=task)
-            self._replay = TrajectoryRecorder(self.replay_dir, replay_id)
-            logger.info(f"Replay artifacts: {self._replay.item_dir}")
 
         async with (
             AsyncYutoriClient(base_url=self.base_url) as client,

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -37,14 +37,13 @@ from _common import (
 from loguru import logger
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from playwright.async_api import Browser, Page, async_playwright
+from playwright.async_api import Page, async_playwright
 from pydantic import BaseModel, Field
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
-from yutori.navigator.page_ready import PageReadyChecker
-from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload  # Optional replay helpers.
+from yutori.navigator.replay import sanitize_step_payload  # Optional replay helpers.
 
 
 class Config(BaseModel):
@@ -156,43 +155,15 @@ class Agent(BrowserAgentMixin):
         self.replay_dir = replay_dir
         self.replay_id = replay_id
 
-        self._client: AsyncYutoriClient | None = None
-        self._browser: Browser | None = None
-        self._page: Page | None = None
-        self._page_ready_checker = PageReadyChecker(
-            timeout=30,
-            initial_wait=2.0,
-            wait_after_ready=1.0,
-            replace_native_select_dropdown=True,
-            disable_new_tabs=True,
-            disable_printing=True,
-        )
-        # Replay bookkeeping is optional and only used when writing local artifacts.
-        self._replay: TrajectoryRecorder | None = None
-        self._messages: list = []
-        # Stored only so the replay viewer can show raw request/response JSON per step.
-        self._step_payloads: list[dict] = []
-        self._step_count = 0
+        self._init_agent_state()
 
         # Custom tools
         self._extract_content_and_links_tool = ExtractContentAndLinksTool()
 
     async def run(self, task: str, start_url: str) -> str:
-        logger.info(f"Task: {task}")
-        logger.info(f"Starting URL: {start_url}")
-
-        self._messages = [{"role": "user", "content": [{"type": "text", "text": task}]}]
-        self._message_index = 0
-        self._step_count = 0
-        self._step_payloads = []
-        self._replay = None
+        self._start_run(task, start_url, replay_prefix="n1_custom")
 
         final_response = ""
-        # Replay output is opt-in; the loop still works without any of this.
-        if self.replay_dir:
-            replay_id = self.replay_id or make_run_id(prefix="n1_custom", label=task)
-            self._replay = TrajectoryRecorder(self.replay_dir, replay_id)
-            logger.info(f"Replay artifacts: {self._replay.item_dir}")
 
         async with (
             AsyncYutoriClient(base_url=self.base_url) as client,

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -41,14 +41,13 @@ from _common import (
 from loguru import logger
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from playwright.async_api import Browser, Page, async_playwright
+from playwright.async_api import async_playwright
 from pydantic import BaseModel, Field
 
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
-from yutori.navigator.page_ready import PageReadyChecker
-from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload  # Optional replay helpers.
+from yutori.navigator.replay import sanitize_step_payload  # Optional replay helpers.
 
 
 class Config(BaseModel):
@@ -202,43 +201,15 @@ class Agent(BrowserAgentMixin):
         self.replay_dir = replay_dir
         self.replay_id = replay_id
 
-        self._client: AsyncYutoriClient | None = None
-        self._browser: Browser | None = None
-        self._page: Page | None = None
-        self._page_ready_checker = PageReadyChecker(
-            timeout=30,
-            initial_wait=2.0,
-            wait_after_ready=1.0,
-            replace_native_select_dropdown=True,
-            disable_new_tabs=True,
-            disable_printing=True,
-        )
-        # Replay bookkeeping is optional and only used when writing local artifacts.
-        self._replay: TrajectoryRecorder | None = None
-        self._messages: list = []
-        # Stored only so the replay viewer can show raw request/response JSON per step.
-        self._step_payloads: list[dict] = []
-        self._step_count = 0
+        self._init_agent_state()
 
         # Custom memo tool suite
         self._memo_tool_suite = MemoToolSuite()
 
     async def run(self, task: str, start_url: str) -> str:
-        logger.info(f"Task: {task}")
-        logger.info(f"Starting URL: {start_url}")
-
-        self._messages = [{"role": "user", "content": [{"type": "text", "text": task}]}]
-        self._message_index = 0
-        self._step_count = 0
-        self._step_payloads = []
-        self._replay = None
+        self._start_run(task, start_url, replay_prefix="navigator_memo")
 
         final_response = ""
-        # Replay output is opt-in; the loop still works without any of this.
-        if self.replay_dir:
-            replay_id = self.replay_id or make_run_id(prefix="navigator_memo", label=task)
-            self._replay = TrajectoryRecorder(self.replay_dir, replay_id)
-            logger.info(f"Replay artifacts: {self._replay.item_dir}")
 
         async with (
             AsyncYutoriClient(base_url=self.base_url) as client,

--- a/tests/test_agent_state_mixin.py
+++ b/tests/test_agent_state_mixin.py
@@ -1,0 +1,119 @@
+"""Characterization tests for ``examples._common.BrowserAgentMixin._init_agent_state``/``_start_run``.
+
+Pins the exact behavior of these two helpers before/after extracting them out of
+``navigator_n1.py``, ``navigator_n1_custom_tools.py``, ``navigator_n1_memo.py``, and
+``navigator_n1_5.py``, each of which previously hand-rolled this same ``__init__``
+browser/replay bookkeeping and ``run()`` reset-and-start-replay prologue.
+"""
+
+from __future__ import annotations
+
+from .conftest import require_examples_extra
+
+require_examples_extra()
+from examples._common import BrowserAgentMixin  # noqa: E402
+from yutori.navigator.page_ready import PageReadyChecker  # noqa: E402
+
+
+def _make_agent(*, replay_dir: str | None = None, replay_id: str | None = None) -> BrowserAgentMixin:
+    agent = BrowserAgentMixin()
+    agent.replay_dir = replay_dir
+    agent.replay_id = replay_id
+    return agent
+
+
+def test_init_agent_state_sets_expected_defaults() -> None:
+    agent = _make_agent()
+
+    agent._init_agent_state()
+
+    assert agent._client is None
+    assert agent._browser is None
+    assert agent._page is None
+    assert isinstance(agent._page_ready_checker, PageReadyChecker)
+    assert agent._replay is None
+    assert agent._messages == []
+    assert agent._step_payloads == []
+    assert agent._step_count == 0
+
+
+def test_init_agent_state_page_ready_checker_matches_prior_hardcoded_kwargs() -> None:
+    agent = _make_agent()
+
+    agent._init_agent_state()
+
+    checker = agent._page_ready_checker
+    assert checker.timeout == 30
+    assert checker.initial_wait == 2.0
+    assert checker.wait_after_ready == 1.0
+    assert checker.replace_native_select_dropdown is True
+    assert checker.disable_new_tabs is True
+    assert checker.disable_printing is True
+
+
+def test_init_agent_state_returns_fresh_mutable_containers() -> None:
+    """Two agents must not share the same list objects."""
+    agent_one = _make_agent()
+    agent_two = _make_agent()
+
+    agent_one._init_agent_state()
+    agent_two._init_agent_state()
+
+    agent_one._messages.append({"role": "user", "content": []})
+    agent_one._step_payloads.append({"step_num": 1})
+
+    assert agent_two._messages == []
+    assert agent_two._step_payloads == []
+
+
+def test_start_run_resets_message_and_step_state_without_replay_dir() -> None:
+    agent = _make_agent(replay_dir=None)
+    agent._init_agent_state()
+    # Simulate leftover state from a prior run.
+    agent._messages = [{"role": "user", "content": ["stale"]}]
+    agent._step_count = 5
+    agent._step_payloads = [{"step_num": 1}]
+
+    agent._start_run("do the thing", "https://example.com", replay_prefix="n1")
+
+    assert agent._messages == [{"role": "user", "content": [{"type": "text", "text": "do the thing"}]}]
+    assert agent._message_index == 0
+    assert agent._step_count == 0
+    assert agent._step_payloads == []
+    assert agent._replay is None
+
+
+def test_start_run_creates_replay_recorder_when_replay_dir_set(tmp_path) -> None:
+    agent = _make_agent(replay_dir=str(tmp_path), replay_id="fixed-run-id")
+    agent._init_agent_state()
+
+    agent._start_run("do the thing", "https://example.com", replay_prefix="n1")
+
+    assert agent._replay is not None
+    assert agent._replay.run_id == "fixed-run-id"
+    assert agent._replay.item_dir == tmp_path / "fixed-run-id"
+    assert agent._replay.item_dir.is_dir()
+
+
+def test_start_run_derives_replay_id_from_prefix_and_task_when_unset(tmp_path) -> None:
+    agent = _make_agent(replay_dir=str(tmp_path), replay_id=None)
+    agent._init_agent_state()
+
+    agent._start_run("Do The Thing!", "https://example.com", replay_prefix="n1_custom")
+
+    assert agent._replay is not None
+    assert agent._replay.run_id.startswith("n1_custom_")
+    assert "do-the-thing" in agent._replay.run_id
+
+
+def test_start_run_uses_given_task_verbatim_for_message_and_label(tmp_path) -> None:
+    """navigator_n1_5.py calls this with an already-reformatted task string; both the
+    seeded message and the replay label must reflect exactly what was passed in."""
+    agent = _make_agent(replay_dir=str(tmp_path), replay_id=None)
+    agent._init_agent_state()
+
+    reformatted_task = "Reformatted: do the thing (tz=UTC, loc=SF)"
+    agent._start_run(reformatted_task, "https://example.com", replay_prefix="navigator_1_5")
+
+    assert agent._messages[0]["content"][0]["text"] == reformatted_task
+    assert agent._replay is not None


### PR DESCRIPTION
## Structural issue

`navigator_n1.py`, `navigator_n1_custom_tools.py`, `navigator_n1_memo.py`, and `navigator_n1_5.py` each hand-rolled two identical blocks:

- **`Agent.__init__`**: constructing the `PageReadyChecker` with the same 6 kwargs, and initializing `_client`/`_browser`/`_page`/`_replay`/`_messages`/`_step_payloads`/`_step_count` to the same starting values.
- **`Agent.run()` prologue**: logging the task/start URL, resetting message/step bookkeeping for a fresh run, and conditionally starting a `TrajectoryRecorder` when `replay_dir` is set (differing only in the `make_run_id` prefix string: `"n1"`, `"n1_custom"`, `"navigator_memo"`, `"navigator_1_5"`).

This is the same family of duplication `_predict()` (#182), `build_agent_arg_parser()` (#183), and `execute_n1_primitive_action` (#177/#181) were already extracted from — this PR picks up the two blocks that extraction pass didn't cover.

## Fix

Added two methods to `BrowserAgentMixin` in `examples/_common.py`:

- `_init_agent_state()` — the shared `__init__` bookkeeping.
- `_start_run(task, start_url, *, replay_prefix)` — the shared `run()` prologue; `replay_prefix` parameterizes the one thing that differed per script.

Every `Agent.__init__`/`run()` now calls these instead of repeating the boilerplate, keeping only its own model-/tool-specific setup around them (custom tool wiring, payload-trim's extra `_request_messages` reset, n1.5's task-reformatting-before-logging).

## Why it's safe

- **No behavior change.** The only reordering is of independent attribute assignments (each attribute still ends up with the exact same final value before it's read); `_start_run`'s `replay_prefix`/`task` args reproduce each script's previous hardcoded `make_run_id(prefix=..., label=task)` call exactly, including `navigator_n1_5.py` labeling the replay with its already-reformatted task string (unchanged from before).
- **Added test coverage before touching behavior.** Neither block had direct unit coverage previously (both required a live Playwright browser to exercise through `run()`). Added `tests/test_agent_state_mixin.py` with characterization tests for both new mixin methods on a bare `BrowserAgentMixin()` instance, following the precedent in `tests/test_predict_mixin.py`.
- **Full suite green**: 528 passed, 3 skipped (up from 521 passed, 3 skipped on `main`), `ruff check .` clean. Verified `pip install -e ".[dev,examples]"` and ran the whole suite locally before and after.
- Net line count went down (~43 fewer lines) despite adding a new test file, since the duplication was fully eliminated rather than partially.

## Test plan

- [x] `pytest -q` — 528 passed, 3 skipped
- [x] `ruff check .` — all checks passed
- [x] Verified all four modified example scripts still import cleanly standalone
- [x] Confirmed the pre-existing `ruff format --check` diffs (12 unrelated files, including `navigator_n1_5.py`) are identical on `main` before this change — not introduced by this PR

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01FcvaeSnfstwCcY6s1c3vMZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor in example scripts only; behavior is pinned by new unit tests and leaves script-specific setup (payload trim, custom tools, n1.5 task formatting) unchanged.
> 
> **Overview**
> Pulls duplicated **Agent `__init__` and `run()` prologue** out of the four `navigator_n1*` example scripts into **`BrowserAgentMixin`** in `examples/_common.py`.
> 
> **`_init_agent_state()`** centralizes browser/client handles, a shared **`PageReadyChecker`** configuration, and replay/message/step counters. **`_start_run(task, start_url, replay_prefix=...)`** logs the run, resets per-run state, seeds the first user message, and optionally starts **`TrajectoryRecorder`** via **`make_run_id`** (each script passes its former hardcoded prefix: `n1`, `n1_custom`, `navigator_memo`, `navigator_1_5`).
> 
> Each example **`Agent`** now calls these helpers and drops redundant imports; **`SupportsBrowserAgentState`** is extended for the shared fields. **`tests/test_agent_state_mixin.py`** adds characterization tests for defaults, replay ID behavior, and n1.5’s verbatim reformatted task string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a54dd9444066ca51ec00cdff8c14d4101a21be0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->