### PR TITLE
refactor(tests): use NAVIGATOR_N1_MODEL constant in test_navigator_replay.py

### DIFF
--- a/tests/test_navigator_replay.py
+++ b/tests/test_navigator_replay.py
@@ -4,6 +4,7 @@ import copy
 
 import pytest
 
+from yutori.navigator import NAVIGATOR_N1_MODEL
 from yutori.navigator.loop import update_trimmed_history
 from yutori.navigator.replay import (
     TrajectoryRecorder,
@@ -81,7 +82,7 @@ def test_sanitize_step_payload_clips_images_before_storage() -> None:
         {
             "step_num": 1,
             "request": {
-                "model": "n1-latest",
+                "model": NAVIGATOR_N1_MODEL,
                 "messages": [_image_message("user", url=large_url, text="Inspect page")],
             },
             "response": {"id": "resp_123"},
@@ -124,7 +125,7 @@ def test_generate_visualization_html_renders_raw_request_and_response_json() -> 
         {
             "step_num": 1,
             "request": {
-                "model": "n1-latest",
+                "model": NAVIGATOR_N1_MODEL,
                 "messages": [_image_message("user", url=large_url, text="Inspect page")],
             },
             "response": {
@@ -154,7 +155,7 @@ async def test_trajectory_recorder_writes_artifacts(tmp_path) -> None:
         {
             "step_num": 1,
             "request": {
-                "model": "n1-latest",
+                "model": NAVIGATOR_N1_MODEL,
                 "messages": [_image_message("user", url=large_url, text="Inspect page")],
             },
             "response": {"id": "resp_123"},


### PR DESCRIPTION
## Day-over-day pattern

Looking at the last several merged PRs together (#226, #227, #228, #229, #230), a clear pattern emerges: `"n1-latest"`/`"n1.5-latest"` string literals scattered across the codebase are being consolidated onto the canonical `NAVIGATOR_N1_MODEL`/`NAVIGATOR_N1_5_MODEL` constants from `yutori/navigator/models.py`, one file/call-site cluster at a time (`loop.py` Protocol stubs, `chat.py` defaults, then `test_client.py`/`test_async_client.py`, then remaining test fixtures in `_client_fixtures.py`/`_call_llm_agent_fixtures.py`).

Each of those PRs was correctly scoped to what it touched, but no single one swept the whole repo, so `tests/test_navigator_replay.py` was missed — it still embeds three raw `"model": "n1-latest"` literals in fixture payload dicts (`sanitize_step_payload`/`generate_visualization_html`/`TrajectoryRecorder` tests).

## What this does

Completes the sweep: imports `NAVIGATOR_N1_MODEL` from `yutori.navigator` and replaces the three literal occurrences with it, matching the import/usage convention already established in `tests/test_client.py` and `tests/_client_fixtures.py`.

Pure consistency change — the constant's value is identical to the literal it replaces, so there is no behavioral change. Verified `tests/test_navigator_replay.py` (20 passed) and `ruff check`/`ruff format --check`.

cc @dhruvbatra as the author of the recent NAVIGATOR_N1_MODEL consolidation PRs (#226-#230), for visibility on this follow-up.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WNK4xNu8zGAM6Rbz5BFk1F)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture updates with no production code or behavioral change.
> 
> **Overview**
> Continues the repo-wide move away from hardcoded `"n1-latest"` strings in tests by updating **`tests/test_navigator_replay.py`**.
> 
> The file now imports **`NAVIGATOR_N1_MODEL`** from `yutori.navigator` and uses it in three step-payload fixtures (sanitize, visualization HTML, and trajectory recorder tests), aligned with other navigator test files. **No runtime or test behavior change** — the constant equals the former literal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54c9169399b063c751bc3d5b3fef019fe1045192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->