### PR TITLE
refactor(examples): extract shared _call_llm_with_tools() into BrowserAgentMixin

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -18,7 +18,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 from yutori import AsyncYutoriClient
 from yutori.navigator import aplaywright_screenshot_to_data_url, denormalize_coordinates
 from yutori.navigator.page_ready import PageReadyChecker
-from yutori.navigator.replay import TrajectoryRecorder, make_run_id
+from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload
 from yutori.navigator.replay import _clip_image_url as _clip_image_url_impl
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
@@ -317,6 +317,8 @@ class SupportsBrowserAgentState(Protocol):
     replay_dir: str | None
     replay_id: str | None
     max_steps: int
+    model: str
+    temperature: float
     _client: Any
     _browser: Any
     _page: Any
@@ -574,6 +576,46 @@ class BrowserAgentMixin:
 
         response = await self._call_llm_with_retries()
         return response.choices[0].message
+
+    @llm_retry
+    async def _call_llm_with_tools(self: SupportsBrowserAgentState, tools: list[dict]) -> ChatCompletion:
+        """Call the model with a fixed ``tools`` list -- the shared body of ``_call_llm_with_retries``.
+
+        ``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py`` each defined a
+        ``_call_llm_with_retries`` that was byte-for-byte identical to this one, differing
+        only in the (fixed, non-trimmed) ``tools`` list passed to the chat completions call.
+        Each now delegates here with its own tool-schema list. ``navigator_n1.py`` and
+        ``navigator_n1_5.py`` additionally trim message history and pass model-specific
+        fields (``tool_set``/``disable_tools``/``json_schema``), so they keep their own
+        ``_call_llm_with_retries`` instead of using this helper.
+        """
+        # This copy is only for replay output; the request itself just uses the same fields directly.
+        request_payload = {
+            "model": self.model,
+            "messages": self._messages,
+            "temperature": self.temperature,
+            "tools": tools,
+        }
+        response = await asyncio.wait_for(
+            self._client.chat.completions.create(
+                model=self.model,
+                messages=self._messages,
+                temperature=self.temperature,
+                tools=tools,
+            ),
+            timeout=120.0,  # 2 minutes
+        )
+        # Replay output records the sanitized raw request/response pair for this step.
+        self._step_payloads.append(
+            sanitize_step_payload(
+                {
+                    "step_num": self._step_count,
+                    "request": request_payload,
+                    "response": response.model_dump(exclude_none=True),
+                }
+            )
+        )
+        return response
 
     async def _dispatch_custom_tool(
         self, action_name: str, arguments: dict[str, Any]

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -28,7 +28,6 @@ from typing import Any
 
 from _common import (
     BrowserAgentMixin,
-    llm_retry,
     run_example_main,
 )
 from openai.types.chat import ChatCompletion
@@ -37,7 +36,6 @@ from pydantic import BaseModel, Field
 
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
-from yutori.navigator.replay import sanitize_step_payload  # Optional replay helpers.
 
 
 class Config(BaseModel):
@@ -157,35 +155,8 @@ class Agent(BrowserAgentMixin):
     async def run(self, task: str, start_url: str) -> str:
         return await self._run_with_browser_lifecycle(task, start_url, replay_prefix="n1_custom")
 
-    @llm_retry
     async def _call_llm_with_retries(self) -> ChatCompletion:
-        # This copy is only for replay output; the request itself just uses the same fields directly.
-        request_payload = {
-            "model": self.model,
-            "messages": self._messages,
-            "temperature": self.temperature,
-            "tools": [self._extract_content_and_links_tool.input_schema],
-        }
-        response = await asyncio.wait_for(
-            self._client.chat.completions.create(
-                model=self.model,
-                messages=self._messages,
-                temperature=self.temperature,
-                tools=[self._extract_content_and_links_tool.input_schema],  # add custom tools here
-            ),
-            timeout=120.0,  # 2 minutes
-        )
-        # Replay output records the sanitized raw request/response pair for this step.
-        self._step_payloads.append(
-            sanitize_step_payload(
-                {
-                    "step_num": self._step_count,
-                    "request": request_payload,
-                    "response": response.model_dump(exclude_none=True),
-                }
-            )
-        )
-        return response
+        return await self._call_llm_with_tools([self._extract_content_and_links_tool.input_schema])
 
     # _predict() and _execute() are inherited from BrowserAgentMixin (identical across the
     # n1 examples).

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -33,7 +33,6 @@ from typing import Any
 
 from _common import (
     BrowserAgentMixin,
-    llm_retry,
     run_example_main,
 )
 from loguru import logger
@@ -42,7 +41,6 @@ from pydantic import BaseModel, Field
 
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
-from yutori.navigator.replay import sanitize_step_payload  # Optional replay helpers.
 
 
 class Config(BaseModel):
@@ -204,35 +202,8 @@ class Agent(BrowserAgentMixin):
     async def run(self, task: str, start_url: str) -> str:
         return await self._run_with_browser_lifecycle(task, start_url, replay_prefix="navigator_memo")
 
-    @llm_retry
     async def _call_llm_with_retries(self) -> ChatCompletion:
-        # This copy is only for replay output; the request itself just uses the same fields directly.
-        request_payload = {
-            "model": self.model,
-            "messages": self._messages,
-            "temperature": self.temperature,
-            "tools": self._memo_tool_suite.input_schemas,
-        }
-        response = await asyncio.wait_for(
-            self._client.chat.completions.create(
-                model=self.model,
-                messages=self._messages,
-                temperature=self.temperature,
-                tools=self._memo_tool_suite.input_schemas,  # add custom tools here
-            ),
-            timeout=120.0,  # 2 minutes
-        )
-        # Replay output records the sanitized raw request/response pair for this step.
-        self._step_payloads.append(
-            sanitize_step_payload(
-                {
-                    "step_num": self._step_count,
-                    "request": request_payload,
-                    "response": response.model_dump(exclude_none=True),
-                }
-            )
-        )
-        return response
+        return await self._call_llm_with_tools(self._memo_tool_suite.input_schemas)
 
     # _predict() and _execute() are inherited from BrowserAgentMixin (identical across the
     # n1 examples).

--- a/tests/test_call_llm_with_tools_mixin.py
+++ b/tests/test_call_llm_with_tools_mixin.py
@@ -1,0 +1,76 @@
+"""Characterization tests for ``examples._common.BrowserAgentMixin._call_llm_with_tools``.
+
+Pins the exact request-building / replay-step-recording behavior of this helper before/after
+extracting it out of ``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py``, each of
+which previously carried a byte-for-byte identical ``_call_llm_with_retries`` body, differing
+only in the fixed ``tools`` list passed to the chat completions call. ``navigator_n1.py`` and
+``navigator_n1_5.py`` additionally trim message history and pass model-specific fields, so
+they keep their own ``_call_llm_with_retries`` and are out of scope here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from .conftest import require_examples_extra
+
+require_examples_extra()
+from examples._common import BrowserAgentMixin  # noqa: E402
+
+
+def _make_agent() -> BrowserAgentMixin:
+    agent = BrowserAgentMixin()
+    agent.model = "n1-latest"
+    agent.temperature = 0.3
+    agent._messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+    agent._step_count = 3
+    agent._step_payloads = []
+
+    response = MagicMock()
+    response.model_dump.return_value = {"role": "assistant", "content": "done"}
+    agent._client = MagicMock()
+    agent._client.chat.completions.create = AsyncMock(return_value=response)
+    return agent
+
+
+async def test_call_llm_with_tools_passes_tools_and_fields_to_create() -> None:
+    agent = _make_agent()
+    tools = [{"type": "function", "function": {"name": "my_tool"}}]
+
+    response = await agent._call_llm_with_tools(tools)
+
+    agent._client.chat.completions.create.assert_awaited_once_with(
+        model="n1-latest",
+        messages=agent._messages,
+        temperature=0.3,
+        tools=tools,
+    )
+    assert response is agent._client.chat.completions.create.return_value
+
+
+async def test_call_llm_with_tools_records_sanitized_step_payload() -> None:
+    agent = _make_agent()
+    tools = [{"type": "function", "function": {"name": "my_tool"}}]
+
+    await agent._call_llm_with_tools(tools)
+
+    assert len(agent._step_payloads) == 1
+    payload = agent._step_payloads[0]
+    assert payload["step_num"] == 3
+    assert payload["request"] == {
+        "model": "n1-latest",
+        "messages": agent._messages,
+        "temperature": 0.3,
+        "tools": tools,
+    }
+    assert payload["response"] == {"role": "assistant", "content": "done"}
+
+
+async def test_call_llm_with_tools_appends_without_clearing_prior_payloads() -> None:
+    agent = _make_agent()
+    agent._step_payloads = [{"step_num": 1}]
+
+    await agent._call_llm_with_tools([])
+
+    assert len(agent._step_payloads) == 2
+    assert agent._step_payloads[0] == {"step_num": 1}


### PR DESCRIPTION
## What

`navigator_n1_custom_tools.py` and `navigator_n1_memo.py` each defined a
byte-for-byte identical `_call_llm_with_retries()`:

- build a `request_payload` dict for replay output
- call `self._client.chat.completions.create(...)` with a fixed timeout
- append a sanitized `{step_num, request, response}` entry to `self._step_payloads`
- return the response

The only difference between the two was which fixed `tools` list was passed
(`[self._extract_content_and_links_tool.input_schema]` vs.
`self._memo_tool_suite.input_schemas`).

## Why

This is the same "identical method across the n1 example agents" pattern that
has been mechanically extracted into `examples/_common.py::BrowserAgentMixin`
several times already in this repo (`_predict`, `_execute`,
`_run_with_browser_lifecycle`, `_run_agent_loop`, `_init_agent_state`/`_start_run`,
etc. — see prior PRs #182, #187, #189, #190). This duplicate slipped through
those passes because it differs by a single expression rather than being
byte-identical, but the bodies are otherwise identical and would silently drift
if one were edited without the other.

Extracted the shared body into `BrowserAgentMixin._call_llm_with_tools(tools)`
(decorated with the existing `llm_retry`); both scripts now delegate to it with
their own tool-schema list. `navigator_n1.py` and `navigator_n1_5.py` additionally
trim message history and pass model-specific fields (`tool_set`/`disable_tools`/
`json_schema`), so they keep their own `_call_llm_with_retries` and are untouched.

## Why it's safe

- No behavior change: the extracted method's body is a verbatim move (request
  payload shape, `chat.completions.create` kwargs, 120s timeout, sanitized
  step-payload recording, and the `llm_retry` retry behavior — now applied at
  the shared call site instead of each subclass's method — are all identical).
- Added `tests/test_call_llm_with_tools_mixin.py`, pinning the new helper's
  request-building and step-payload-recording behavior (no prior test exercised
  this code path directly).
- Full test suite green: **546 passed, 3 skipped** (up from 543 passed, 3
  skipped on `main`).
- `ruff format` / `ruff check` clean on all changed files.
- Blast radius: 3 production files (`examples/_common.py`,
  `examples/navigator_n1_custom_tools.py`, `examples/navigator_n1_memo.py`) + 1
  new test file. No call-site changes outside `examples/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S57gNfAh5WsASCjwgujrZ6


---
_Generated by [Claude Code](https://claude.ai/code/session_01S57gNfAh5WsASCjwgujrZ6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only refactor with verbatim behavior move; `navigator_n1` variants with trimming stay untouched.
> 
> **Overview**
> Pulls duplicated LLM call logic from **`navigator_n1_custom_tools.py`** and **`navigator_n1_memo.py`** into **`BrowserAgentMixin._call_llm_with_tools(tools)`** in **`examples/_common.py`**. The helper keeps the same behavior: **`llm_retry`**, a 120s **`chat.completions.create`**, and sanitized replay step payloads via **`sanitize_step_payload`**.
> 
> Each example agent’s **`_call_llm_with_retries`** now only forwards its fixed tool schema list. **`SupportsBrowserAgentState`** documents **`model`** and **`temperature`** for that path. **`navigator_n1.py`** and **`navigator_n1_5.py`** are unchanged—they still use their own **`_call_llm_with_retries`** with payload trimming and model-specific kwargs.
> 
> Adds **`tests/test_call_llm_with_tools_mixin.py`** to lock in request kwargs and step-payload recording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca9c87d1fb99e7f03dcf35a0a580112b66cd3df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->