### PR TITLE
refactor(tests): add async_client fixture mirroring the sync client fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from yutori import YutoriClient
+from yutori import AsyncYutoriClient, YutoriClient
 
 
 @pytest.fixture
@@ -11,6 +11,14 @@ def client():
     client = YutoriClient(api_key="yt-test")
     yield client
     client.close()
+
+
+@pytest.fixture
+async def async_client():
+    """Shared AsyncYutoriClient fixture for async tests, mirroring `client` above."""
+    client = AsyncYutoriClient(api_key="yt-test")
+    yield client
+    await client.close()
 
 
 def require_examples_extra() -> None:

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -47,166 +47,166 @@ class TestAsyncYutoriClientInit:
 
 @pytest.mark.asyncio
 class TestAsyncYutoriClientGetUsage:
-    async def test_get_usage_success(self):
+    async def test_get_usage_success(self, async_client):
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=make_mock_usage_response()):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.get_usage()
-                assert result["num_active_scouts"] == 2
-                assert result["activity"]["period"] == "24h"
+            client = async_client
+            result = await client.get_usage()
+            assert result["num_active_scouts"] == 2
+            assert result["activity"]["period"] == "24h"
 
-    async def test_get_usage_with_period(self):
+    async def test_get_usage_with_period(self, async_client):
         with patch.object(
             httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=make_mock_usage_response("30d")
         ) as mock_get:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.get_usage(period="30d")
-                assert result["activity"]["period"] == "30d"
-                call_kwargs = mock_get.call_args[1]
-                assert call_kwargs["params"] == {"period": "30d"}
+            client = async_client
+            result = await client.get_usage(period="30d")
+            assert result["activity"]["period"] == "30d"
+            call_kwargs = mock_get.call_args[1]
+            assert call_kwargs["params"] == {"period": "30d"}
 
 
 @pytest.mark.asyncio
 class TestAsyncScoutsNamespace:
-    async def test_scouts_list(self):
+    async def test_scouts_list(self, async_client):
         mock_response = make_json_response({"scouts": []})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.scouts.list(limit=10, status="active")
-                assert result == {"scouts": []}
-                params = mock_get.call_args[1]["params"]
-                assert params["page_size"] == 10
-                assert "limit" not in params
-                assert params["status"] == "active"
+            client = async_client
+            result = await client.scouts.list(limit=10, status="active")
+            assert result == {"scouts": []}
+            params = mock_get.call_args[1]["params"]
+            assert params["page_size"] == 10
+            assert "limit" not in params
+            assert params["status"] == "active"
 
-    async def test_scouts_list_forwards_cursor(self):
+    async def test_scouts_list_forwards_cursor(self, async_client):
         mock_response = make_json_response({"scouts": []})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                await client.scouts.list(cursor="next-page")
-                params = mock_get.call_args[1]["params"]
-                assert params["cursor"] == "next-page"
-                assert "page_size" not in params
+            client = async_client
+            await client.scouts.list(cursor="next-page")
+            params = mock_get.call_args[1]["params"]
+            assert params["cursor"] == "next-page"
+            assert "page_size" not in params
 
-    async def test_scouts_get(self):
+    async def test_scouts_get(self, async_client):
         mock_response = make_json_response({"id": "scout-123"})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.scouts.get("scout-123")
-                assert result["id"] == "scout-123"
+            client = async_client
+            result = await client.scouts.get("scout-123")
+            assert result["id"] == "scout-123"
 
-    async def test_scouts_create(self):
+    async def test_scouts_create(self, async_client):
         mock_response = make_json_response({"id": "new-scout"})
 
         with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.scouts.create(query="Monitor site")
-                assert result["id"] == "new-scout"
+            client = async_client
+            result = await client.scouts.create(query="Monitor site")
+            assert result["id"] == "new-scout"
 
-    async def test_scouts_update_status(self):
+    async def test_scouts_update_status(self, async_client):
         mock_response = make_json_response({"id": "scout-123", "status": "paused"})
 
         with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.scouts.update("scout-123", status="paused")
