### PR TITLE
refactor(cli): extract render_entity_table() shared by scouts/task list output

### DIFF
--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from typing import Any
 
 import httpx
@@ -33,6 +33,7 @@ __all__ = [
     "print_task_list",
     "print_task_result_output",
     "print_task_submission_result",
+    "render_entity_table",
     "safe_str",
     "truncate_for_display",
 ]
@@ -269,6 +270,55 @@ def print_task_result_output(console: Console, result: dict[str, Any], *, max_le
     console.print(text, markup=False)
 
 
+def render_entity_table(
+    console: Console,
+    title: str,
+    items: list[dict[str, Any]],
+    *,
+    id_key: str,
+    id_label: str,
+    fourth_column_label: str,
+    fourth_column_fn: Callable[[dict[str, Any]], Any],
+) -> None:
+    """Render the 5-column Rich table shared by task-list and scout-list output.
+
+    Column shape: ``{id_label}`` / Query / Status / ``{fourth_column_label}`` / Reason.
+    ``id_key`` selects each item's identifier field (e.g. ``"task_id"`` for
+    browse/research, ``"id"`` for scouts); ``fourth_column_fn`` derives the 4th
+    column's value per item (e.g. a truncated created-at date, or a formatted
+    interval). Every cell goes through ``safe_str`` so API strings render
+    literally. Shared by ``print_task_list`` (browse/research) and
+    ``yutori scouts list``, which otherwise built structurally identical
+    tables that only differed in these four spots.
+    """
+    table = Table(title=title)
+    table.add_column(id_label, style="cyan", no_wrap=True)
+    table.add_column("Query", max_width=50)
+    table.add_column("Status", style="green")
+    table.add_column(fourth_column_label)
+    table.add_column("Reason", max_width=32)
+
+    for item in items:
+        # The list endpoints return the prompt under `query` for every entity
+        # type (browse create takes it as `task`).
+        query = truncate_for_display(str(item.get("query", "")))
+
+        table.add_row(
+            safe_str(item.get(id_key, "")),
+            safe_str(query),
+            safe_str(item.get("status", "unknown")),
+            safe_str(fourth_column_fn(item)),
+            safe_str(item.get("rejection_reason") or ""),
+        )
+
+    console.print(table)
+
+
+def _created_at_date(item: dict[str, Any]) -> str:
+    """Return just the YYYY-MM-DD date from an ISO-8601 ``created_at`` timestamp."""
+    return str(item.get("created_at") or "")[:10]
+
+
 def print_task_list(console: Console, task_type: str, result: dict[str, Any]) -> None:
     """Render a browsing/research task-list response as a Rich table.
 
@@ -282,30 +332,15 @@ def print_task_list(console: Console, task_type: str, result: dict[str, Any]) ->
     tasks = result.get("tasks", [])
 
     if tasks:
-        table = Table(title=f"Your {task_type} Tasks")
-        table.add_column("Task ID", style="cyan", no_wrap=True)
-        table.add_column("Query", max_width=50)
-        table.add_column("Status", style="green")
-        table.add_column("Created")
-        table.add_column("Reason", max_width=32)
-
-        for task in tasks:
-            # The list endpoint returns the prompt under `query` for both task types
-            # (browse create takes it as `task`).
-            query = truncate_for_display(str(task.get("query", "")))
-
-            # created_at is an ISO-8601 datetime; show just the YYYY-MM-DD date.
-            created = str(task.get("created_at") or "")[:10]
-
-            table.add_row(
-                safe_str(task.get("task_id", "")),
-                safe_str(query),
-                safe_str(task.get("status", "unknown")),
-                safe_str(created),
-                safe_str(task.get("rejection_reason") or ""),
-            )
-
-        console.print(table)
+        render_entity_table(
+            console,
+            f"Your {task_type} Tasks",
+            tasks,
+            id_key="task_id",
+            id_label="Task ID",
+            fourth_column_label="Created",
+            fourth_column_fn=_created_at_date,
+        )
     else:
         console.print(f"[yellow]No {task_type.lower()} tasks found.[/yellow]")
 

--- a/yutori/cli/commands/scouts.py
+++ b/yutori/cli/commands/scouts.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import typer
 from rich.console import Console
-from rich.table import Table
 
 from yutori.cli.commands import (
     INTERVAL_PRESETS,
@@ -13,8 +12,8 @@ from yutori.cli.commands import (
     print_creation_result,
     print_optional_field,
     print_rejection_reason,
+    render_entity_table,
     safe_str,
-    truncate_for_display,
 )
 
 app = typer.Typer(help="Manage scouts")
@@ -35,27 +34,15 @@ def list_scouts(
             console.print("[yellow]No scouts found.[/yellow]")
             return
 
-        table = Table(title="Your Scouts")
-        table.add_column("ID", style="cyan", no_wrap=True)
-        table.add_column("Query", max_width=50)
-        table.add_column("Status", style="green")
-        table.add_column("Interval")
-        table.add_column("Reason", max_width=32)
-
-        for scout in scouts:
-            interval_str = format_interval(scout.get("output_interval") or 0, short=True)
-
-            query = truncate_for_display(str(scout.get("query", "")))
-
-            table.add_row(
-                safe_str(scout.get("id", "")),
-                safe_str(query),
-                safe_str(scout.get("status", "unknown")),
-                interval_str,
-                safe_str(scout.get("rejection_reason") or ""),
-            )
-
-        console.print(table)
+        render_entity_table(
+            console,
+            "Your Scouts",
+            scouts,
+            id_key="id",
+            id_label="ID",
+            fourth_column_label="Interval",
+            fourth_column_fn=lambda scout: format_interval(scout.get("output_interval") or 0, short=True),
+        )
 
 
 @app.command()


### PR DESCRIPTION
## What

`yutori scouts list` (`yutori/cli/commands/scouts.py`) built its own Rich table with the same 5-column shape (ID / Query / Status / 4th-column / Reason) as `print_task_list` (`yutori/cli/commands/__init__.py`), which already unifies `browse list` / `research list` rendering. `scouts.py` predates `print_task_list` and was never migrated onto it, even though the two blocks were structurally identical modulo four spots:

- the ID field key (`task_id` vs `id`) and its column label (`"Task ID"` vs `"ID"`)
- the 4th column's label and value (`"Created"` + truncated `created_at` vs `"Interval"` + `format_interval(...)`)

This PR extracts a new `render_entity_table(console, title, items, *, id_key, id_label, fourth_column_label, fourth_column_fn)` helper in `commands/__init__.py`. `print_task_list` now builds its table via this helper (keeping its own summary/cursor-hint logic, which `scouts.py` doesn't have), and `list_scouts` calls the same helper directly instead of hand-rolling the table.

## Why this is safe

- **No public API change** — this only touches internal CLI rendering helpers, not anything importable from the `yutori` package surface.
- **Behavior-preserving**: column order, headers, truncation, and `safe_str`/`.get(..., default)` idioms are identical to before. The one intentional normalization is that the "Interval" cell (previously written directly, unlike every other cell) is now also passed through `safe_str` like the rest — a no-op in practice since `format_interval()` only ever emits plain `"<int><unit>"` text with no Rich markup characters.
- **Only 2 files touched**: `yutori/cli/commands/__init__.py`, `yutori/cli/commands/scouts.py`.
- **Verified**: full test suite passes (560 passed, 3 skipped), including the existing `scouts list` tests covering rejection-reason columns, markup-escaping (`test_scouts_list_renders_markup_like_queries_literally`), and non-string field stringification (`test_scouts_list_stringifies_non_string_fields_before_escaping`), plus the `browse`/`research` list tests that exercise `print_task_list`. `ruff check` and `ruff format --check` both pass on the changed files.

## Test plan

- [x] `pytest tests/` — 560 passed, 3 skipped
- [x] `ruff check yutori/cli/commands/__init__.py yutori/cli/commands/scouts.py` — clean
- [x] `ruff format --check yutori/cli/commands/__init__.py yutori/cli/commands/scouts.py` — clean
- [x] Manually traced `list_scouts` and `print_task_list` call sites against `render_entity_table` to confirm identical column order/content vs. the pre-refactor code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pCwymiCMikDwBus3TTkcr

---
_Generated by [Claude Code](https://claude.ai/code/session_016pCwymiCMikDwBus3TTkcr)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CLI display refactor only; column layout and escaping stay the same aside from routing the interval cell through `safe_str`.
> 
> **Overview**
> Introduces **`render_entity_table()`** in `yutori/cli/commands/__init__.py` so browse/research task lists and **`yutori scouts list`** share one 5-column Rich table (ID, Query, Status, 4th column, Reason) instead of duplicating the same layout.
> 
> **`print_task_list`** now delegates table rendering to that helper (with `_created_at_date` for the Created column) while keeping its empty-state message, summary totals, and cursor hint. **`list_scouts`** calls the same helper with scout-specific `id`/`Interval` and `format_interval(..., short=True)` for the fourth column.
> 
> The Interval cell is now passed through **`safe_str`** like the other columns (behaviorally unchanged for normal interval strings). **`render_entity_table`** is exported from the commands package **`__all__`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56eb259176bd5ca2dafa53a9cfef5a3b41095b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->