### PR TITLE
refactor(examples): extract _move_with_modifier_held() for n1.5 click/scroll actions

### DIFF
--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -42,6 +42,7 @@ Usage:
 import argparse
 import asyncio
 import json
+from typing import Any
 
 from _common import (
     BrowserAgentMixin,
@@ -386,6 +387,32 @@ class Agent(BrowserAgentMixin):
         await asyncio.sleep(sleep)
         return await self._finish_action(message)
 
+    async def _move_with_modifier_held(
+        self,
+        modifier: str | None,
+        abs_x: int,
+        abs_y: int,
+        action: Any,
+        *,
+        pre_action_sleep: float = 0,
+    ) -> None:
+        """Move the mouse to ``(abs_x, abs_y)``, optionally holding ``modifier`` down, run ``action``, then release it.
+
+        Shared by the click and scroll branches of :meth:`_execute`, which each conditionally
+        pressed a modifier key, moved the mouse, performed their own follow-up mouse action,
+        then released the modifier -- otherwise identical bracketing. ``action`` is an
+        already-created coroutine (e.g. ``self._page.mouse.click(...)``); ``pre_action_sleep``
+        covers the click branch's extra settle delay between the move and the click itself.
+        """
+        if modifier:
+            await self._page.keyboard.down(modifier)
+        await self._page.mouse.move(abs_x, abs_y)
+        if pre_action_sleep:
+            await asyncio.sleep(pre_action_sleep)
+        await action
+        if modifier:
+            await self._page.keyboard.up(modifier)
+
     async def _move_mouse_and_finish(self, arguments: dict, *, mouse_action: str | None, message: str) -> str | None:
         """Resolve coordinates, move the mouse there, optionally press/release, then finish.
 
@@ -427,13 +454,13 @@ class Agent(BrowserAgentMixin):
                 button = {"middle_click": "middle", "right_click": "right"}.get(action_name, "left")
                 click_count = {"double_click": 2, "triple_click": 3}.get(action_name, 1)
 
-                if modifier:
-                    await self._page.keyboard.down(modifier)
-                await self._page.mouse.move(abs_x, abs_y)
-                await asyncio.sleep(0.1)
-                await self._page.mouse.click(abs_x, abs_y, button=button, click_count=click_count)
-                if modifier:
-                    await self._page.keyboard.up(modifier)
+                await self._move_with_modifier_held(
+                    modifier,
+                    abs_x,
+                    abs_y,
+                    self._page.mouse.click(abs_x, abs_y, button=button, click_count=click_count),
+                    pre_action_sleep=0.1,
+                )
                 await asyncio.sleep(0.5)
                 return await self._finish_action(f"Clicked {click_count}x with {button}")
 
@@ -499,12 +526,9 @@ class Agent(BrowserAgentMixin):
                     elif direction == "right":
                         delta_x = px
 
-                    if modifier:
-                        await self._page.keyboard.down(modifier)
-                    await self._page.mouse.move(abs_x, abs_y)
-                    await self._page.mouse.wheel(delta_x, delta_y)
-                    if modifier:
-                        await self._page.keyboard.up(modifier)
+                    await self._move_with_modifier_held(
+                        modifier, abs_x, abs_y, self._page.mouse.wheel(delta_x, delta_y)
+                    )
                     await asyncio.sleep(0.5)
                     return await self._finish_action(f"Scrolled {direction}")
                 else:


### PR DESCRIPTION
## Summary
- `navigator_n1_5.py`'s click and scroll branches of `_execute()` each independently pressed an optional modifier key, moved the mouse, ran their own follow-up mouse action, then released the modifier — otherwise identical bracketing.
- Extracted the shared shape into `_move_with_modifier_held()`, mirroring the `_navigate_and_finish()`/`_move_mouse_and_finish()` extractions already done for the navigation and mouse-move branches in this same file (#203, #205).
- No behavior change: verified call ordering (`down -> move -> [sleep] -> action -> up`) matches the original code exactly via a smoke test.

## Test plan
- [x] `pytest` before and after: 560 passed, 3 skipped (unchanged) — no test imports this standalone example script directly, so the safety net here is the manual call-order verification described above.
- [x] `ruff check .` clean.
- [x] Manual smoke test confirming the extracted helper reproduces the exact original call sequence for both the click branch (with modifier + pre-action sleep) and the scroll branch (no modifier).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDHpPnm5kFMhbBqr4Y7Cua)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only refactor with preserved call order; no production library or test surface changes.
> 
> **Overview**
> In **`examples/navigator_n1_5.py`**, the click and coordinate-based scroll paths in **`_execute`** duplicated the same sequence: optional modifier **`keyboard.down`**, mouse move, follow-up action, then **`keyboard.up`**.
> 
> This PR pulls that into **`_move_with_modifier_held`**, in line with existing **`_navigate_and_finish`** / **`_move_mouse_and_finish`** helpers. Clicks pass the Playwright click coroutine with **`pre_action_sleep=0.1`**; scroll passes **`mouse.wheel`**. **`typing.Any`** is added for the **`action`** parameter.
> 
> **No intended runtime change** — ordering stays **`down → move → [sleep] → action → up`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac67900256efd8dc8bc3a0508db3e905071a494d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->