### PR TITLE
Extract _verification_failure() helper for repeated verification-failure handling

### DIFF
--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -872,6 +872,16 @@ def _summarize_cli_output(output: str) -> str:
     return _truncate_summary(compact)
 
 
+def _verification_failure(
+    result: subprocess.CompletedProcess[str], output: str, *, task_url: str | None = None
+) -> tuple[StepResult, bool]:
+    auth_failed = looks_like_auth_failure(output)
+    detail = output or describe_completed_process(result)
+    if task_url:
+        detail = f"{detail} View task: {task_url}"
+    return StepResult("Verification", "failed", detail), auth_failed
+
+
 def run_verification(
     console: Console,
     *,
@@ -919,9 +929,7 @@ def run_verification(
     submission = run_command(submit_command, timeout=INSTALL_CMD_TIMEOUT)
     submission_output = collect_process_output(submission)
     if submission.returncode != 0:
-        auth_failed = looks_like_auth_failure(submission_output)
-        detail = submission_output or describe_completed_process(submission)
-        return StepResult("Verification", "failed", detail), auth_failed
+        return _verification_failure(submission, submission_output)
 
     task_id = parse_cli_field(submission.stdout, "Task ID")
     # Older CLI versions print the literal placeholder "N/A" (and exit 0)
@@ -958,9 +966,7 @@ def run_verification(
                 poll = run_command((cli_invocation, "browse", "get", task_id))
                 poll_output = collect_process_output(poll)
                 if poll.returncode != 0:
-                    auth_failed = looks_like_auth_failure(poll_output)
-                    detail = poll_output or describe_completed_process(poll)
-                    return StepResult("Verification", "failed", f"{detail} View task: {task_url}"), auth_failed
+                    return _verification_failure(poll, poll_output, task_url=task_url)
 
                 last_output = poll.stdout
                 status = parse_cli_field(poll.stdout, "Status") or "queued"


### PR DESCRIPTION
## What

`run_verification()` in `yutori/cli/commands/install_flow.py` had two call sites (submission failure and poll failure) that repeated the identical 3-step recipe for building a failure result:

```python
auth_failed = looks_like_auth_failure(output)
detail = output or describe_completed_process(result)
# (poll branch only) detail = f"{detail} View task: {task_url}"
return StepResult("Verification", "failed", detail), auth_failed
```

## Why

Extracted a small helper:

```python
def _verification_failure(
    result: subprocess.CompletedProcess[str], output: str, *, task_url: str | None = None
) -> tuple[StepResult, bool]:
    auth_failed = looks_like_auth_failure(output)
    detail = output or describe_completed_process(result)
    if task_url:
        detail = f"{detail} View task: {task_url}"
    return StepResult("Verification", "failed", detail), auth_failed
```

and had both branches delegate to it.

## Why it's safe

- Single file, internal CLI implementation only — not part of the SDK's public/exported surface.
- **No behavioral change**: produces the identical `(StepResult, auth_failed)` tuple for identical inputs.
- `tests/test_install_flow.py` already has characterization tests for both branches (`test_run_verification_classifies_auth_error_as_auth_failure`, `test_run_verification_non_auth_api_error_returns_auth_failed_false`, plus the poll-timeout/failure paths) — all 81 tests pass unchanged.

## Test plan

- [x] `pytest tests/test_install_flow.py` — 81 passed
- [x] `pytest` (full suite) — 473 passed, 15 skipped
- [x] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013F33LvNHqBZRHDCdRvuDie

---
_Generated by [Claude Code](https://claude.ai/code/session_013F33LvNHqBZRHDCdRvuDie)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CLI refactor with no logic change; existing install-flow characterization tests cover both call sites.
> 
> **Overview**
> **Refactors** duplicate verification-failure handling in `run_verification()` by introducing `_verification_failure()`, which centralizes auth classification, failure detail text, and optional dashboard task URL appending.
> 
> Both the **submit** branch (non-zero return from `browse run`) and the **poll** branch (non-zero return from `browse get`) now delegate to this helper instead of repeating the same three-step logic inline.
> 
> Behavior is unchanged: callers still receive the same `(StepResult("Verification", "failed", …), auth_failed)` tuple for the same subprocess output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e69112fb9023818c42b4912cbd91278b6c135089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->