### PR TITLE
refactor(examples): extract _init_common_agent_config() into BrowserAgentMixin

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -359,7 +359,12 @@ class BrowserAgentMixin:
     bookkeeping that was also duplicated verbatim across all four scripts
     (browser handles, the ``PageReadyChecker``, and per-run message/replay
     setup); every ``Agent.__init__``/``run()`` still has its own model- and
-    tool-specific setup around these calls.
+    tool-specific setup around these calls. ``_init_common_agent_config``
+    additionally covers the shared constructor-kwarg assignment (plus the
+    ``_init_agent_state`` call) that ``navigator_n1.py``, ``navigator_n1_custom_tools.py``,
+    and ``navigator_n1_memo.py`` all build from the same nine kwargs;
+    ``navigator_n1_5.py`` interleaves several more model-specific kwargs among
+    those same nine and keeps its own inline assignment.
 
     ``_run_with_browser_lifecycle`` covers the entire ``run()`` body -- opening
     the client/browser, navigating, running :meth:`_run_agent_loop`, and
@@ -373,6 +378,40 @@ class BrowserAgentMixin:
     instead of ``_execute`` itself; ``navigator_n1.py`` has no custom tools and uses the
     default. ``navigator_n1_5.py`` keeps its own differently-shaped ``_execute``.
     """
+
+    def _init_common_agent_config(
+        self: SupportsBrowserAgentState,
+        *,
+        base_url: str,
+        model: str,
+        temperature: float,
+        max_steps: int,
+        viewport_width: int,
+        viewport_height: int,
+        headless: bool,
+        replay_dir: str | None,
+        replay_id: str | None,
+    ) -> None:
+        """Assign the constructor kwargs shared by every example ``Agent.__init__`` and init agent state.
+
+        ``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py`` had byte-for-byte
+        identical ``__init__`` bodies built from exactly these nine kwargs plus a call to
+        :meth:`_init_agent_state` -- only their trailing custom-tool setup line differed.
+        ``navigator_n1.py`` sets the same nine kwargs (plus its own payload-trim fields set
+        separately around this call); ``navigator_n1_5.py`` interleaves several more
+        model-specific kwargs among these same nine and keeps its own inline assignment.
+        """
+        self.base_url = base_url
+        self.model = model
+        self.temperature = temperature
+        self.max_steps = max_steps
+        self.viewport_width = viewport_width
+        self.viewport_height = viewport_height
+        self.headless = headless
+        self.replay_dir = replay_dir
+        self.replay_id = replay_id
+
+        self._init_agent_state()
 
     def _init_agent_state(self: SupportsBrowserAgentState) -> None:
         """Initialize the browser/replay/message bookkeeping shared by every example ``Agent.__init__``.

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -75,19 +75,19 @@ class Agent(BrowserAgentMixin):
         replay_dir: str | None = None,
         replay_id: str | None = None,
     ):
-        self.base_url = base_url
-        self.model = model
-        self.temperature = temperature
-        self.max_steps = max_steps
-        self.viewport_width = viewport_width
-        self.viewport_height = viewport_height
-        self.headless = headless
+        self._init_common_agent_config(
+            base_url=base_url,
+            model=model,
+            temperature=temperature,
+            max_steps=max_steps,
+            viewport_width=viewport_width,
+            viewport_height=viewport_height,
+            headless=headless,
+            replay_dir=replay_dir,
+            replay_id=replay_id,
+        )
         self.max_request_bytes = max_request_bytes
         self.keep_recent_screenshots = keep_recent_screenshots
-        self.replay_dir = replay_dir
-        self.replay_id = replay_id
-
-        self._init_agent_state()
         self._request_messages: list | None = None
 
     async def run(self, task: str, start_url: str) -> str:

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -137,17 +137,17 @@ class Agent(BrowserAgentMixin):
         replay_dir: str | None = None,
         replay_id: str | None = None,
     ):
