### PR TITLE
refactor(tests): use NAVIGATOR_N1_MODEL/NAVIGATOR_N1_5_MODEL constants in client tests

### DIFF
--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 
 from yutori import APIError, AsyncYutoriClient, AuthenticationError
+from yutori.navigator import NAVIGATOR_N1_5_MODEL, NAVIGATOR_N1_MODEL
 
 from ._client_fixtures import (
     make_json_response,
@@ -302,8 +303,6 @@ class TestAsyncPydanticSchemaIntegration:
 @pytest.mark.asyncio
 class TestAsyncChatNamespace:
     async def test_chat_completions_default_model_is_canonical_n1_5_constant(self, async_client):
-        from yutori.navigator import NAVIGATOR_N1_5_MODEL
-
         mock_completion = make_mock_chat_completion(content="click", model=NAVIGATOR_N1_5_MODEL)
 
         with mocked_async_openai_client(mock_completion) as mock_openai_client:
@@ -312,7 +311,7 @@ class TestAsyncChatNamespace:
             assert call_kwargs["model"] == NAVIGATOR_N1_5_MODEL
 
     async def test_chat_completions(self, async_client):
-        mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
+        mock_completion = make_mock_chat_completion(content="click", model=NAVIGATOR_N1_MODEL)
 
         with mocked_async_openai_client(mock_completion):
             result = await async_client.chat.completions.create(
@@ -329,12 +328,12 @@ class TestAsyncChatNamespace:
             "required": ["status"],
             "additionalProperties": False,
         }
-        mock_completion = make_mock_chat_completion(content='{"status":"ok"}', model="n1.5-latest")
+        mock_completion = make_mock_chat_completion(content='{"status":"ok"}', model=NAVIGATOR_N1_5_MODEL)
 
         with mocked_async_openai_client(mock_completion) as mock_openai_client:
             result = await async_client.chat.completions.create(
                 messages=[{"role": "user", "content": "Reply with JSON."}],
-                model="n1.5-latest",
+                model=NAVIGATOR_N1_5_MODEL,
                 tool_set=TOOL_SET_CORE,
                 disable_tools=["hold_key"],
                 json_schema=json_schema,
@@ -343,7 +342,7 @@ class TestAsyncChatNamespace:
             assert result.choices[0].message.content == '{"status":"ok"}'
 
         call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
-        assert call_kwargs["model"] == "n1.5-latest"
+        assert call_kwargs["model"] == NAVIGATOR_N1_5_MODEL
         assert call_kwargs["extra_body"] == {
             "trace_id": "trace-123",
             "tool_set": TOOL_SET_CORE,
@@ -357,7 +356,7 @@ class TestAsyncChatNamespace:
         from yutori.navigator import acreate_trimmed
         from yutori.navigator.payload import trimmed_messages_to_fit
 
-        mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
+        mock_completion = make_mock_chat_completion(content="click", model=NAVIGATOR_N1_MODEL)
         original_messages = make_trimmable_messages()
         original_snapshot = deepcopy(original_messages)
 
@@ -381,14 +380,14 @@ class TestAsyncChatNamespace:
 
         from yutori.navigator import trimmed_messages_to_fit
 
-        mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
+        mock_completion = make_mock_chat_completion(content="click", model=NAVIGATOR_N1_MODEL)
         original_messages = make_trimmable_messages()
         original_snapshot = deepcopy(original_messages)
         trimmed_messages, _, _ = trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)
 
         with mocked_async_openai_client(mock_completion) as mock_openai_client:
             result = await async_client.chat.completions.create(
-                model="n1-latest",
+                model=NAVIGATOR_N1_MODEL,
                 messages=trimmed_messages,
             )
             assert result.choices[0].message.content == "click"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from yutori import APIError, AuthenticationError, YutoriClient
+from yutori.navigator import NAVIGATOR_N1_5_MODEL, NAVIGATOR_N1_MODEL
 
 from ._client_fixtures import (
     make_json_response,
@@ -369,8 +370,6 @@ class TestPydanticSchemaIntegration:
 
 class TestChatNamespace:
     def test_chat_completions_default_model_is_canonical_n1_5_constant(self, client):
-        from yutori.navigator import NAVIGATOR_N1_5_MODEL
-
         mock_completion = make_mock_chat_completion(content="click", model=NAVIGATOR_N1_5_MODEL)
 
         with mocked_sync_openai_client(mock_completion) as mock_openai_client:
@@ -379,17 +378,17 @@ class TestChatNamespace:
             assert call_kwargs["model"] == NAVIGATOR_N1_5_MODEL
 
     def test_chat_completions(self, client):
-        mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
+        mock_completion = make_mock_chat_completion(content="click", model=NAVIGATOR_N1_MODEL)
 
         with mocked_sync_openai_client(mock_completion) as mock_openai_client:
             result = client.chat.completions.create(
                 messages=[{"role": "user", "content": "Click login"}],
-                model="n1-latest",
+                model=NAVIGATOR_N1_MODEL,
             )
             assert result.choices[0].message.content == "click"
             mock_openai_client.chat.completions.create.assert_called_once()
             call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
-            assert call_kwargs["model"] == "n1-latest"
+            assert call_kwargs["model"] == NAVIGATOR_N1_MODEL
 
     def test_chat_completions_n1_5_forwards_extra_body_options(self, client):
         from yutori.navigator import TOOL_SET_CORE
@@ -400,12 +399,12 @@ class TestChatNamespace:
             "required": ["status"],
             "additionalProperties": False,
         }
-        mock_completion = make_mock_chat_completion(content='{"status":"ok"}', model="n1.5-latest")
+        mock_completion = make_mock_chat_completion(content='{"status":"ok"}', model=NAVIGATOR_N1_5_MODEL)
 
         with mocked_sync_openai_client(mock_completion) as mock_openai_client:
             result = client.chat.completions.create(
                 messages=[{"role": "user", "content": "Reply with JSON."}],
-                model="n1.5-latest",
+                model=NAVIGATOR_N1_5_MODEL,
                 tool_set=TOOL_SET_CORE,
                 disable_tools=["hold_key"],
                 json_schema=json_schema,
@@ -413,7 +412,7 @@ class TestChatNamespace:
             )
             assert result.choices[0].message.content == '{"status":"ok"}'
             call_kwargs = mock_openai_client.chat.completions.create.call_args[1]
-            assert call_kwargs["model"] == "n1.5-latest"
+            assert call_kwargs["model"] == NAVIGATOR_N1_5_MODEL
             assert call_kwargs["extra_body"] == {
                 "trace_id": "trace-123",
                 "tool_set": TOOL_SET_CORE,
@@ -427,7 +426,7 @@ class TestChatNamespace:
         from yutori.navigator import create_trimmed
         from yutori.navigator.payload import trimmed_messages_to_fit
 
-        mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
+        mock_completion = make_mock_chat_completion(content="click", model=NAVIGATOR_N1_MODEL)
         original_messages = make_trimmable_messages()
         original_snapshot = deepcopy(original_messages)
 
@@ -451,14 +450,14 @@ class TestChatNamespace:
 
         from yutori.navigator import trimmed_messages_to_fit
 
-        mock_completion = make_mock_chat_completion(content="click", model="n1-latest")
+        mock_completion = make_mock_chat_completion(content="click", model=NAVIGATOR_N1_MODEL)
         original_messages = make_trimmable_messages()
         original_snapshot = deepcopy(original_messages)
         trimmed_messages, _, _ = trimmed_messages_to_fit(original_messages, max_bytes=100, keep_recent=1)
 
         with mocked_sync_openai_client(mock_completion) as mock_openai_client:
             result = client.chat.completions.create(
-                model="n1-latest",
+                model=NAVIGATOR_N1_MODEL,
                 messages=trimmed_messages,
             )
             assert result.choices[0].message.content == "click"


### PR DESCRIPTION
## What

`tests/test_client.py` and `tests/test_async_client.py` had several call sites in `TestChatNamespace`/`TestAsyncChatNamespace` that hardcoded the literal strings `"n1-latest"` and `"n1.5-latest"` for `model=...` kwargs, instead of using the canonical `NAVIGATOR_N1_MODEL` / `NAVIGATOR_N1_5_MODEL` constants from `yutori.navigator.models`. This switches all remaining hardcoded occurrences in those two files to the constants, and promotes the previously per-test local `from yutori.navigator import NAVIGATOR_N1_5_MODEL` import (used by only one test before this change) to a module-level import shared by all the now-consistent call sites.

## Why

PRs #226 and #227 (merged just before this one) did the same consolidation for `yutori/navigator/loop.py`'s Protocol stubs and `yutori/_sync/chat.py`/`yutori/_async/chat.py`'s default `model=` values, explicitly to establish `NAVIGATOR_N1_5_MODEL` as the single source of truth and prevent literal drift. That effort left the sibling test literals in the very same test classes (added alongside #227's own characterization tests) inconsistent — some call sites in `TestChatNamespace`/`TestAsyncChatNamespace` already referenced the constant while others a few lines below still hardcoded the raw string. This PR finishes that consolidation.

## Why safe

- Pure rename/reference change: `NAVIGATOR_N1_MODEL == "n1-latest"` and `NAVIGATOR_N1_5_MODEL == "n1.5-latest"` are pinned by `tests/test_navigator_models.py`, so every replaced literal keeps the exact same runtime value.
- No production code touched — only two test files.
- Full suite unchanged before/after: **564 passed, 3 skipped**.
- `ruff check` and `ruff format --check` clean on both touched files.

---
_Generated by [Claude Code](https://claude.ai/code/session_0111KN4RfXNzhamC1F1rJJci)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test files change; model string values stay the same via existing constant definitions.
> 
> **Overview**
> **Test-only cleanup** in `tests/test_client.py` and `tests/test_async_client.py`: chat namespace tests no longer hardcode `"n1-latest"` / `"n1.5-latest"` for mocks and `model=` arguments.
> 
> Those literals are replaced with **`NAVIGATOR_N1_MODEL`** and **`NAVIGATOR_N1_5_MODEL`** from `yutori.navigator`, imported once at module scope (replacing a per-test import for the N1.5 default-model case). Behavior is unchanged; this aligns tests with the same canonical constants used in production chat defaults after recent navigator refactors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc4c0cb28f698c7862685ad9a2ff77ec80d964b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->