### PR TITLE
refactor(examples): extract _call_llm_and_record() into BrowserAgentMixin

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -577,32 +577,21 @@ class BrowserAgentMixin:
         response = await self._call_llm_with_retries()
         return response.choices[0].message
 
-    @llm_retry
-    async def _call_llm_with_tools(self: SupportsBrowserAgentState, tools: list[dict]) -> ChatCompletion:
-        """Call the model with a fixed ``tools`` list -- the shared body of ``_call_llm_with_retries``.
+    async def _call_llm_and_record(self: SupportsBrowserAgentState, **create_kwargs: Any) -> ChatCompletion:
+        """Call ``chat.completions.create`` and record a sanitized replay step for it.
 
-        ``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py`` each defined a
-        ``_call_llm_with_retries`` that was byte-for-byte identical to this one, differing
-        only in the (fixed, non-trimmed) ``tools`` list passed to the chat completions call.
-        Each now delegates here with its own tool-schema list. ``navigator_n1.py`` and
-        ``navigator_n1_5.py`` additionally trim message history and pass model-specific
-        fields (``tool_set``/``disable_tools``/``json_schema``), so they keep their own
-        ``_call_llm_with_retries`` instead of using this helper.
+        ``create_kwargs`` are passed straight through to the API call and also recorded
+        (pre-sanitization) as the request half of the replay step -- across every caller the
+        two are always identical, so there's no separate "request payload" to build.
+
+        Shared by ``_call_llm_with_tools`` below and the model-specific ``_call_llm_with_retries``
+        implementations in ``navigator_n1.py`` and ``navigator_n1_5.py``, which additionally trim
+        message history and pass their own model-specific fields (``tools``/``tool_set``/
+        ``disable_tools``/``json_schema``) before delegating here.
         """
-        # This copy is only for replay output; the request itself just uses the same fields directly.
-        request_payload = {
-            "model": self.model,
-            "messages": self._messages,
-            "temperature": self.temperature,
-            "tools": tools,
-        }
+        request_payload = dict(create_kwargs)
         response = await asyncio.wait_for(
-            self._client.chat.completions.create(
-                model=self.model,
-                messages=self._messages,
-                temperature=self.temperature,
-                tools=tools,
-            ),
+            self._client.chat.completions.create(**create_kwargs),
             timeout=120.0,  # 2 minutes
         )
         # Replay output records the sanitized raw request/response pair for this step.
@@ -616,6 +605,25 @@ class BrowserAgentMixin:
             )
         )
         return response
+
+    @llm_retry
+    async def _call_llm_with_tools(self: SupportsBrowserAgentState, tools: list[dict]) -> ChatCompletion:
+        """Call the model with a fixed ``tools`` list -- the shared body of ``_call_llm_with_retries``.
+
+        ``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py`` each defined a
+        ``_call_llm_with_retries`` that was byte-for-byte identical to this one, differing
+        only in the (fixed, non-trimmed) ``tools`` list passed to the chat completions call.
+        Each now delegates here with its own tool-schema list. ``navigator_n1.py`` and
+        ``navigator_n1_5.py`` additionally trim message history and pass model-specific
+        fields (``tool_set``/``disable_tools``/``json_schema``), so they keep their own
+        ``_call_llm_with_retries`` instead of using this helper.
+        """
+        return await self._call_llm_and_record(
+            model=self.model,
+            messages=self._messages,
+            temperature=self.temperature,
+            tools=tools,
+        )
 
     async def _dispatch_custom_tool(
         self, action_name: str, arguments: dict[str, Any]

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -35,7 +35,6 @@ from pydantic import BaseModel, Field
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
 from yutori.navigator.loop import update_trimmed_history
-from yutori.navigator.replay import sanitize_step_payload  # Optional replay helpers.
 
 
 class Config(BaseModel):
@@ -105,31 +104,11 @@ class Agent(BrowserAgentMixin):
         if removed:
             logger.info(f"Trimmed {removed} old screenshot(s); payload ~{size_bytes / (1024 * 1024):.2f} MB")
 
-        # This copy is only for replay output; the request itself just uses the same fields directly.
-        request_payload = {
-            "model": self.model,
-            "messages": self._request_messages,
-            "temperature": self.temperature,
-        }
-        response = await asyncio.wait_for(
-            self._client.chat.completions.create(
-                model=self.model,
-                messages=self._request_messages,
-                temperature=self.temperature,
-            ),
-            timeout=120.0,  # 2 minutes
+        return await self._call_llm_and_record(
+            model=self.model,
+            messages=self._request_messages,
+            temperature=self.temperature,
         )
-        # Replay output records the sanitized raw request/response pair for this step.
-        self._step_payloads.append(
-            sanitize_step_payload(
-                {
-                    "step_num": self._step_count,
-                    "request": request_payload,
-                    "response": response.model_dump(exclude_none=True),
-                }
-            )
-        )
-        return response
 
     # _predict() and _execute() are inherited from BrowserAgentMixin (identical across the
     # n1 examples); this script has no custom tools, so it also uses the default

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -74,7 +74,6 @@ from yutori.navigator import (
     map_keys_individual,
 )
 from yutori.navigator.loop import update_trimmed_history
-from yutori.navigator.replay import sanitize_step_payload  # Optional replay helpers.
 from yutori.navigator.tools import (
     EXECUTE_JS_SCRIPT,
     EXTRACT_ELEMENTS_SCRIPT,
@@ -260,37 +259,14 @@ class Agent(BrowserAgentMixin):
         if removed:
             logger.info(f"Trimmed {removed} old screenshot(s); payload ~{size_bytes / (1024 * 1024):.2f} MB")
 
-        # This copy is only for replay output; the request itself just uses the same fields directly.
-        request_payload = {
-            "model": self.model,
-            "messages": self._request_messages,
-            "temperature": self.temperature,
-            "tool_set": self.tool_set,
-            "disable_tools": self.disable_tools or None,
-            "json_schema": self.json_schema,
-        }
-        response = await asyncio.wait_for(
-            self._client.chat.completions.create(
-                model=self.model,
-                messages=self._request_messages,
-                temperature=self.temperature,
-                tool_set=self.tool_set,
-                disable_tools=self.disable_tools or None,
-                json_schema=self.json_schema,
-            ),
-            timeout=120.0,  # 2 minutes
+        return await self._call_llm_and_record(
+            model=self.model,
+            messages=self._request_messages,
+            temperature=self.temperature,
+            tool_set=self.tool_set,
+            disable_tools=self.disable_tools or None,
+            json_schema=self.json_schema,
         )
-        # Replay output records the sanitized raw request/response pair for this step.
-        self._step_payloads.append(
-            sanitize_step_payload(
-                {
-                    "step_num": self._step_count,
-                    "request": request_payload,
-                    "response": response.model_dump(exclude_none=True),
-                }
-            )
-        )
-        return response
 
     async def _predict(self) -> ChatCompletion:
         screenshot_url = await self._take_screenshot()


### PR DESCRIPTION
## Issue

The `wait_for(chat.completions.create(...))` + `sanitize_step_payload()` + `_step_payloads.append()` tail was byte-for-byte duplicated in three places:

- `examples/_common.py`'s `BrowserAgentMixin._call_llm_with_tools`
- `examples/navigator_n1.py`'s `Agent._call_llm_with_retries`
- `examples/navigator_n1_5.py`'s `Agent._call_llm_with_retries`

Each site also separately re-built its own `create_kwargs` into a `request_payload` dict purely for the replay record, even though (in every caller) the two dicts are always identical — the replay record simply mirrors the kwargs passed to `chat.completions.create`.

## Improvement

Extracted the shared tail into a new `BrowserAgentMixin._call_llm_and_record(self, **create_kwargs)` helper that:
1. Builds the replay `request_payload` directly from `create_kwargs` (no separate copy to keep in sync),
2. Calls `self._client.chat.completions.create(**create_kwargs)` under the same 120s `asyncio.wait_for` timeout,
3. Appends the sanitized step payload to `self._step_payloads`,
4. Returns the response.

Each of the three call sites now just forwards its own model-specific fields (`tools` for the plain n1 mixin path, `tool_set`/`disable_tools`/`json_schema` for n1.5) and delegates. Dropped now-unused `sanitize_step_payload` imports in `navigator_n1.py` and `navigator_n1_5.py` (only `_common.py` calls it now). Net: -37 lines across 3 files, no new files.

## Safety

- Pure structural extraction — no behavior change. `create_kwargs` are forwarded to `chat.completions.create` exactly as before, and the recorded `request_payload` dict has exactly the same shape/keys as before at each call site.
- `tests/test_call_llm_with_tools_mixin.py` pins the exact request-building/replay-recording contract for `_call_llm_with_tools` (asserts the `create()` call args and the recorded `request`/`response`/`step_num` payload) and passes unmodified.
- Full test suite: `546 passed, 3 skipped` locally.
- `ruff check .` clean; `ruff format --check` on the touched hunks is clean (the one pre-existing formatting drift in `navigator_n1_5.py` predates this change and is unrelated — confirmed via `git stash`).

Out of scope: the known too-large `_sync`/`_async` namespace unification (already logged elsewhere as needing a deliberate design decision, not attempted here).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BrhohMfGuUVCUfMkiigpct)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural deduplication in example agents only; API kwargs and replay shape stay the same, with existing mixin tests covering the contract.
> 
> **Overview**
> Pulls the repeated **chat completions call + replay step recording** (120s timeout, `sanitize_step_payload`, append to `_step_payloads`) into a new **`BrowserAgentMixin._call_llm_and_record(**create_kwargs)`**, using the same kwargs for the API request and the replay `request` payload.
> 
> **`_call_llm_with_tools`** in `_common.py` and **`_call_llm_with_retries`** in `navigator_n1.py` / `navigator_n1_5.py` now only supply model-specific fields (e.g. trimmed `messages`, `tools`, or n1.5 `tool_set` / `disable_tools` / `json_schema`) and delegate. Unused **`sanitize_step_payload`** imports are removed from the navigator example scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 510b1f581d9ce2ae33b7abd491fe9eaf677c426c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->