### PR TITLE
refactor(examples): extract shared _call_llm() request/replay body into BrowserAgentMixin

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -616,32 +616,31 @@ class BrowserAgentMixin:
         response = await self._call_llm_with_retries()
         return response.choices[0].message
 
-    @llm_retry
-    async def _call_llm_with_tools(self: SupportsBrowserAgentState, tools: list[dict]) -> ChatCompletion:
-        """Call the model with a fixed ``tools`` list -- the shared body of ``_call_llm_with_retries``.
+    async def _call_llm(
+        self: SupportsBrowserAgentState,
+        messages: list,
+        *,
+        extra_fields: dict[str, Any] | None = None,
+    ) -> ChatCompletion:
+        """Call the model with ``messages`` and record a sanitized request/response pair for replay.
 
-        ``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py`` each defined a
-        ``_call_llm_with_retries`` that was byte-for-byte identical to this one, differing
-        only in the (fixed, non-trimmed) ``tools`` list passed to the chat completions call.
-        Each now delegates here with its own tool-schema list. ``navigator_n1.py`` and
-        ``navigator_n1_5.py`` additionally trim message history and pass model-specific
-        fields (``tool_set``/``disable_tools``/``json_schema``), so they keep their own
-        ``_call_llm_with_retries`` instead of using this helper.
+        Shared by :meth:`_call_llm_with_tools` (fixed ``tools`` list, untrimmed
+        ``self._messages``) and the trimmed-history ``_call_llm_with_retries`` overrides in
+        ``navigator_n1.py`` and ``navigator_n1_5.py`` (which pass ``self._request_messages``
+        plus their own model-specific ``extra_fields``, e.g. ``tool_set``/``disable_tools``/
+        ``json_schema``). All three previously built this same request-payload-dict /
+        timeout-guarded-create / sanitized-step-payload body independently; ``extra_fields``
+        is merged into the payload dict, which then doubles as the ``create()`` kwargs, so the
+        logged request and the actual call can no longer drift apart.
         """
-        # This copy is only for replay output; the request itself just uses the same fields directly.
         request_payload = {
             "model": self.model,
-            "messages": self._messages,
+            "messages": messages,
             "temperature": self.temperature,
-            "tools": tools,
+            **(extra_fields or {}),
         }
         response = await asyncio.wait_for(
-            self._client.chat.completions.create(
-                model=self.model,
-                messages=self._messages,
-                temperature=self.temperature,
-                tools=tools,
-            ),
+            self._client.chat.completions.create(**request_payload),
             timeout=120.0,  # 2 minutes
         )
         # Replay output records the sanitized raw request/response pair for this step.
@@ -655,6 +654,20 @@ class BrowserAgentMixin:
             )
         )
         return response
+
+    @llm_retry
+    async def _call_llm_with_tools(self: SupportsBrowserAgentState, tools: list[dict]) -> ChatCompletion:
+        """Call the model with a fixed ``tools`` list -- the shared body of ``_call_llm_with_retries``.
+
+        ``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py`` each defined a
+        ``_call_llm_with_retries`` that was byte-for-byte identical to this one, differing
+        only in the (fixed, non-trimmed) ``tools`` list passed to the chat completions call.
+        Each now delegates here with its own tool-schema list. ``navigator_n1.py`` and
+        ``navigator_n1_5.py`` additionally trim message history and pass model-specific
+        fields (``tool_set``/``disable_tools``/``json_schema``), so they keep their own
+        ``_call_llm_with_retries`` instead of using this helper.
+        """
+        return await self._call_llm(self._messages, extra_fields={"tools": tools})
 
     async def _dispatch_custom_tool(
         self, action_name: str, arguments: dict[str, Any]

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -35,7 +35,6 @@ from pydantic import BaseModel, Field
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
 from yutori.navigator.loop import update_trimmed_history
-from yutori.navigator.replay import sanitize_step_payload  # Optional replay helpers.
 
 
 class Config(BaseModel):
@@ -105,31 +104,7 @@ class Agent(BrowserAgentMixin):
         if removed:
             logger.info(f"Trimmed {removed} old screenshot(s); payload ~{size_bytes / (1024 * 1024):.2f} MB")
 
-        # This copy is only for replay output; the request itself just uses the same fields directly.
-        request_payload = {
-            "model": self.model,
-            "messages": self._request_messages,
-            "temperature": self.temperature,
-        }
-        response = await asyncio.wait_for(
-            self._client.chat.completions.create(
-                model=self.model,
-                messages=self._request_messages,
-                temperature=self.temperature,
-            ),
-            timeout=120.0,  # 2 minutes
-        )
-        # Replay output records the sanitized raw request/response pair for this step.
-        self._step_payloads.append(
-            sanitize_step_payload(
-                {
-                    "step_num": self._step_count,
-                    "request": request_payload,
-                    "response": response.model_dump(exclude_none=True),
-                }
-            )
-        )
-        return response
+        return await self._call_llm(self._request_messages)
 
     # _predict() and _execute() are inherited from BrowserAgentMixin (identical across the
     # n1 examples); this script has no custom tools, so it also uses the default

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -74,7 +74,6 @@ from yutori.navigator import (
     map_keys_individual,
 )
 from yutori.navigator.loop import update_trimmed_history
-from yutori.navigator.replay import sanitize_step_payload  # Optional replay helpers.
 from yutori.navigator.tools import (
     EXECUTE_JS_SCRIPT,
     EXTRACT_ELEMENTS_SCRIPT,
@@ -260,37 +259,14 @@ class Agent(BrowserAgentMixin):
         if removed:
             logger.info(f"Trimmed {removed} old screenshot(s); payload ~{size_bytes / (1024 * 1024):.2f} MB")
 
-        # This copy is only for replay output; the request itself just uses the same fields directly.
-        request_payload = {
-            "model": self.model,
-            "messages": self._request_messages,
-            "temperature": self.temperature,
-            "tool_set": self.tool_set,
-            "disable_tools": self.disable_tools or None,
-            "json_schema": self.json_schema,
-        }
-        response = await asyncio.wait_for(
-            self._client.chat.completions.create(
-                model=self.model,
-                messages=self._request_messages,
-                temperature=self.temperature,
-                tool_set=self.tool_set,
-                disable_tools=self.disable_tools or None,
-                json_schema=self.json_schema,
-            ),
-            timeout=120.0,  # 2 minutes
+        return await self._call_llm(
+            self._request_messages,
+            extra_fields={
+                "tool_set": self.tool_set,
+                "disable_tools": self.disable_tools or None,
+                "json_schema": self.json_schema,
+            },
         )
-        # Replay output records the sanitized raw request/response pair for this step.
-        self._step_payloads.append(
-            sanitize_step_payload(
-                {
-                    "step_num": self._step_count,
-                    "request": request_payload,
-                    "response": response.model_dump(exclude_none=True),
-                }
-            )
-        )
-        return response
 
     async def _predict(self) -> ChatCompletion:
         screenshot_url = await self._take_screenshot()

--- a/tests/test_call_llm_mixin.py
+++ b/tests/test_call_llm_mixin.py
@@ -1,0 +1,89 @@
+"""Characterization tests for ``examples._common.BrowserAgentMixin._call_llm``.
+
+Pins the exact request-building / replay-step-recording behavior of this helper, extracted
+out of ``_call_llm_with_tools`` (fixed ``tools`` list) and the trimmed-history
+``_call_llm_with_retries`` overrides in ``navigator_n1.py`` (no extra fields) and
+``navigator_n1_5.py`` (``tool_set``/``disable_tools``/``json_schema``), which each previously
+built this same request-payload-dict / timeout-guarded-create / sanitized-step-payload body
+independently.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from .conftest import require_examples_extra
+
+require_examples_extra()
+from examples._common import BrowserAgentMixin  # noqa: E402
+
+
+def _make_agent() -> BrowserAgentMixin:
+    agent = BrowserAgentMixin()
+    agent.model = "n1-latest"
+    agent.temperature = 0.3
+    agent._step_count = 3
+    agent._step_payloads = []
+
+    response = MagicMock()
+    response.model_dump.return_value = {"role": "assistant", "content": "done"}
+    agent._client = MagicMock()
+    agent._client.chat.completions.create = AsyncMock(return_value=response)
+    return agent
+
+
+async def test_call_llm_without_extra_fields_passes_only_base_fields() -> None:
+    agent = _make_agent()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+
+    response = await agent._call_llm(messages)
+
+    agent._client.chat.completions.create.assert_awaited_once_with(
+        model="n1-latest",
+        messages=messages,
+        temperature=0.3,
+    )
+    assert response is agent._client.chat.completions.create.return_value
+
+
+async def test_call_llm_merges_extra_fields_into_the_call() -> None:
+    agent = _make_agent()
+    messages = [{"role": "user", "content": []}]
+
+    await agent._call_llm(messages, extra_fields={"tool_set": "n1_5", "disable_tools": None})
+
+    agent._client.chat.completions.create.assert_awaited_once_with(
+        model="n1-latest",
+        messages=messages,
+        temperature=0.3,
+        tool_set="n1_5",
+        disable_tools=None,
+    )
+
+
+async def test_call_llm_records_sanitized_step_payload_matching_the_actual_call() -> None:
+    agent = _make_agent()
+    messages = [{"role": "user", "content": []}]
+
+    await agent._call_llm(messages, extra_fields={"tools": [{"type": "function"}]})
+
+    assert len(agent._step_payloads) == 1
+    payload = agent._step_payloads[0]
+    assert payload["step_num"] == 3
+    assert payload["request"] == {
+        "model": "n1-latest",
+        "messages": messages,
+        "temperature": 0.3,
+        "tools": [{"type": "function"}],
+    }
+    assert payload["response"] == {"role": "assistant", "content": "done"}
+
+
+async def test_call_llm_appends_without_clearing_prior_payloads() -> None:
+    agent = _make_agent()
+    agent._step_payloads = [{"step_num": 1}]
+
+    await agent._call_llm([{"role": "user", "content": []}])
+
+    assert len(agent._step_payloads) == 2
+    assert agent._step_payloads[0] == {"step_num": 1}


