### PR TITLE
refactor(examples): extract shared browser-lifecycle run() body into BrowserAgentMixin

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -11,8 +11,10 @@ from typing import Any, Protocol
 from loguru import logger
 from openai import APIConnectionError, APITimeoutError, InternalServerError, RateLimitError
 from openai.types.chat import ChatCompletion
+from playwright.async_api import async_playwright
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
+from yutori import AsyncYutoriClient
 from yutori.navigator import aplaywright_screenshot_to_data_url, denormalize_coordinates
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder, make_run_id
@@ -307,6 +309,7 @@ class SupportsBrowserAgentState(Protocol):
     or replay-persistence methods below are called.
     """
 
+    base_url: str
     headless: bool
     viewport_width: int
     viewport_height: int
@@ -352,6 +355,11 @@ class BrowserAgentMixin:
     (browser handles, the ``PageReadyChecker``, and per-run message/replay
     setup); every ``Agent.__init__``/``run()`` still has its own model- and
     tool-specific setup around these calls.
+
+    ``_run_with_browser_lifecycle`` covers the entire ``run()`` body -- opening
+    the client/browser, navigating, running :meth:`_run_agent_loop`, and
+    cleanup -- shared verbatim by ``navigator_n1.py``, ``navigator_n1_custom_tools.py``,
+    and ``navigator_n1_memo.py``; ``navigator_n1_5.py`` keeps its own ``run()``.
     """
 
     def _init_agent_state(self: SupportsBrowserAgentState) -> None:
@@ -466,6 +474,50 @@ class BrowserAgentMixin:
 
         if self._step_count >= self.max_steps:
             logger.warning(f"Reached maximum steps ({self.max_steps})")