-        self.base_url = base_url
-        self.model = model
-        self.temperature = temperature
-        self.max_steps = max_steps
-        self.viewport_width = viewport_width
-        self.viewport_height = viewport_height
-        self.headless = headless
-        self.replay_dir = replay_dir
-        self.replay_id = replay_id
-
-        self._init_agent_state()
+        self._init_common_agent_config(
+            base_url=base_url,
+            model=model,
+            temperature=temperature,
+            max_steps=max_steps,
+            viewport_width=viewport_width,
+            viewport_height=viewport_height,
+            headless=headless,
+            replay_dir=replay_dir,
+            replay_id=replay_id,
+        )
 
         # Custom tools
         self._extract_content_and_links_tool = ExtractContentAndLinksTool()

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -184,17 +184,17 @@ class Agent(BrowserAgentMixin):
         replay_dir: str | None = None,
         replay_id: str | None = None,
     ):
-        self.base_url = base_url
-        self.model = model
-        self.temperature = temperature
-        self.max_steps = max_steps
-        self.viewport_width = viewport_width
-        self.viewport_height = viewport_height
-        self.headless = headless
-        self.replay_dir = replay_dir
-        self.replay_id = replay_id
-
-        self._init_agent_state()
+        self._init_common_agent_config(
+            base_url=base_url,
+            model=model,
+            temperature=temperature,
+            max_steps=max_steps,
+            viewport_width=viewport_width,
+            viewport_height=viewport_height,
+            headless=headless,
+            replay_dir=replay_dir,
+            replay_id=replay_id,
+        )
 
         # Custom memo tool suite
         self._memo_tool_suite = MemoToolSuite()

--- a/tests/test_init_common_agent_config.py
+++ b/tests/test_init_common_agent_config.py
@@ -1,0 +1,97 @@
+"""Characterization tests for ``examples._common.BrowserAgentMixin._init_common_agent_config``.
+
+Pins the exact constructor-kwarg-assignment behavior before/after extracting it out of
+``navigator_n1.py``, ``navigator_n1_custom_tools.py``, and ``navigator_n1_memo.py``.
+``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py`` previously had byte-for-byte
+identical ``__init__`` bodies built from exactly these nine kwargs (differing only in their
+trailing custom-tool setup line); ``navigator_n1.py`` set the same nine kwargs with its own
+payload-trim fields interleaved. ``navigator_n1_5.py`` interleaves several more model-specific
+kwargs among these same nine and keeps its own inline assignment, so it is out of scope here.
+"""
+
+from __future__ import annotations
+
+from .conftest import require_examples_extra
+
+require_examples_extra()
+from examples._common import BrowserAgentMixin  # noqa: E402
+from yutori.navigator.page_ready import PageReadyChecker  # noqa: E402
+
+
+def _make_agent() -> BrowserAgentMixin:
+    return BrowserAgentMixin()
+
+
+def test_init_common_agent_config_assigns_all_kwargs() -> None:
+    agent = _make_agent()
+
+    agent._init_common_agent_config(
+        base_url="https://api.example.com/v1",
+        model="some-model",
+        temperature=0.7,
+        max_steps=42,
+        viewport_width=1024,
+        viewport_height=768,
+        headless=True,
+        replay_dir="/tmp/replays",
+        replay_id="fixed-run-id",
+    )
+
+    assert agent.base_url == "https://api.example.com/v1"
+    assert agent.model == "some-model"
+    assert agent.temperature == 0.7
+    assert agent.max_steps == 42
+    assert agent.viewport_width == 1024
+    assert agent.viewport_height == 768
+    assert agent.headless is True
+    assert agent.replay_dir == "/tmp/replays"
+    assert agent.replay_id == "fixed-run-id"
+
+
+def test_init_common_agent_config_also_initializes_agent_state() -> None:
+    agent = _make_agent()
+
+    agent._init_common_agent_config(
+        base_url="https://api.example.com/v1",
+        model="some-model",
+        temperature=0.3,
+        max_steps=100,
+        viewport_width=1280,
+        viewport_height=800,
+        headless=False,
+        replay_dir=None,
+        replay_id=None,
+    )
+
+    assert agent._client is None
+    assert agent._browser is None
+    assert agent._page is None
+    assert isinstance(agent._page_ready_checker, PageReadyChecker)
+    assert agent._replay is None
+    assert agent._messages == []
+    assert agent._step_payloads == []
+    assert agent._step_count == 0
+
+
+def test_init_common_agent_config_returns_fresh_mutable_containers() -> None:
+    """Two agents must not share the same list objects (matches ``_init_agent_state``)."""
+    agent_one = _make_agent()
+    agent_two = _make_agent()
+
+    kwargs = dict(
+        base_url="https://api.example.com/v1",
+        model="some-model",
+        temperature=0.3,
+        max_steps=100,
+        viewport_width=1280,
+        viewport_height=800,
+        headless=False,
+        replay_dir=None,
+        replay_id=None,
+    )
+    agent_one._init_common_agent_config(**kwargs)
+    agent_two._init_common_agent_config(**kwargs)
+
+    agent_one._messages.append({"role": "user", "content": []})
+
+    assert agent_two._messages == []


