### PR TITLE
refactor(cli): consolidate env-scoped executable lookup in install_flow

### DIFF
--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -195,6 +195,20 @@ def _resolve_env(env: Mapping[str, str] | None) -> Mapping[str, str]:
     return env or os.environ
 
 
+def _which(name: str, env: Mapping[str, str] | None = None) -> str | None:
+    """Locate the ``name`` executable on the PATH of *env* (default ``os.environ``).
+
+    Every executable lookup in the installer must be scoped to the resolved
+    environment's PATH rather than to ``shutil.which``'s process-PATH default:
+    ``resolve_uv_path`` / ``resolve_npx_path`` / ``inspect_cli_install`` /
+    ``detect_sdk_install_plan`` all accept an explicit ``env`` and are called
+    with a synthetic one (by the installer's own callers and by the tests).
+    Centralizing the ``path=`` argument keeps a new call site from silently
+    reading the process PATH instead.
+    """
+    return shutil.which(name, path=_resolve_env(env).get("PATH"))
+
+
 def _synthetic_returncode_for_exception(exc: BaseException) -> int:
     """Map a caught subprocess-launch exception to a synthetic returncode.
 
@@ -369,7 +383,7 @@ def resolve_uv_path(env: Mapping[str, str] | None = None) -> str | None:
     if explicit_uv and _is_executable(explicit_uv):
         return explicit_uv
 
-    uv_path = shutil.which("uv", path=resolved_env.get("PATH"))
+    uv_path = _which("uv", resolved_env)
     if uv_path:
         return uv_path
 
@@ -383,7 +397,7 @@ def resolve_uv_path(env: Mapping[str, str] | None = None) -> str | None:
 
 def resolve_npx_path(env: Mapping[str, str] | None = None) -> str | None:
     resolved_env = _resolve_env(env)
-    return shutil.which("npx", path=resolved_env.get("PATH"))
+    return _which("npx", resolved_env)
 
 
 def python_has_pip(interpreter: str, env: Mapping[str, str] | None = None) -> bool:
@@ -481,7 +495,7 @@ def inspect_cli_install(env: Mapping[str, str] | None = None) -> tuple[CLIInstal
         return None, StepResult("CLI", "failed", describe_completed_process(version_result))
 
     cli_version = version_result.stdout.strip() or version_result.stderr.strip() or "yutori installed"
-    shell_cli = shutil.which("yutori", path=resolved_env.get("PATH"))
+    shell_cli = _which("yutori", resolved_env)
     shell_cli_path = Path(shell_cli) if shell_cli else None
     current_shell_resolves_to_install = bool(shell_cli and normalize_path(shell_cli) == normalize_path(cli_path))
     state = CLIInstallState(
@@ -519,11 +533,7 @@ def detect_sdk_install_plan(cwd: Path | None = None, env: Mapping[str, str] | No
             venv_python = Path(resolved_env["VIRTUAL_ENV"]) / "Scripts" / "python.exe"
         else:
             venv_python = Path(resolved_env["VIRTUAL_ENV"]) / "bin" / "python"
-        python_path = (
-            str(venv_python)
-            if _is_executable(venv_python)
-            else shutil.which("python", path=resolved_env.get("PATH"))
-        )
+        python_path = str(venv_python) if _is_executable(venv_python) else _which("python", resolved_env)
         return SDKInstallPlan(
             reason=f"Detected active virtual environment at {resolved_env['VIRTUAL_ENV']}.",
             command=((python_path or "python"), "-m", "pip", "install", "yutori"),
@@ -541,8 +551,7 @@ def detect_sdk_install_plan(cwd: Path | None = None, env: Mapping[str, str] | No
     )
     # Prefer python3 but fall back to python — some minimal images and recent
     # Homebrew installs expose only one of the two.
-    path_env = resolved_env.get("PATH")
-    interpreter = shutil.which("python3", path=path_env) or shutil.which("python", path=path_env)
+    interpreter = _which("python3", resolved_env) or _which("python", resolved_env)
     available = bool(interpreter) and python_has_pip(interpreter or "", resolved_env)
     return SDKInstallPlan(
         reason=reason,


### PR DESCRIPTION
## The structural issue

`yutori/cli/commands/install_flow.py` deliberately threads an explicit `env` mapping through every step of the installer — `resolve_uv_path`, `resolve_npx_path`, `inspect_cli_install`, and `detect_sdk_install_plan` all take `env: Mapping[str, str] | None` and normalize it via the existing `_resolve_env` helper. Executable lookups therefore have to be scoped to *that* environment's PATH, not to `shutil.which`'s process-PATH default.

That contract was re-derived by hand at five separate call sites:

```python
shutil.which("uv", path=resolved_env.get("PATH"))
shutil.which("npx", path=resolved_env.get("PATH"))
shutil.which("yutori", path=resolved_env.get("PATH"))
shutil.which("python", path=resolved_env.get("PATH"))
shutil.which("python3", path=path_env) or shutil.which("python", path=path_env)
```

The `path=` argument is load-bearing but invisible: omitting it still type-checks, still runs, and silently reads the process PATH instead of the caller's env — the exact failure mode the `env` parameter exists to prevent.

## Why it's an improvement

Adds one `_which(name, env)` helper next to `_resolve_env` (the module's existing env-normalization primitive) and routes all five sites through it. The PATH-scoping rule now lives in exactly one place, with a docstring naming the four public functions that depend on it, so a sixth lookup added later can't quietly drop `path=`. Net effect is fewer lines, one fewer local (`path_env`), and a named concept where there was a repeated idiom.

No public API surface, signature, exported name, or behavior changes — `_which` is module-private and `install_flow` is explicitly not part of the public SDK surface (per its own module docstring).

## Why it's safe

- **Mechanically equivalent.** `_which` expands to the identical `shutil.which(name, path=<env>.get("PATH"))` call at every site. `_resolve_env` is idempotent — `env or os.environ` never returns a falsy mapping, so re-resolving an already-resolved `resolved_env` is a no-op, and an env without a `PATH` key yields `path=None` exactly as before. The dropped `path_env` local was only a hoisted `.get("PATH")`.
- `shutil` is still imported and still the callee, so the existing tests that patch `yutori.cli.commands.install_flow.shutil.which` intercept unchanged — including `test_resolve_npx_path_uses_path_lookup`, which asserts the exact call shape `mock_which.assert_called_once_with("npx", path="/usr/local/bin")`.

Verified:
- `pytest -q -m "not slow"` → **563 passed, 3 skipped** (covers `test_install_flow.py`'s `resolve_uv_path` / `resolve_npx_path` / `inspect_cli_install` / `detect_sdk_install_plan` cases, all four `detect_sdk_install_plan` branches, and the call-shape assertion above).
- `ruff check .` → clean.
- `ruff format --diff` on the touched file reports no change to any added or edited line (the file carries pre-existing formatting drift on unrelated lines, unchanged here and identical on `main`).
- `python -m py_compile` on the touched file → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCjrHU3qPdo1bdmAYchKnM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCjrHU3qPdo1bdmAYchKnM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of installer PATH lookups with no public API or behavior change. Risk is limited to a mistaken PATH default, which the helper is designed to prevent.
> 
> **Overview**
> Routes all installer executable lookups through a private `_which` helper so PATH is always taken from the caller's `env` mapping, not the process default.
> 
> `resolve_uv_path`, `resolve_npx_path`, `inspect_cli_install`, and `detect_sdk_install_plan` now call `_which` instead of repeating `shutil.which(..., path=resolved_env.get("PATH"))`. Behavior is unchanged; this just makes the env-scoped lookup rule live in one place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 582d590a7b3cd25502c0fac50e9f5528f4102821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->