### PR TITLE
refactor(examples): extract shared Agent.__init__ into BrowserAgentMixin

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -397,7 +397,11 @@ class BrowserAgentMixin:
     ``_init_agent_state`` call) that ``navigator_n1.py``, ``navigator_n1_custom_tools.py``,
     and ``navigator_n1_memo.py`` all build from the same nine kwargs;
     ``navigator_n1_5.py`` interleaves several more model-specific kwargs among
-    those same nine and keeps its own inline assignment.
+    those same nine and keeps its own inline assignment. This mixin's own
+    ``__init__`` covers that same nine-kwarg signature directly, so
+    ``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py`` -- which had
+    no other constructor-kwarg divergence -- now call ``super().__init__(**kwargs)``
+    instead of redefining the full signature themselves.
 
     ``_run_with_browser_lifecycle`` covers the entire ``run()`` body -- opening
     the client/browser, navigating, running :meth:`_run_agent_loop`, and
@@ -411,6 +415,40 @@ class BrowserAgentMixin:
     instead of ``_execute`` itself; ``navigator_n1.py`` has no custom tools and uses the
     default. ``navigator_n1_5.py`` keeps its own differently-shaped ``_execute``.
     """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        model: str = NAVIGATOR_N1_MODEL,
+        temperature: float = 0.3,
+        max_steps: int = 100,
+        viewport_width: int = 1280,
+        viewport_height: int = 800,
+        headless: bool = False,
+        replay_dir: str | None = None,
+        replay_id: str | None = None,
+    ) -> None:
+        """Shared constructor for example ``Agent`` subclasses that add no kwargs of their own.
+
+        ``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py`` had byte-for-byte
+        identical ``__init__`` bodies built from exactly this nine-kwarg signature -- only
+        their trailing custom-tool setup line differed. Both now call ``super().__init__(**kwargs)``
+        and add just that one line. ``navigator_n1.py`` interleaves two more payload-trim kwargs
+        into this same signature and keeps its own ``__init__``; ``navigator_n1_5.py`` interleaves
+        several more model-specific kwargs and also keeps its own.
+        """
+        self._init_common_agent_config(
+            base_url=base_url,
+            model=model,
+            temperature=temperature,
+            max_steps=max_steps,
+            viewport_width=viewport_width,
+            viewport_height=viewport_height,
+            headless=headless,
+            replay_dir=replay_dir,
+            replay_id=replay_id,
+        )
 
     def _init_common_agent_config(
         self: SupportsBrowserAgentState,
@@ -427,12 +465,10 @@ class BrowserAgentMixin:
     ) -> None:
         """Assign the constructor kwargs shared by every example ``Agent.__init__`` and init agent state.
 
