### PR TITLE
refactor(auth): consolidate __getattr__ lazy-import dispatch to match n1 shim idiom

### DIFF
--- a/yutori/auth/__init__.py
+++ b/yutori/auth/__init__.py
@@ -8,16 +8,15 @@ penalizing SDK users who never use the OAuth login flow.
 from .credentials import clear_config, load_config, require_api_key, resolve_api_key, save_config
 from .types import AuthStatus, LoginResult
 
+# Names lazily re-exported from .flow (see module docstring for why).
+_LAZY_FLOW_ATTRS = frozenset({"run_login_flow", "get_auth_status"})
+
 
 def __getattr__(name: str):
-    if name == "run_login_flow":
-        from .flow import run_login_flow
+    if name in _LAZY_FLOW_ATTRS:
+        from . import flow
 
-        return run_login_flow
-    if name == "get_auth_status":
-        from .flow import get_auth_status
-
-        return get_auth_status
+        return getattr(flow, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 


### PR DESCRIPTION
## Issue

`yutori/auth/__init__.py` hand-rolls a per-name `if`/`if` chain in its module-level `__getattr__` to lazily import `run_login_flow` and `get_auth_status` from `.flow` (heavyweight imports — `http.server`, `threading`, `webbrowser` — that the module docstring explicitly says should stay lazy for SDK users who never touch the OAuth login flow).

`yutori/n1/__init__.py` already solves the identical shape of problem (PEP 562 lazy-attribute dispatch) more cleanly, with a `frozenset` of names plus `importlib`/`getattr`. A repo-wide grep confirms these are the only two `__getattr__` implementations in the package, so this is a contained, non-systemic fix — not part of the previously-flagged, larger `_sync`/`_async` duplication (which stays out of scope).

## Improvement

Mirror the `n1` idiom in `auth/__init__.py`:

```python
_LAZY_FLOW_ATTRS = frozenset({"run_login_flow", "get_auth_status"})

def __getattr__(name: str):
    if name in _LAZY_FLOW_ATTRS:
        from . import flow
        return getattr(flow, name)
    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
```

## Safety

- **No behavior change**: `.flow` is still only imported on first access of either name; any other attribute still raises the identical `AttributeError` message.
- **Blast radius**: 1 file.
- Existing coverage in `tests/test_auth.py`, `tests/test_cli_auth.py`, and `tests/test_install_flow.py` all exercise these attrs through the package.
- Full suite: `uv run pytest -q` → 560 passed, 3 skipped (same as before the change).
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0126J6XW6h1mFwY9sW2kytnm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file refactor with equivalent lazy-import semantics; no auth or API behavior changes.
> 
> **Overview**
> Refactors **`yutori/auth/__init__.py`** lazy re-exports so **`run_login_flow`** and **`get_auth_status`** are handled through a single **`_LAZY_FLOW_ATTRS`** `frozenset` and one **`__getattr__`** branch that imports **`.flow`** and uses **`getattr(flow, name)`**, instead of separate per-name **`if`** blocks.
> 
> **Lazy-loading behavior is unchanged**: **`.flow`** still loads only on first access to either name, and unknown attributes still raise the same **`AttributeError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aff61fafad219bf02fe3eb513fbe576b701d8556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->