### PR TITLE
refactor(examples): extract run_example_main() to dedupe main() across n1 examples

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -268,6 +268,38 @@ async def run_example_agent(agent_cls: Callable[..., SupportsAgentRun], config: 
     return result
 
 
+async def run_example_main(
+    config_cls: Callable[[], Any],
+    description: str,
+    *,
+    api_label: str,
+    agent_cls: Callable[..., SupportsAgentRun],
+    include_payload_trim: bool = False,
+) -> None:
+    """Configure logging, parse CLI args, and run ``agent_cls`` -- the shared ``main()`` body.
+
+    ``navigator_n1.py``, ``navigator_n1_custom_tools.py``, and ``navigator_n1_memo.py`` each
+    defined this same configure/build-parser/parse/validate/run sequence in their own
+    ``main()`` (``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py`` were
+    byte-for-byte identical; ``navigator_n1.py`` differs only by passing
+    ``include_payload_trim=True``). ``navigator_n1_5.py`` builds its parser directly with
+    extra tool-set/json-schema/timezone/location arguments, so it keeps its own ``main()``.
+    """
+    configure_example_logging()
+
+    default_config = config_cls()
+    parser = build_agent_arg_parser(
+        description,
+        default_config,
+        api_label=api_label,
+        include_payload_trim=include_payload_trim,
+    )
+    args = parser.parse_args()
+    config = config_cls.model_validate(vars(args))
+
+    await run_example_agent(agent_cls, config)
+
+
 class SupportsBrowserAgentState(Protocol):
     """Instance attributes :class:`BrowserAgentMixin` methods expect from ``self``.
 

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -26,11 +26,9 @@ import json
 
 from _common import (
     BrowserAgentMixin,
-    build_agent_arg_parser,
-    configure_example_logging,
     execute_n1_primitive_action,
     llm_retry,
-    run_example_agent,
+    run_example_main,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
@@ -194,19 +192,13 @@ class Agent(BrowserAgentMixin):
 
 
 async def main():
-    configure_example_logging()
-
-    default_config = Config()
-    parser = build_agent_arg_parser(
+    await run_example_main(
+        Config,
         "Example of using the Yutori Navigator API (Navigator n1) to perform a web browsing task",
-        default_config,
         api_label="Yutori Navigator n1",
+        agent_cls=Agent,
         include_payload_trim=True,
     )
-    args = parser.parse_args()
-    config = Config.model_validate(vars(args))
-
-    await run_example_agent(Agent, config)
 
 
 if __name__ == "__main__":

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -28,11 +28,9 @@ from functools import cached_property
 
 from _common import (
     BrowserAgentMixin,
-    build_agent_arg_parser,
-    configure_example_logging,
     execute_n1_primitive_action,
     llm_retry,
-    run_example_agent,
+    run_example_main,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
@@ -253,18 +251,12 @@ class Agent(BrowserAgentMixin):
 
 
 async def main():
-    configure_example_logging()
-
-    default_config = Config()
-    parser = build_agent_arg_parser(
+    await run_example_main(
+        Config,
         "Example of using the Yutori Navigator API (Navigator n1) to perform a web browsing task",
-        default_config,
         api_label="Yutori Navigator n1",
+        agent_cls=Agent,
     )
-    args = parser.parse_args()
-    config = Config.model_validate(vars(args))
-
-    await run_example_agent(Agent, config)
 
 
 if __name__ == "__main__":

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -32,11 +32,9 @@ from functools import cached_property
 
 from _common import (
     BrowserAgentMixin,
-    build_agent_arg_parser,
-    configure_example_logging,
     execute_n1_primitive_action,
     llm_retry,
-    run_example_agent,
+    run_example_main,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
@@ -309,18 +307,12 @@ class Agent(BrowserAgentMixin):
 
 
 async def main():
-    configure_example_logging()
-
-    default_config = Config()
-    parser = build_agent_arg_parser(
+    await run_example_main(
+        Config,
         "Example of using the Yutori Navigator API (Navigator n1) to perform a web browsing task",
-        default_config,
         api_label="Yutori Navigator n1",
+        agent_cls=Agent,
     )
-    args = parser.parse_args()
-    config = Config.model_validate(vars(args))
-
-    await run_example_agent(Agent, config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`examples/navigator_n1_custom_tools.py` and `examples/navigator_n1_memo.py` had byte-for-byte identical `main()` bodies (configure logging → build the shared arg parser → parse/validate `Config` → run the agent). `examples/navigator_n1.py` carried the exact same sequence, differing only by passing `include_payload_trim=True`.

This extracts the shared sequence into a new `examples/_common.py::run_example_main()` helper, and each of the three `main()` functions now calls it with their own `description`/`api_label`/`agent_cls` (and `include_payload_trim` for `navigator_n1.py`).

`examples/navigator_n1_5.py` builds its parser directly (it has extra tool-set/json-schema/timezone/location arguments not shared with the others) and is intentionally left untouched — it already didn't fit this shared shape before this change.

This is a direct continuation of the existing `build_agent_arg_parser()` / `run_example_agent()` extractions already in this repo (which left the surrounding `main()` boilerplate itself still duplicated).

## Why this is safe

- Purely mechanical: every statement in the old `main()` bodies maps 1:1 onto a `run_example_main()` argument or its body.
- No public API / behavior change — this only touches `examples/`, not the `yutori` package.
- No test imports `main()` or exercises these scripts directly (checked: only `examples/_common.py` helpers are imported by tests, e.g. `tests/test_build_agent_arg_parser.py`, `tests/test_run_agent_loop.py`).
- Verified `python <script> --help` produces **identical** argparse usage/help output before and after for all three touched scripts.
- Full test suite: 533 passed, 3 skipped (unchanged from main).
- `ruff check .` and `ruff format --check` both clean on the touched files.

## Test plan

- [x] `python examples/navigator_n1.py --help`, `navigator_n1_custom_tools.py --help`, `navigator_n1_memo.py --help` produce the same output as before the change.
- [x] `pytest -x -q` — 533 passed, 3 skipped.
- [x] `ruff check .` — all checks passed.
- [x] `ruff format --check examples/_common.py examples/navigator_n1.py examples/navigator_n1_custom_tools.py examples/navigator_n1_memo.py` — clean (the one pre-existing `navigator_n1_5.py` formatting note is unrelated/untouched by this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018AM2sJ79oqUBF8rkhHE1iE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Examples-only mechanical deduplication with no package API changes; CLI behavior is intended to stay identical.
> 
> **Overview**
> Adds **`run_example_main()`** in `examples/_common.py` to own the shared example entry path: configure logging, build the shared CLI parser, parse/validate `Config`, and invoke **`run_example_agent()`**.
> 
> **`navigator_n1.py`**, **`navigator_n1_custom_tools.py`**, and **`navigator_n1_memo.py`** drop duplicated `main()` boilerplate and call the helper with their `Config`, description, `api_label`, and `Agent` class; only **`navigator_n1.py`** passes **`include_payload_trim=True`**. **`navigator_n1_5.py`** is unchanged because its CLI setup does not match this pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf4c6c3843cc537693822331fbc6bc3f055eafc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->