### PR TITLE
refactor(client): hoist duplicated require_api_key import to module level

### DIFF
--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -14,6 +14,7 @@ from ._async import (
     AsyncScoutsNamespace,
 )
 from ._http import _AsyncBaseNamespace, build_query_params
+from .auth.credentials import require_api_key
 from .config import DEFAULT_BASE_URL, DEFAULT_TIMEOUT_SECONDS, sanitize_base_url
 
 
@@ -56,8 +57,6 @@ class AsyncYutoriClient(_AsyncBaseNamespace):
         Raises:
             AuthenticationError: If no API key is provided or found in environment.
         """
-        from yutori.auth.credentials import require_api_key
-
         self._api_key = require_api_key(api_key)
         base_url = sanitize_base_url(base_url)
         super().__init__(httpx.AsyncClient(timeout=timeout), base_url, self._api_key)

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -9,6 +9,7 @@ import httpx
 
 from ._http import _SyncBaseNamespace, build_query_params
 from ._sync import BrowsingNamespace, ChatNamespace, ResearchNamespace, ScoutsNamespace
+from .auth.credentials import require_api_key
 from .config import DEFAULT_BASE_URL, DEFAULT_TIMEOUT_SECONDS, sanitize_base_url
 
 
@@ -46,8 +47,6 @@ class YutoriClient(_SyncBaseNamespace):
         Raises:
             AuthenticationError: If no API key is provided or found in environment.
         """
-        from yutori.auth.credentials import require_api_key
-
         self._api_key = require_api_key(api_key)
         base_url = sanitize_base_url(base_url)
         super().__init__(httpx.Client(timeout=timeout), base_url, self._api_key)


### PR DESCRIPTION
## What

`YutoriClient.__init__` (`yutori/client.py`) and `AsyncYutoriClient.__init__` (`yutori/async_client.py`) each had an identical local import buried inside the method body:

```python
from yutori.auth.credentials import require_api_key
```

This moves both to ordinary top-level imports, matching every other dependency these two files already import at module scope, and removes the duplicated local-import line from both `__init__` methods.

## Why

There's no circular-import reason for the local import: `yutori.auth.credentials` only depends on `yutori.exceptions` and `yutori.auth.constants` (which itself only depends on `yutori.config`), and none of those import back from `client.py` or `async_client.py`. The local import was just an inconsistent, duplicated pattern with no functional purpose — everything else these files need (`httpx`, `._http`, `._sync`/`._async`, `.config`) is already imported at the top.

## Why this is safe (no public API change)

- Pure internal reorganization — `require_api_key` is still resolved and called exactly once per client construction, with the same precedence chain (`param > YUTORI_API_KEY env var > config file`) and the same `AuthenticationError` on failure.
- No new circular import: confirmed with `python -c "import yutori"` (both `YutoriClient` and `AsyncYutoriClient` import and construct cleanly) before making any other changes.
- Full test suite: **477 passed, 16 skipped** — identical to `main` before this change.
- `ruff check` / `ruff format` clean.
- Public constructors, method signatures, and error types are untouched.

## Verification

```bash
python -c "import yutori; print(yutori.YutoriClient, yutori.AsyncYutoriClient)"
pytest -q   # 477 passed, 16 skipped
ruff check yutori/client.py yutori/async_client.py
ruff format --check yutori/client.py yutori/async_client.py
```

🤖 Generated by an automated hourly refactor cronjob.

---
_Generated by [Claude Code](https://claude.ai/code/session_014xqBCWm9rf3Rj4AtQp6Myx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal import layout only; no API, auth logic, or runtime behavior changes.
> 
> **Overview**
> **Hoists** the duplicated `require_api_key` import out of `YutoriClient.__init__` and `AsyncYutoriClient.__init__` into top-level `from .auth.credentials import require_api_key` in `yutori/client.py` and `yutori/async_client.py`, matching how other dependencies are imported in those modules.
> 
> Constructor behavior is unchanged: `require_api_key(api_key)` still runs on every client construction with the same resolution order and `AuthenticationError` when no key is found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 192baaf6e445c3376b2f7a1a4e14b14418682265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->