### PR TITLE
refactor(cli): hoist function-local imports to module level in commands/__init__.py

### DIFF
--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -13,6 +13,8 @@ from rich.markup import escape
 from rich.table import Table
 
 from yutori.auth.credentials import resolve_api_key
+from yutori.auth.flow import get_auth_status
+from yutori.client import YutoriClient
 from yutori.exceptions import APIConnectionError, APIError, AuthenticationError
 
 __all__ = [
@@ -84,8 +86,6 @@ def safe_str(value: Any) -> str:
 
 def get_authenticated_client() -> Any:
     """Get an authenticated YutoriClient, or exit with an error message."""
-    from yutori.client import YutoriClient
-
     api_key = resolve_api_key()
     if not api_key:
         _console.print("[red]Not authenticated. Run 'yutori auth login' first.[/red]")
@@ -102,8 +102,6 @@ def _auth_recovery_hint() -> str:
     saved credentials anyway. Every variant mentions 'yutori auth login' so
     the output stays stable for callers grepping it.
     """
-    from yutori.auth.flow import get_auth_status
-
     source = get_auth_status().source
     if source == "env_var":
         return (


### PR DESCRIPTION
## Structural issue

`get_authenticated_client()` and `_auth_recovery_hint()` in `yutori/cli/commands/__init__.py` each imported a dependency inside the function body (`from yutori.client import YutoriClient` and `from yutori.auth.flow import get_auth_status` respectively) instead of at module scope, with no comment explaining why.

## Why this is an improvement

These local imports look like a lazy-load optimization for CLI startup latency, but they buy nothing: importing `yutori.cli.main` (the CLI entry point) already fully imports both dependencies before either function can ever run —

- `yutori/__init__.py` eagerly imports `.client` (which defines `YutoriClient`), and `yutori.cli.main` triggers that import as soon as it imports any `yutori.*` submodule.
- `yutori/cli/commands/auth.py` — imported eagerly by `yutori/cli/main.py` via `from .commands import auth, browse, research, scouts, usage` — already imports `yutori.auth.flow` (which defines `get_auth_status`) at module level.

Verified directly:
```
$ python3 -c "import sys, yutori.cli.main; print('yutori.client' in sys.modules, 'yutori.auth.flow' in sys.modules)"
True True
```
So both modules are already in `sys.modules` before `get_authenticated_client()`/`_auth_recovery_hint()` are ever called — the local imports were pure indirection, not a real lazy-load. This mirrors the same pattern already fixed for `require_api_key` in `client.py`/`async_client.py` (#234).

## Why this is safe

- No circular import: `yutori.client` and `yutori.auth.flow` (and everything they import) do not import from `yutori.cli` anywhere — confirmed via `import yutori.cli.main` succeeding cleanly after the hoist.
- No behavior change — same objects, same call sites, just resolved at module import time instead of function-call time.
- Public API unchanged (this module is CLI-internal, not part of the SDK's public surface).
- Full test suite: 564 passed / 3 skipped, identical before and after.
- `ruff check .` and `ruff format --check yutori/cli/commands/__init__.py` clean.
- 1 file touched, +2/-4 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K1hAbV3WS1Tt5YsDXxxvry)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor in CLI internals; no logic, auth, or API behavior changes.
> 
> **Overview**
> Moves `YutoriClient` and `get_auth_status` from function-local imports in `get_authenticated_client()` and `_auth_recovery_hint()` to module-level imports in `yutori/cli/commands/__init__.py`.
> 
> No behavior change: those modules are already loaded by CLI startup, so the inner imports were not a real lazy-load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa3b9db491f71414347ce1ac6cc5b26a71e5ec34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->