### PR TITLE
refactor(navigator): use NAVIGATOR_N1_5_MODEL constant in loop.py Protocol stubs

### DIFF
--- a/yutori/navigator/loop.py
+++ b/yutori/navigator/loop.py
@@ -25,7 +25,7 @@ class SupportsSyncChatCompletionsCreate(Protocol):
         self,
         messages: Iterable[ChatCompletionMessageParam],
         *,
-        model: str = "n1.5-latest",
+        model: str = NAVIGATOR_N1_5_MODEL,
         **kwargs: Any,
     ) -> ChatCompletion:
         """Create a sync chat completion."""
@@ -38,7 +38,7 @@ class SupportsAsyncChatCompletionsCreate(Protocol):
         self,
         messages: Iterable[ChatCompletionMessageParam],
         *,
-        model: str = "n1.5-latest",
+        model: str = NAVIGATOR_N1_5_MODEL,
         **kwargs: Any,
     ) -> ChatCompletion:
         """Create an async chat completion."""


### PR DESCRIPTION
## What

`yutori/navigator/loop.py` already imports the canonical model-ID constant:

```python
from .models import NAVIGATOR_N1_5_MODEL
```

and uses it correctly in `create_trimmed`/`acreate_trimmed` (`model: str = NAVIGATOR_N1_5_MODEL`). However, the two `Protocol` method stubs earlier in the same file (`SupportsSyncChatCompletionsCreate.create` and `SupportsAsyncChatCompletionsCreate.create`) still hardcoded the literal string `"n1.5-latest"` instead of the constant.

This PR replaces both literals with `NAVIGATOR_N1_5_MODEL`, matching the pattern already used later in the same file.

## Why it's an improvement

- Single source of truth for the model ID within this file — a future rename of the model ID constant now flows automatically into these `Protocol` stub signatures instead of requiring a manual find-and-replace.
- Mirrors an already-landed pattern in this repo's history: a prior commit fixed the same literal-vs-constant inconsistency in `examples/`. This closes out the one remaining in-package instance.

## Why it's safe

- `tests/test_navigator_models.py` asserts `NAVIGATOR_N1_5_MODEL == "n1.5-latest"`, so the literal value is unchanged — this is a pure same-file constant-consistency fix with no behavior change.
- `Protocol` classes are structural typing stubs — `SupportsSyncChatCompletionsCreate`/`SupportsAsyncChatCompletionsCreate` are never instantiated, so this only affects type-checking/documentation, not runtime behavior.
- No call sites need to change.

## Explicitly out of scope

`yutori/_sync/chat.py` and `yutori/_async/chat.py` also contain the same `"n1.5-latest"` literal, but were deliberately left untouched. Importing from `yutori.navigator.models` there would force the core REST client to eagerly pull in the whole `navigator` package (including PIL) for every user — a real, if small, import-time behavior change / package-boundary violation. Those are out of scope for this change.

## Testing

- `pytest tests/` — 474 passed, 16 skipped, 1 deselected (slow marker)
- `pytest tests/test_navigator_models.py -v` — 6 passed
- `ruff check yutori/navigator/loop.py` — clean
- `ruff format --check yutori/navigator/loop.py` — already formatted


---
_Generated by [Claude Code](https://claude.ai/code/session_01SQ55NpGVFzzgBvo3hnkX6H)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime behavior change—only Protocol default annotations updated to use an existing constant already used in the same module.
> 
> **Overview**
> Aligns the default `model` parameter on the sync and async chat-completion **Protocol** stubs in `loop.py` with the rest of the file by using `NAVIGATOR_N1_5_MODEL` instead of the hardcoded `"n1.5-latest"` string.
> 
> This is a typing/consistency-only change; runtime behavior and the actual model ID stay the same (the constant is already asserted to equal `"n1.5-latest"` in tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d85758d9bd123b4fb76e73877462054dfe94dd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->