### PR TITLE
refactor(chat): use NAVIGATOR_N1_5_MODEL constant for chat completions default

### DIFF
--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -301,6 +301,16 @@ class TestAsyncPydanticSchemaIntegration:
 
 @pytest.mark.asyncio
 class TestAsyncChatNamespace:
+    async def test_chat_completions_default_model_is_canonical_n1_5_constant(self, async_client):
+        from yutori.navigator import NAVIGATOR_N1_5_MODEL
+
+        mock_completion = make_mock_chat_completion(content="click", model=NAVIGATOR_N1_5_MODEL)
+
+        with mocked_async_openai_client(mock_completion) as mock_openai_client:
+            await async_client.chat.completions.create(messages=[{"role": "user", "content": "Click login"}])
+            call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+            assert call_kwargs["model"] == NAVIGATOR_N1_5_MODEL
+
     async def test_chat_completions(self, async_client):
         mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -368,6 +368,16 @@ class TestPydanticSchemaIntegration:
 
 
 class TestChatNamespace:
+    def test_chat_completions_default_model_is_canonical_n1_5_constant(self, client):
+        from yutori.navigator import NAVIGATOR_N1_5_MODEL
+
+        mock_completion = make_mock_chat_completion(content="click", model=NAVIGATOR_N1_5_MODEL)
+
+        with mocked_sync_openai_client(mock_completion) as mock_openai_client:
+            client.chat.completions.create(messages=[{"role": "user", "content": "Click login"}])
+            call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
+            assert call_kwargs["model"] == NAVIGATOR_N1_5_MODEL
+
     def test_chat_completions(self, client):
         mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
 

--- a/yutori/_async/chat.py
+++ b/yutori/_async/chat.py
@@ -9,6 +9,7 @@ from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 
 from .._http import apply_chat_extra_body
+from ..navigator.models import NAVIGATOR_N1_5_MODEL
 
 
 class AsyncChatCompletions:
@@ -21,7 +22,7 @@ class AsyncChatCompletions:
         self,
         messages: Iterable[ChatCompletionMessageParam],
         *,
-        model: str = "n1.5-latest",
+        model: str = NAVIGATOR_N1_5_MODEL,
         tool_set: str | None = None,
         disable_tools: list[str] | None = None,
         json_schema: dict | None = None,

--- a/yutori/_sync/chat.py
+++ b/yutori/_sync/chat.py
@@ -9,6 +9,7 @@ from openai import OpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 
 from .._http import apply_chat_extra_body
+from ..navigator.models import NAVIGATOR_N1_5_MODEL
 
 
 class ChatCompletions:
@@ -21,7 +22,7 @@ class ChatCompletions:
         self,
         messages: Iterable[ChatCompletionMessageParam],
         *,
-        model: str = "n1.5-latest",
+        model: str = NAVIGATOR_N1_5_MODEL,
         tool_set: str | None = None,
         disable_tools: list[str] | None = None,
         json_schema: dict | None = None,


### PR DESCRIPTION
## Issue

`yutori/_sync/chat.py` and `yutori/_async/chat.py` hardcode the literal `"n1.5-latest"` as the default `model` value for `ChatCompletions.create()` / `AsyncChatCompletions.create()`, instead of using the canonical `NAVIGATOR_N1_5_MODEL` constant defined in `yutori/navigator/models.py`. That constant is already the single source of truth used by `yutori/navigator/loop.py` and `examples/navigator_n1_5.py`, and PR #226 (merged hours earlier) fixed the exact same drift-risk pattern for `loop.py`'s `Protocol` stubs — this closes the same gap in the two files that actually own the SDK's runtime default.

## Improvement

Import `NAVIGATOR_N1_5_MODEL` from `yutori.navigator.models` in both files and use it as the `model` parameter default, replacing the duplicated literal.

## Why this is safe

- The constant's value is unchanged (`NAVIGATOR_N1_5_MODEL == "n1.5-latest"`, already pinned by `tests/test_navigator_models.py`), so this is a no-op at runtime.
- No circular import: `yutori.navigator.models` has no dependency on `yutori._sync`/`yutori._async`.
- Added a characterization test to each of `tests/test_client.py` and `tests/test_async_client.py` that asserts the actual default `model` sent to the OpenAI-compatible endpoint when `model` is omitted — this default was previously untested (all existing chat tests pass `model=` explicitly).
- Full suite: 564 passed, 3 skipped (up from 562 passed before this change), `ruff check .` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011MKjYHQtwKpz8Yc5ZHiW8V)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor only; the constant value is unchanged so default model behavior at runtime stays the same.
> 
> **Overview**
> Sync and async **`chat.completions.create()`** now default `model` to **`NAVIGATOR_N1_5_MODEL`** from `yutori.navigator.models` instead of the duplicated `"n1.5-latest"` literal, matching navigator loop helpers and other call sites.
> 
> Adds characterization tests in **`tests/test_client.py`** and **`tests/test_async_client.py`** that call create without `model` and assert the OpenAI client receives the canonical constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d363912bbb7b962ca957553c792152257685a25a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->