### PR TITLE
refactor(tests): parametrize run_interactive_command exception-mapping tests

### DIFF
--- a/tests/test_install_flow.py
+++ b/tests/test_install_flow.py
@@ -923,41 +923,26 @@ def test_maybe_install_mcp_server_user_cancels_with_ctrl_c():
 # ---------------------------------------------------------------------------
 
 
-def test_run_interactive_command_maps_timeout_to_124():
-    expired = subprocess.TimeoutExpired(cmd="npx", timeout=1)
-    with patch("yutori.cli.commands.install_flow.subprocess.run", side_effect=expired):
+@pytest.mark.parametrize(
+    "side_effect,expected_returncode",
+    [
+        (subprocess.TimeoutExpired(cmd="npx", timeout=1), 124),
+        (FileNotFoundError("no such file: 'npx'"), 127),
+        # Bare OSError covers ENOEXEC, EMFILE, ENOMEM, etc. — fork/exec failures
+        # that aren't FileNotFoundError or PermissionError. They all collapse to
+        # "could not start the child" from the user's perspective.
+        (OSError("ENOMEM"), 127),
+        (KeyboardInterrupt(), 130),
+    ],
+)
+def test_run_interactive_command_maps_exceptions_to_returncode(side_effect, expected_returncode):
+    with patch("yutori.cli.commands.install_flow.subprocess.run", side_effect=side_effect):
         result = run_interactive_command(("npx", "add-mcp", "uvx yutori-mcp"), timeout=1)
 
-    assert result.returncode == 124
-    assert result.stdout is None
-    assert result.stderr is None
-
-
-def test_run_interactive_command_maps_missing_binary_to_127():
-    with patch(
-        "yutori.cli.commands.install_flow.subprocess.run",
-        side_effect=FileNotFoundError("no such file: 'npx'"),
-    ):
-        result = run_interactive_command(("npx", "add-mcp", "uvx yutori-mcp"))
-
-    assert result.returncode == 127
-
-
-def test_run_interactive_command_maps_oserror_to_127():
-    # Bare OSError covers ENOEXEC, EMFILE, ENOMEM, etc. — fork/exec failures
-    # that aren't FileNotFoundError or PermissionError. They all collapse to
-    # "could not start the child" from the user's perspective.
-    with patch("yutori.cli.commands.install_flow.subprocess.run", side_effect=OSError("ENOMEM")):
-        result = run_interactive_command(("npx", "add-mcp", "uvx yutori-mcp"))
-
-    assert result.returncode == 127
-
-
-def test_run_interactive_command_maps_keyboard_interrupt_to_130():
-    with patch("yutori.cli.commands.install_flow.subprocess.run", side_effect=KeyboardInterrupt()):
-        result = run_interactive_command(("npx", "add-mcp", "uvx yutori-mcp"))
-
-    assert result.returncode == 130
+    assert result.returncode == expected_returncode
+    if expected_returncode == 124:
+        assert result.stdout is None
+        assert result.stderr is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`tests/test_install_flow.py` had four separate tests for `run_interactive_command`'s exception→returncode mapping:

- `test_run_interactive_command_maps_timeout_to_124`
- `test_run_interactive_command_maps_missing_binary_to_127`
- `test_run_interactive_command_maps_oserror_to_127`
- `test_run_interactive_command_maps_keyboard_interrupt_to_130`

Each had an identical body — patch `subprocess.run` with a `side_effect`, call `run_interactive_command`, assert the returncode — differing only in the exception and expected returncode. This is exactly the case-table shape the same file already uses elsewhere (e.g. `test_looks_like_auth_failure_detects_auth_signals` / `..._ignores_non_auth_errors`, both `@pytest.mark.parametrize`).

## Change

Collapsed the four tests into a single `@pytest.mark.parametrize`'d `test_run_interactive_command_maps_exceptions_to_returncode`, keeping the existing explanatory comment about bare `OSError` covering ENOEXEC/EMFILE/ENOMEM. The timeout case's extra `stdout is None` / `stderr is None` assertions are preserved via an `if expected_returncode == 124` branch, so coverage is identical to before.

## Safety

- Pure test refactor — no production code touched, no behavior change.
- Single file diff (`tests/test_install_flow.py`).
- All 4 parametrized cases pass individually and the full suite passes: `545 passed, 3 skipped` locally (1 pre-existing, unrelated failure in `test_packaging.py` due to a missing `build` module in this sandbox — confirmed present on `main` before this change too, via `git stash`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PeSWLi6tkzNij13KKdgCX7)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure test refactor with no production code touched and equivalent assertions preserved.
> 
> **Overview**
> **Test-only refactor** in `tests/test_install_flow.py`: four nearly identical tests for `run_interactive_command` exception→returncode mapping are merged into one `@pytest.mark.parametrize` test (`test_run_interactive_command_maps_exceptions_to_returncode`).
> 
> The parametrized table still covers **124** (timeout), **127** (`FileNotFoundError` and bare `OSError`), and **130** (`KeyboardInterrupt`), with the existing `OSError` comment kept on the `ENOMEM` case. Timeout-specific checks that **`stdout` and `stderr` are `None`** remain via an `if expected_returncode == 124` branch.
> 
> No production code changes; behavior under test is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90c120f89563488486ed3c76f6698ca51009b7b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->