### PR TITLE
refactor(tests): parametrize 400/500 API-error tests in test_client.py

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -473,24 +473,18 @@ class TestChatNamespace:
 
 
 class TestErrorHandling:
-    def test_api_error_on_400(self):
-        mock_response = make_status_response(400, "Bad request")
+    @pytest.mark.parametrize(
+        ("status_code", "reason"),
+        [(400, "Bad request"), (500, "Internal server error")],
+    )
+    def test_api_error(self, status_code, reason):
+        mock_response = make_status_response(status_code, reason)
 
         with patch.object(httpx.Client, "get", return_value=mock_response):
             client = YutoriClient(api_key="yt-test")
             with pytest.raises(APIError) as exc_info:
                 client.get_usage()
-            assert exc_info.value.status_code == 400
-            client.close()
-
-    def test_api_error_on_500(self):
-        mock_response = make_status_response(500, "Internal server error")
-
-        with patch.object(httpx.Client, "get", return_value=mock_response):
-            client = YutoriClient(api_key="yt-test")
-            with pytest.raises(APIError) as exc_info:
-                client.get_usage()
-            assert exc_info.value.status_code == 500
+            assert exc_info.value.status_code == status_code
             client.close()
 
 


### PR DESCRIPTION
## Issue

`TestErrorHandling.test_api_error_on_400` and `test_api_error_on_500` in `tests/test_client.py` ran the exact same body (mock an httpx response, call `client.get_usage()`, assert an `APIError` with the matching `status_code`) against two different status codes, differing only in the status code/reason literals.

This is the same duplication shape that the immediately-preceding commit on this branch (#216, `refactor(tests): parametrize 401/403 auth-error tests in client test suites`) had just fixed for the neighboring `test_get_usage_auth_error` test in the same file/class style — this pair was simply missed by that pass since it lives in a different test class (`TestErrorHandling` vs `TestYutoriClientGetUsage`).

## Change

Collapsed the two tests into a single `@pytest.mark.parametrize(("status_code", "reason"), [(400, "Bad request"), (500, "Internal server error")])` test, matching the exact pattern #216 established.

## Why it's safe

- Test-only change, zero production code touched.
- No coverage change: both status codes are still independently exercised, now as `test_api_error[400-Bad request]`/`test_api_error[500-Internal server error]`.
- Full suite: `473 passed, 16 skipped` before and after (identical pass/skip counts; skips are pre-existing and unrelated — Playwright/examples extras not installed in this sandbox).
- `ruff check` and `ruff format --check` both clean on the touched file.

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_017UxRho2ZesQ3FpQfuJ77NY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests-only change with no production code touched and identical behavioral coverage for both status codes.
> 
> **Overview**
> **Test-only refactor** in `TestErrorHandling`: the separate `test_api_error_on_400` and `test_api_error_on_500` cases are merged into one parametrized `test_api_error` that still mocks httpx `get`, calls `get_usage()`, and asserts `APIError` with the expected `status_code`.
> 
> The `@pytest.mark.parametrize` tuple uses `(400, "Bad request")` and `(500, "Internal server error")`, matching the style already used in the same file for auth errors (e.g. `test_get_usage_auth_error`). Coverage for both status codes is unchanged; only duplication is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6647239ed77a00e20f2b60a32f32656c381246f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->