### PR TITLE
refactor(examples): extract shared _execute() body into BrowserAgentMixin

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import sys
 from collections.abc import Callable
 from typing import Any, Protocol
@@ -328,7 +329,9 @@ class SupportsBrowserAgentState(Protocol):
 
     async def _call_llm_with_retries(self) -> ChatCompletion: ...
 
-    async def _execute(self, tool_call: Any) -> tuple[bool, str | None]: ...
+    async def _dispatch_custom_tool(
+        self, action_name: str, arguments: dict[str, Any]
+    ) -> tuple[bool, str | None] | None: ...
 
 
 class BrowserAgentMixin:
@@ -360,6 +363,13 @@ class BrowserAgentMixin:
     the client/browser, navigating, running :meth:`_run_agent_loop`, and
     cleanup -- shared verbatim by ``navigator_n1.py``, ``navigator_n1_custom_tools.py``,
     and ``navigator_n1_memo.py``; ``navigator_n1_5.py`` keeps its own ``run()``.
+
+    ``_execute`` covers the argument-parsing / n1-primitive-fallback / page-ready-wait /
+    catch-all-error structure that was also duplicated verbatim across those same three
+    scripts' ``_execute()`` methods; each only differed in which custom tools (if any) it
+    checked first. Scripts with custom tools now override :meth:`_dispatch_custom_tool`
+    instead of ``_execute`` itself; ``navigator_n1.py`` has no custom tools and uses the
+    default. ``navigator_n1_5.py`` keeps its own differently-shaped ``_execute``.
     """
 
     def _init_agent_state(self: SupportsBrowserAgentState) -> None:
@@ -564,6 +574,64 @@ class BrowserAgentMixin:
 
         response = await self._call_llm_with_retries()
         return response.choices[0].message
+
+    async def _dispatch_custom_tool(
+        self, action_name: str, arguments: dict[str, Any]
+    ) -> tuple[bool, str | None] | None:
+        """Handle an example-specific custom tool call, or decline it.
+
+        Overridden by ``navigator_n1_custom_tools.py`` (``extract_content_and_links``)
+        and ``navigator_n1_memo.py`` (``add_question``/``add_options``/``list_records``)
+        to handle their own tools before :meth:`_execute` falls back to
+        :func:`execute_n1_primitive_action`. The default (used by ``navigator_n1.py``,
+        which defines no custom tools) always declines by returning ``None``.
+
+        Return ``None`` if ``action_name`` isn't recognized, so ``_execute`` falls
+        through to the n1 primitive-action dispatch. Return ``(should_exit, result)``
+        directly to handle it and skip the primitive-action path entirely.
+        """
+        return None
+
+    async def _execute(self: SupportsBrowserAgentState, tool_call: Any) -> tuple[bool, str | None]:
+        """Parse a tool call's arguments and execute it -- the shared body of every example ``_execute()``.
+
+        ``navigator_n1.py``, ``navigator_n1_custom_tools.py``, and ``navigator_n1_memo.py``
+        each defined this same argument-parsing / custom-tool-dispatch / n1-primitive-fallback
+        / page-ready-wait / catch-all-error structure verbatim, differing only in which custom
+        tools (if any) :meth:`_dispatch_custom_tool` recognizes. ``navigator_n1_5.py`` targets a
+        different model and action vocabulary and keeps its own differently-shaped ``_execute``.
+        """
+        action_name = tool_call.function.name
+
+        try:
+            arguments = json.loads(tool_call.function.arguments)
+        except json.JSONDecodeError:
+            logger.error(f"Failed to parse arguments: {tool_call.function.arguments}")
+            return False, f"[ERROR] Failed to parse arguments: {tool_call.function.arguments}"
+
+        try:
+            custom_result = await self._dispatch_custom_tool(action_name, arguments)
+            if custom_result is not None:
+                return custom_result
+
+            if not await execute_n1_primitive_action(
+                self._page, action_name, arguments, self.viewport_width, self.viewport_height
+            ):
+                logger.warning(f"Unknown action: {action_name}")
+                return False, f"[ERROR] Unknown action: {action_name}"
+
+            # Wait for any navigation or dynamic content
+            try:
+                await self._page.wait_for_load_state("domcontentloaded", timeout=3000)
+            except Exception:
+                pass
+            await self._wait_for_page_ready()
+
+        except Exception as e:
+            logger.error(f"Error executing {action_name}: {e}")
+            return False, f"[ERROR] Error executing {action_name}: {e}"
+
+        return False, None
 
     def _clip_image_url(self, url: str, max_len: int = 50) -> str:
         # Delegates to the canonical implementation in yutori.navigator.replay, passing

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -22,17 +22,14 @@ Usage:
 """
 
 import asyncio
