### PR TITLE
refactor(tests): extract make_call_llm_agent() shared by call_llm mixin tests

### DIFF
--- a/tests/_call_llm_agent_fixtures.py
+++ b/tests/_call_llm_agent_fixtures.py
@@ -1,0 +1,35 @@
+"""Shared ``BrowserAgentMixin`` agent-builder for ``_call_llm``/``_call_llm_with_tools`` tests.
+
+``test_call_llm_mixin.py`` and ``test_call_llm_with_tools_mixin.py`` each defined a
+``_make_agent()`` that was byte-for-byte identical except for one line: the
+``_call_llm_with_tools`` tests pre-populate ``agent._messages`` (read internally via
+``self._messages``), while the ``_call_llm`` tests pass a local ``messages`` list explicitly
+and don't need ``agent._messages`` set. Centralizing the shared setup here mirrors the
+``tests/_client_fixtures.py`` precedent for the sync/async client test suites.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from examples._common import BrowserAgentMixin
+
+
+def make_call_llm_agent() -> BrowserAgentMixin:
+    """Build a ``BrowserAgentMixin`` with a mocked chat-completions client.
+
+    ``model``/``temperature`` are set to fixed values, ``_step_count``/``_step_payloads``
+    are initialized, and ``_client.chat.completions.create`` is mocked to return a response
+    whose ``model_dump()`` is ``{"role": "assistant", "content": "done"}``.
+    """
+    agent = BrowserAgentMixin()
+    agent.model = "n1-latest"
+    agent.temperature = 0.3
+    agent._step_count = 3
+    agent._step_payloads = []
+
+    response = MagicMock()
+    response.model_dump.return_value = {"role": "assistant", "content": "done"}
+    agent._client = MagicMock()
+    agent._client.chat.completions.create = AsyncMock(return_value=response)
+    return agent

--- a/tests/test_call_llm_mixin.py
+++ b/tests/test_call_llm_mixin.py
@@ -10,26 +10,16 @@ independently.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
-
 from .conftest import require_examples_extra
 
 require_examples_extra()
 from examples._common import BrowserAgentMixin  # noqa: E402
 
+from ._call_llm_agent_fixtures import make_call_llm_agent  # noqa: E402
+
 
 def _make_agent() -> BrowserAgentMixin:
-    agent = BrowserAgentMixin()
-    agent.model = "n1-latest"
-    agent.temperature = 0.3
-    agent._step_count = 3
-    agent._step_payloads = []
-
-    response = MagicMock()
-    response.model_dump.return_value = {"role": "assistant", "content": "done"}
-    agent._client = MagicMock()
-    agent._client.chat.completions.create = AsyncMock(return_value=response)
-    return agent
+    return make_call_llm_agent()
 
 
 async def test_call_llm_without_extra_fields_passes_only_base_fields() -> None:

--- a/tests/test_call_llm_with_tools_mixin.py
+++ b/tests/test_call_llm_with_tools_mixin.py
@@ -10,26 +10,17 @@ they keep their own ``_call_llm_with_retries`` and are out of scope here.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
-
 from .conftest import require_examples_extra
 
 require_examples_extra()
 from examples._common import BrowserAgentMixin  # noqa: E402
 
+from ._call_llm_agent_fixtures import make_call_llm_agent  # noqa: E402
+
 
 def _make_agent() -> BrowserAgentMixin:
-    agent = BrowserAgentMixin()
-    agent.model = "n1-latest"
-    agent.temperature = 0.3
+    agent = make_call_llm_agent()
     agent._messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
-    agent._step_count = 3
-    agent._step_payloads = []
-
-    response = MagicMock()
-    response.model_dump.return_value = {"role": "assistant", "content": "done"}
-    agent._client = MagicMock()
-    agent._client.chat.completions.create = AsyncMock(return_value=response)
     return agent
 
 


### PR DESCRIPTION
## What

`tests/test_call_llm_mixin.py` (added in #195) and `tests/test_call_llm_with_tools_mixin.py`
(added earlier, in #191) each defined a module-private `_make_agent()` helper that was
byte-for-byte identical except for one line: the with-tools test file pre-populates
`agent._messages` (read internally by `_call_llm_with_tools` via `self._messages`), while
the `_call_llm` test file passes a local `messages` list explicitly to `_call_llm(messages)`
and never needs `agent._messages` set.

This is exactly the kind of duplication the periodic refactor sweep is meant to catch: a
small overlap introduced across two PRs landed a couple of days apart, extracting the same
underlying method (`_call_llm`) from two different call sites (`_call_llm_with_tools` first,
then the shared `_call_llm` body itself).

## Why it's an improvement

Both helpers built the exact same `BrowserAgentMixin` fixture (mocked chat-completions
client, `model`/`temperature`/`_step_count`/`_step_payloads`), differing only by one line.
Centralizing the shared setup in `tests/_call_llm_agent_fixtures.py::make_call_llm_agent()`
removes that duplication and mirrors the existing `tests/_client_fixtures.py` precedent
already used by `test_client.py`/`test_async_client.py` for the same kind of shared-fixture
extraction (see #197).

## Why it's safe

- Test-only change — no production code touched, no behavior change.
- Both test files' `_make_agent()` still return an equivalent agent (verified: the with-tools
  version now builds on the shared helper and adds its one `_messages` line on top, exactly
  matching what it did inline before).
- Full test suite is green before and after: 553 passed, 3 skipped, unchanged.
- `ruff check` / `ruff format --check` clean on all three touched files.
- Only 3 files touched (2 edited, 1 new), well under the ≤5-file backlog guideline.

## Testing

```
python -m pytest -q
# 553 passed, 3 skipped (same as main)

ruff check tests/test_call_llm_mixin.py tests/test_call_llm_with_tools_mixin.py tests/_call_llm_agent_fixtures.py
ruff format --check tests/test_call_llm_mixin.py tests/test_call_llm_with_tools_mixin.py tests/_call_llm_agent_fixtures.py
# All checks passed / already formatted
```

🤖 Generated by an automated refactor cronjob.

https://claude.ai/code/session_018qSGdSNY3DyJq4EiLRxRxk


---
_Generated by [Claude Code](https://claude.ai/code/session_018qSGdSNY3DyJq4EiLRxRxk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes; fixture behavior is intended to stay equivalent.
> 
> **Overview**
> Pulls duplicated **`BrowserAgentMixin`** test setup out of **`test_call_llm_mixin.py`** and **`test_call_llm_with_tools_mixin.py`** into new **`tests/_call_llm_agent_fixtures.py::make_call_llm_agent()`**, following the same shared-fixture pattern as **`_client_fixtures.py`**.
> 
> Each file’s **`_make_agent()`** now delegates to that helper instead of inlining mocked client, model/temperature, and step payload state. The with-tools tests still set **`agent._messages`** locally after the shared build—the only difference between the two suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59ef837f678a64eee8be18e9ec7e55ac28aaae4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->