### PR TITLE
refactor(tests): parametrize 401/403 auth-error tests in client test suites

### DIFF
--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -399,16 +399,12 @@ class TestAsyncChatNamespace:
 
 @pytest.mark.asyncio
 class TestAsyncErrorHandling:
-    async def test_auth_error(self):
-        mock_response = make_status_response(401, "Unauthorized")
-
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
-            async with AsyncYutoriClient(api_key="yt-invalid") as client:
-                with pytest.raises(AuthenticationError):
-                    await client.get_usage()
-
-    async def test_auth_error_forbidden(self):
-        mock_response = make_status_response(403, "Forbidden")
+    @pytest.mark.parametrize(
+        ("status_code", "reason"),
+        [(401, "Unauthorized"), (403, "Forbidden")],
+    )
+    async def test_auth_error(self, status_code, reason):
+        mock_response = make_status_response(status_code, reason)
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
             async with AsyncYutoriClient(api_key="yt-invalid") as client:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -80,17 +80,12 @@ class TestYutoriClientGetUsage:
             assert call_kwargs["params"] == {}
             client.close()
 
-    def test_get_usage_auth_error(self):
-        mock_response = make_status_response(401, "Unauthorized")
-
-        with patch.object(httpx.Client, "get", return_value=mock_response):
-            client = YutoriClient(api_key="yt-invalid")
-            with pytest.raises(AuthenticationError):
-                client.get_usage()
-            client.close()
-
-    def test_get_usage_forbidden_auth_error(self):
-        mock_response = make_status_response(403, "Forbidden")
+    @pytest.mark.parametrize(
+        ("status_code", "reason"),
+        [(401, "Unauthorized"), (403, "Forbidden")],
+    )
+    def test_get_usage_auth_error(self, status_code, reason):
+        mock_response = make_status_response(status_code, reason)
 
         with patch.object(httpx.Client, "get", return_value=mock_response):
             client = YutoriClient(api_key="yt-invalid")


### PR DESCRIPTION
## Issue

`tests/test_client.py::TestYutoriClientGetUsage` had two near-identical tests, `test_get_usage_auth_error` and `test_get_usage_forbidden_auth_error`, whose bodies differed only in the mocked status code (401 vs 403) and reason phrase. `tests/test_async_client.py::TestAsyncErrorHandling` had the same duplicated pattern (`test_auth_error` / `test_auth_error_forbidden`).

## Fix

Collapsed each duplicated pair into a single `@pytest.mark.parametrize(("status_code", "reason"), [(401, "Unauthorized"), (403, "Forbidden")])` test, matching the parametrization style already used elsewhere in this suite (e.g. the `run_interactive_command` exception-mapping tests). Both status codes are still independently exercised — now as `[401-Unauthorized]` / `[403-Forbidden]` parametrized cases — with no change to what's being asserted.

## Why this is safe

- Test-only change (`tests/test_client.py`, `tests/test_async_client.py`); no production code touched, no public-API or behavioral change to the SDK.
- Purely a consolidation of duplicated test bodies — the assertions and mocked responses are unchanged, just parametrized instead of copy-pasted.
- Full test suite passes locally: `473 passed, 16 skipped` (skips are the pre-existing extras-gated skips, unrelated to this change).
- `ruff check .` and `ruff format --check` both pass.

This does **not** touch the known `_sync`/`_async` namespace duplication issue tracked in the shared backlog — that's a separate, much larger item (would need codegen or a shared base class) and is explicitly out of scope for this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UnzD4XMBiotqYxTfFuogrj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test layout in two files; no SDK or runtime behavior is modified.
> 
> **Overview**
> **Test-only refactor** that removes duplicated auth-error coverage in the sync and async client test suites.
> 
> In `tests/test_client.py`, the separate `test_get_usage_auth_error` and `test_get_usage_forbidden_auth_error` cases are merged into one `test_get_usage_auth_error` using `@pytest.mark.parametrize` over `(401, "Unauthorized")` and `(403, "Forbidden")`. The same consolidation applies in `tests/test_async_client.py` for `TestAsyncErrorHandling`, replacing `test_auth_error` and `test_auth_error_forbidden` with a single parametrized `test_auth_error`.
> 
> Assertions and mocked HTTP behavior are unchanged; only the test structure is DRY’d to align with other parametrized tests in these files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e119ceabb8e85fcc454e4deaa5736e56f1c4325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->