-import json
 
 from _common import (
     BrowserAgentMixin,
-    execute_n1_primitive_action,
     llm_retry,
     run_example_main,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
-from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
 from pydantic import BaseModel, Field
 
 from yutori.config import DEFAULT_BASE_URL
@@ -134,36 +131,9 @@ class Agent(BrowserAgentMixin):
         )
         return response
 
-    # _predict() is inherited from BrowserAgentMixin (identical across the n1 examples).
-
-    async def _execute(self, tool_call: ChatCompletionMessageToolCall) -> tuple[bool, str | None]:
-        action_name = tool_call.function.name
-
-        try:
-            arguments = json.loads(tool_call.function.arguments)
-        except json.JSONDecodeError:
-            logger.error(f"Failed to parse arguments: {tool_call.function.arguments}")
-            return False, f"[ERROR] Failed to parse arguments: {tool_call.function.arguments}"
-
-        try:
-            if not await execute_n1_primitive_action(
-                self._page, action_name, arguments, self.viewport_width, self.viewport_height
-            ):
-                logger.warning(f"Unknown action: {action_name}")
-                return False, f"[ERROR] Unknown action: {action_name}"
-
-            # Wait for any navigation or dynamic content
-            try:
-                await self._page.wait_for_load_state("domcontentloaded", timeout=3000)
-            except Exception:
-                pass
-            await self._wait_for_page_ready()
-
-        except Exception as e:
-            logger.error(f"Error executing {action_name}: {e}")
-            return False, f"[ERROR] Error executing {action_name}: {e}"
-
-        return False, None
+    # _predict() and _execute() are inherited from BrowserAgentMixin (identical across the
+    # n1 examples); this script has no custom tools, so it also uses the default
+    # _dispatch_custom_tool() (always declines, falling through to the n1 primitive actions).
 
 
 async def main():

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -22,19 +22,16 @@ Usage:
 """
 
 import asyncio
-import json
 import re
 from functools import cached_property
+from typing import Any
 
 from _common import (
     BrowserAgentMixin,
-    execute_n1_primitive_action,
     llm_retry,
     run_example_main,
 )
-from loguru import logger
 from openai.types.chat import ChatCompletion
-from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
 from playwright.async_api import Page
 from pydantic import BaseModel, Field
 
@@ -190,40 +187,16 @@ class Agent(BrowserAgentMixin):
         )
         return response
 
-    # _predict() is inherited from BrowserAgentMixin (identical across the n1 examples).
+    # _predict() and _execute() are inherited from BrowserAgentMixin (identical across the
+    # n1 examples).
 
-    async def _execute(self, tool_call: ChatCompletionMessageToolCall) -> tuple[bool, str | None]:
-        action_name = tool_call.function.name
-
-        try:
-            arguments = json.loads(tool_call.function.arguments)
-        except json.JSONDecodeError:
-            logger.error(f"Failed to parse arguments: {tool_call.function.arguments}")
-            return False, f"[ERROR] Failed to parse arguments: {tool_call.function.arguments}"
-
-        try:
-            if action_name == "extract_content_and_links":
-                await self._wait_for_page_ready()
-                return False, await self._extract_content_and_links_tool(self._page)
-
-            if not await execute_n1_primitive_action(
-                self._page, action_name, arguments, self.viewport_width, self.viewport_height
-            ):
-                logger.warning(f"Unknown action: {action_name}")
-                return False, f"[ERROR] Unknown action: {action_name}"
-
-            # Wait for any navigation or dynamic content
-            try:
-                await self._page.wait_for_load_state("domcontentloaded", timeout=3000)
-            except Exception:
-                pass
+    async def _dispatch_custom_tool(
+        self, action_name: str, arguments: dict[str, Any]
+    ) -> tuple[bool, str | None] | None:
+        if action_name == "extract_content_and_links":
             await self._wait_for_page_ready()
-
-        except Exception as e:
-            logger.error(f"Error executing {action_name}: {e}")
-            return False, f"[ERROR] Error executing {action_name}: {e}"
-
-        return False, None
+            return False, await self._extract_content_and_links_tool(self._page)
+        return None
 
 
 async def main():

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -29,16 +29,15 @@ import json
 import os
 from datetime import datetime, timezone
 from functools import cached_property
+from typing import Any
 
 from _common import (
     BrowserAgentMixin,
-    execute_n1_primitive_action,
     llm_retry,
     run_example_main,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
-from openai.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
 from pydantic import BaseModel, Field
 
 from yutori.config import DEFAULT_BASE_URL
@@ -235,50 +234,26 @@ class Agent(BrowserAgentMixin):
         )
         return response
 
-    # _predict() is inherited from BrowserAgentMixin (identical across the n1 examples).
+    # _predict() and _execute() are inherited from BrowserAgentMixin (identical across the
+    # n1 examples).
 
-    async def _execute(self, tool_call: ChatCompletionMessageToolCall) -> tuple[bool, str | None]:
-        # Returns (should_exit, result)
-        action_name = tool_call.function.name
+    async def _dispatch_custom_tool(
+        self, action_name: str, arguments: dict[str, Any]
+    ) -> tuple[bool, str | None] | None:
+        if action_name == "add_question":
+            result = await self._memo_tool_suite.add_question(**arguments)
+            return False, result
 
-        try:
-            arguments = json.loads(tool_call.function.arguments)
-        except json.JSONDecodeError:
-            logger.error(f"Failed to parse arguments: {tool_call.function.arguments}")
-            return False, f"[ERROR] Failed to parse arguments: {tool_call.function.arguments}"
+        if action_name == "add_options":
+            result = await self._memo_tool_suite.add_options(**arguments)
+            return False, result
 
-        try:
-            if action_name == "add_question":
-                result = await self._memo_tool_suite.add_question(**arguments)
-                return False, result
+        if action_name == "list_records":
+            result = await self._memo_tool_suite.list_records()
+            logger.info("Task completed (`list_records` tool called)")
+            return True, result
 
-            elif action_name == "add_options":
-                result = await self._memo_tool_suite.add_options(**arguments)
-                return False, result
-
-            elif action_name == "list_records":
-                result = await self._memo_tool_suite.list_records()
-                logger.info("Task completed (`list_records` tool called)")
-                return True, result
-
-            if not await execute_n1_primitive_action(
-                self._page, action_name, arguments, self.viewport_width, self.viewport_height
-            ):
-                logger.warning(f"Unknown action: {action_name}")
-                return False, f"[ERROR] Unknown action: {action_name}"
-
-            # Wait for any navigation or dynamic content
-            try:
-                await self._page.wait_for_load_state("domcontentloaded", timeout=3000)
-            except Exception:
-                pass
-            await self._wait_for_page_ready()
-
-        except Exception as e:
-            logger.error(f"Error executing {action_name}: {e}")
-            return False, f"[ERROR] Error executing {action_name}: {e}"
-
-        return False, None
+        return None
 
 
 async def main():

--- a/tests/test_execute_mixin.py
+++ b/tests/test_execute_mixin.py
@@ -1,0 +1,108 @@
+"""Characterization tests for ``examples._common.BrowserAgentMixin._execute``.
+
+Pins the exact argument-parsing / custom-tool-dispatch / n1-primitive-fallback /
+page-ready-wait / catch-all-error behavior before/after extracting it out of
+``navigator_n1.py``, ``navigator_n1_custom_tools.py``, and ``navigator_n1_memo.py``
+(which previously each carried a byte-for-byte identical ``_execute`` body, differing
+only in which custom tools -- if any -- they checked before falling back to
+:func:`examples._common.execute_n1_primitive_action`). ``navigator_n1_5.py`` defines its
+own, differently-shaped ``_execute`` and is out of scope here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from .conftest import require_examples_extra
+
+require_examples_extra()
+from examples._common import BrowserAgentMixin  # noqa: E402
+
+
+def _make_agent() -> BrowserAgentMixin:
+    agent = BrowserAgentMixin()
+    agent.viewport_width = 1280
+    agent.viewport_height = 800
+    agent._page = MagicMock()
+    agent._page.wait_for_load_state = AsyncMock()
+    agent._wait_for_page_ready = AsyncMock()
+    return agent
+
+
+def _tool_call(name: str, arguments: str) -> MagicMock:
+    tool_call = MagicMock()
+    tool_call.function.name = name
+    tool_call.function.arguments = arguments
+    return tool_call
+
+
+async def test_execute_returns_error_on_invalid_json() -> None:
+    agent = _make_agent()
+
+    with patch("examples._common.execute_n1_primitive_action", AsyncMock()) as primitive:
+        result = await agent._execute(_tool_call("left_click", "not json"))
+
+    assert result == (False, "[ERROR] Failed to parse arguments: not json")
+    primitive.assert_not_awaited()
+
+
+async def test_execute_falls_back_to_primitive_action_when_dispatch_declines() -> None:
+    agent = _make_agent()
+
+    with patch("examples._common.execute_n1_primitive_action", AsyncMock(return_value=True)) as primitive:
+        result = await agent._execute(_tool_call("left_click", '{"coordinates": [1, 2]}'))
+
+    assert result == (False, None)
+    primitive.assert_awaited_once_with(agent._page, "left_click", {"coordinates": [1, 2]}, 1280, 800)
+    agent._page.wait_for_load_state.assert_awaited_once_with("domcontentloaded", timeout=3000)
+    agent._wait_for_page_ready.assert_awaited_once()
+
+
+async def test_execute_returns_error_for_unknown_action() -> None:
+    agent = _make_agent()
+
+    with patch("examples._common.execute_n1_primitive_action", AsyncMock(return_value=False)):
+        result = await agent._execute(_tool_call("not_a_real_action", "{}"))
+
+    assert result == (False, "[ERROR] Unknown action: not_a_real_action")
+    agent._wait_for_page_ready.assert_not_awaited()
+
+
+async def test_execute_uses_custom_dispatch_result_directly() -> None:
+    agent = _make_agent()
+    agent._dispatch_custom_tool = AsyncMock(return_value=(True, "custom result"))
+
+    with patch("examples._common.execute_n1_primitive_action", AsyncMock()) as primitive:
+        result = await agent._execute(_tool_call("my_custom_tool", '{"foo": "bar"}'))
+
+    assert result == (True, "custom result")
+    agent._dispatch_custom_tool.assert_awaited_once_with("my_custom_tool", {"foo": "bar"})
+    primitive.assert_not_awaited()
+
+
+async def test_execute_ignores_load_state_timeout() -> None:
+    agent = _make_agent()
+    agent._page.wait_for_load_state = AsyncMock(side_effect=TimeoutError("no navigation"))
+
+    with patch("examples._common.execute_n1_primitive_action", AsyncMock(return_value=True)):
+        result = await agent._execute(_tool_call("left_click", "{}"))
+
+    assert result == (False, None)
+    agent._wait_for_page_ready.assert_awaited_once()
+
+
+async def test_execute_catches_exceptions_and_returns_error() -> None:
+    agent = _make_agent()
+
+    with patch("examples._common.execute_n1_primitive_action", AsyncMock(side_effect=RuntimeError("boom"))):
+        result = await agent._execute(_tool_call("left_click", "{}"))
+
+    assert result == (False, "[ERROR] Error executing left_click: boom")
+
+
+async def test_default_dispatch_custom_tool_always_declines() -> None:
+    agent = _make_agent()
+
+    result = await agent._dispatch_custom_tool("anything", {"foo": "bar"})
+
+    assert result is None


