### PR TITLE
refactor(examples): consolidate the four click-action branches in execute_n1_primitive_action

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -189,24 +189,18 @@ async def execute_n1_primitive_action(
     Playwright calls propagate to the caller, which already wraps action
     execution in its own try/except.
     """
-    if action_name == "left_click":
+    if action_name in ("left_click", "double_click", "right_click", "triple_click"):
+        # All four share the same coordinate resolution and post-click pause;
+        # only the actual mouse call differs.
         abs_x, abs_y = _click_coordinates(arguments, viewport_width, viewport_height)
-        await page.mouse.click(abs_x, abs_y)
-        await asyncio.sleep(0.5)
-
-    elif action_name == "double_click":
-        abs_x, abs_y = _click_coordinates(arguments, viewport_width, viewport_height)
-        await page.mouse.dblclick(abs_x, abs_y)
-        await asyncio.sleep(0.5)
-
-    elif action_name == "right_click":
-        abs_x, abs_y = _click_coordinates(arguments, viewport_width, viewport_height)
-        await page.mouse.click(abs_x, abs_y, button="right")
-        await asyncio.sleep(0.5)
-
-    elif action_name == "triple_click":
-        abs_x, abs_y = _click_coordinates(arguments, viewport_width, viewport_height)
-        await page.mouse.click(abs_x, abs_y, click_count=3)
+        if action_name == "double_click":
+            await page.mouse.dblclick(abs_x, abs_y)
+        elif action_name == "right_click":
+            await page.mouse.click(abs_x, abs_y, button="right")
+        elif action_name == "triple_click":
+            await page.mouse.click(abs_x, abs_y, click_count=3)
+        else:
+            await page.mouse.click(abs_x, abs_y)
         await asyncio.sleep(0.5)
 
     elif action_name == "type":


### PR DESCRIPTION
## What

`examples/_common.py`'s `execute_n1_primitive_action()` had four separate `if`/`elif` branches for `left_click`, `double_click`, `right_click`, and `triple_click`, each repeating the exact same two lines (resolve coordinates via `_click_coordinates()`, then `await asyncio.sleep(0.5)` afterward) and differing only in the actual Playwright mouse call. Collapsed these into a single branch keyed on the same four action names, which resolves coordinates once and switches on just the mouse call — matching the alias-tuple style already used elsewhere in the same function (e.g. `("goto", "goto_url")`, `("back", "go_back")`).

## Why this is safe

- Purely internal to one function in one file (`examples/_common.py`, a shared helper for the example scripts — not part of the published `yutori` package/public API surface).
- No behavior change: each action still resolves coordinates the same way, calls the same Playwright mouse method with the same arguments, and sleeps the same 0.5s afterward.
- Verified by the existing characterization tests in `tests/test_execute_n1_primitive_action.py::TestClickActions` (covers `left_click`, `double_click`, `right_click`, `triple_click`, including the default-coordinates case), plus the full test suite: `pytest -m "not slow"` → 559 passed, 3 skipped, 1 deselected (unchanged from before the diff).
- `ruff check .` passes clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_016NDmqGABNX2g1vzu5boMnQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal example-helper refactor with equivalent Playwright calls and existing `TestClickActions` coverage; no auth, data, or public API impact.
> 
> **Overview**
> **Refactors** how the four n1 pointer click actions are handled in `execute_n1_primitive_action` inside `examples/_common.py`.
> 
> Instead of four separate `elif` blocks that each called `_click_coordinates` and slept 0.5s, those actions now share one branch keyed on `left_click`, `double_click`, `right_click`, and `triple_click`. Coordinates are resolved once; an inner `if`/`elif` picks the Playwright mouse call (`click`, `dblclick`, right button, or triple `click_count`). This matches the alias-tuple style used elsewhere in the same function (e.g. `goto` / `goto_url`).
> 
> No intended behavior change for example scripts that use this helper; it is not part of the published `yutori` package API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e05db95db6e2e83f211b410cd28f5cd58ec7b47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->