### PR TITLE
refactor(cli): extract inspect_cli_install's paired failure return

### DIFF
--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -468,31 +468,45 @@ def summarize_results(console: Console, results: Sequence[StepResult]) -> None:
     console.print(table)
 
 
+def _cli_inspect_failure(detail: str) -> tuple[None, StepResult]:
+    """Build the ``(None, failed "CLI" StepResult)`` pair every ``inspect_cli_install`` bailout returns.
+
+    The two values are not independent: ``install_flow_command`` reads them
+    separately (the state gates PATH repair and verification, the status gates
+    the exit code), so a ``None`` state must always be paired with a
+    ``"failed"`` step. Building that pair here keeps the six bailout paths from
+    re-deriving the invariant, and a seventh from pairing a ``None`` state with
+    a non-failed status. Mirrors :func:`_verification_failure`, which does the
+    same for ``run_verification``'s paired return.
+    """
+    return None, StepResult("CLI", "failed", detail)
+
+
 def inspect_cli_install(env: Mapping[str, str] | None = None) -> tuple[CLIInstallState | None, StepResult]:
     resolved_env = _resolve_env(env)
     uv_path = resolve_uv_path(resolved_env)
     if not uv_path:
-        return None, StepResult("CLI", "failed", "uv is not available, so the installed CLI could not be verified.")
+        return _cli_inspect_failure("uv is not available, so the installed CLI could not be verified.")
 
     bin_dir_result = run_command([uv_path, "tool", "dir", "--bin"], env=resolved_env)
     if bin_dir_result.returncode != 0:
-        return None, StepResult("CLI", "failed", describe_completed_process(bin_dir_result))
+        return _cli_inspect_failure(describe_completed_process(bin_dir_result))
 
     # uv may print a line per directory plus warnings — take the last non-empty line.
     candidate_lines = [line.strip() for line in bin_dir_result.stdout.splitlines() if line.strip()]
     if not candidate_lines:
-        return None, StepResult("CLI", "failed", "`uv tool dir --bin` returned no path.")
+        return _cli_inspect_failure("`uv tool dir --bin` returned no path.")
     bin_dir = Path(candidate_lines[-1])
     if not bin_dir.is_absolute():
-        return None, StepResult("CLI", "failed", f"`uv tool dir --bin` returned a non-absolute path: {bin_dir}")
+        return _cli_inspect_failure(f"`uv tool dir --bin` returned a non-absolute path: {bin_dir}")
     cli_name = "yutori.exe" if os.name == "nt" else "yutori"
     cli_path = bin_dir / cli_name
     if not cli_path.exists():
-        return None, StepResult("CLI", "failed", f"Expected CLI binary at {cli_path}, but it was not found.")
+        return _cli_inspect_failure(f"Expected CLI binary at {cli_path}, but it was not found.")
 
     version_result = run_command([str(cli_path), "--version"], env=resolved_env)
     if version_result.returncode != 0:
-        return None, StepResult("CLI", "failed", describe_completed_process(version_result))
+        return _cli_inspect_failure(describe_completed_process(version_result))
 
     cli_version = version_result.stdout.strip() or version_result.stderr.strip() or "yutori installed"
     shell_cli = _which("yutori", resolved_env)


### PR DESCRIPTION
## Structural issue

`inspect_cli_install` (`yutori/cli/commands/install_flow.py`) returns a
`tuple[CLIInstallState | None, StepResult]`, and the two elements are **not**
independent. `install_flow_command` reads them separately:

```python
cli_state, cli_result = inspect_cli_install()
if cli_result.status == "failed":
    exit_code = 1
if cli_state is not None:
    path_result = maybe_repair_path(...)
...
elif cli_state is None:
    verification_result = StepResult("Verification", "skipped", "Verification requires a working CLI install.")
```

So the state gates PATH repair and verification while the status gates the
process exit code — meaning a `None` state must always be paired with a
`"failed"` `"CLI"` step.

That invariant was re-derived by hand at all **six** bailout paths inside the
function, each spelling out `return None, StepResult("CLI", "failed", <detail>)`.
The `("CLI", "failed")` pair and the tuple shape were repeated six times, and
nothing structural stopped a seventh bailout from pairing a `None` state with a
non-failed status — which would silently skip PATH repair *and* verification
while still exiting 0.

## Why the refactor improves it

Extract a single `_cli_inspect_failure(detail) -> tuple[None, StepResult]` and
route all six bailouts through it, so the pairing lives in exactly one place and
each call site says only what it actually differs in: the detail string.

This also follows the convention the file already established — `_verification_failure`
sits directly above `run_verification` and does precisely the same job for that
function's paired `(StepResult, bool)` return. `inspect_cli_install` was the
remaining step function that still built its paired failure inline.

## Why it is safe

No behavior change. The helper returns the identical `(None, StepResult("CLI", "failed", detail))`
tuple that every call site constructed, with the detail string — the only
per-site variation — passed through unchanged. Nothing else in the function or
its callers is touched; the success path (`return state, StepResult("CLI", "success", detail)`)
is left exactly as it was.

Verified locally:

- `python -m pytest -q tests/test_install_flow.py tests/test_cli.py` -> **111 passed**
- Full suite `python -m pytest -q -m "not slow"` -> **563 passed, 3 skipped, 1 deselected**, byte-identical to the pre-change baseline on the same tree (captured before the edit, re-run after)
- `ruff check .` -> **All checks passed!** (this is what CI runs)
- `ruff format --diff` on the changed file: the four reported hunks are **pre-existing** drift on `main`, not introduced here. Confirmed by capturing the same command's output against a `git stash`ed baseline — the two outputs are identical apart from hunk line-number offsets, so the added code is format-clean. Left untouched rather than smuggling an unrelated reformat into a refactor diff.

Note: 13 test files could not be collected in the sandbox until the optional
`examples` extras (`tenacity`/`loguru`/`pydantic`/`playwright`) were installed;
the 563-test figures above are *after* installing them, so the whole suite ran.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nn1DmtDNAp5x1aLGoc2GVC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn1DmtDNAp5x1aLGoc2GVC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no behavior change; failure tuples stay identical and only install-flow inspection is touched.
> 
> **Overview**
> Centralizes the paired `(None, failed CLI StepResult)` return that every `inspect_cli_install` bailout must produce.
> 
> Adds `_cli_inspect_failure(detail)` and routes all six failure paths through it, matching the existing `_verification_failure` pattern. Call sites now only supply the detail string. Success path and callers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f8fce56aa26d063707f089b1da9d3ff28d8a808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->