### PR DESCRIPTION
## Issue

`BrowserAgentMixin._call_llm_with_tools()` (in `examples/_common.py`), `navigator_n1.py`'s `Agent._call_llm_with_retries()`, and `navigator_n1_5.py`'s `Agent._call_llm_with_retries()` each independently built the same shape of code:

1. Build a `request_payload` dict (`model`/`messages`/`temperature` plus a few extra fields).
2. `await asyncio.wait_for(self._client.chat.completions.create(...), timeout=120.0)`, passing those same fields as kwargs a second time.
3. Append a `sanitize_step_payload(...)` entry to `self._step_payloads` for replay, built from the same `request_payload`.

They differed only in which `messages` list they passed (`self._messages` vs. the trimmed `self._request_messages`) and which extra kwargs went along (`tools=...` / `tool_set`+`disable_tools`+`json_schema` / none). Because the request-payload dict and the actual `create()` call were two independently-maintained literals, they could in principle drift apart (the dict is what replay logs as "what was sent").

## Fix

Extracted the shared body into `BrowserAgentMixin._call_llm(messages, *, extra_fields=None)`:

- `request_payload` is built once from `model`/`messages`/`temperature` plus `**(extra_fields or {})`.
- The actual call is now `self._client.chat.completions.create(**request_payload)`, so the logged request and the real call are guaranteed to match (single source of truth) instead of being kept in sync by hand.
- The sanitized step-payload recording is unchanged.

