### PR TITLE
refactor(tests): parametrize 400/500 API-error test in test_async_client.py

### DIFF
--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -411,13 +411,17 @@ class TestAsyncErrorHandling:
                 with pytest.raises(AuthenticationError):
                     await client.get_usage()
 
-    async def test_api_error(self, async_client):
-        mock_response = make_status_response(500, "Server error")
+    @pytest.mark.parametrize(
+        ("status_code", "reason"),
+        [(400, "Bad request"), (500, "Internal server error")],
+    )
+    async def test_api_error(self, async_client, status_code, reason):
+        mock_response = make_status_response(status_code, reason)
 
         with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
             with pytest.raises(APIError) as exc_info:
                 await async_client.get_usage()
-            assert exc_info.value.status_code == 500
+            assert exc_info.value.status_code == status_code
 
 
 class TestAsyncTransportErrorWrapping:


### PR DESCRIPTION
## Summary

Looking at the last day's commits together (#215, #216, #217) surfaces a small inconsistency none of them introduced individually:

- #216 parametrized the 401/403 auth-error test in **both** `test_client.py` and `test_async_client.py`.
- #217 then parametrized the 400/500 API-error test (`TestErrorHandling.test_api_error`) — but only in `test_client.py` (sync). Its async twin, `TestAsyncErrorHandling.test_api_error`, was left covering only the 500 case.

This PR applies the same parametrization to the async test, so both suites cover 400 and 500 identically, matching the established pattern.

No behavioral change — purely test-only, mirrors the exact style already used in `test_client.py`'s `TestErrorHandling.test_api_error` and this same file's `test_auth_error`.

## Test plan

- [x] `python3 -m pytest tests/test_async_client.py tests/test_client.py -v` — 90/90 passed, including new `test_api_error[400-Bad request]` / `test_api_error[500-Internal server error]` cases
- [x] Full suite: `python3 -m pytest -q` — 474 passed, 16 pre-existing skips (unrelated)
- [x] `ruff check` / `ruff format --check` — clean

cc @dhruvbatra — authored #215/#216/#217, the precedent this follows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRYgTsm3yPZuwcXsiFf4fs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only alignment with existing sync tests; no runtime behavior changes.
> 
> **Overview**
> **Test-only change:** `TestAsyncErrorHandling.test_api_error` in `test_async_client.py` now uses `@pytest.mark.parametrize` for **400** and **500** responses, matching `TestErrorHandling.test_api_error` in `test_client.py` and the same file’s `test_auth_error` pattern.
> 
> Each case still asserts `APIError` is raised and that `exc_info.value.status_code` matches the mocked status. No production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 347ab30d2f5a0f69972a25b1196f9966745c2ccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->