-                assert result["status"] == "paused"
-                assert "/pause" in mock_post.call_args[0][0]
+            client = async_client
+            result = await client.scouts.update("scout-123", status="paused")
+            assert result["status"] == "paused"
+            assert "/pause" in mock_post.call_args[0][0]
 
-    async def test_scouts_update_fields(self):
+    async def test_scouts_update_fields(self, async_client):
         mock_response = make_json_response({"id": "scout-123", "query": "new query"})
 
         with patch.object(httpx.AsyncClient, "patch", new_callable=AsyncMock, return_value=mock_response):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.scouts.update("scout-123", query="new query")
-                assert result["query"] == "new query"
+            client = async_client
+            result = await client.scouts.update("scout-123", query="new query")
+            assert result["query"] == "new query"
 
-    async def test_scouts_update_is_public(self):
+    async def test_scouts_update_is_public(self, async_client):
         mock_response = make_json_response({"id": "scout-123", "is_public": False})
 
         with patch.object(httpx.AsyncClient, "patch", new_callable=AsyncMock, return_value=mock_response) as mock_patch:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                await client.scouts.update("scout-123", is_public=False)
-                payload = mock_patch.call_args[1]["json"]
-                assert payload["is_public"] is False
+            client = async_client
+            await client.scouts.update("scout-123", is_public=False)
+            payload = mock_patch.call_args[1]["json"]
+            assert payload["is_public"] is False
 
-    async def test_scouts_update_status_and_fields_raises(self):
-        async with AsyncYutoriClient(api_key="yt-test") as client:
-            with pytest.raises(ValueError, match="Cannot update status and other fields simultaneously"):
-                await client.scouts.update("scout-123", status="paused", query="new query")
+    async def test_scouts_update_status_and_fields_raises(self, async_client):
+        client = async_client
+        with pytest.raises(ValueError, match="Cannot update status and other fields simultaneously"):
+            await client.scouts.update("scout-123", status="paused", query="new query")
 
-    async def test_scouts_delete(self):
+    async def test_scouts_delete(self, async_client):
         mock_response = make_status_response(200)
 
         with patch.object(httpx.AsyncClient, "delete", new_callable=AsyncMock, return_value=mock_response):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.scouts.delete("scout-123")
-                assert result == {}
+            client = async_client
+            result = await client.scouts.delete("scout-123")
+            assert result == {}
 
-    async def test_scouts_get_updates(self):
+    async def test_scouts_get_updates(self, async_client):
         mock_response = make_json_response({"updates": []})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.scouts.get_updates("scout-123")
-                assert "updates" in result
+            client = async_client
+            result = await client.scouts.get_updates("scout-123")
+            assert "updates" in result
 
 
 @pytest.mark.asyncio
 class TestAsyncBrowsingNamespace:
-    async def test_browsing_list(self):
+    async def test_browsing_list(self, async_client):
         mock_response = make_json_response({"tasks": [], "total": 0})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.browsing.list(limit=20, status="succeeded", cursor="cur-1")
-                assert result == {"tasks": [], "total": 0}
-                assert mock_get.call_args[0][0].endswith("/browsing/tasks")
-                params = mock_get.call_args[1]["params"]
-                assert params["page_size"] == 20
-                assert "limit" not in params
-                assert params["status"] == "succeeded"
-                assert params["cursor"] == "cur-1"
+            client = async_client
+            result = await client.browsing.list(limit=20, status="succeeded", cursor="cur-1")
+            assert result == {"tasks": [], "total": 0}
+            assert mock_get.call_args[0][0].endswith("/browsing/tasks")
+            params = mock_get.call_args[1]["params"]
+            assert params["page_size"] == 20
+            assert "limit" not in params
+            assert params["status"] == "succeeded"
+            assert params["cursor"] == "cur-1"
 
-    async def test_browsing_create(self):
+    async def test_browsing_create(self, async_client):
         mock_response = make_json_response({"task_id": "task-123"})
 
         with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.browsing.create(
-                    task="Click login",
-                    start_url="https://example.com",
-                )
-                assert result["task_id"] == "task-123"
+            client = async_client
+            result = await client.browsing.create(
+                task="Click login",
+                start_url="https://example.com",
+            )
+            assert result["task_id"] == "task-123"
 
