### PR TITLE
refactor(examples): extract _trim_request_messages() shared by navigator_n1/n1_5

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -19,6 +19,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 from yutori import AsyncYutoriClient
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL, aplaywright_screenshot_to_data_url, denormalize_coordinates
+from yutori.navigator.loop import update_trimmed_history
 from yutori.navigator.page_ready import PageReadyChecker
 from yutori.navigator.replay import TrajectoryRecorder, make_run_id, sanitize_step_payload
 from yutori.navigator.replay import _clip_image_url as _clip_image_url_impl
@@ -686,6 +687,27 @@ class BrowserAgentMixin:
             )
         )
         return response
+
+    def _trim_request_messages(self) -> list:
+        """Trim ``self._request_messages`` against ``self._messages`` and log any removed screenshots.
+
+        Shared by ``navigator_n1.py``'s and ``navigator_n1_5.py``'s ``_call_llm_with_retries``,
+        which each independently built this same "call :func:`update_trimmed_history`, then log
+        the removed-screenshot count" preamble before calling :meth:`_call_llm` with their own
+        (absent vs. ``tool_set``/``disable_tools``/``json_schema``) ``extra_fields``. Callers are
+        responsible for their own ``self.max_request_bytes``/``self.keep_recent_screenshots``/
+        ``self._request_messages`` attributes -- not every ``BrowserAgentMixin`` subclass uses
+        payload trimming, so those aren't part of :class:`SupportsBrowserAgentState`.
+        """
+        self._request_messages, size_bytes, removed = update_trimmed_history(
+            self._messages,
+            self._request_messages,
+            max_bytes=self.max_request_bytes,
+            keep_recent=self.keep_recent_screenshots,
+        )
+        if removed:
+            logger.info(f"Trimmed {removed} old screenshot(s); payload ~{size_bytes / (1024 * 1024):.2f} MB")
+        return self._request_messages
 
     @llm_retry
     async def _call_llm_with_tools(self: SupportsBrowserAgentState, tools: list[dict]) -> ChatCompletion:

--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -29,12 +29,10 @@ from _common import (
     llm_retry,
     run_example_main,
 )
-from loguru import logger
 from openai.types.chat import ChatCompletion
 
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
-from yutori.navigator.loop import update_trimmed_history
 
 
 class Config(BaseAgentConfig):
@@ -79,16 +77,7 @@ class Agent(BrowserAgentMixin):
 
     @llm_retry
     async def _call_llm_with_retries(self) -> ChatCompletion:
-        self._request_messages, size_bytes, removed = update_trimmed_history(
-            self._messages,
-            self._request_messages,
-            max_bytes=self.max_request_bytes,
-            keep_recent=self.keep_recent_screenshots,
-        )
-        if removed:
-            logger.info(f"Trimmed {removed} old screenshot(s); payload ~{size_bytes / (1024 * 1024):.2f} MB")
-
-        return await self._call_llm(self._request_messages)
+        return await self._call_llm(self._trim_request_messages())
 
     # _predict() and _execute() are inherited from BrowserAgentMixin (identical across the
     # n1 examples); this script has no custom tools, so it also uses the default

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -73,7 +73,6 @@ from yutori.navigator import (
     map_key_to_playwright,
     map_keys_individual,
 )
