### PR TITLE
refactor(navigator): rename local html vars shadowing the html import in replay.py

### DIFF
--- a/yutori/navigator/replay.py
+++ b/yutori/navigator/replay.py
@@ -178,7 +178,7 @@ class TrajectoryRecorder:
     ) -> None:
         """Render the optional static HTML replay viewer for one run."""
 
-        html = generate_visualization_html(
+        visualization_html = generate_visualization_html(
             task_id=self.run_id,
             messages=messages,
             result=result,
@@ -186,7 +186,7 @@ class TrajectoryRecorder:
             coord_space_width=coord_space_width,
             coord_space_height=coord_space_height,
         )
-        await self._write_text(self.artifact_path("visualization.html"), html)
+        await self._write_text(self.artifact_path("visualization.html"), visualization_html)
 
 
 def generate_visualization_html(
@@ -208,7 +208,7 @@ def generate_visualization_html(
     result_score = getattr(result, "score", None) if result is not None else None
     result_json = _dump_result_json(result)
 
-    html: list[str] = [
+    html_lines: list[str] = [
         "<!DOCTYPE html>",
         "<html lang=\"en\">",
         "<head>",
@@ -234,25 +234,25 @@ def generate_visualization_html(
             badge_class = "success"
         elif result_score == 0:
             badge_class = "failure"
-        html.append(f"<div class=\"score {badge_class}\">score {result_score}</div>")
-    html.extend(["</header>", "<main>"])
+        html_lines.append(f"<div class=\"score {badge_class}\">score {result_score}</div>")
+    html_lines.extend(["</header>", "<main>"])
 
     if system_prompt:
-        html.extend(_render_text_details_panel("System Prompt", system_prompt))
+        html_lines.extend(_render_text_details_panel("System Prompt", system_prompt))
 
     if user_query:
-        html.extend(_render_text_details_panel("User Prompt", user_query, open=True))
+        html_lines.extend(_render_text_details_panel("User Prompt", user_query, open=True))
 
     if not steps:
-        html.append("<section class=\"panel empty\">No assistant steps were recorded.</section>")
+        html_lines.append("<section class=\"panel empty\">No assistant steps were recorded.</section>")
 
     for step in steps:
-        html.append(_render_step(step))
+        html_lines.append(_render_step(step))
 
     if result_json:
-        html.extend(_render_text_details_panel("Result Artifact", result_json))
+        html_lines.extend(_render_text_details_panel("Result Artifact", result_json))
 
-    html.extend(
+    html_lines.extend(
         [
             "</main>",
             "<div class=\"modal\" id=\"modal\" onclick=\"closeReplayModal(event)\">",
@@ -267,7 +267,7 @@ def generate_visualization_html(
             "</html>",
         ]
     )
-    return "\n".join(html)
+    return "\n".join(html_lines)
 
 
 def _build_steps(
@@ -574,7 +574,7 @@ def _render_text_details_panel(title: str, content: str, *, open: bool = False) 
     """Build the collapsible ``<details class="panel">`` block used by ``generate_visualization_html``
     for the System Prompt, User Prompt, and Result Artifact sections.
 
-    Returned as a 4-line list to match the existing ``html.extend([...])`` call style
+    Returned as a 4-line list to match the existing ``html_lines.extend([...])`` call style
     so the on-disk visualization HTML keeps its line layout exactly.
     """
     open_attr = " open" if open else ""


### PR DESCRIPTION
## What

In `yutori/navigator/replay.py`, two local variables named `html` shadowed the module-level `import html` (stdlib) within their scopes:

- `generate_visualization_html` used a local list `html` (the HTML-line accumulator) → renamed to `html_lines`.
- Its caller `TrajectoryRecorder.save_html` used a local `html` (the generated document string) → renamed to `visualization_html`.

Also updated the `_render_text_details_panel` docstring that referenced the old `html.extend([...])` call style.

## Why

Neither function references the stdlib `html` module internally — `html.escape` is used only via `_escape_html`, in an unshadowed scope — so the shadowing was harmless, but it's a readability nit that linters flag (builtin/stdlib name shadowing). This was previously noted during an audit but left as a "cosmetic nit"; the fix is small and fully mechanical.

## Risk

Pure rename of function-internal locals. No public API, signature, or behavioral change.

## Verification

- `ruff check .` — clean
- `pytest tests/test_navigator_replay.py` — 20/20 passing
- Smoke: `generate_visualization_html(...)` still emits a well-formed `<!DOCTYPE html>…</html>` document with `html.escape`-based escaping intact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLTWXc7hBkmcojGJirpeLM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical internal renames only; no logic or public API changes.
> 
> **Overview**
> Renames two locals in `yutori/navigator/replay.py` so they no longer shadow the stdlib `html` import: the generated document string in `TrajectoryRecorder.save_html` becomes `visualization_html`, and the line accumulator in `generate_visualization_html` becomes `html_lines` (with matching `.append`/`.extend` call sites).
> 
> The `_render_text_details_panel` docstring is updated to reference `html_lines.extend`. **No behavior, API, or output changes**—only naming and linter/readability cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508894b9035c34249bb9b7bd1de43dd8879224d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->