### PR TITLE
refactor(cli): hoist yutori.__version__ import to module level in cli/main.py

### DIFF
--- a/yutori/cli/main.py
+++ b/yutori/cli/main.py
@@ -10,6 +10,8 @@ except ImportError:
     print("Yutori CLI dependencies are missing. Reinstall with: pip install yutori")
     sys.exit(1)
 
+from yutori import __version__
+
 from .commands import auth, browse, research, scouts, usage
 from .commands.install_flow import install_flow_command
 
@@ -27,8 +29,6 @@ app.add_typer(usage.app, name="usage")
 
 
 def _print_version() -> None:
-    from yutori import __version__
-
     typer.echo(f"yutori {__version__}")
 
 


### PR DESCRIPTION
## What

`_print_version()` in `yutori/cli/main.py` imported `yutori.__version__` inside the function body:

```python
def _print_version() -> None:
    from yutori import __version__

    typer.echo(f"yutori {__version__}")
```

This hoists it to a normal module-level import.

## Why this is safe

There's no circular-import reason for the local import: `yutori.cli.main` is a submodule of the `yutori` package. Python always fully executes a package's `__init__.py` before running any of its submodules' module bodies — and `yutori/cli/main.py` already imports `.commands` (itself a subpackage of `yutori`) at module scope, which forces the same full `yutori/__init__.py` initialization anyway. So `__version__` is guaranteed to already exist on the `yutori` module by the time `cli/main.py` is imported, whether the import is local or top-level. The local import was pure indirection, not a lazy-load optimization.

This mirrors two identical hoists already merged in this repo for the same pattern:
- `require_api_key` in `client.py`/`async_client.py` (#234)
- `YutoriClient`/`get_auth_status` in `cli/commands/__init__.py` (#238)

A repo-wide grep (`from yutori`/`import yutori` inside function bodies) confirms this was the only remaining instance of the pattern outside the one documented, intentionally-lazy case in `yutori/auth/__init__.py` (lazy `flow` import, explained in that module's own docstring — pulls in `http.server`/`threading`/`webbrowser` and is deliberately deferred for SDK users who never use OAuth login).

## Verification

- No public API change — this is a private CLI entry-point module, and behavior is identical (`yutori --version` / `yutori version` output unchanged, confirmed manually).
- Full test suite: 564 passed / 3 skipped, identical to the pre-change baseline.
- `ruff check .` and `ruff format --check yutori/cli/main.py` both clean.
- `python -c "import yutori; from yutori.cli import main"` succeeds with no circular-import error.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LCr9myCxYecqfz9dXwDcop)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic import hoist in a private CLI entrypoint with no behavior or API change.
> 
> **Overview**
> Moves `from yutori import __version__` out of `_print_version()` onto a module-level import in `cli/main.py`. Version output is unchanged; this only removes an unnecessary local import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb0b5119bc45c213c8617eb434b15c62b3ad10d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->