### PR TITLE
refactor(cli): extract list_and_render_tasks() shared by browse/research list

### DIFF
--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "print_creation_result",
     "print_optional_field",
     "print_rejection_reason",
+    "list_and_render_tasks",
     "print_task_get_header",
     "print_task_list",
     "print_task_result_output",
@@ -357,6 +358,26 @@ def print_task_list(console: Console, task_type: str, result: dict[str, Any]) ->
     next_cursor = result.get("next_cursor")
     if result.get("has_more") and next_cursor:
         console.print(f"More results available. Re-run with --cursor {safe_str(next_cursor)}")
+
+
+def list_and_render_tasks(
+    console: Console,
+    client: Any,
+    namespace: str,
+    task_type: str,
+    *,
+    limit: int | None,
+    status: str | None,
+    cursor: str | None,
+) -> None:
+    """Fetch and render a task list -- the shared body of ``browse list`` and ``research list``.
+
+    ``namespace`` selects the client attribute to call ``.list(...)`` on (e.g.
+    ``"browsing"`` or ``"research"``); ``task_type`` is the display title passed
+    through to ``print_task_list``.
+    """
+    result = getattr(client, namespace).list(limit=limit, status=status, cursor=cursor)
+    print_task_list(console, task_type, result)
 
 
 def format_interval(seconds: int, *, short: bool = False) -> str:

--- a/yutori/cli/commands/browse.py
+++ b/yutori/cli/commands/browse.py
@@ -7,9 +7,9 @@ from rich.console import Console
 
 from yutori.cli.commands import (
     cli_client,
+    list_and_render_tasks,
     print_optional_field,
     print_task_get_header,
-    print_task_list,
     print_task_result_output,
     print_task_submission_result,
 )
@@ -26,8 +26,7 @@ def list_tasks(
 ) -> None:
     """List your browsing tasks."""
     with cli_client() as client:
-        result = client.browsing.list(limit=limit, status=status, cursor=cursor)
-        print_task_list(console, "Browsing", result)
+        list_and_render_tasks(console, client, "browsing", "Browsing", limit=limit, status=status, cursor=cursor)
 
 
 @app.command()

--- a/yutori/cli/commands/research.py
+++ b/yutori/cli/commands/research.py
@@ -7,9 +7,9 @@ from rich.console import Console
 
 from yutori.cli.commands import (
     cli_client,
+    list_and_render_tasks,
     print_optional_field,
     print_task_get_header,
-    print_task_list,
     print_task_result_output,
     print_task_submission_result,
 )
@@ -26,8 +26,7 @@ def list_tasks(
 ) -> None:
     """List your research tasks."""
     with cli_client() as client:
-        result = client.research.list(limit=limit, status=status, cursor=cursor)
-        print_task_list(console, "Research", result)
+        list_and_render_tasks(console, client, "research", "Research", limit=limit, status=status, cursor=cursor)
 
 
 @app.command()


### PR DESCRIPTION
## What

`browse.list_tasks` and `research.list_tasks` were byte-for-byte identical Typer commands except for two tokens: the client namespace attribute (`client.browsing` vs `client.research`) and the label string (`"Browsing"` vs `"Research"`). The immediately-preceding commit (`055c400`, "extract `render_entity_table()` shared by scouts/task list output") already unified the *rendering* one layer down, but left this thin command wrapper duplicated across both files.

## Fix

Added `list_and_render_tasks()` to `yutori/cli/commands/__init__.py`, next to the existing `print_task_list`:

```python
def list_and_render_tasks(
    console: Console,
    client: Any,
    namespace: str,
    task_type: str,
    *,
    limit: int | None,
    status: str | None,
    cursor: str | None,
) -> None:
    result = getattr(client, namespace).list(limit=limit, status=status, cursor=cursor)
    print_task_list(console, task_type, result)
```

`browse.py`/`research.py` now call it (`"browsing"`/`"Browsing"` and `"research"`/`"Research"` respectively) instead of repeating the fetch-then-render body, and drop the now-unused `print_task_list` import.

(`scouts.list` is not part of this — it lacks `cursor` and uses a different status vocabulary, so it's genuinely different, not duplicated.)

## Why it's safe

- Pure mechanical extraction: identical control flow, identical arguments passed to `print_task_list`, no behavior change.
- `tests/test_cli.py` drives these commands only through the public CLI surface (`runner.invoke(app, args)`) with `get_authenticated_client` patched to a `MagicMock` — never reaches into `browse.py`/`research.py` internals, so it's a complete, unmodified regression check.
- `ruff check`/`ruff format --check` clean on all 3 changed files.

## Verification

- `tests/test_cli.py`: 29/29 pass.
- Full suite: 422 passed / 51 failed / 16 skipped, identical before and after (verified via `git stash` A/B) — the 51 failures are pre-existing and environment-only (missing Playwright browser binaries, packaging build tools unavailable in this sandbox), unrelated to this change.

🤖 Generated by an automated refactor cronjob.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T4d1y3ZfxWTxHRk3RyvKgh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with identical arguments and rendering; no auth, API contract, or CLI surface changes.
> 
> **Overview**
> **Browse** and **research** `list` commands no longer duplicate the same fetch-and-print flow. Both now call a shared **`list_and_render_tasks()`** in `yutori/cli/commands/__init__.py`, which uses `getattr(client, namespace).list(...)` and then **`print_task_list()`**.
> 
> The helper is exported from the commands package; **`browse.py`** and **`research.py`** pass `"browsing"`/`"Browsing"` or `"research"`/`"Research"` respectively and drop the direct **`print_task_list`** import. Behavior and CLI options are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43ec9eca4c68c1f301c4b34de7ef34d5a3d5ddc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->