-    async def test_browsing_create_with_local_browser_and_auth(self):
+    async def test_browsing_create_with_local_browser_and_auth(self, async_client):
         mock_response = make_json_response({"task_id": "task-456"})
 
         with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.browsing.create(
-                    task="Log in and export data",
-                    start_url="https://example.com/login",
-                    require_auth=True,
-                    browser="local",
-                    webhook_format="zapier",
-                )
-                assert result["task_id"] == "task-456"
-                payload = mock_post.call_args[1]["json"]
-                assert payload["require_auth"] is True
-                assert payload["browser"] == "local"
-                assert payload["webhook_format"] == "zapier"
+            client = async_client
+            result = await client.browsing.create(
+                task="Log in and export data",
+                start_url="https://example.com/login",
+                require_auth=True,
+                browser="local",
+                webhook_format="zapier",
+            )
+            assert result["task_id"] == "task-456"
+            payload = mock_post.call_args[1]["json"]
+            assert payload["require_auth"] is True
+            assert payload["browser"] == "local"
+            assert payload["webhook_format"] == "zapier"
 
-    async def test_browsing_get(self):
+    async def test_browsing_get(self, async_client):
         mock_response = make_json_response({"task_id": "task-123", "status": "succeeded"})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.browsing.get("task-123")
-                assert result["status"] == "succeeded"
+            client = async_client
+            result = await client.browsing.get("task-123")
+            assert result["status"] == "succeeded"
 