-from yutori.navigator.loop import update_trimmed_history
 from yutori.navigator.tools import (
     EXECUTE_JS_SCRIPT,
     EXTRACT_ELEMENTS_SCRIPT,
@@ -250,17 +249,8 @@ class Agent(BrowserAgentMixin):
 
     @llm_retry
     async def _call_llm_with_retries(self) -> ChatCompletion:
-        self._request_messages, size_bytes, removed = update_trimmed_history(
-            self._messages,
-            self._request_messages,
-            max_bytes=self.max_request_bytes,
-            keep_recent=self.keep_recent_screenshots,
-        )
-        if removed:
-            logger.info(f"Trimmed {removed} old screenshot(s); payload ~{size_bytes / (1024 * 1024):.2f} MB")
-
         return await self._call_llm(
-            self._request_messages,
+            self._trim_request_messages(),
             extra_fields={
                 "tool_set": self.tool_set,
                 "disable_tools": self.disable_tools or None,

--- a/tests/test_trim_request_messages_mixin.py
+++ b/tests/test_trim_request_messages_mixin.py
@@ -1,0 +1,82 @@
+"""Characterization tests for ``examples._common.BrowserAgentMixin._trim_request_messages``.
+
+Pins the exact trim-and-log behavior of this helper before/after extracting it out of
+``navigator_n1.py`` and ``navigator_n1_5.py``, each of which previously carried a
+byte-for-byte identical "call ``update_trimmed_history``, then log the removed-screenshot
+count" preamble inside their own ``_call_llm_with_retries``, differing only in the
+``extra_fields`` passed to the ``_call_llm`` call that followed.
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+
+from .conftest import require_examples_extra
+
+require_examples_extra()
+from examples._common import BrowserAgentMixin  # noqa: E402
+
+
+def _image_message(role: str, *, url: str = "data:image/png;base64,abc", text: str | None = None) -> dict:
+    content: list[dict] = []
+    if text is not None:
+        content.append({"type": "text", "text": text})
+    content.append({"type": "image_url", "image_url": {"url": url, "detail": "high"}})
+    return {"role": role, "content": content}
+
+
+def _make_agent(
+    *, messages: list, request_messages: list | None, max_request_bytes: int, keep_recent: int
+) -> BrowserAgentMixin:
+    agent = BrowserAgentMixin()
+    agent._messages = messages
+    agent._request_messages = request_messages
+    agent.max_request_bytes = max_request_bytes
+    agent.keep_recent_screenshots = keep_recent
+    return agent
+
+
+def test_trim_request_messages_returns_full_history_copy_when_under_budget() -> None:
+    messages = [_image_message("user", text="one")]
+    agent = _make_agent(messages=messages, request_messages=None, max_request_bytes=1_000_000, keep_recent=1)
+
+    result = agent._trim_request_messages()
+
+    assert result == messages
+    assert result is not messages
+    assert agent._request_messages is result
+
+
+def test_trim_request_messages_trims_and_logs_when_over_budget(capsys) -> None:
+    large_url = "data:image/png;base64," + ("A" * 5000)
+    messages = [
+        _image_message("user", url=large_url, text="one"),
+        _image_message("tool", url=large_url, text="two"),
+        _image_message("tool", url=large_url, text="three"),
+    ]
+    agent = _make_agent(messages=messages, request_messages=None, max_request_bytes=12_000, keep_recent=1)
+
+    sink_id = logger.add(lambda message: print(message, end=""))
+    try:
+        result = agent._trim_request_messages()
+    finally:
+        logger.remove(sink_id)
+
+    assert messages[0]["content"][1]["image_url"]["url"] == large_url
+    assert result is agent._request_messages
+    assert "Trimmed" in capsys.readouterr().out
+
+
+def test_trim_request_messages_reuses_existing_request_copy() -> None:
+    messages = [_image_message("user", text="one")]
+    existing_request_messages = [dict(messages[0])]
+    agent = _make_agent(
+        messages=messages,
+        request_messages=existing_request_messages,
+        max_request_bytes=1_000_000,
+        keep_recent=1,
+    )
+
+    result = agent._trim_request_messages()
+
+    assert result is existing_request_messages

--- a/tests/test_trim_request_messages_mixin.py
+++ b/tests/test_trim_request_messages_mixin.py
@@ -9,11 +9,11 @@ count" preamble inside their own ``_call_llm_with_retries``, differing only in t
 
 from __future__ import annotations
 
-from loguru import logger
-
 from .conftest import require_examples_extra
 
 require_examples_extra()
+from loguru import logger  # noqa: E402
+
 from examples._common import BrowserAgentMixin  # noqa: E402
 
 


### PR DESCRIPTION
## Issue

`navigator_n1.py` and `navigator_n1_5.py`'s `_call_llm_with_retries()` each independently built the exact same "call `update_trimmed_history()`, then log the removed-screenshot count" preamble before calling `_call_llm()`:

```python
self._request_messages, size_bytes, removed = update_trimmed_history(
    self._messages,
    self._request_messages,
    max_bytes=self.max_request_bytes,
    keep_recent=self.keep_recent_screenshots,
)
if removed:
    logger.info(f"Trimmed {removed} old screenshot(s); payload ~{size_bytes / (1024 * 1024):.2f} MB")
```

They only diverged in what they passed to the following `_call_llm()` call (no `extra_fields` vs. `tool_set`/`disable_tools`/`json_schema`). This duplication wasn't part of the earlier `_call_llm` extraction (#195), which only unified the request-payload/create/replay-recording body downstream of this preamble.

## Improvement

Extracted the shared preamble into `BrowserAgentMixin._trim_request_messages()` in `examples/_common.py`. Both call sites now delegate and feed the returned trimmed list straight into `_call_llm(...)`:

```python
# navigator_n1.py
return await self._call_llm(self._trim_request_messages())

# navigator_n1_5.py
return await self._call_llm(
    self._trim_request_messages(),
    extra_fields={"tool_set": self.tool_set, "disable_tools": self.disable_tools or None, "json_schema": self.json_schema},
)
```

Removed the now-unused `update_trimmed_history` imports (and the now-unused `logger` import in `navigator_n1.py`, which had no other use of `logger`).

## Safety

- No behavior change: same `update_trimmed_history()` call with the same arguments, same log message, same value threaded into `_call_llm()`.
- Added `tests/test_trim_request_messages_mixin.py` — no prior test exercised this code path directly (only the underlying `update_trimmed_history()` was tested, in `tests/test_navigator_replay.py`). Covers: under-budget passthrough, over-budget trim+log, and reuse of an existing request-messages copy.
- Full suite green: **556 passed, 3 skipped** (up from 553/3 before this change — the 3 new tests).
- `ruff check`/`ruff format --check` clean on all touched files. `examples/navigator_n1_5.py` has pre-existing, unrelated ruff-format debt outside the touched region (confirmed via `git stash` before this change), matching the precedent already noted in PR #195.

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01McQhyyroFKNAcv14WCsiVd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only refactor with no intended runtime behavior change; risk is limited to LLM request trimming/logging in the two navigator example scripts.
> 
> **Overview**
> Pulls duplicated **LLM request payload trimming** out of `navigator_n1.py` and `navigator_n1_5.py` into **`BrowserAgentMixin._trim_request_messages()`** in `examples/_common.py`. That helper still runs `update_trimmed_history` with the same byte budget and “keep recent screenshots” settings, logs when old screenshots are dropped, and returns the trimmed message list.
> 
> Both example agents now call `_trim_request_messages()` from `_call_llm_with_retries` before `_call_llm` (n1.5 unchanged in still passing `tool_set` / `disable_tools` / `json_schema`). Redundant imports (`update_trimmed_history`, unused `logger` in n1) are removed.
> 
> Adds **`tests/test_trim_request_messages_mixin.py`** to lock in under-budget copy behavior, over-budget trim + log, and reuse of an existing request-messages buffer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93ac45938dee4e6f758a7f649144402db14716b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->