### PR TITLE
refactor(client): type __exit__/__aexit__ params to match httpx's own signature

### DIFF
--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import TracebackType
 from typing import Any
 
 import httpx
@@ -110,5 +111,10 @@ class AsyncYutoriClient(_AsyncBaseNamespace):
     async def __aenter__(self) -> AsyncYutoriClient:
         return self
 
-    async def __aexit__(self, exc_type: type | None, exc: BaseException | None, traceback: Any) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         await self.close()

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import TracebackType
 from typing import Any
 
 import httpx
@@ -100,5 +101,10 @@ class YutoriClient(_SyncBaseNamespace):
     def __enter__(self) -> YutoriClient:
         return self
 
-    def __exit__(self, exc_type: type | None, exc: BaseException | None, traceback: Any) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         self.close()


### PR DESCRIPTION
## What

`YutoriClient.__exit__` and `AsyncYutoriClient.__aexit__` declared their context-manager protocol parameters with catch-all types (`exc_type: type | None`, `traceback: Any`) instead of the precise types the context-manager protocol actually provides.

## Why

Both classes wrap `httpx.Client`/`httpx.AsyncClient`, and `httpx`'s own `__exit__`/`__aexit__` already use the precise signature: `exc_type: type[BaseException] | None`, `traceback: types.TracebackType | None`. Matching that gives downstream users' type checkers/IDEs real information about the `traceback` argument instead of `Any`, and tightens `exc_type` from a bare `type` to `type[BaseException]`.

## Why it's safe

- Both `client.py` and `async_client.py` start with `from __future__ import annotations`, so annotations are never evaluated at runtime — this is a pure type-hint change with zero behavioral effect.
- No call sites pass these params explicitly; they're always supplied by the interpreter's `with`/`async with` protocol.
- Ran the full existing context-manager test coverage locally: `tests/test_client.py` (`with YutoriClient(...) as client:`) and `tests/test_async_client.py` (`async with AsyncYutoriClient(...) as client:`) — 92 passed, 0 failed.
- `ruff check` and `ruff format --check` both pass on the changed files.

## Test plan

- [x] `pytest tests/test_client.py tests/test_async_client.py` — 92 passed
- [x] `ruff check` / `ruff format --check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFasw3WKyQ97qtxnUaRSU8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only change with no runtime logic; context-manager behavior is unchanged.
> 
> **Overview**
> Tightens the context-manager exit method annotations on **`YutoriClient`** and **`AsyncYutoriClient`** so they match the standard protocol and **`httpx`**’s own signatures.
> 
> **`exc_type`** is now **`type[BaseException] | None`** instead of a bare **`type | None`**, and **`traceback`** is **`TracebackType | None`** instead of **`Any`**, with **`TracebackType`** imported from **`types`**. Method bodies are unchanged; with **`from __future__ import annotations`**, this is typing-only for checkers and IDEs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8beff09cf6550679ff87fee1009df4bd1bc68c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->