-    async def test_browsing_get_with_rejection_reason(self):
+    async def test_browsing_get_with_rejection_reason(self, async_client):
         mock_response = make_json_response(
             {
                 "task_id": "task-123",
@@ -216,45 +216,45 @@ class TestAsyncBrowsingNamespace:
         )
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.browsing.get("task-123")
-                assert result["status"] == "failed"
-                assert result["rejection_reason"] == "billing_limit_reached"
+            client = async_client
+            result = await client.browsing.get("task-123")
+            assert result["status"] == "failed"
+            assert result["rejection_reason"] == "billing_limit_reached"
 
 
 @pytest.mark.asyncio
 class TestAsyncResearchNamespace:
-    async def test_research_list(self):
+    async def test_research_list(self, async_client):
         mock_response = make_json_response({"tasks": [], "total": 0})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.research.list(limit=20, status="succeeded", cursor="cur-1")
-                assert result == {"tasks": [], "total": 0}
-                assert mock_get.call_args[0][0].endswith("/research/tasks")
-                params = mock_get.call_args[1]["params"]
-                assert params["page_size"] == 20
-                assert "limit" not in params
-                assert params["status"] == "succeeded"
-                assert params["cursor"] == "cur-1"
+            client = async_client
+            result = await client.research.list(limit=20, status="succeeded", cursor="cur-1")
+            assert result == {"tasks": [], "total": 0}
+            assert mock_get.call_args[0][0].endswith("/research/tasks")
+            params = mock_get.call_args[1]["params"]
+            assert params["page_size"] == 20
+            assert "limit" not in params
+            assert params["status"] == "succeeded"
+            assert params["cursor"] == "cur-1"
 
-    async def test_research_create(self):
+    async def test_research_create(self, async_client):
         mock_response = make_json_response({"task_id": "research-123"})
 
         with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.research.create(query="Find AI funding")
-                assert result["task_id"] == "research-123"
+            client = async_client
+            result = await client.research.create(query="Find AI funding")
+            assert result["task_id"] == "research-123"
 
-    async def test_research_get(self):
+    async def test_research_get(self, async_client):
         mock_response = make_json_response({"task_id": "research-123", "status": "succeeded"})
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.research.get("research-123")
-                assert result["status"] == "succeeded"
+            client = async_client
+            result = await client.research.get("research-123")
+            assert result["status"] == "succeeded"
 
-    async def test_research_get_with_rejection_reason(self):
+    async def test_research_get_with_rejection_reason(self, async_client):
         mock_response = make_json_response(
             {
                 "task_id": "research-123",
@@ -264,10 +264,10 @@ class TestAsyncResearchNamespace:
         )
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.research.get("research-123")
-                assert result["status"] == "failed"
-                assert result["rejection_reason"] == "rate_limit_exceeded"
+            client = async_client
+            result = await client.research.get("research-123")
+            assert result["status"] == "failed"
+            assert result["rejection_reason"] == "rate_limit_exceeded"
 
 
 @pytest.mark.asyncio
@@ -283,71 +283,71 @@ class TestAsyncPydanticSchemaIntegration:
         def model_json_schema(cls):
             return {"type": "object", "properties": {"name": {"type": "string"}}}
 
-    async def test_browsing_create_with_model_class(self):
+    async def test_browsing_create_with_model_class(self, async_client):
         with patch.object(
             httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=self._make_mock_response()
         ) as mock_post:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                await client.browsing.create(task="t", start_url="https://x.com", output_schema=self._FakeModel)
-                payload = mock_post.call_args[1]["json"]
-                assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
+            client = async_client
+            await client.browsing.create(task="t", start_url="https://x.com", output_schema=self._FakeModel)
+            payload = mock_post.call_args[1]["json"]
+            assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
-    async def test_browsing_create_with_model_instance(self):
+    async def test_browsing_create_with_model_instance(self, async_client):
         with patch.object(
             httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=self._make_mock_response()
         ) as mock_post:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                await client.browsing.create(task="t", start_url="https://x.com", output_schema=self._FakeModel())
-                payload = mock_post.call_args[1]["json"]
-                assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
+            client = async_client
+            await client.browsing.create(task="t", start_url="https://x.com", output_schema=self._FakeModel())
+            payload = mock_post.call_args[1]["json"]
+            assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
-    async def test_research_create_with_model_class(self):
+    async def test_research_create_with_model_class(self, async_client):
         with patch.object(
             httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=self._make_mock_response()
         ) as mock_post:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                await client.research.create(query="q", output_schema=self._FakeModel)
-                payload = mock_post.call_args[1]["json"]
-                assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
+            client = async_client
+            await client.research.create(query="q", output_schema=self._FakeModel)
+            payload = mock_post.call_args[1]["json"]
+            assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
-    async def test_scouts_create_with_model_class(self):
+    async def test_scouts_create_with_model_class(self, async_client):
         mock = make_json_response({"id": "s-1"})
         with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock) as mock_post:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                await client.scouts.create(query="q", output_schema=self._FakeModel)
-                payload = mock_post.call_args[1]["json"]
-                assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
+            client = async_client
+            await client.scouts.create(query="q", output_schema=self._FakeModel)
+            payload = mock_post.call_args[1]["json"]
+            assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
-    async def test_scouts_update_with_model_class(self):
+    async def test_scouts_update_with_model_class(self, async_client):
         mock = make_json_response({"id": "s-1"})
         with patch.object(httpx.AsyncClient, "patch", new_callable=AsyncMock, return_value=mock) as mock_patch:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                await client.scouts.update("s-1", output_schema=self._FakeModel)
-                payload = mock_patch.call_args[1]["json"]
-                assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
+            client = async_client
+            await client.scouts.update("s-1", output_schema=self._FakeModel)
+            payload = mock_patch.call_args[1]["json"]
+            assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
-    async def test_scouts_update_with_model_instance(self):
+    async def test_scouts_update_with_model_instance(self, async_client):
         mock = make_json_response({"id": "s-1"})
         with patch.object(httpx.AsyncClient, "patch", new_callable=AsyncMock, return_value=mock) as mock_patch:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                await client.scouts.update("s-1", output_schema=self._FakeModel())
-                payload = mock_patch.call_args[1]["json"]
-                assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
+            client = async_client
+            await client.scouts.update("s-1", output_schema=self._FakeModel())
+            payload = mock_patch.call_args[1]["json"]
+            assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
 
 @pytest.mark.asyncio
 class TestAsyncChatNamespace:
-    async def test_chat_completions(self):
+    async def test_chat_completions(self, async_client):
         mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
 
         with mocked_async_openai_client(mock_completion):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.chat.completions.create(
-                    messages=[{"role": "user", "content": "Click login"}],
-                )
-                assert result.choices[0].message.content == "click"
+            client = async_client
+            result = await client.chat.completions.create(
+                messages=[{"role": "user", "content": "Click login"}],
+            )
+            assert result.choices[0].message.content == "click"
 
-    async def test_chat_completions_n1_5_forwards_extra_body_options(self):
+    async def test_chat_completions_n1_5_forwards_extra_body_options(self, async_client):
         from yutori.navigator import TOOL_SET_CORE
 
         json_schema = {
@@ -359,16 +359,16 @@ class TestAsyncChatNamespace:
         mock_completion = make_mock_chat_completion(content='{"status":"ok"}', model="n1.5-latest")
 
         with mocked_async_openai_client(mock_completion) as mock_openai_client:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.chat.completions.create(
-                    messages=[{"role": "user", "content": "Reply with JSON."}],
-                    model="n1.5-latest",
-                    tool_set=TOOL_SET_CORE,
-                    disable_tools=["hold_key"],
-                    json_schema=json_schema,
-                    extra_body={"trace_id": "trace-123"},
-                )
-                assert result.choices[0].message.content == '{"status":"ok"}'
+            client = async_client
+            result = await client.chat.completions.create(
+                messages=[{"role": "user", "content": "Reply with JSON."}],
+                model="n1.5-latest",
+                tool_set=TOOL_SET_CORE,
+                disable_tools=["hold_key"],
+                json_schema=json_schema,
+                extra_body={"trace_id": "trace-123"},
+            )
+            assert result.choices[0].message.content == '{"status":"ok"}'
 
         call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
         assert call_kwargs["model"] == "n1.5-latest"
@@ -379,7 +379,7 @@ class TestAsyncChatNamespace:
             "json_schema": json_schema,
         }
 
-    async def test_n1_helper_acreate_trimmed_public_helper_uses_trimmed_copy(self):
+    async def test_n1_helper_acreate_trimmed_public_helper_uses_trimmed_copy(self, async_client):
         from copy import deepcopy
 
         from yutori.navigator import acreate_trimmed
@@ -390,14 +390,14 @@ class TestAsyncChatNamespace:
         original_snapshot = deepcopy(original_messages)
 
         with mocked_async_openai_client(mock_completion) as mock_openai_client:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await acreate_trimmed(
-                    client.chat.completions,
-                    original_messages,
-                    max_bytes=100,
-                    keep_recent=1,
-                )
-                assert result.choices[0].message.content == "click"
+            client = async_client
+            result = await acreate_trimmed(
+                client.chat.completions,
+                original_messages,
+                max_bytes=100,
+                keep_recent=1,
+            )
+            assert result.choices[0].message.content == "click"
 
         call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
         sent_messages = call_kwargs["messages"]
@@ -405,7 +405,7 @@ class TestAsyncChatNamespace:
         assert sent_messages == trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)[0]
         assert original_messages == original_snapshot
 
