### PR TITLE
fix(cli): catch APIConnectionError in cli_api_errors, not just httpx.HTTPError

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -448,7 +448,26 @@ def test_usage_rejected_key_prints_auth_guidance_not_traceback():
     assert "Traceback" not in result.stdout
 
 
-def test_scouts_list_network_error_prints_message_not_traceback():
+def test_scouts_list_connection_error_prints_message_not_traceback():
+    # This is the exception type a real YutoriClient call actually raises for
+    # network failures: yutori/_http.py wraps every httpx.HTTPError into an
+    # APIConnectionError before it leaves the SDK, so this is what cli_api_errors
+    # must catch for offline/network-failure CLI usage to show a friendly message.
+    from yutori.exceptions import APIConnectionError
+
+    client = _make_client_mock()
+    client.scouts.list.side_effect = APIConnectionError("Network error calling the Yutori API (ConnectError): refused")
+
+    result = _invoke_cli(client, ["scouts", "list"])
+
+    assert result.exit_code == 1
+    assert "Network error" in result.stdout
+    assert "Traceback" not in result.stdout
+
+
+def test_scouts_list_raw_httpx_error_prints_message_not_traceback():
+    # Defensive fallback: cli_api_errors also catches a raw httpx.HTTPError
+    # directly, in case a network error ever reaches this layer unwrapped.
     import httpx
 
     client = _make_client_mock()

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -13,7 +13,7 @@ from rich.markup import escape
 from rich.table import Table
 
 from yutori.auth.credentials import resolve_api_key
-from yutori.exceptions import APIError, AuthenticationError
+from yutori.exceptions import APIConnectionError, APIError, AuthenticationError
 
 __all__ = [
     "INTERVAL_PRESETS",
@@ -123,6 +123,12 @@ def cli_api_errors() -> Iterator[None]:
     a multi-screen Typer traceback. The AuthenticationError class name stays
     in the output because the installer's AUTH_FAILURE_MARKERS
     (yutori/cli/commands/install_flow.py) classify failures by grepping it.
+
+    ``APIConnectionError`` is the type real client calls actually raise for
+    network failures — ``yutori/_http.py`` wraps every ``httpx.HTTPError``
+    into one before it leaves the SDK. The raw ``httpx.HTTPError`` catch is
+    kept alongside it as a defensive fallback for the same friendly message
+    in case a network error ever reaches this layer unwrapped.
     """
     try:
         yield
@@ -133,7 +139,7 @@ def cli_api_errors() -> Iterator[None]:
     except APIError as exc:
         _console.print(f"[red]APIError: {safe_str(exc)}[/red]")
         raise typer.Exit(1) from exc
-    except httpx.HTTPError as exc:
+    except (APIConnectionError, httpx.HTTPError) as exc:
         _console.print(f"[red]Network error: {safe_str(exc)}[/red]")
         _console.print("Check your connection and try again.")
         raise typer.Exit(1) from exc


### PR DESCRIPTION
## What

`cli_api_errors()` (the CLI's shared error handler, wrapped around every API-calling command via `cli_client()`) catches `AuthenticationError`, `APIError`, and `httpx.HTTPError`, printing a friendly message and exiting with code 1 instead of dumping a Typer traceback.

The problem: `yutori/_http.py`'s `_SyncBaseNamespace._request` / `_AsyncBaseNamespace._request` always catch `httpx.HTTPError` internally and re-raise it as `APIConnectionError` (see `_to_connection_error`) before it ever leaves the SDK client. `APIConnectionError` is a plain `YutoriSDKError` subclass — **not** a subclass of `httpx.HTTPError`. So a real network failure (offline, DNS failure, connection refused, timeout) from any `YutoriClient`/`AsyncYutoriClient` call falls through every `except` clause in `cli_api_errors()` uncaught, and the CLI user gets a raw multi-screen traceback — exactly what this function's own docstring says it exists to prevent ("Without this... being offline dumps a multi-screen Typer traceback").

This fixes it by also catching `APIConnectionError` in `cli_api_errors()`.

## Why this was hiding

The existing regression test (`test_scouts_list_network_error_prints_message_not_traceback`) set `httpx.ConnectError` directly as a `MagicMock`'s `side_effect`, which isn't what a real client raises — so the test passed while the real end-to-end path was broken. I reproduced the bug against a real `YutoriClient` (patching `httpx.Client.get` to raise `httpx.ConnectError`, the same technique already used in `tests/test_client.py::TestTransportErrorWrapping`) and confirmed the exception escaped `cli_api_errors()` uncaught before this fix, and is now caught and printed as `Network error: ...` after it.

## Why it's safe

- Small, additive change: one new import, one exception type added to an existing `except (...)` tuple, same message/exit-code behavior as the existing `httpx.HTTPError` branch.
- No behavioral change to any success path or to `APIError`/`AuthenticationError` handling.
- Full test suite passes (562 passed / 3 skipped) and `ruff check .` is clean.
- Updated the pre-existing test to use the exception type a real client actually raises (`APIConnectionError`), and added a new test (`test_scouts_list_raw_httpx_error_prints_message_not_traceback`) to keep coverage of the defensive raw-`httpx.HTTPError` fallback path too.

## Test plan

- [x] `pytest -m "not slow"` — 561 passed, 3 skipped
- [x] `ruff check .` — all checks passed
- [x] Manually reproduced the bug against a real `YutoriClient` with a patched transport raising `httpx.ConnectError`, confirmed it escaped `cli_api_errors()` before the fix and is caught after

---
_Generated by [Claude Code](https://claude.ai/code/session_011ADHxNugRkbZvoCTbf4EhJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive exception handling on the CLI error path only; success paths and auth/API error behavior are unchanged.
> 
> **Overview**
> **`cli_api_errors()`** now treats **`APIConnectionError`** like network failures: same “Network error” message and exit code 1, instead of an uncaught traceback when the SDK wraps transport errors.
> 
> The SDK re-raises **`httpx.HTTPError`** as **`APIConnectionError`**, which is not an **`httpx`** subclass, so the old handler only matched mocks that raised raw **`httpx`** errors. **`httpx.HTTPError`** remains in the **`except`** tuple as a fallback.
> 
> Tests were updated to assert the real **`APIConnectionError`** path and to keep a separate case for unwrapped **`httpx`** errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe2bb061bc4ec4e32e1afa6ad4f647fb3afc055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->