### PR DESCRIPTION
## Issue

`navigator_n1.py`, `navigator_n1_custom_tools.py`, and `navigator_n1_memo.py` each carried a byte-for-byte identical `_execute()` body: parse the tool call's JSON arguments, fall back to `execute_n1_primitive_action()`, wait for navigation/page-ready, and a catch-all exception handler that turns any error into an `[ERROR] ...` string result. The three scripts differed only in which custom tools (if any) they checked *before* that shared fallback: `navigator_n1_custom_tools.py`'s `extract_content_and_links`, and `navigator_n1_memo.py`'s `add_question`/`add_options`/`list_records`.

This is a case of "identical scaffolding, different plug-in behavior" — a template-method candidate that survived the prior rounds of `BrowserAgentMixin` extraction (which pulled out `__init__`/`run()` bookkeeping, the predict/execute step loop, and the full `run()` body) because those rounds intentionally left `_execute()` alone as "the one place scripts genuinely differ."

## Improvement

- Extracted `_execute()` onto `BrowserAgentMixin` in `examples/_common.py` as a template method.
- Added a new overridable hook, `_dispatch_custom_tool(action_name, arguments)`: return `None` to decline (falls through to `execute_n1_primitive_action`, matching the prior default control flow), or `(should_exit, result)` to handle it directly (matching each script's prior inline early-return).
- `navigator_n1.py` has no custom tools, so it now relies entirely on the inherited `_execute()` + the default `_dispatch_custom_tool()` (always declines) — no per-script override at all.
- `navigator_n1_custom_tools.py` and `navigator_n1_memo.py` now only implement `_dispatch_custom_tool()` with their tool-specific logic (a handful of lines each), no longer duplicating the surrounding parse/fallback/wait/error-handling boilerplate.
- `navigator_n1_5.py` targets a different model and action vocabulary and keeps its own differently-shaped `_execute()`, untouched.
- Removed now-unused imports (`json`, `execute_n1_primitive_action`, `ChatCompletionMessageToolCall`) from the three example scripts.

## Safety

- No behavior change: the exact control flow (JSON-parse error message, custom-tool-first ordering, primitive-action fallback, `wait_for_load_state`/`_wait_for_page_ready` sequencing, and the generic exception-to-error-string mapping) is preserved byte-for-byte, just relocated.
- Added `tests/test_execute_mixin.py` with characterization tests for the new `_execute`/`_dispatch_custom_tool` methods (no prior direct unit coverage existed for this method — it was previously only exercised indirectly via each script's own `_execute`).
- Full test suite green: 542 passed, 3 skipped (up from 535/3 before this change).
- `ruff check .` and `ruff format --check` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xrqeK194WGc4diTb4S7sB

---
_Generated by [Claude Code](https://claude.ai/code/session_015xrqeK194WGc4diTb4S7sB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only refactor with behavior preserved via template method and new unit tests; production library code is untouched.
> 
> **Overview**
> **Deduplicates tool execution** across the three Navigator n1 example agents by moving the shared `_execute()` flow into `BrowserAgentMixin` in `examples/_common.py`.
> 
> The mixin now owns JSON parsing, optional custom-tool handling via a new **`_dispatch_custom_tool`** hook (return `None` to fall through to `execute_n1_primitive_action`, or `(should_exit, result)` to handle locally), n1 primitive dispatch, post-action load-state wait, and error-to-`[ERROR]` mapping. `navigator_n1.py` uses the default hook only; **custom-tools** and **memo** examples override `_dispatch_custom_tool` with their tool-specific logic and drop their copied `_execute` bodies and related imports.
> 
> **`navigator_n1_5.py` is unchanged** (different model/actions and its own `_execute`). **`tests/test_execute_mixin.py`** adds characterization tests for the extracted behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d1852456b1d941c19ac3a94c3d109552ddd00a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->