### PR TITLE
refactor(tests): extract _image_message() into shared _client_fixtures

### DIFF
--- a/tests/_client_fixtures.py
+++ b/tests/_client_fixtures.py
@@ -85,6 +85,19 @@ def make_mock_usage_response(period: str = "24h") -> MagicMock:
     return make_json_response(data)
 
 
+def _image_message(role: str, *, url: str = "data:image/png;base64,abc", text: str | None = None) -> dict[str, Any]:
+    """Build a single chat message with an ``image_url`` content block (plus optional text).
+
+    Shared by the trim-request-messages and navigator-replay test suites, which each need
+    minimal image-bearing messages to exercise size-based trimming/sanitization logic.
+    """
+    content: list[dict] = []
+    if text is not None:
+        content.append({"type": "text", "text": text})
+    content.append({"type": "image_url", "image_url": {"url": url, "detail": "high"}})
+    return {"role": role, "content": content}
+
+
 def make_trimmable_messages() -> list[dict[str, Any]]:
     """Build a fresh two-message list with an oversized ``image_url`` block in each message.
 

--- a/tests/test_navigator_replay.py
+++ b/tests/test_navigator_replay.py
@@ -14,13 +14,7 @@ from yutori.navigator.replay import (
     sanitize_step_payload,
 )
 
-
-def _image_message(role: str, *, url: str = "data:image/png;base64,abc", text: str | None = None) -> dict:
-    content: list[dict] = []
-    if text is not None:
-        content.append({"type": "text", "text": text})
-    content.append({"type": "image_url", "image_url": {"url": url, "detail": "high"}})
-    return {"role": role, "content": content}
+from ._client_fixtures import _image_message
 
 
 def _tool_call(name: str, arguments: str, *, call_id: str = "call_1") -> dict:

--- a/tests/test_trim_request_messages_mixin.py
+++ b/tests/test_trim_request_messages_mixin.py
@@ -9,20 +9,13 @@ count" preamble inside their own ``_call_llm_with_retries``, differing only in t
 
 from __future__ import annotations
 
+from ._client_fixtures import _image_message
 from .conftest import require_examples_extra
 
 require_examples_extra()
 from loguru import logger  # noqa: E402
 
 from examples._common import BrowserAgentMixin  # noqa: E402
-
-
-def _image_message(role: str, *, url: str = "data:image/png;base64,abc", text: str | None = None) -> dict:
-    content: list[dict] = []
-    if text is not None:
-        content.append({"type": "text", "text": text})
-    content.append({"type": "image_url", "image_url": {"url": url, "detail": "high"}})
-    return {"role": role, "content": content}
 
 
 def _make_agent(


### PR DESCRIPTION
## Issue

`tests/test_trim_request_messages_mixin.py` and `tests/test_navigator_replay.py` each independently defined the exact same helper:

```python
def _image_message(role: str, *, url: str = "data:image/png;base64,abc", text: str | None = None) -> dict:
    content: list[dict] = []
    if text is not None:
        content.append({"type": "text", "text": text})
    content.append({"type": "image_url", "image_url": {"url": url, "detail": "high"}})
    return {"role": role, "content": content}
```

Byte-for-byte identical (same signature, same default values, no divergence), copy-pasted with no shared import between the two files.

## Improvement

Moved `_image_message()` into `tests/_client_fixtures.py`, which is already the established home for shared message-building test fixtures in this repo (e.g. `make_trimmable_messages()`). Both `test_trim_request_messages_mixin.py` and `test_navigator_replay.py` now import it from there instead of redefining it locally.

## Safety

- Test-only change; no production code touched.
- Purely mechanical extraction — the function body is unchanged, only its location moved.
- `tests/_client_fixtures.py` has no dependency on the `examples` extra, so `test_navigator_replay.py` (which doesn't otherwise need `examples`) gains no new optional dependency.
- Verified: `pytest` is green before and after with an identical pass count (560 passed, 3 skipped).
- `ruff check` and `ruff format --check` pass on all three touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01SNE5f6UHgu9T1fttQ9iSMx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNE5f6UHgu9T1fttQ9iSMx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mechanical extraction with no production code changes; behavior is unchanged.
> 
> **Overview**
> Deduplicates the identical `_image_message()` helper that was copy-pasted in **`test_trim_request_messages_mixin.py`** and **`test_navigator_replay.py`** by defining it once in **`tests/_client_fixtures.py`** (alongside other shared message fixtures like `make_trimmable_messages()`).
> 
> Both test modules now import `_image_message` from `_client_fixtures` instead of maintaining local copies. The helper body is unchanged aside from an explicit `dict[str, Any]` return type and a short docstring explaining shared use for trimming/sanitization tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e9f4c99a49c5f297dcdf68d677cab77d59c2de3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->