+
+        return final_response
+
+    async def _run_with_browser_lifecycle(
+        self: SupportsBrowserAgentState,
+        task: str,
+        start_url: str,
+        *,
+        replay_prefix: str,
+    ) -> str:
+        """Run a full task: start the run, open the client/browser, and loop until done.
+
+        ``navigator_n1.py``, ``navigator_n1_custom_tools.py``, and ``navigator_n1_memo.py``
+        each carried a byte-for-byte identical ``run()`` body (open ``AsyncYutoriClient`` +
+        Playwright, launch the browser, navigate to ``start_url``, run
+        :meth:`_run_agent_loop`, and clean up in ``finally``), differing only in the
+        ``replay_prefix`` passed to :meth:`_start_run`. ``navigator_n1.py`` additionally
+        resets ``self._request_messages`` for payload trimming -- callers that need that
+        do so themselves before calling this. ``navigator_n1_5.py`` diverges right after
+        page-ready (stop-and-summarize handling, an extra ``except Exception`` branch,
+        URL-suffixed tool results) and keeps its own ``run()``.
+        """
+        self._start_run(task, start_url, replay_prefix=replay_prefix)
+
+        final_response = ""
+
+        async with (
+            AsyncYutoriClient(base_url=self.base_url) as client,
+            async_playwright() as playwright,
+        ):
+            try:
+                self._client = client
+                await self._init_browser(playwright)
+                await self._page.goto(start_url)
+                await self._page.wait_for_load_state("domcontentloaded")
+                await self._wait_for_page_ready()
+
+                final_response = await self._run_agent_loop()
+
+            except KeyboardInterrupt:
+                logger.info("Interrupted by user")
+            finally:
+                await self._persist_replay()
+                await self._close_browser()
 
         return final_response
 

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -33,10 +33,8 @@ from _common import (
 from loguru import logger
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from playwright.async_api import async_playwright
 from pydantic import BaseModel, Field
 
-from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
 from yutori.navigator.loop import update_trimmed_history
@@ -96,31 +94,8 @@ class Agent(BrowserAgentMixin):
         self._request_messages: list | None = None
 
     async def run(self, task: str, start_url: str) -> str:
-        self._start_run(task, start_url, replay_prefix="n1")
         self._request_messages = None
-
-        final_response = ""
-
-        async with (
-            AsyncYutoriClient(base_url=self.base_url) as client,
-            async_playwright() as playwright,
-        ):
-            try:
-                self._client = client
-                await self._init_browser(playwright)
-                await self._page.goto(start_url)
-                await self._page.wait_for_load_state("domcontentloaded")
-                await self._wait_for_page_ready()
-
-                final_response = await self._run_agent_loop()
-
-            except KeyboardInterrupt:
-                logger.info("Interrupted by user")
-            finally:
-                await self._persist_replay()
-                await self._close_browser()
-
-        return final_response
+        return await self._run_with_browser_lifecycle(task, start_url, replay_prefix="n1")
 
     @llm_retry
     async def _call_llm_with_retries(self) -> ChatCompletion:

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -35,10 +35,9 @@ from _common import (
 from loguru import logger
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from playwright.async_api import Page, async_playwright
+from playwright.async_api import Page
 from pydantic import BaseModel, Field
 
-from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
 from yutori.navigator.replay import sanitize_step_payload  # Optional replay helpers.
@@ -159,30 +158,7 @@ class Agent(BrowserAgentMixin):
         self._extract_content_and_links_tool = ExtractContentAndLinksTool()
 
     async def run(self, task: str, start_url: str) -> str:
-        self._start_run(task, start_url, replay_prefix="n1_custom")
-
-        final_response = ""
-
-        async with (
-            AsyncYutoriClient(base_url=self.base_url) as client,
-            async_playwright() as playwright,
-        ):
-            try:
-                self._client = client
-                await self._init_browser(playwright)
-                await self._page.goto(start_url)
-                await self._page.wait_for_load_state("domcontentloaded")
-                await self._wait_for_page_ready()
-
-                final_response = await self._run_agent_loop()
-
-            except KeyboardInterrupt:
-                logger.info("Interrupted by user")
-            finally:
-                await self._persist_replay()
-                await self._close_browser()
-
-        return final_response
+        return await self._run_with_browser_lifecycle(task, start_url, replay_prefix="n1_custom")
 
     @llm_retry
     async def _call_llm_with_retries(self) -> ChatCompletion:

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -39,10 +39,8 @@ from _common import (
 from loguru import logger
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
-from playwright.async_api import async_playwright
 from pydantic import BaseModel, Field
 
-from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
 from yutori.navigator.replay import sanitize_step_payload  # Optional replay helpers.
@@ -205,30 +203,7 @@ class Agent(BrowserAgentMixin):
         self._memo_tool_suite = MemoToolSuite()
 
     async def run(self, task: str, start_url: str) -> str:
-        self._start_run(task, start_url, replay_prefix="navigator_memo")
-
-        final_response = ""
-
-        async with (
-            AsyncYutoriClient(base_url=self.base_url) as client,
-            async_playwright() as playwright,
-        ):
-            try:
-                self._client = client
-                await self._init_browser(playwright)
-                await self._page.goto(start_url)
-                await self._page.wait_for_load_state("domcontentloaded")
-                await self._wait_for_page_ready()
-
-                final_response = await self._run_agent_loop()
-
-            except KeyboardInterrupt:
-                logger.info("Interrupted by user")
-            finally:
-                await self._persist_replay()
-                await self._close_browser()
-
-        return final_response
+        return await self._run_with_browser_lifecycle(task, start_url, replay_prefix="navigator_memo")
 
     @llm_retry
     async def _call_llm_with_retries(self) -> ChatCompletion:

--- a/tests/test_browser_lifecycle.py
+++ b/tests/test_browser_lifecycle.py
@@ -1,0 +1,106 @@
+"""Characterization tests for ``examples._common.BrowserAgentMixin._run_with_browser_lifecycle``.
+
+Pins the exact behavior of this helper before/after extracting it out of
+``navigator_n1.py``, ``navigator_n1_custom_tools.py``, and ``navigator_n1_memo.py``, each of
+which previously carried a byte-for-byte identical ``run()`` body (open the client/browser,
+navigate, run the predict/execute loop, clean up), differing only in the ``replay_prefix``
+passed to ``_start_run``. ``navigator_n1_5.py`` diverges after page-ready and keeps its own
+``run()``, so it is out of scope here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from .conftest import require_examples_extra
+
+require_examples_extra()
+from examples._common import BrowserAgentMixin  # noqa: E402
+
+
+def _make_agent() -> BrowserAgentMixin:
+    agent = BrowserAgentMixin()
+    agent.base_url = "https://example.yutori.com"
+    agent._page = MagicMock()
+    agent._page.goto = AsyncMock()
+    agent._page.wait_for_load_state = AsyncMock()
+    agent._start_run = MagicMock()
+    agent._init_browser = AsyncMock()
+    agent._wait_for_page_ready = AsyncMock()
+    agent._run_agent_loop = AsyncMock(return_value="final answer")
+    agent._persist_replay = AsyncMock()
+    agent._close_browser = AsyncMock()
+    return agent
+
+
+def _mock_async_context_manager(yielded: object) -> MagicMock:
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=yielded)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+async def test_run_with_browser_lifecycle_happy_path() -> None:
+    agent = _make_agent()
+    client_instance = MagicMock()
+    playwright_instance = MagicMock()
+    client_cm = _mock_async_context_manager(client_instance)
+    playwright_cm = _mock_async_context_manager(playwright_instance)
+
+    with (
+        patch("examples._common.AsyncYutoriClient", return_value=client_cm) as client_ctor,
+        patch("examples._common.async_playwright", return_value=playwright_cm),
+    ):
+        result = await agent._run_with_browser_lifecycle("do it", "https://example.com", replay_prefix="n1")
+
+    client_ctor.assert_called_once_with(base_url="https://example.yutori.com")
+    agent._start_run.assert_called_once_with("do it", "https://example.com", replay_prefix="n1")
+    assert agent._client is client_instance
+    agent._init_browser.assert_awaited_once_with(playwright_instance)
+    agent._page.goto.assert_awaited_once_with("https://example.com")
+    agent._page.wait_for_load_state.assert_awaited_once_with("domcontentloaded")
+    agent._wait_for_page_ready.assert_awaited_once()
+    agent._run_agent_loop.assert_awaited_once()
+    agent._persist_replay.assert_awaited_once()
+    agent._close_browser.assert_awaited_once()
+    assert result == "final answer"
+
+
+async def test_run_with_browser_lifecycle_swallows_keyboard_interrupt() -> None:
+    agent = _make_agent()
+    agent._run_agent_loop = AsyncMock(side_effect=KeyboardInterrupt())
+    client_cm = _mock_async_context_manager(MagicMock())
+    playwright_cm = _mock_async_context_manager(MagicMock())
+
+    with (
+        patch("examples._common.AsyncYutoriClient", return_value=client_cm),
+        patch("examples._common.async_playwright", return_value=playwright_cm),
+    ):
+        result = await agent._run_with_browser_lifecycle("do it", "https://example.com", replay_prefix="n1")
+
+    # No final response was ever set before the interrupt.
+    assert result == ""
+    agent._persist_replay.assert_awaited_once()
+    agent._close_browser.assert_awaited_once()
+
+
+async def test_run_with_browser_lifecycle_cleans_up_on_loop_exception() -> None:
+    """Non-KeyboardInterrupt exceptions propagate, but cleanup still runs (via ``finally``)."""
+    agent = _make_agent()
+    agent._run_agent_loop = AsyncMock(side_effect=RuntimeError("boom"))
+    client_cm = _mock_async_context_manager(MagicMock())
+    playwright_cm = _mock_async_context_manager(MagicMock())
+
+    with (
+        patch("examples._common.AsyncYutoriClient", return_value=client_cm),
+        patch("examples._common.async_playwright", return_value=playwright_cm),
+    ):
+        try:
+            await agent._run_with_browser_lifecycle("do it", "https://example.com", replay_prefix="n1")
+            raised = False
+        except RuntimeError:
+            raised = True
+
+    assert raised
+    agent._persist_replay.assert_awaited_once()
+    agent._close_browser.assert_awaited_once()


### PR DESCRIPTION
## Summary

- `navigator_n1.py`, `navigator_n1_custom_tools.py`, and `navigator_n1_memo.py` each carried a byte-for-byte identical `run()` body: open `AsyncYutoriClient` + Playwright, launch the browser, navigate to `start_url`, run `_run_agent_loop()`, and clean up in `finally` — differing only in the `replay_prefix` string passed to `_start_run()`.
- This was the one piece of `run()` not yet covered by the prior `#186` (`_init_agent_state`/`_start_run`) and `#187` (`_run_agent_loop`) extractions in this same mixin-consolidation series.
- Extracted `_run_with_browser_lifecycle()` onto `BrowserAgentMixin` in `examples/_common.py`; all three scripts' `run()` now delegate to it with their own `replay_prefix`. `navigator_n1.py` keeps its extra `self._request_messages = None` reset immediately before the call (payload-trimming state the other two scripts don't have).
- `navigator_n1_5.py` diverges right after page-ready (stop-and-summarize handling, an extra `except Exception` branch, URL-suffixed tool results) and keeps its own `run()`, consistent with the existing documented rationale for that script across the whole series.

## Safety

No behavior change: same client/browser open order, same navigation calls, same `try`/`except KeyboardInterrupt`/`finally` structure — just relocated. Now-unused `AsyncYutoriClient`/`async_playwright` imports were removed from the three scripts (still imported once in `_common.py`).

Added `tests/test_browser_lifecycle.py` with characterization tests for the new mixin method (happy path, `KeyboardInterrupt` swallowing, and cleanup-still-runs-on-exception via `finally`), since it had no prior direct unit coverage.

Full suite green:
- With the `examples` extra installed: 536 passed, 3 skipped (up from 533/3)
- Without it: 473 passed, 10 skipped (up from 473/9 — the extra skip is the new test module's own `loguru` import-skip guard, matching the existing pattern)

`ruff check` clean. `ruff format --check` shows only pre-existing drift in files this change doesn't touch.

## Test plan

- [x] `pytest -q` (full suite, with `examples` extra) — 536 passed, 3 skipped
- [x] `pytest -q` (full suite, without `examples` extra) — 473 passed, 10 skipped
- [x] `ruff check .`
- [x] `ruff format --check .` (no new drift introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnXuzW8byvnieDrsWLvoxW


---
_Generated by [Claude Code](https://claude.ai/code/session_01FnXuzW8byvnieDrsWLvoxW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication in example scripts with no intended behavior change; coverage added for the extracted helper.
> 
> **Overview**
> Pulls the duplicated **`run()`** flow (Yutori client + Playwright, navigate, agent loop, **`finally`** cleanup) into **`BrowserAgentMixin._run_with_browser_lifecycle`** in **`examples/_common.py`**, with **`replay_prefix`** as the only per-script knob.
> 
> **`navigator_n1.py`**, **`navigator_n1_custom_tools.py`**, and **`navigator_n1_memo.py`** now delegate from **`run()`**; **`navigator_n1.py`** still clears **`_request_messages`** before the call. **`AsyncYutoriClient`** / **`async_playwright`** imports move to **`_common.py`** and drop from those scripts. **`navigator_n1_5.py`** is unchanged and keeps its own **`run()`**.
> 
> Adds **`tests/test_browser_lifecycle.py`** to lock in happy path, **`KeyboardInterrupt`** handling, and cleanup on other exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58eea89796bbefd3b2c8abfb980e9d20b16f1306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->