### PR TITLE
refactor(cli): rename local version var shadowing the importlib.metadata import in install_flow.py

### DIFF
--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -480,7 +480,7 @@ def inspect_cli_install(env: Mapping[str, str] | None = None) -> tuple[CLIInstal
     if version_result.returncode != 0:
         return None, StepResult("CLI", "failed", describe_completed_process(version_result))
 
-    version = version_result.stdout.strip() or version_result.stderr.strip() or "yutori installed"
+    cli_version = version_result.stdout.strip() or version_result.stderr.strip() or "yutori installed"
     shell_cli = shutil.which("yutori", path=resolved_env.get("PATH"))
     shell_cli_path = Path(shell_cli) if shell_cli else None
     current_shell_resolves_to_install = bool(shell_cli and normalize_path(shell_cli) == normalize_path(cli_path))
@@ -488,14 +488,14 @@ def inspect_cli_install(env: Mapping[str, str] | None = None) -> tuple[CLIInstal
         cli_path=cli_path,
         bin_dir=bin_dir,
         uv_path=uv_path,
-        version=version,
+        version=cli_version,
         on_path=current_shell_resolves_to_install,
         shell_cli_path=shell_cli_path,
     )
     if shell_cli_path is None:
-        detail = f"{version} at {cli_path}. `yutori` is not currently reachable from PATH."
+        detail = f"{cli_version} at {cli_path}. `yutori` is not currently reachable from PATH."
     elif current_shell_resolves_to_install:
-        detail = f"{version} at {cli_path}"
+        detail = f"{cli_version} at {cli_path}"
     else:
         detail = f"Current shell resolves `yutori` to {shell_cli_path}, not {cli_path}."
     return state, StepResult("CLI", "success", detail)


### PR DESCRIPTION
## What

`inspect_cli_install()` in `yutori/cli/commands/install_flow.py` assigned the installed CLI's `--version` output to a local variable named `version`, shadowing the module-level `from importlib.metadata import PackageNotFoundError, version` import within that function's scope.

This is the same pattern PR #232 just fixed for the `html` local shadowing the `import html` stdlib module in `navigator/replay.py::generate_visualization_html`/`save_html`.

## Why it's safe

- Nothing inside `inspect_cli_install` calls the imported `version()` — it's only used by the unrelated `_yutori_version()` helper elsewhere in the file — so the shadowing was harmless, purely a readability nit a linter would flag.
- Pure rename of an internal local (`version` -> `cli_version`) at all 4 use sites. The `CLIInstallState.version=` keyword/dataclass field name is unchanged, so no public API or behavior change.
- Verified via a repo-wide AST scan for the same shadowing pattern (imports vs. local assignments, function params, and loop/comprehension targets across every function in `yutori/`) — this was the only other instance found beyond the one #232 already fixed.
- `ruff check .` clean.
- Full test suite green: 563 passed, 3 skipped (identical to the pre-change baseline). The one failing test (`test_packaging.py::test_built_distributions_include_packaged_assets`) is a pre-existing, unrelated sandbox issue (missing `build` module for the `python -m build` subprocess call) — reproduced identically on `main` before this change.
- `tests/test_install_flow.py`'s 81 tests (including 3 direct `inspect_cli_install` tests) pass unchanged.

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01YQxpMMAxxjHRw9ERaFbgMc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal variable rename only; no logic, API, or runtime behavior changes.
> 
> **Overview**
> In **`inspect_cli_install()`**, the string parsed from the installed CLI’s `--version` output is now held in **`cli_version`** instead of **`version`**, so it no longer shadows the module-level **`importlib.metadata.version`** import (same readability fix as PR #232 elsewhere).
> 
> **`CLIInstallState.version`** and all installer behavior are unchanged; only the local name and the success-detail strings that referenced it were updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22e3fdb807c21912bcf04bc4825e56f7ded4c308. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->