### PR TITLE
refactor(tests): use NAVIGATOR_N1_MODEL constant in remaining test fixtures

### DIFF
--- a/tests/_call_llm_agent_fixtures.py
+++ b/tests/_call_llm_agent_fixtures.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 from examples._common import BrowserAgentMixin
+from yutori.navigator import NAVIGATOR_N1_MODEL
 
 
 def make_call_llm_agent() -> BrowserAgentMixin:
@@ -23,7 +24,7 @@ def make_call_llm_agent() -> BrowserAgentMixin:
     whose ``model_dump()`` is ``{"role": "assistant", "content": "done"}``.
     """
     agent = BrowserAgentMixin()
-    agent.model = "n1-latest"
+    agent.model = NAVIGATOR_N1_MODEL
     agent.temperature = 0.3
     agent._step_count = 3
     agent._step_payloads = []

--- a/tests/_client_fixtures.py
+++ b/tests/_client_fixtures.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 
+from yutori.navigator import NAVIGATOR_N1_MODEL
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -147,7 +149,7 @@ def make_trimmable_messages() -> list[dict[str, Any]]:
 
 
 def make_mock_chat_completion(
-    *, content: str = "click", model: str = "n1-latest", completion_id: str = "chatcmpl-123"
+    *, content: str = "click", model: str = NAVIGATOR_N1_MODEL, completion_id: str = "chatcmpl-123"
 ) -> ChatCompletion:
     """Build a minimal :class:`openai.types.chat.ChatCompletion` for mocking chat.completions.create.
 

--- a/tests/test_call_llm_mixin.py
+++ b/tests/test_call_llm_mixin.py
@@ -14,6 +14,7 @@ from .conftest import require_examples_extra
 
 require_examples_extra()
 from examples._common import BrowserAgentMixin  # noqa: E402
+from yutori.navigator import NAVIGATOR_N1_MODEL  # noqa: E402
 
 from ._call_llm_agent_fixtures import make_call_llm_agent  # noqa: E402
 
@@ -29,7 +30,7 @@ async def test_call_llm_without_extra_fields_passes_only_base_fields() -> None:
     response = await agent._call_llm(messages)
 
     agent._client.chat.completions.create.assert_awaited_once_with(
-        model="n1-latest",
+        model=NAVIGATOR_N1_MODEL,
         messages=messages,
         temperature=0.3,
     )
@@ -43,7 +44,7 @@ async def test_call_llm_merges_extra_fields_into_the_call() -> None:
     await agent._call_llm(messages, extra_fields={"tool_set": "n1_5", "disable_tools": None})
 
     agent._client.chat.completions.create.assert_awaited_once_with(
-        model="n1-latest",
+        model=NAVIGATOR_N1_MODEL,
         messages=messages,
         temperature=0.3,
         tool_set="n1_5",
@@ -61,7 +62,7 @@ async def test_call_llm_records_sanitized_step_payload_matching_the_actual_call(
     payload = agent._step_payloads[0]
     assert payload["step_num"] == 3
     assert payload["request"] == {
-        "model": "n1-latest",
+        "model": NAVIGATOR_N1_MODEL,
         "messages": messages,
         "temperature": 0.3,
         "tools": [{"type": "function"}],

--- a/tests/test_call_llm_with_tools_mixin.py
+++ b/tests/test_call_llm_with_tools_mixin.py
@@ -14,6 +14,7 @@ from .conftest import require_examples_extra
 
 require_examples_extra()
 from examples._common import BrowserAgentMixin  # noqa: E402
+from yutori.navigator import NAVIGATOR_N1_MODEL  # noqa: E402
 
 from ._call_llm_agent_fixtures import make_call_llm_agent  # noqa: E402
 
@@ -31,7 +32,7 @@ async def test_call_llm_with_tools_passes_tools_and_fields_to_create() -> None:
     response = await agent._call_llm_with_tools(tools)
 
     agent._client.chat.completions.create.assert_awaited_once_with(
-        model="n1-latest",
+        model=NAVIGATOR_N1_MODEL,
         messages=agent._messages,
         temperature=0.3,
         tools=tools,
@@ -49,7 +50,7 @@ async def test_call_llm_with_tools_records_sanitized_step_payload() -> None:
     payload = agent._step_payloads[0]
     assert payload["step_num"] == 3
     assert payload["request"] == {
-        "model": "n1-latest",
+        "model": NAVIGATOR_N1_MODEL,
         "messages": agent._messages,
         "temperature": 0.3,
         "tools": tools,


### PR DESCRIPTION
## What

PRs #226–#228 replaced the hardcoded literals `"n1-latest"` / `"n1.5-latest"` with the canonical `NAVIGATOR_N1_MODEL` / `NAVIGATOR_N1_5_MODEL` constants (from `yutori/navigator/models.py`) across `loop.py`'s Protocol stubs, `_sync/chat.py`/`_async/chat.py`'s defaults, and `test_client.py`/`test_async_client.py`'s assertions. Four sites were missed:

- `tests/_client_fixtures.py::make_mock_chat_completion` — shared fixture's default `model` value
- `tests/_call_llm_agent_fixtures.py::make_call_llm_agent` — shared fixture's fixed `agent.model` value
- `tests/test_call_llm_mixin.py` — asserts against that literal (2 sites)
- `tests/test_call_llm_with_tools_mixin.py` — asserts against that literal (2 sites)

## Why it's safe

- Pure literal → constant substitution; `NAVIGATOR_N1_MODEL == "n1-latest"` is pinned by `tests/test_navigator_models.py`, so this is a no-op at runtime/test-outcome level.
- No behavior change, no new test needed (the existing suite already exercises every touched line).
- Deliberately left `tests/test_navigator_replay.py`'s own `"n1-latest"` literals alone — those exercise payload-sanitization/HTML-rendering logic where the value is incidental example data, not an assertion tied to the canonical model constant, so folding them into the constant would be a stretch outside this pattern's intent.

## Verification

- `pytest -q`: 564 passed, 3 skipped (same counts before/after)
- `ruff check .`: clean
- `ruff format --check` on all 4 touched files: clean (pre-existing formatting drift in 11 unrelated files, untouched by this diff)


---
_Generated by [Claude Code](https://claude.ai/code/session_015FLuQenQdVXwxfiEiM34uF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only constant substitution with no runtime or behavioral impact.
> 
> **Overview**
> Completes the earlier test refactor by swapping remaining hardcoded **`"n1-latest"`** strings for **`NAVIGATOR_N1_MODEL`** from `yutori.navigator`.
> 
> Shared fixtures **`make_call_llm_agent`** and **`make_mock_chat_completion`** now set their default model from that constant. **`test_call_llm_mixin`** and **`test_call_llm_with_tools_mixin`** assert the same value via the constant instead of a literal. No production or test behavior change—only alignment with the canonical model id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf2de74f438dd7a57e261e7b225189f72f0b7910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->