All three call sites now delegate:
- `_call_llm_with_tools(tools)` → `self._call_llm(self._messages, extra_fields={"tools": tools})`
- `navigator_n1.py` → `self._call_llm(self._request_messages)`
- `navigator_n1_5.py` → `self._call_llm(self._request_messages, extra_fields={"tool_set": ..., "disable_tools": ..., "json_schema": ...})`

Dropped the now-unused `sanitize_step_payload` imports from `navigator_n1.py` and `navigator_n1_5.py` (still used, and now only needed, inside `_common.py`).

## Safety verification

- No behavior change: the same kwargs reach `chat.completions.create()` in the same three cases, and the same sanitized step-payload shape is recorded (verified by the new characterization tests, which pin the exact call args and payload shape).
- Added `tests/test_call_llm_mixin.py` covering `_call_llm` directly (no extra fields, merged extra fields, sanitized-step-payload shape, append-without-clearing) — matches this repo's existing convention (see `tests/test_call_llm_with_tools_mixin.py`) of characterization tests against the mixin rather than the example scripts (which use bare `from _common import ...` and aren't importable as a package in tests).
- Full suite: **553 passed, 3 skipped** (up from 549/3 on `main`), no failures.
- `ruff check .`: all checks pass repo-wide.
- `ruff format --check` on touched files: clean, except `examples/navigator_n1_5.py`, which has pre-existing formatting debt in *unrelated* regions of the file (confirmed via `git stash` that this same "would reformat" result exists on `main` before this change, and the diff hunks don't overlap the lines this PR touches).

Scope: 3 source files + 1 new test file, all within `examples/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_015HsRjN7mhNSJE3LiVhR39K)_