### PR TITLE
refactor(tests): extract make_trimmable_messages() fixture for payload-trim tests

### DIFF
--- a/tests/_client_fixtures.py
+++ b/tests/_client_fixtures.py
@@ -85,6 +85,33 @@ def make_mock_usage_response(period: str = "24h") -> MagicMock:
     return make_json_response(data)
 
 
+def make_trimmable_messages() -> list[dict[str, Any]]:
+    """Build a fresh two-message list with an oversized ``image_url`` block in each message.
+
+    Used by the payload-trimming tests in the sync/async client suites (``create_trimmed``/
+    ``acreate_trimmed`` and the standalone ``trimmed_messages_to_fit`` pattern), which each need
+    a messages list big enough that trimming with ``max_bytes=100`` actually removes an image.
+    Returns a new list on every call so callers can safely mutate or ``deepcopy`` the result
+    without affecting other tests.
+    """
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Check the page"},
+                {"type": "image_url", "image_url": {"url": "A" * 5000}},
+            ],
+        },
+        {
+            "role": "tool",
+            "content": [
+                {"type": "text", "text": "Tool output"},
+                {"type": "image_url", "image_url": {"url": "A" * 5000}},
+            ],
+        },
+    ]
+
+
 def make_mock_chat_completion(
     *, content: str = "click", model: str = "n1-latest", completion_id: str = "chatcmpl-123"
 ) -> ChatCompletion:

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -12,6 +12,7 @@ from ._client_fixtures import (
     make_mock_chat_completion,
     make_mock_usage_response,
     make_status_response,
+    make_trimmable_messages,
     mocked_async_openai_client,
 )
 
@@ -385,22 +386,7 @@ class TestAsyncChatNamespace:
         from yutori.navigator.payload import trimmed_messages_to_fit
 
         mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
-        original_messages = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "Check the page"},
-                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
-                ],
-            },
-            {
-                "role": "tool",
-                "content": [
-                    {"type": "text", "text": "Tool output"},
-                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
-                ],
-            },
-        ]
+        original_messages = make_trimmable_messages()
         original_snapshot = deepcopy(original_messages)
 
         with mocked_async_openai_client(mock_completion) as mock_openai_client:
@@ -425,22 +411,7 @@ class TestAsyncChatNamespace:
         from yutori.navigator import trimmed_messages_to_fit
 
         mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
-        original_messages = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "Check the page"},
-                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
-                ],
-            },
-            {
-                "role": "tool",
-                "content": [
-                    {"type": "text", "text": "Tool output"},
-                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
-                ],
-            },
-        ]
+        original_messages = make_trimmable_messages()
         original_snapshot = deepcopy(original_messages)
         trimmed_messages, _, _ = trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,6 +12,7 @@ from ._client_fixtures import (
     make_mock_chat_completion,
     make_mock_usage_response,
     make_status_response,
+    make_trimmable_messages,
     mocked_sync_openai_client,
 )
 
@@ -432,22 +433,7 @@ class TestChatNamespace:
         from yutori.navigator.payload import trimmed_messages_to_fit
 
         mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
-        original_messages = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "Check the page"},
-                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
-                ],
-            },
-            {
-                "role": "tool",
-                "content": [
-                    {"type": "text", "text": "Tool output"},
-                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
-                ],
-            },
-        ]
+        original_messages = make_trimmable_messages()
         original_snapshot = deepcopy(original_messages)
 
         with mocked_sync_openai_client(mock_completion) as mock_openai_client:
@@ -473,22 +459,7 @@ class TestChatNamespace:
         from yutori.navigator import trimmed_messages_to_fit
 
         mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
-        original_messages = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "Check the page"},
-                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
-                ],
-            },
-            {
-                "role": "tool",
-                "content": [
-                    {"type": "text", "text": "Tool output"},
-                    {"type": "image_url", "image_url": {"url": "A" * 5000}},
-                ],
-            },
-        ]
+        original_messages = make_trimmable_messages()
         original_snapshot = deepcopy(original_messages)
         trimmed_messages, _, _ = trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)
 


### PR DESCRIPTION
## What

`tests/test_client.py` and `tests/test_async_client.py` each defined the same 14-line
`original_messages = [...]` literal twice — a two-message list, each with an oversized
(5000-char) `image_url` block, used by the payload-trimming tests
(`create_trimmed`/`acreate_trimmed` and the standalone `trimmed_messages_to_fit` pattern).
That's 4 byte-for-byte copies of the same fixture data across the two files.

Extracted `make_trimmable_messages()` into `tests/_client_fixtures.py`, which already holds
the shared sync/async test fixtures (`make_mock_chat_completion`, `make_json_response`, etc.) —
this follows that exact established pattern. It returns a fresh list on every call so callers
can `deepcopy`/mutate the result without cross-test interference, matching how the call sites
already use it.

## Why

This is the same "duplicated test-data literal" shape as several previously-merged refactors in
this repo (e.g. #169's `_default_cli_state`/`_default_sdk_plan` factories) — pure test fixture
deduplication with a well-established precedent, not a production code change.

## Why it's safe

- Test-only change; zero production code touched.
- Every replaced call site produces the exact same list contents as before (verified by diff —
  the extracted literal is copied verbatim from the four original inline copies).
- Full test suite passes unchanged: `553 passed, 3 skipped` before and after.
- `ruff check` / `ruff format --check` clean on all three touched files.

## Test plan

- [x] `pytest tests/` — 553 passed, 3 skipped (same as baseline on `main`)
- [x] `ruff check tests/_client_fixtures.py tests/test_client.py tests/test_async_client.py`
- [x] `ruff format --check tests/_client_fixtures.py tests/test_client.py tests/test_async_client.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPpHKgDemixiQTTAW6BsQN


---
_Generated by [Claude Code](https://claude.ai/code/session_01SPpHKgDemixiQTTAW6BsQN)_