-        ``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py`` had byte-for-byte
-        identical ``__init__`` bodies built from exactly these nine kwargs plus a call to
-        :meth:`_init_agent_state` -- only their trailing custom-tool setup line differed.
-        ``navigator_n1.py`` sets the same nine kwargs (plus its own payload-trim fields set
-        separately around this call); ``navigator_n1_5.py`` interleaves several more
-        model-specific kwargs among these same nine and keeps its own inline assignment.
+        Called both by :meth:`__init__` above (for subclasses with no extra kwargs) and directly
+        by ``navigator_n1.py``'s ``Agent.__init__`` (which sets the same nine kwargs plus its own
+        payload-trim fields set separately around this call). ``navigator_n1_5.py`` interleaves
+        several more model-specific kwargs among these same nine and keeps its own inline assignment.
         """
         self.base_url = base_url
         self.model = model

--- a/examples/navigator_n1_custom_tools.py
+++ b/examples/navigator_n1_custom_tools.py
@@ -35,9 +35,6 @@ from openai.types.chat import ChatCompletion
 from playwright.async_api import Page
 from pydantic import Field
 
-from yutori.config import DEFAULT_BASE_URL
-from yutori.navigator import NAVIGATOR_N1_MODEL
-
 
 class Config(BaseAgentConfig):
     task: str = Field(default="Get the titles and links of all the blog posts")
@@ -112,29 +109,8 @@ class ExtractContentAndLinksTool:
 
 
 class Agent(BrowserAgentMixin):
-    def __init__(
-        self,
-        base_url: str = DEFAULT_BASE_URL,
-        model: str = NAVIGATOR_N1_MODEL,
-        temperature: float = 0.3,
-        max_steps: int = 100,
-        viewport_width: int = 1280,
-        viewport_height: int = 800,
-        headless: bool = False,
-        replay_dir: str | None = None,
-        replay_id: str | None = None,
-    ):
-        self._init_common_agent_config(
-            base_url=base_url,
-            model=model,
-            temperature=temperature,
-            max_steps=max_steps,
-            viewport_width=viewport_width,
-            viewport_height=viewport_height,
-            headless=headless,
-            replay_dir=replay_dir,
-            replay_id=replay_id,
-        )
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
 
         # Custom tools
         self._extract_content_and_links_tool = ExtractContentAndLinksTool()

--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -40,9 +40,6 @@ from loguru import logger
 from openai.types.chat import ChatCompletion
 from pydantic import Field
 
-from yutori.config import DEFAULT_BASE_URL
-from yutori.navigator import NAVIGATOR_N1_MODEL
-
 
 class Config(BaseAgentConfig):
     task: str = Field(
@@ -159,29 +156,8 @@ class MemoToolSuite:
 
 
 class Agent(BrowserAgentMixin):
-    def __init__(
-        self,
-        base_url: str = DEFAULT_BASE_URL,
-        model: str = NAVIGATOR_N1_MODEL,
-        temperature: float = 0.3,
-        max_steps: int = 100,
-        viewport_width: int = 1280,
-        viewport_height: int = 800,
-        headless: bool = False,
-        replay_dir: str | None = None,
-        replay_id: str | None = None,
-    ):
-        self._init_common_agent_config(
-            base_url=base_url,
-            model=model,
-            temperature=temperature,
-            max_steps=max_steps,
-            viewport_width=viewport_width,
-            viewport_height=viewport_height,
-            headless=headless,
-            replay_dir=replay_dir,
-            replay_id=replay_id,
-        )
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
 
         # Custom memo tool suite
         self._memo_tool_suite = MemoToolSuite()

--- a/tests/test_browser_agent_mixin_init.py
+++ b/tests/test_browser_agent_mixin_init.py
@@ -1,0 +1,89 @@
+"""Characterization tests for ``examples._common.BrowserAgentMixin.__init__``.
+
+Pins the exact behavior of this constructor before/after extracting it out of
+``navigator_n1_custom_tools.py`` and ``navigator_n1_memo.py``, which previously each defined a
+byte-for-byte identical ``Agent.__init__`` (same nine-kwarg signature, calling
+``_init_common_agent_config`` with all nine values) -- only their trailing custom-tool setup
+line differed. Both now call ``super().__init__(**kwargs)`` and add just that one line.
+``navigator_n1.py`` interleaves two more payload-trim kwargs into this same signature and keeps
+its own ``__init__``; ``navigator_n1_5.py`` interleaves several more model-specific kwargs and
+also keeps its own.
+"""
+
+from __future__ import annotations
+
+from .conftest import require_examples_extra
+
+require_examples_extra()
+from examples._common import BrowserAgentMixin  # noqa: E402
+from yutori.config import DEFAULT_BASE_URL  # noqa: E402
+from yutori.navigator import NAVIGATOR_N1_MODEL  # noqa: E402
+
+
+def test_init_assigns_default_kwargs() -> None:
+    agent = BrowserAgentMixin()
+
+    assert agent.base_url == DEFAULT_BASE_URL
+    assert agent.model == NAVIGATOR_N1_MODEL
+    assert agent.temperature == 0.3
+    assert agent.max_steps == 100
+    assert agent.viewport_width == 1280
+    assert agent.viewport_height == 800
+    assert agent.headless is False
+    assert agent.replay_dir is None
+    assert agent.replay_id is None
+
+
+def test_init_assigns_overridden_kwargs() -> None:
+    agent = BrowserAgentMixin(
+        base_url="https://api.example.com/v1",
+        model="some-model",
+        temperature=0.7,
+        max_steps=42,
+        viewport_width=1024,
+        viewport_height=768,
+        headless=True,
+        replay_dir="/tmp/replays",
+        replay_id="fixed-run-id",
+    )
+
+    assert agent.base_url == "https://api.example.com/v1"
+    assert agent.model == "some-model"
+    assert agent.temperature == 0.7
+    assert agent.max_steps == 42
+    assert agent.viewport_width == 1024
+    assert agent.viewport_height == 768
+    assert agent.headless is True
+    assert agent.replay_dir == "/tmp/replays"
+    assert agent.replay_id == "fixed-run-id"
+
+
+def test_init_also_initializes_agent_state() -> None:
+    """Matches ``_init_common_agent_config``'s behavior, since ``__init__`` delegates to it."""
+    agent = BrowserAgentMixin()
+
+    assert agent._client is None
+    assert agent._browser is None
+    assert agent._page is None
+    assert agent._replay is None
+    assert agent._messages == []
+    assert agent._step_payloads == []
+    assert agent._step_count == 0
+
+
+def test_subclass_can_extend_init_with_super_and_kwargs() -> None:
+    """Mirrors the ``navigator_n1_custom_tools.py``/``navigator_n1_memo.py`` pattern: a
+    subclass that adds no constructor kwargs of its own now forwards everything to
+    ``super().__init__(**kwargs)`` and only adds its own extra setup line."""
+
+    class Agent(BrowserAgentMixin):
+        def __init__(self, **kwargs) -> None:
+            super().__init__(**kwargs)
+            self.custom_tool = "configured"
+
+    agent = Agent(model="custom-model", headless=True)
+
+    assert agent.model == "custom-model"
+    assert agent.headless is True
+    assert agent.custom_tool == "configured"
+    assert agent._messages == []