-    async def test_n1_payload_helper_supports_standard_async_create_pattern(self):
+    async def test_n1_payload_helper_supports_standard_async_create_pattern(self, async_client):
         from copy import deepcopy
 
         from yutori.navigator import trimmed_messages_to_fit
@@ -416,12 +416,12 @@ class TestAsyncChatNamespace:
         trimmed_messages, _, _ = trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)
 
         with mocked_async_openai_client(mock_completion) as mock_openai_client:
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                result = await client.chat.completions.create(
-                    model="n1-latest",
-                    messages=trimmed_messages,
-                )
-                assert result.choices[0].message.content == "click"
+            client = async_client
+            result = await client.chat.completions.create(
+                model="n1-latest",
+                messages=trimmed_messages,
+            )
+            assert result.choices[0].message.content == "click"
 
         call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
         assert call_kwargs["messages"] == trimmed_messages
@@ -446,24 +446,24 @@ class TestAsyncErrorHandling:
                 with pytest.raises(AuthenticationError):
                     await client.get_usage()
 
-    async def test_api_error(self):
+    async def test_api_error(self, async_client):
         mock_response = make_status_response(500, "Server error")
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                with pytest.raises(APIError) as exc_info:
-                    await client.get_usage()
-                assert exc_info.value.status_code == 500
+            client = async_client
+            with pytest.raises(APIError) as exc_info:
+                await client.get_usage()
+            assert exc_info.value.status_code == 500
 
 
 class TestAsyncTransportErrorWrapping:
