### PR TITLE
refactor(examples): extract _move_mouse_and_finish() for n1.5 mouse actions

### DIFF
--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -386,6 +386,26 @@ class Agent(BrowserAgentMixin):
         await asyncio.sleep(sleep)
         return await self._finish_action(message)
 
+    async def _move_mouse_and_finish(self, arguments: dict, *, mouse_action: str | None, message: str) -> str | None:
+        """Resolve coordinates, move the mouse there, optionally press/release, then finish.
+
+        Shared by the ``mouse_move``/``mouse_down``/``mouse_up`` branches of :meth:`_execute`,
+        which each resolved coordinates, moved the mouse there, performed at most one of
+        ``mouse.down()``/``mouse.up()``, slept 0.3s, and finished with their own message --
+        otherwise identical. ``mouse_action`` is ``"down"``, ``"up"``, or ``None`` (plain move).
+        """
+        resolved = await self._resolve_coordinates(arguments)
+        if isinstance(resolved, str):
+            return resolved
+        abs_x, abs_y = resolved
+        await self._page.mouse.move(abs_x, abs_y)
+        if mouse_action == "down":
+            await self._page.mouse.down()
+        elif mouse_action == "up":
+            await self._page.mouse.up()
+        await asyncio.sleep(0.3)
+        return await self._finish_action(message)
+
     async def _execute(self, tool_call: ChatCompletionMessageToolCall) -> str | None:
         action_name = tool_call.function.name
 
@@ -419,33 +439,15 @@ class Agent(BrowserAgentMixin):
 
             # ---- Mouse movement actions ----
             elif action_name == "mouse_move":
-                resolved = await self._resolve_coordinates(arguments)
-                if isinstance(resolved, str):
-                    return resolved
-                abs_x, abs_y = resolved
-                await self._page.mouse.move(abs_x, abs_y)
-                await asyncio.sleep(0.3)
-                return await self._finish_action("Mouse moved and hovering")
+                return await self._move_mouse_and_finish(
+                    arguments, mouse_action=None, message="Mouse moved and hovering"
+                )
 
             elif action_name == "mouse_down":
-                resolved = await self._resolve_coordinates(arguments)
-                if isinstance(resolved, str):
-                    return resolved
-                abs_x, abs_y = resolved
-                await self._page.mouse.move(abs_x, abs_y)
-                await self._page.mouse.down()
-                await asyncio.sleep(0.3)
-                return await self._finish_action("Mouse button pressed")
+                return await self._move_mouse_and_finish(arguments, mouse_action="down", message="Mouse button pressed")
 
             elif action_name == "mouse_up":
-                resolved = await self._resolve_coordinates(arguments)
-                if isinstance(resolved, str):
-                    return resolved
-                abs_x, abs_y = resolved
-                await self._page.mouse.move(abs_x, abs_y)
-                await self._page.mouse.up()
-                await asyncio.sleep(0.3)
-                return await self._finish_action("Mouse button released")
+                return await self._move_mouse_and_finish(arguments, mouse_action="up", message="Mouse button released")
 
             elif action_name == "drag":
                 start_coords = arguments.get("start_coordinates", [0, 0])


### PR DESCRIPTION
## Summary
- `navigator_n1_5.py`'s `mouse_move`/`mouse_down`/`mouse_up` branches of `_execute()` each repeated the same shape (resolve coordinates, move the mouse, at most one of `mouse.down()`/`mouse.up()`, sleep 0.3s, finish with a message), differing only in the optional down/up call and the message.
- Extracted the shared shape into `_move_mouse_and_finish()`, mirroring the `_navigate_and_finish()` extraction already done in #203 for the `goto_url`/`go_back`/`go_forward`/`refresh` branches of the same file.
- No behavior change — same operation order, same sleep duration, same messages, same error-return path for each of the three actions.

## Test plan
- [x] `pytest` — 560 passed, 3 skipped (same baseline as before the change)
- [x] `ruff check .` — all checks passed
- [x] Manual diff review confirming the three branches collapse to one-line delegating calls with identical resulting behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U684GYGQMEbhpvJouicXXQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01U684GYGQMEbhpvJouicXXQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only structural refactor with identical control flow; no security or production API surface changes.
> 
> **Overview**
> Deduplicates the **`mouse_move`**, **`mouse_down`**, and **`mouse_up`** handlers in `navigator_n1_5.py` by routing them through a new **`_move_mouse_and_finish()`** helper, following the same pattern as **`_navigate_and_finish()`** for navigation actions.
> 
> The helper centralizes coordinate resolution, mouse move, optional **`mouse.down()`** / **`mouse.up()`**, the 0.3s sleep, and **`_finish_action()`** with a per-action message. **`_execute`** now delegates each of the three branches in one line instead of repeating ~8 lines each.
> 
> **No intended behavior change** — same order of operations, sleeps, return messages, and error paths from **`_resolve_coordinates`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 851aebbb7072df9b6cfbbe59bd4c57e410a8aaf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->