### PR DESCRIPTION
## What

`navigator_n1_custom_tools.py::Agent.__init__` and `navigator_n1_memo.py::Agent.__init__` were byte-for-byte identical (confirmed via `diff`): same nine-kwarg signature, forwarding straight into `_init_common_agent_config` — only the trailing custom-tool setup line after the call differed.

Added a `__init__` to `BrowserAgentMixin` (in `examples/_common.py`) covering that shared nine-kwarg signature (delegating to the already-tested `_init_common_agent_config`). Both example scripts now define:

```python
class Agent(BrowserAgentMixin):
    def __init__(self, **kwargs: Any) -> None:
        super().__init__(**kwargs)
        # ...their one extra custom-tool setup line...
```

instead of redefining the full nine-parameter signature + call body. Removed the now-unused `DEFAULT_BASE_URL`/`NAVIGATOR_N1_MODEL` imports from both files (their defaults now live only in the mixin).

`navigator_n1.py` (interleaves two extra payload-trim kwargs) and `navigator_n1_5.py` (interleaves several more model-specific kwargs) keep their own `__init__`, matching the existing precedent already established for `_init_common_agent_config` and `BaseAgentConfig` (see their docstrings).

## Why

This mirrors the exact pattern of every other recent extraction in this repo (`_init_common_agent_config`, `BaseAgentConfig`, `_run_with_browser_lifecycle`, `_execute`, etc.) — the constructor signature/body was the one remaining piece of duplication between these two files that hadn't yet been collapsed.

## Safety / verification

- No behavior change: `_init_common_agent_config` receives the exact same resolved kwargs as before.
- Added `tests/test_browser_agent_mixin_init.py` (no prior test exercised `BrowserAgentMixin.__init__` directly) covering: default kwargs, overridden kwargs, agent-state initialization side effect, and the `super().__init__(**kwargs)` subclassing pattern used by the two example scripts.
- Full test suite green: **560 passed, 3 skipped** (up from 556/3 on `main`), `ruff check`/`ruff format --check` clean on all touched files.
- Manually smoke-tested both scripts end-to-end outside pytest: instantiated `Agent()`/`Agent(model=..., headless=...)` directly and confirmed attributes + custom-tool objects are set correctly, and ran `--help` on both to confirm the `Config.model_dump()` → `Agent(**kwargs)` CLI construction path still works unchanged.

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01TJrMNx7f4eXAt3jTHzyBBS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only refactor with behavior preserved via the same `_init_common_agent_config` path; covered by new characterization tests.
> 
> **Overview**
> Moves the duplicated nine-kwarg example `Agent` constructor into **`BrowserAgentMixin.__init__`**, which delegates to the existing **`_init_common_agent_config`** (same defaults and agent-state setup as before).
> 
> **`navigator_n1_custom_tools.py`** and **`navigator_n1_memo.py`** now use **`def __init__(self, **kwargs)` → `super().__init__(**kwargs)`** plus their single custom-tool setup line, and drop redundant **`DEFAULT_BASE_URL`** / **`NAVIGATOR_N1_MODEL`** imports. **`navigator_n1.py`** and **`navigator_n1_5.py`** keep their own constructors.
> 
> Adds **`tests/test_browser_agent_mixin_init.py`** to lock in default/overridden kwargs, agent-state initialization, and the subclass **`super().__init__(**kwargs)`** pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d3856b5e3d368d04cdbb77cf641491dd4be574e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->