### PR TITLE
refactor(examples): extract _press_key_and_finish() for n1.5 key_press/hold_key

### DIFF
--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -434,6 +434,20 @@ class Agent(BrowserAgentMixin):
         await asyncio.sleep(0.3)
         return await self._finish_action(message)
 
+    async def _press_key_and_finish(self, key_expr: str) -> str | None:
+        """Map ``key_expr`` to Playwright key names, press each in sequence, then finish.
+
+        Shared by the ``key_press`` branch and ``hold_key``'s no-duration fallback of
+        :meth:`_execute`, which each mapped the same key expression, pressed the resulting
+        keys, slept 0.3s, and finished with the same "Pressed key: ..." message --
+        otherwise identical.
+        """
+        key_presses = map_key_to_playwright(key_expr)
+        for key in key_presses:
+            await self._page.keyboard.press(key)
+        await asyncio.sleep(0.3)
+        return await self._finish_action(f"Pressed key: {key_expr}")
+
     async def _execute(self, tool_call: ChatCompletionMessageToolCall) -> str | None:
         action_name = tool_call.function.name
 
@@ -546,11 +560,7 @@ class Agent(BrowserAgentMixin):
 
             elif action_name == "key_press":
                 key_expr = arguments.get("key", "")
-                key_presses = map_key_to_playwright(key_expr)
-                for key in key_presses:
-                    await self._page.keyboard.press(key)
-                await asyncio.sleep(0.3)
-                return await self._finish_action(f"Pressed key: {key_expr}")
+                return await self._press_key_and_finish(key_expr)
 
             elif action_name == "hold_key":
                 key_expr = arguments.get("key", "")
@@ -565,11 +575,7 @@ class Agent(BrowserAgentMixin):
                     await asyncio.sleep(0.3)
                     return await self._finish_action(f"Held key '{key_expr}' for {duration}s")
                 else:
-                    key_presses = map_key_to_playwright(key_expr)
-                    for key in key_presses:
-                        await self._page.keyboard.press(key)
-                    await asyncio.sleep(0.3)
-                    return await self._finish_action(f"Pressed key: {key_expr}")
+                    return await self._press_key_and_finish(key_expr)
 
             # ---- Navigation actions ----
             elif action_name == "goto_url":


### PR DESCRIPTION
## Issue

`examples/navigator_n1_5.py`'s `_execute()` had two branches with byte-for-byte identical bodies:

- the `key_press` branch, and
- `hold_key`'s no-duration fallback (the `else` clause when `duration` is `None` or `<= 0`)

Both mapped the same key expression to Playwright key names via `map_key_to_playwright`, pressed each key in sequence, slept 0.3s, and finished with the same `"Pressed key: {key_expr}"` message.

This is the same file that just had three related extractions land (#205 `_move_mouse_and_finish`, #206 `_move_with_modifier_held`, #207 canonical default constants) — this duplication is in the keyboard-actions branch, which those PRs didn't touch.

## Improvement

Extracted the shared body into a new `_press_key_and_finish(key_expr)` helper method, mirroring the docstring/naming convention of the existing `_navigate_and_finish` / `_move_mouse_and_finish` / `_move_with_modifier_held` extractions in this same file. Both call sites now just delegate to it.

## Why this is safe

- Purely mechanical extraction — no control flow or argument changes, just moving an identical code block into a shared method and calling it from both places.
- Full test suite: **560 passed, 3 skipped** before and after (unchanged) — no existing test imports this standalone example script's `Agent._execute` directly.
- `ruff check` clean on the changed file.
- Verified behavioral equivalence directly: instantiated `Agent` with a mocked Playwright `page` and drove `_execute()` for both `key_press` and `hold_key` (no duration) with the same key expression (`"ctrl+c"`). Both produced the identical `page.keyboard.press` call sequence (`Control+c`) and the identical result string (`"Pressed key: ctrl+c"`). Also verified the `hold_key` duration path (down/up sequence) is untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYYUYR2NoQp91bgaUQfKqm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication in a standalone example script with no behavior or API changes.
> 
> **Overview**
> **Refactor only** in `examples/navigator_n1_5.py`: duplicated keyboard handling in `key_press` and `hold_key` (when `duration` is missing or ≤ 0) is moved into **`_press_key_and_finish(key_expr)`**, following the same pattern as `_navigate_and_finish` and `_move_mouse_and_finish`.
> 
> Both branches now delegate to that helper; **`hold_key` with a positive `duration`** still uses down/sleep/up and is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c7966d5aa697528f715fca271ed74a65b3fce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->