### PR TITLE
refactor(examples): extract _find_record() helper in navigator_n1_memo.py

### DIFF
--- a/examples/navigator_n1_memo.py
+++ b/examples/navigator_n1_memo.py
@@ -125,14 +125,20 @@ class MemoToolSuite:
         with open(file_path, "w") as f:
             f.write("\n".join(lines))
 
-    async def add_question(self, index: int, question: str, description: str | None = None) -> str:
-        records = await self.read_jsonl(self.file_path)
+    @staticmethod
+    def _find_record(records: list[dict], index: int) -> dict | None:
         for record in records:
             if record["index"] == index:
-                record["question"] = question
-                record["description"] = description
-                logger.warning(f"Updated question {index} with new question: {question} and description: {description}")
-                break
+                return record
+        return None
+
+    async def add_question(self, index: int, question: str, description: str | None = None) -> str:
+        records = await self.read_jsonl(self.file_path)
+        record = self._find_record(records, index)
+        if record is not None:
+            record["question"] = question
+            record["description"] = description
+            logger.warning(f"Updated question {index} with new question: {question} and description: {description}")
         else:
             records.append({"index": index, "question": question, "description": description})
         await self.write_jsonl(self.file_path, records)
@@ -140,12 +146,10 @@ class MemoToolSuite:
 
     async def add_options(self, question_index: int, options: list[str]) -> str:
         records = await self.read_jsonl(self.file_path)
-        for record in records:
-            if record["index"] == question_index:
-                record.setdefault("options", []).extend(options)
-                break
-        else:
+        record = self._find_record(records, question_index)
+        if record is None:
             raise ValueError(f"Question index {question_index} not found")
+        record.setdefault("options", []).extend(options)
         await self.write_jsonl(self.file_path, records)
         return f"Successfully added options to question {question_index}"
 


### PR DESCRIPTION
## What

`MemoToolSuite.add_question` and `MemoToolSuite.add_options` (`examples/navigator_n1_memo.py`) each hand-rolled the identical "find record by index" `for`/`else` loop over the JSONL records, differing only in their found/not-found branches (update-in-place + warn-log vs. append; and setdefault-extend vs. raise `ValueError`).

Extracted a `_find_record(records, index) -> dict | None` static helper; both methods now branch on its return value instead of duplicating the linear search.

## Why this is safe

- Pure mechanical extraction, confined to a single file, no other module references this logic.
- Verified identical behavior via a before/after script (compared against `git stash`) exercising: adding a new question, adding a question with no description, adding options to two different questions, updating an existing question (warn-log path), and adding options to a nonexistent question (the `ValueError` path). Return values, the resulting JSONL file contents, and the error message are all byte-identical before/after (only timestamps/tmpdir paths/log line-numbers differ, as expected).
- `ruff check` / `ruff format --diff` clean.

🤖 Generated as part of an automated hourly refactor pass.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01T7kHvhTDd3MkfMVUxPdUrC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only mechanical refactor with no API or cross-module impact; behavior preserved per PR verification.
> 
> **Overview**
> **Refactors** `MemoToolSuite` in `examples/navigator_n1_memo.py` by pulling the repeated “find JSONL record by `index`” loop into a static **`_find_record(records, index)`** helper that returns the matching dict or `None`.
> 
> **`add_question`** and **`add_options`** now call that helper instead of each implementing their own `for`/`else` search; update-vs-append and missing-index **`ValueError`** behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1187d19550b0e511db79d62bf6c195fa9ed68768. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->