-    async def test_connect_error_wrapped(self):
+    async def test_connect_error_wrapped(self, async_client):
         from yutori.exceptions import APIConnectionError
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, side_effect=httpx.ConnectError("refused")):
-            async with AsyncYutoriClient(api_key="yt-test") as client:
-                with pytest.raises(APIConnectionError, match="ConnectError.*refused"):
-                    await client.scouts.list()
+            client = async_client
+            with pytest.raises(APIConnectionError, match="ConnectError.*refused"):
+                await client.scouts.list()
 
 
 class TestAsyncLazyChatNamespace:


### PR DESCRIPTION
## What

`tests/conftest.py` already has a `client` pytest fixture that constructs a
`YutoriClient(api_key="yt-test")` for sync tests. There was no async
equivalent: every one of the ~33 namespace/error-handling tests in
`tests/test_async_client.py` manually opened

```python
async with AsyncYutoriClient(api_key="yt-test") as client:
    ...
```

This adds an `async_client` fixture (mirroring `client`) and switches those
tests to use it, replacing the repeated `async with ... as client:` opening
with `client = async_client`.

Left untouched (intentionally):
- The two `AsyncYutoriClient(api_key="yt-invalid")` auth-failure tests, which
  need a different key than the fixture provides.
- `TestAsyncLazyChatNamespace.test_chat_not_built_at_init_and_close_safe`,
  which specifically exercises the async context manager's
  `__aenter__`/`__aexit__` lifecycle (asserting state right after exit) —
  converting it to the fixture would remove the exact behavior under test.
- The plain `AsyncYutoriClient(...)` constructions in
  `TestAsyncYutoriClientInit`, which test construction/env-var behavior
  itself, not namespace calls.

## Why

This is the same "duplicated setup extracted into a shared fixture" pattern
already used elsewhere in this test suite (e.g. the existing `client` fixture,
and `_client_fixtures.py`'s `make_mock_chat_completion`/`mocked_*_openai_client`
helpers). It removes ~33 repetitions of the same one-line client construction
and de-indents the test bodies by one level, with no change to what each test
actually exercises.

## Why it's safe

Purely a test-file change — no production code touched. Verified with:
- `pytest -q -m "not slow"`: 472 passed, 16 skipped (unchanged from before
  the change).
- `ruff format --check` / `ruff check` on both changed files: clean.

## Test plan

- [x] `pytest tests/test_async_client.py tests/test_client.py -q` — 89 passed
- [x] `pytest -q -m "not slow"` (full suite) — 472 passed, 16 skipped
- [x] `ruff format --check tests/conftest.py tests/test_async_client.py`
- [x] `ruff check tests/conftest.py tests/test_async_client.py`


---
_Generated by [Claude Code](https://claude.ai/code/session_01YbZLWMZpRJPSEcL7RQTXgH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes; coverage and assertions are preserved aside from intentional exceptions noted in the PR.
> 
> **Overview**
> Adds a shared **`async_client`** pytest fixture in `conftest.py` that builds `AsyncYutoriClient(api_key="yt-test")`, yields it, and **`await`s `close()`** on teardown—parallel to the existing sync **`client`** fixture.
> 
> Most **`test_async_client.py`** cases now take **`async_client`** instead of opening **`async with AsyncYutoriClient(...)`** in each test, which removes repeated setup and one level of nesting. **Behavior under test is unchanged** for those cases.
> 
> **Left as inline client construction:** init/env tests, auth failures with **`yt-invalid`**, and the lazy-chat test that asserts **`__aenter__`/`__aexit__`** lifecycle after the context manager exits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fd64e66ac930e6a9b1633b9deb812a33559604b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->