### PR TITLE
Extract shared BaseAgentConfig for n1 example scripts

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -13,15 +13,47 @@ from loguru import logger
 from openai import APIConnectionError, APITimeoutError, InternalServerError, RateLimitError
 from openai.types.chat import ChatCompletion
 from playwright.async_api import async_playwright
+from pydantic import BaseModel, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from yutori import AsyncYutoriClient
-from yutori.navigator import aplaywright_screenshot_to_data_url, denormalize_coordinates
+from yutori.config import DEFAULT_BASE_URL
+from yutori.navigator import NAVIGATOR_N1_MODEL, aplaywright_screenshot_to_data_url, denormalize_coordinates
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload
 from yutori.navigator.replay import _clip_image_url as _clip_image_url_impl
 
 RETRYABLE_EXCEPTIONS = (APIConnectionError, APITimeoutError, RateLimitError, InternalServerError)
+
+
+class BaseAgentConfig(BaseModel):
+    """Shared task/model/agent/browser/replay fields for the n1 example scripts' ``Config``.
+
+    ``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py`` previously each defined a
+    byte-for-byte identical ``Config`` with exactly these nine fields (differing only in their
+    ``task``/``start_url`` defaults, which subclasses override). ``navigator_n1.py`` subclasses
+    this and adds two payload-trim fields. ``navigator_n1_5.py`` interleaves several more
+    model-specific fields among a differently-ordered version of this same set, so it keeps its
+    own standalone ``Config`` instead of subclassing.
+    """
+
+    # task
+    task: str = Field(default="List the team member names")
+    start_url: str = "https://www.yutori.com"
+    # model
+    base_url: str = DEFAULT_BASE_URL
+    model: str = NAVIGATOR_N1_MODEL
+    temperature: float = 0.3
+    # agent
+    max_steps: int = 100
+    # browser
+    viewport_width: int = 1280
+    viewport_height: int = 800
+    headless: bool = False
+    # optional local replay artifacts
+    replay_dir: str | None = None
+    replay_id: str | None = None
+
 
 llm_retry = retry(
     retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -24,39 +24,23 @@ Usage:
 import asyncio
 
 from _common import (
+    BaseAgentConfig,
     BrowserAgentMixin,
     llm_retry,
     run_example_main,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
-from pydantic import BaseModel, Field
 
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
 from yutori.navigator.loop import update_trimmed_history
 
 
-class Config(BaseModel):
-    # task
-    task: str = Field(default="List the team member names")
-    start_url: str = "https://www.yutori.com"
-    # model
-    base_url: str = DEFAULT_BASE_URL
-    model: str = NAVIGATOR_N1_MODEL
-    temperature: float = 0.3
-    # agent
-    max_steps: int = 100
-    # browser
-    viewport_width: int = 1280
-    viewport_height: int = 800
-    headless: bool = False
+class Config(BaseAgentConfig):
     # payload management
     max_request_bytes: int = 9_500_000
     keep_recent_screenshots: int = 6
-    # optional local replay artifacts
-    replay_dir: str | None = None
-    replay_id: str | None = None
 
 
 class Agent(BrowserAgentMixin):

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -27,34 +27,21 @@ from functools import cached_property
 from typing import Any
 
 from _common import (
+    BaseAgentConfig,
     BrowserAgentMixin,
     run_example_main,
 )
 from openai.types.chat import ChatCompletion
 from playwright.async_api import Page
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
 
 
-class Config(BaseModel):
-    # task
+class Config(BaseAgentConfig):
     task: str = Field(default="Get the titles and links of all the blog posts")
     start_url: str = "https://www.yutori.com"
-    # model
-    base_url: str = DEFAULT_BASE_URL
-    model: str = NAVIGATOR_N1_MODEL
-    temperature: float = 0.3
-    # agent
-    max_steps: int = 100
-    # browser
-    viewport_width: int = 1280
-    viewport_height: int = 800
-    headless: bool = False
-    # optional local replay artifacts
-    replay_dir: str | None = None
-    replay_id: str | None = None
 
 
 class ExtractContentAndLinksTool:

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -32,36 +32,23 @@ from functools import cached_property
 from typing import Any
 
 from _common import (
+    BaseAgentConfig,
     BrowserAgentMixin,
     run_example_main,
 )
 from loguru import logger
 from openai.types.chat import ChatCompletion
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
 
 
-class Config(BaseModel):
-    # task
+class Config(BaseAgentConfig):
     task: str = Field(
         default="Take the quiz and record every question, description, and all the options along the way",
     )
     start_url: str = "https://www.triviaplaza.com/three-letter-computer-terms-quiz/"
-    # model
-    base_url: str = DEFAULT_BASE_URL
-    model: str = NAVIGATOR_N1_MODEL
-    temperature: float = 0.3
-    # agent
-    max_steps: int = 100
-    # browser
-    viewport_width: int = 1280
-    viewport_height: int = 800
-    headless: bool = False
-    # optional local replay artifacts
-    replay_dir: str | None = None
-    replay_id: str | None = None
 
 
 class MemoToolSuite:


### PR DESCRIPTION
## What

`examples/navigator_n1_custom_tools.py` and `examples/navigator_n1_memo.py` each defined a byte-for-byte identical `Config(BaseModel)` class with the same nine task/model/agent/browser/replay fields (differing only in their `task`/`start_url` defaults). `examples/navigator_n1.py` duplicated the same nine fields plus two payload-trim fields.

Extracted the shared fields into a new `BaseAgentConfig` in `examples/_common.py`. All three scripts' `Config` classes now subclass it and declare only their own field overrides. `examples/navigator_n1_5.py` is left untouched — its fields are interleaved differently among model-specific options, so subclassing wouldn't be a clean fit.

## Why it's safe

- Pure structural consolidation — field values/defaults are unchanged, only their declaration location moves.
- Touches 4 files, under the 5-file cap.
- Verified locally: `Config()` defaults are identical before/after for all three scripts, and `Config.model_validate(vars(args))` round-trips through `build_agent_arg_parser` produce identical results (checked via `==` against the default instances).
- `ruff check` / `ruff format --check` pass on all changed files.

## Test plan

- [x] `ruff check` / `ruff format --check` pass
- [x] Manually verified `Config()` defaults and the argparse round-trip are unchanged for `navigator_n1.py`, `navigator_n1_custom_tools.py`, and `navigator_n1_memo.py`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmaCEXWafSguqE7vYDFD7q

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmaCEXWafSguqE7vYDFD7q)_