### PR TITLE
refactor(tests): extract patch_async_http() for httpx.AsyncClient patching

### DIFF
--- a/tests/_client_fixtures.py
+++ b/tests/_client_fixtures.py
@@ -47,6 +47,27 @@ USAGE_RESPONSE = {
 }
 
 
+def patch_async_http(method: str, response: Any = None, *, side_effect: Any = None) -> Any:
+    """Patch ``httpx.AsyncClient.<method>`` with an :class:`AsyncMock`.
+
+    Every async transport test has to pass ``new_callable=AsyncMock`` to
+    ``patch.object`` — without it the awaited call yields a ``MagicMock``
+    instead of the mocked response. That boilerplate was repeated at every
+    call site in the async client suite, and was long enough to push several
+    of them onto three wrapped lines. Pass ``response`` for the awaited return
+    value, or ``side_effect`` to raise a transport error instead.
+
+    Used exactly like ``patch.object``: as a context manager that yields the
+    mock, so callers can still assert on ``call_args``.
+
+    The sync suite deliberately keeps plain ``patch.object(httpx.Client, ...)``
+    — it needs no ``new_callable`` argument, so a wrapper there would add
+    indirection without removing anything.
+    """
+    mock_kwargs = {"side_effect": side_effect} if side_effect is not None else {"return_value": response}
+    return patch.object(httpx.AsyncClient, method, new_callable=AsyncMock, **mock_kwargs)
+
+
 def make_json_response(data: Any, *, status_code: int = 200) -> MagicMock:
     """Build a mocked :class:`httpx.Response` whose ``.content`` and ``.json()`` both reflect `data`.
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,7 +1,5 @@
 """Tests for the async AsyncYutoriClient."""
 
-from unittest.mock import AsyncMock, patch
-
 import httpx
 import pytest
 
@@ -14,6 +12,7 @@ from ._client_fixtures import (
     make_status_response,
     make_trimmable_messages,
     mocked_async_openai_client,
+    patch_async_http,
 )
 
 
@@ -48,15 +47,13 @@ class TestAsyncYutoriClientInit:
 @pytest.mark.asyncio
 class TestAsyncYutoriClientGetUsage:
     async def test_get_usage_success(self, async_client):
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=make_mock_usage_response()):
+        with patch_async_http("get", make_mock_usage_response()):
             result = await async_client.get_usage()
             assert result["num_active_scouts"] == 2
             assert result["activity"]["period"] == "24h"
 
     async def test_get_usage_with_period(self, async_client):
-        with patch.object(
-            httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=make_mock_usage_response("30d")
-        ) as mock_get:
+        with patch_async_http("get", make_mock_usage_response("30d")) as mock_get:
             result = await async_client.get_usage(period="30d")
             assert result["activity"]["period"] == "30d"
             call_kwargs = mock_get.call_args[1]
@@ -68,7 +65,7 @@ class TestAsyncScoutsNamespace:
     async def test_scouts_list(self, async_client):
         mock_response = make_json_response({"scouts": []})
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
+        with patch_async_http("get", mock_response) as mock_get:
             result = await async_client.scouts.list(limit=10, status="active")
             assert result == {"scouts": []}
             params = mock_get.call_args[1]["params"]
@@ -79,7 +76,7 @@ class TestAsyncScoutsNamespace:
     async def test_scouts_list_forwards_cursor(self, async_client):
         mock_response = make_json_response({"scouts": []})
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
+        with patch_async_http("get", mock_response) as mock_get:
             await async_client.scouts.list(cursor="next-page")
             params = mock_get.call_args[1]["params"]
             assert params["cursor"] == "next-page"
@@ -88,21 +85,21 @@ class TestAsyncScoutsNamespace:
     async def test_scouts_get(self, async_client):
         mock_response = make_json_response({"id": "scout-123"})
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
+        with patch_async_http("get", mock_response):
             result = await async_client.scouts.get("scout-123")
             assert result["id"] == "scout-123"
 
     async def test_scouts_create(self, async_client):
         mock_response = make_json_response({"id": "new-scout"})
 
-        with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response):
+        with patch_async_http("post", mock_response):
             result = await async_client.scouts.create(query="Monitor site")
             assert result["id"] == "new-scout"
 
     async def test_scouts_update_status(self, async_client):
         mock_response = make_json_response({"id": "scout-123", "status": "paused"})
 
-        with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
+        with patch_async_http("post", mock_response) as mock_post:
             result = await async_client.scouts.update("scout-123", status="paused")
             assert result["status"] == "paused"
             assert "/pause" in mock_post.call_args[0][0]
@@ -110,14 +107,14 @@ class TestAsyncScoutsNamespace:
     async def test_scouts_update_fields(self, async_client):
         mock_response = make_json_response({"id": "scout-123", "query": "new query"})
 
-        with patch.object(httpx.AsyncClient, "patch", new_callable=AsyncMock, return_value=mock_response):
+        with patch_async_http("patch", mock_response):
             result = await async_client.scouts.update("scout-123", query="new query")
             assert result["query"] == "new query"
 
     async def test_scouts_update_is_public(self, async_client):
         mock_response = make_json_response({"id": "scout-123", "is_public": False})
 
-        with patch.object(httpx.AsyncClient, "patch", new_callable=AsyncMock, return_value=mock_response) as mock_patch:
+        with patch_async_http("patch", mock_response) as mock_patch:
             await async_client.scouts.update("scout-123", is_public=False)
             payload = mock_patch.call_args[1]["json"]
             assert payload["is_public"] is False
@@ -129,14 +126,14 @@ class TestAsyncScoutsNamespace:
     async def test_scouts_delete(self, async_client):
         mock_response = make_status_response(200)
 
-        with patch.object(httpx.AsyncClient, "delete", new_callable=AsyncMock, return_value=mock_response):
+        with patch_async_http("delete", mock_response):
             result = await async_client.scouts.delete("scout-123")
             assert result == {}
 
     async def test_scouts_get_updates(self, async_client):
         mock_response = make_json_response({"updates": []})
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
+        with patch_async_http("get", mock_response):
             result = await async_client.scouts.get_updates("scout-123")
             assert "updates" in result
 
@@ -146,7 +143,7 @@ class TestAsyncBrowsingNamespace:
     async def test_browsing_list(self, async_client):
         mock_response = make_json_response({"tasks": [], "total": 0})
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
+        with patch_async_http("get", mock_response) as mock_get:
             result = await async_client.browsing.list(limit=20, status="succeeded", cursor="cur-1")
             assert result == {"tasks": [], "total": 0}
             assert mock_get.call_args[0][0].endswith("/browsing/tasks")
@@ -159,7 +156,7 @@ class TestAsyncBrowsingNamespace:
     async def test_browsing_create(self, async_client):
         mock_response = make_json_response({"task_id": "task-123"})
 
-        with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response):
+        with patch_async_http("post", mock_response):
             result = await async_client.browsing.create(
                 task="Click login",
                 start_url="https://example.com",
@@ -169,7 +166,7 @@ class TestAsyncBrowsingNamespace:
     async def test_browsing_create_with_local_browser_and_auth(self, async_client):
         mock_response = make_json_response({"task_id": "task-456"})
 
-        with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
+        with patch_async_http("post", mock_response) as mock_post:
             result = await async_client.browsing.create(
                 task="Log in and export data",
                 start_url="https://example.com/login",
@@ -186,7 +183,7 @@ class TestAsyncBrowsingNamespace:
     async def test_browsing_get(self, async_client):
         mock_response = make_json_response({"task_id": "task-123", "status": "succeeded"})
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
+        with patch_async_http("get", mock_response):
             result = await async_client.browsing.get("task-123")
             assert result["status"] == "succeeded"
 
@@ -199,7 +196,7 @@ class TestAsyncBrowsingNamespace:
             }
         )
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
+        with patch_async_http("get", mock_response):
             result = await async_client.browsing.get("task-123")
             assert result["status"] == "failed"
             assert result["rejection_reason"] == "billing_limit_reached"
@@ -210,7 +207,7 @@ class TestAsyncResearchNamespace:
     async def test_research_list(self, async_client):
         mock_response = make_json_response({"tasks": [], "total": 0})
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
+        with patch_async_http("get", mock_response) as mock_get:
             result = await async_client.research.list(limit=20, status="succeeded", cursor="cur-1")
             assert result == {"tasks": [], "total": 0}
             assert mock_get.call_args[0][0].endswith("/research/tasks")
@@ -223,14 +220,14 @@ class TestAsyncResearchNamespace:
     async def test_research_create(self, async_client):
         mock_response = make_json_response({"task_id": "research-123"})
 
-        with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock_response):
+        with patch_async_http("post", mock_response):
             result = await async_client.research.create(query="Find AI funding")
             assert result["task_id"] == "research-123"
 
     async def test_research_get(self, async_client):
         mock_response = make_json_response({"task_id": "research-123", "status": "succeeded"})
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
+        with patch_async_http("get", mock_response):
             result = await async_client.research.get("research-123")
             assert result["status"] == "succeeded"
 
@@ -243,7 +240,7 @@ class TestAsyncResearchNamespace:
             }
         )
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
+        with patch_async_http("get", mock_response):
             result = await async_client.research.get("research-123")
             assert result["status"] == "failed"
             assert result["rejection_reason"] == "rate_limit_exceeded"
@@ -263,46 +260,40 @@ class TestAsyncPydanticSchemaIntegration:
             return {"type": "object", "properties": {"name": {"type": "string"}}}
 
     async def test_browsing_create_with_model_class(self, async_client):
-        with patch.object(
-            httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=self._make_mock_response()
-        ) as mock_post:
+        with patch_async_http("post", self._make_mock_response()) as mock_post:
             await async_client.browsing.create(task="t", start_url="https://x.com", output_schema=self._FakeModel)
             payload = mock_post.call_args[1]["json"]
             assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
     async def test_browsing_create_with_model_instance(self, async_client):
-        with patch.object(
-            httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=self._make_mock_response()
-        ) as mock_post:
+        with patch_async_http("post", self._make_mock_response()) as mock_post:
             await async_client.browsing.create(task="t", start_url="https://x.com", output_schema=self._FakeModel())
             payload = mock_post.call_args[1]["json"]
             assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
     async def test_research_create_with_model_class(self, async_client):
-        with patch.object(
-            httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=self._make_mock_response()
-        ) as mock_post:
+        with patch_async_http("post", self._make_mock_response()) as mock_post:
             await async_client.research.create(query="q", output_schema=self._FakeModel)
             payload = mock_post.call_args[1]["json"]
             assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
     async def test_scouts_create_with_model_class(self, async_client):
         mock = make_json_response({"id": "s-1"})
-        with patch.object(httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=mock) as mock_post:
+        with patch_async_http("post", mock) as mock_post:
             await async_client.scouts.create(query="q", output_schema=self._FakeModel)
             payload = mock_post.call_args[1]["json"]
             assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
     async def test_scouts_update_with_model_class(self, async_client):
         mock = make_json_response({"id": "s-1"})
-        with patch.object(httpx.AsyncClient, "patch", new_callable=AsyncMock, return_value=mock) as mock_patch:
+        with patch_async_http("patch", mock) as mock_patch:
             await async_client.scouts.update("s-1", output_schema=self._FakeModel)
             payload = mock_patch.call_args[1]["json"]
             assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
 
     async def test_scouts_update_with_model_instance(self, async_client):
         mock = make_json_response({"id": "s-1"})
-        with patch.object(httpx.AsyncClient, "patch", new_callable=AsyncMock, return_value=mock) as mock_patch:
+        with patch_async_http("patch", mock) as mock_patch:
             await async_client.scouts.update("s-1", output_schema=self._FakeModel())
             payload = mock_patch.call_args[1]["json"]
             assert payload["output_schema"] == {"type": "object", "properties": {"name": {"type": "string"}}}
@@ -406,7 +397,7 @@ class TestAsyncErrorHandling:
     async def test_auth_error(self, status_code, reason):
         mock_response = make_status_response(status_code, reason)
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
+        with patch_async_http("get", mock_response):
             async with AsyncYutoriClient(api_key="yt-invalid") as client:
                 with pytest.raises(AuthenticationError):
                     await client.get_usage()
@@ -418,7 +409,7 @@ class TestAsyncErrorHandling:
     async def test_api_error(self, async_client, status_code, reason):
         mock_response = make_status_response(status_code, reason)
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response):
+        with patch_async_http("get", mock_response):
             with pytest.raises(APIError) as exc_info:
                 await async_client.get_usage()
             assert exc_info.value.status_code == status_code
@@ -428,7 +419,7 @@ class TestAsyncTransportErrorWrapping:
     async def test_connect_error_wrapped(self, async_client):
         from yutori.exceptions import APIConnectionError
 
-        with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, side_effect=httpx.ConnectError("refused")):
+        with patch_async_http("get", side_effect=httpx.ConnectError("refused")):
             with pytest.raises(APIConnectionError, match="ConnectError.*refused"):
                 await async_client.scouts.list()
 


### PR DESCRIPTION
## Issue

Every one of the **29** `patch.object(...)` call sites in `tests/test_async_client.py` repeated the same async-mocking boilerplate:

```python
with patch.object(httpx.AsyncClient, "get", new_callable=AsyncMock, return_value=mock_response) as mock_get:
```

The `new_callable=AsyncMock` argument is not optional here — without it the awaited call yields a `MagicMock` rather than the mocked response — so it had to be repeated verbatim at every site. At 100+ characters the resulting expression also exceeded the 120-char line limit at four call sites, forcing each onto three wrapped lines that obscured what was actually being patched:

```python
with patch.object(
    httpx.AsyncClient, "post", new_callable=AsyncMock, return_value=self._make_mock_response()
) as mock_post:
```

## Improvement

Extracted `patch_async_http(method, response, *, side_effect=...)` into `tests/_client_fixtures.py` — the established home for shared sync/async client test fixtures, which already hosts the analogous `mocked_sync_openai_client` / `mocked_async_openai_client` patch context managers.

All 29 call sites now read:

```python
with patch_async_http("get", mock_response) as mock_get:
```

and the four wrapped calls collapse back to one line each. `AsyncMock`/`patch` are no longer imported by the test module at all.

The sync suite (`tests/test_client.py`) is deliberately left alone: `patch.object(httpx.Client, "get", return_value=...)` needs no `new_callable` argument, so a wrapper there would add indirection without removing anything. That reasoning is recorded in the helper's docstring so the asymmetry doesn't read as an oversight.

## Safety

- **Test-only, no library code touched.** No change to any shipped module.
- The helper returns the `patch.object` patcher **unchanged**, so each call site still behaves exactly as before: same context-manager protocol, same mock yielded for `call_args` assertions.
- Every rewrite is mechanical — `return_value` sites pass the response positionally, the one `side_effect` site (`TestAsyncTransportErrorWrapping`) passes it by keyword. No test was added, removed, renamed, or re-parameterized.
- **Verified**: `pytest` gives **561 passed, 3 skipped** — byte-identical to the counts on `main` before the change. `ruff check .` clean; both touched files pass `ruff format --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126BGesadgXMjCrXjju5iZH

---
_Generated by [Claude Code](https://claude.ai/code/session_0126BGesadgXMjCrXjju5iZH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test fixtures and mock setup; no production code or runtime behavior is affected.
> 
> **Overview**
> Adds **`patch_async_http()`** in `tests/_client_fixtures.py` to centralize `patch.object(httpx.AsyncClient, …, new_callable=AsyncMock, …)` setup, with optional `return_value` or `side_effect`.
> 
> **`tests/test_async_client.py`** switches all async HTTP mocks to that helper (29 sites), drops direct `AsyncMock`/`patch` imports, and shortens several multi-line `patch.object` blocks to single-line `with patch_async_http(...)` calls. Sync client tests are unchanged on purpose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0cd572a3d1f57ee9ad1cef4c6905f65ddfda150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->