### PR DESCRIPTION
## Issue

`navigator_n1_custom_tools.py` and `navigator_n1_memo.py` had byte-for-byte identical `Agent.__init__` bodies: the same nine constructor-kwarg assignments (`base_url`, `model`, `temperature`, `max_steps`, `viewport_width`, `viewport_height`, `headless`, `replay_dir`, `replay_id`) followed by a call to `self._init_agent_state()`, differing only in their trailing custom-tool setup line (`self._extract_content_and_links_tool = ...` vs. `self._memo_tool_suite = ...`). Confirmed via a byte-level diff of the extracted blocks before touching anything.

`navigator_n1.py` builds from the same nine kwargs too, with its own payload-trim fields (`max_request_bytes`, `keep_recent_screenshots`) set independently around them — since none of these assignments have order dependencies, it was safe to fold in as well.

This is a new pattern that emerged after the last few rounds of `BrowserAgentMixin` extractions (PRs #186-191) pulled the rest of the `run()`/`_execute()`/`_predict()` bodies out of these same three scripts, leaving this `__init__` duplication as the next-most-obvious remaining boilerplate.

## Fix

Extracted `_init_common_agent_config(self, *, base_url, model, temperature, max_steps, viewport_width, viewport_height, headless, replay_dir, replay_id)` onto `BrowserAgentMixin` in `examples/_common.py`. All three scripts now call this helper instead of repeating the assignment block; `navigator_n1.py` sets its two extra payload-trim fields around the call.

`navigator_n1_5.py` interleaves several more model-specific kwargs (`tool_set`, `disable_tools`, `json_schema`, `user_timezone`, `user_location`) among these same nine and is intentionally left with its own inline assignment — consistent with the existing precedent elsewhere in this mixin (it already keeps its own `_predict`/`_execute`/`run()` for the same reason).

## Why this is safe

- No behavior change: the same attributes are set to the same values, in an order with no inter-dependencies, and `_init_agent_state()` is still called exactly once per `__init__`.
- Added `tests/test_init_common_agent_config.py` — no prior test exercised this `__init__` logic directly (per this repo's convention of adding characterization tests before refactoring previously-untested code paths). It pins that all nine kwargs are assigned correctly, that `_init_agent_state()` still runs, and that two agent instances don't share mutable containers.
- Full test suite green: 549 passed, 3 skipped (up from 546 passed, 3 skipped before this change).
- `ruff check` / `ruff format --check` clean on all 5 touched files (pre-existing formatting drift exists elsewhere in the repo, unrelated to this change).
- Manually imported and instantiated all three `Agent` classes post-refactor and confirmed identical attribute values to before.

5 files touched: `examples/_common.py`, `examples/navigator_n1.py`, `examples/navigator_n1_custom_tools.py`, `examples/navigator_n1_memo.py`, `tests/test_init_common_agent_config.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUqs7xYGuXJ8ExW7Bbwrfv

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUqs7xYGuXJ8ExW7Bbwrfv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only refactor with no intended behavior change; coverage added for the extracted init path.
> 
> **Overview**
> Adds **`BrowserAgentMixin._init_common_agent_config`** in `examples/_common.py` to assign the nine shared constructor kwargs and call **`_init_agent_state`**, replacing duplicated assignment blocks in **`navigator_n1.py`**, **`navigator_n1_custom_tools.py`**, and **`navigator_n1_memo.py`**.
> 
> **`navigator_n1.py`** still sets payload-trim fields and **`_request_messages`** after the helper; the custom-tools and memo examples only keep their tool-specific setup afterward. **`navigator_n1_5.py`** is unchanged (extra model kwargs stay inline).
> 
> New **`tests/test_init_common_agent_config.py`** characterization tests pin kwarg assignment, agent-state init, and per-instance mutable lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ad9437e60b85c14fa265cf19a4574d292f570e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->