### PR TITLE
refactor(examples): dedupe navigation-settle pattern in execute_n1_primitive_action

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -168,6 +168,18 @@ def _click_coordinates(
     return denormalize_coordinates(coords, viewport_width, viewport_height)
 
 
+async def _navigate_and_settle(page: Any, nav_coro: Any, *, sleep: float) -> None:
+    """Await a Playwright navigation call, wait for load, then settle for ``sleep`` seconds.
+
+    Shared by the ``goto``/``back``/``refresh`` branches of :func:`execute_n1_primitive_action`,
+    which each await a different navigation call, wait for ``"domcontentloaded"``, then sleep
+    for their own fixed duration -- otherwise identical.
+    """
+    await nav_coro
+    await page.wait_for_load_state("domcontentloaded")
+    await asyncio.sleep(sleep)
+
+
 async def execute_n1_primitive_action(
     page: Any,
     action_name: str,
@@ -259,19 +271,13 @@ async def execute_n1_primitive_action(
 
     elif action_name in ("goto", "goto_url"):
         url = arguments.get("url", "")
-        await page.goto(url)
-        await page.wait_for_load_state("domcontentloaded")
-        await asyncio.sleep(1)
+        await _navigate_and_settle(page, page.goto(url), sleep=1)
 
     elif action_name in ("back", "go_back"):
-        await page.go_back()
-        await page.wait_for_load_state("domcontentloaded")
-        await asyncio.sleep(0.5)
+        await _navigate_and_settle(page, page.go_back(), sleep=0.5)
 
     elif action_name == "refresh":
-        await page.reload()
-        await page.wait_for_load_state("domcontentloaded")
-        await asyncio.sleep(1)
+        await _navigate_and_settle(page, page.reload(), sleep=1)
 
     elif action_name == "wait":
         await asyncio.sleep(5)


### PR DESCRIPTION
## What

`execute_n1_primitive_action`'s `goto`/`goto_url`, `back`/`go_back`, and `refresh` branches (`examples/_common.py`) each repeated the identical idiom:

```python
await page.<nav_call>()
await page.wait_for_load_state("domcontentloaded")
await asyncio.sleep(<n>)
```

differing only in the nav call and sleep duration. Extracted a small `_navigate_and_settle(page, nav_coro, *, sleep)` helper for the three call sites.

## Why it's an improvement

This exact shape of duplication was already recognized and extracted once in this repo — `examples/navigator_n1_5.py` has `_navigate_and_finish()` doing the same consolidation for its own `goto_url`/`go_back`/`go_forward`/`refresh` branches. `_common.py`'s copy of the pattern (used by `navigator_n1.py`, `navigator_n1_memo.py`, `navigator_n1_custom_tools.py`) had never gotten the same treatment.

## Why it's safe

- Single file changed, 3 call sites, all identified via direct reading of the function (no dynamic dispatch to miss a caller).
- Same calls in the same order for every branch — no behavior change.
- `tests/test_execute_n1_primitive_action.py::TestNavigationActions` already has dedicated `test_goto`/`test_goto_url_alias`/`test_back`/`test_go_back_alias`/`test_refresh` cases asserting the exact Playwright calls and await order; all pass unchanged after the refactor.
- Full suite: `561 passed, 3 skipped` (unchanged from before the change).
- `ruff check` / `ruff format --check` both clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KsQJwh8n3yowhR1TbDTtP5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only refactor with identical call order and existing navigation tests; no auth, data, or production runtime paths touched.
> 
> **Overview**
> Introduces **`_navigate_and_settle`** in `examples/_common.py` to centralize the shared post-navigation sequence (await nav coroutine → `wait_for_load_state("domcontentloaded")` → `asyncio.sleep`).
> 
> The **`goto`/`goto_url`**, **`back`/`go_back`**, and **`refresh`** branches in **`execute_n1_primitive_action`** now call that helper instead of inlining the same three steps; each branch still passes its own Playwright call and sleep duration (**1s** for goto/refresh, **0.5s** for back).
> 
> No intended behavior change—only structural deduplication aligned with the similar pattern already used in `navigator_n1_5.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac8edc03a14183fdd6a5db02fef5acf03ba8567c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->