### PR TITLE
refactor(examples): use payload.py's canonical default constants instead of hardcoded literals

### DIFF
--- a/examples/navigator_n1.py
+++ b/examples/navigator_n1.py
@@ -33,12 +33,13 @@ from openai.types.chat import ChatCompletion
 
 from yutori.config import DEFAULT_BASE_URL
 from yutori.navigator import NAVIGATOR_N1_MODEL
+from yutori.navigator.payload import DEFAULT_KEEP_RECENT_SCREENSHOTS, DEFAULT_MAX_REQUEST_BYTES
 
 
 class Config(BaseAgentConfig):
     # payload management
-    max_request_bytes: int = 9_500_000
-    keep_recent_screenshots: int = 6
+    max_request_bytes: int = DEFAULT_MAX_REQUEST_BYTES
+    keep_recent_screenshots: int = DEFAULT_KEEP_RECENT_SCREENSHOTS
 
 
 class Agent(BrowserAgentMixin):
@@ -51,8 +52,8 @@ class Agent(BrowserAgentMixin):
         viewport_width: int = 1280,
         viewport_height: int = 800,
         headless: bool = False,
-        max_request_bytes: int = 9_500_000,
-        keep_recent_screenshots: int = 6,
+        max_request_bytes: int = DEFAULT_MAX_REQUEST_BYTES,
+        keep_recent_screenshots: int = DEFAULT_KEEP_RECENT_SCREENSHOTS,
         replay_dir: str | None = None,
         replay_id: str | None = None,
     ):

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -74,6 +74,7 @@ from yutori.navigator import (
     map_key_to_playwright,
     map_keys_individual,
 )
+from yutori.navigator.payload import DEFAULT_KEEP_RECENT_SCREENSHOTS, DEFAULT_MAX_REQUEST_BYTES
 from yutori.navigator.tools import (
     EXECUTE_JS_SCRIPT,
     EXTRACT_ELEMENTS_SCRIPT,
@@ -111,8 +112,8 @@ class Config(BaseModel):
     viewport_height: int = 800
     headless: bool = False
     # payload management
-    max_request_bytes: int = 9_500_000
-    keep_recent_screenshots: int = 6
+    max_request_bytes: int = DEFAULT_MAX_REQUEST_BYTES
+    keep_recent_screenshots: int = DEFAULT_KEEP_RECENT_SCREENSHOTS
     # optional local replay artifacts
     replay_dir: str | None = None
     replay_id: str | None = None
@@ -133,8 +134,8 @@ class Agent(BrowserAgentMixin):
         viewport_width: int = 1280,
         viewport_height: int = 800,
         headless: bool = False,
-        max_request_bytes: int = 9_500_000,
-        keep_recent_screenshots: int = 6,
+        max_request_bytes: int = DEFAULT_MAX_REQUEST_BYTES,
+        keep_recent_screenshots: int = DEFAULT_KEEP_RECENT_SCREENSHOTS,
         replay_dir: str | None = None,
         replay_id: str | None = None,
     ):


### PR DESCRIPTION
## What

`examples/navigator_n1.py` and `examples/navigator_n1_5.py` each hardcoded the literals `9_500_000` and `6` as the default values for `max_request_bytes`/`keep_recent_screenshots`, in both their `Config` class and `Agent.__init__` signature (4 occurrences total across the 2 files).

These literals duplicate `yutori.navigator.payload.DEFAULT_MAX_REQUEST_BYTES`/`DEFAULT_KEEP_RECENT_SCREENSHOTS`, which are already the single source of truth used internally throughout the SDK — `yutori/navigator/loop.py` imports and uses both as defaults in four different function signatures, and `payload.py` itself uses them in `trim_images_to_fit`/`trimmed_messages_to_fit`.

This PR replaces the 4 hardcoded literal-pairs with imports of the existing constants, matching the example scripts' established precedent of importing directly from `yutori.navigator` submodules (`_common.py` already does this for `yutori.navigator.loop`, `yutori.navigator.replay`, `yutori.navigator.page_ready`; `navigator_n1_5.py` already does this for `yutori.navigator.tools`).

## Why

If `DEFAULT_MAX_REQUEST_BYTES`/`DEFAULT_KEEP_RECENT_SCREENSHOTS` are ever tuned in `payload.py` (the SDK's actual payload-trimming behavior), these two example scripts' advertised CLI defaults would silently drift out of sync with the rest of the SDK, since they were re-deriving the values as separate literals instead of referencing the canonical constants.

## Safety

- Purely substitutive: the constants equal the exact same literals today (`9_500_000` and `6`, pinned by `tests/test_navigator_payload.py`), so this is 100% behavior-preserving.
- Only 2 files touched, no logic changes, no test changes needed.
- Verified: `Config().max_request_bytes == DEFAULT_MAX_REQUEST_BYTES == 9_500_000` and `Config().keep_recent_screenshots == DEFAULT_KEEP_RECENT_SCREENSHOTS == 6` for both example modules after the change (direct import check), plus that both `Agent.__init__` signature defaults match.
- Full test suite: 560 passed, 3 skipped (unchanged from baseline).
- `ruff check .` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CTpMSoC7f7kXGpgzBfFLL5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Substitutive default-value change only in example code; no runtime logic or SDK behavior changes.
> 
> **Overview**
> The **navigator n1** and **n1.5** example scripts no longer hardcode `9_500_000` and `6` for payload trimming. Their `Config` defaults and `Agent.__init__` parameters now use `DEFAULT_MAX_REQUEST_BYTES` and `DEFAULT_KEEP_RECENT_SCREENSHOTS` from `yutori.navigator.payload`, matching the SDK’s internal defaults in `loop.py` and trimming helpers.
> 
> Behavior is unchanged today; the point is that if those constants are tuned in one place, example CLI defaults stay aligned with the rest of the Navigator stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7e967294eda31428204978a491a035421017e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->