### PR TITLE
refactor(examples): extract _navigate_and_finish() for n1.5 nav actions

### DIFF
--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -373,6 +373,19 @@ class Agent(BrowserAgentMixin):
         await self._wait_for_page_ready()
         return result
 
+    async def _navigate_and_finish(self, nav_coro, *, sleep: float, message: str) -> str | None:
+        """Await a Playwright navigation call, wait for load, settle, then finish the action.
+
+        Shared by the ``goto_url``/``go_back``/``go_forward``/``refresh`` branches of
+        :meth:`_execute`, which each awaited a different navigation call, waited for
+        ``"domcontentloaded"``, slept for their own fixed duration, and finished with
+        their own message -- otherwise identical.
+        """
+        await nav_coro
+        await self._page.wait_for_load_state("domcontentloaded")
+        await asyncio.sleep(sleep)
+        return await self._finish_action(message)
+
     async def _execute(self, tool_call: ChatCompletionMessageToolCall) -> str | None:
         action_name = tool_call.function.name
 
@@ -536,28 +549,16 @@ class Agent(BrowserAgentMixin):
                 url = arguments.get("url", "")
                 if "://" not in url:
                     url = f"https://{url}"
-                await self._page.goto(url)
-                await self._page.wait_for_load_state("domcontentloaded")
-                await asyncio.sleep(1)
-                return await self._finish_action(f"Navigated to {url}")
+                return await self._navigate_and_finish(self._page.goto(url), sleep=1, message=f"Navigated to {url}")
 
             elif action_name == "go_back":
-                await self._page.go_back()
-                await self._page.wait_for_load_state("domcontentloaded")
-                await asyncio.sleep(0.5)
-                return await self._finish_action("Navigated back")
+                return await self._navigate_and_finish(self._page.go_back(), sleep=0.5, message="Navigated back")
 
             elif action_name == "go_forward":
-                await self._page.go_forward()
-                await self._page.wait_for_load_state("domcontentloaded")
-                await asyncio.sleep(0.5)
-                return await self._finish_action("Navigated forward")
+                return await self._navigate_and_finish(self._page.go_forward(), sleep=0.5, message="Navigated forward")
 
             elif action_name == "refresh":
-                await self._page.reload()
-                await self._page.wait_for_load_state("domcontentloaded")
-                await asyncio.sleep(1)
-                return await self._finish_action("Refreshed the page")
+                return await self._navigate_and_finish(self._page.reload(), sleep=1, message="Refreshed the page")
 
             elif action_name == "wait":
                 duration = max(0, min(arguments.get("duration", 5), 100))


### PR DESCRIPTION
## Issue

In `examples/navigator_n1_5.py`, the `goto_url`/`go_back`/`go_forward`/`refresh` branches of `Agent._execute()` each repeated the same three-step shape:

1. await a Playwright navigation call
2. `await self._page.wait_for_load_state("domcontentloaded")`
3. `await asyncio.sleep(<fixed duration>)`
4. `return await self._finish_action(<message>)`

The only per-branch differences were the navigation call itself, the sleep duration, and the result message.

## Improvement

Extracted the shared shape into a new `_navigate_and_finish(nav_coro, *, sleep, message)` helper (placed right next to the existing `_finish_action` helper it delegates to). Each of the four branches now collapses to a single call, e.g.:

```python
elif action_name == "go_back":
    return await self._navigate_and_finish(self._page.go_back(), sleep=0.5, message="Navigated back")
```

`goto_url` keeps its own URL-prefixing logic before calling the helper, since that part is unique to it.

## Safety

- Single file changed (`examples/navigator_n1_5.py`), no functionality change — this is a pure mechanical extraction. Each branch still awaits the exact same navigation call, waits for the same load state, sleeps for the same duration, and returns the same message as before.
- `navigator_n1_5.py`'s other branches (clicks, scroll, keyboard, etc.) are untouched; this only touches the four navigation branches that shared the identical pattern.
- Verified:
  - `ruff check .` — passes
  - `ruff format --diff` — no new formatting issues introduced by this change (file had pre-existing unrelated formatting drift before this PR, left untouched)
  - Full test suite: `pytest -m "not slow"` — 559 passed, 3 skipped (same as before the change)

🤖 Generated as part of the automated hourly structural-refactor job for this repo.


---
_Generated by [Claude Code](https://claude.ai/code/session_0157o2ZurXYCuNPmhq2gPbHp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file example refactor with identical navigation, wait, sleep, and message behavior; no auth, data, or production path changes.
> 
> **Overview**
> Deduplicates the repeated post-navigation flow in the Navigator n1.5 example agent by introducing **`_navigate_and_finish`**, which awaits a Playwright navigation coroutine, waits for **`domcontentloaded`**, applies a branch-specific sleep, then delegates to **`_finish_action`**.
> 
> The **`goto_url`**, **`go_back`**, **`go_forward`**, and **`refresh`** handlers in **`Agent._execute`** now each call this helper instead of inlining the same four steps. **`goto_url`** still normalizes URLs (adds **`https://`** when needed) before navigation; sleep durations and user-facing messages are unchanged per action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47578b45b5c393eaba3d7fecd0b2b6af7e0b7ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->