### PR TITLE
refactor(cli): type the shared CLI client helpers as YutoriClient

### DIFF
--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -84,7 +84,7 @@ def safe_str(value: Any) -> str:
     return escape(str(value))
 
 
-def get_authenticated_client() -> Any:
+def get_authenticated_client() -> YutoriClient:
     """Get an authenticated YutoriClient, or exit with an error message."""
     api_key = resolve_api_key()
     if not api_key:
@@ -144,7 +144,7 @@ def cli_api_errors() -> Iterator[None]:
 
 
 @contextlib.contextmanager
-def cli_client() -> Iterator[Any]:
+def cli_client() -> Iterator[YutoriClient]:
     """Authenticated client with CLI error handling — the one entry point
     for API-calling commands.
 
@@ -366,7 +366,7 @@ def print_task_list(console: Console, task_type: str, result: dict[str, Any]) ->
 
 def list_and_render_tasks(
     console: Console,
-    client: Any,
+    client: YutoriClient,
     namespace: str,
     task_type: str,
     *,


### PR DESCRIPTION
## (a) The structural issue

Three helpers in `yutori/cli/commands/__init__.py` declare the SDK client as `Any`, even though `YutoriClient` is the only type any of them ever constructs or receives:

| Helper | Was | Reality |
| --- | --- | --- |
| `get_authenticated_client()` | `-> Any` | body is literally `return YutoriClient(api_key=api_key)` |
| `cli_client()` | `-> Iterator[Any]` | yields `get_authenticated_client().__enter__()`, and `YutoriClient.__enter__` is annotated `-> YutoriClient` |
| `list_and_render_tasks(client=...)` | `client: Any` | both call sites (`browse.py:29`, `research.py:29`) pass the `cli_client()` value |

`YutoriClient` is already imported at module scope in this file (line 17) for exactly this construction, so the `Any` wasn't buying an import-cycle escape — it just wasn't tightened.

## (b) Why it's an improvement

`cli_client()` is the single entry point every API-calling CLI command goes through, so its `Any` return type silently erased type checking for the entire CLI command layer. Every one of these was unchecked against the real client surface:

```
browse.py:43     client.browsing.create(...)
browse.py:62     client.browsing.get(task_id)
research.py:40   client.research.create(...)
research.py:56   client.research.get(task_id)
scouts.py:30     client.scouts.list(...)
scouts.py:54     client.scouts.get(scout_id)
scouts.py:86     client.scouts.create(...)
scouts.py:119    client.scouts.delete(scout_id)
usage.py:63      client.get_usage(period=period)
```

I verified all nine resolve to real `YutoriClient` attributes. With the annotation tightened, a future typo or a renamed namespace method in one of those command bodies becomes a type error instead of a runtime `AttributeError` in the user's terminal. Same pattern class as #230 (`__exit__`/`__aexit__` catch-all types tightened to the precise `BaseException`/`TracebackType` protocol types).

## (c) Why it's safe

Annotation-only; no logic touched (see the diff — three annotations, nothing else).

- **Zero runtime effect.** The module has `from __future__ import annotations`, so annotations are never evaluated. I additionally confirmed they *do* resolve cleanly if someone calls `typing.get_type_hints()` on them, so no downstream introspection breaks either.
- **No new type errors.** `mypy --ignore-missing-imports yutori/` output is byte-identical before and after (11 pre-existing errors in 4 unrelated files, unchanged). `pyright yutori/cli` likewise byte-identical (2 pre-existing `install_flow.py` errors, unchanged). Note `getattr(client, namespace)` inside `list_and_render_tasks` stays dynamic, so tightening the parameter type does not make the dynamic dispatch newly ill-typed.
- **Test suite unchanged.** `pytest -q -m "not slow"`: 563 passed / 3 skipped / 1 deselected, identical to the pre-change baseline. `tests/test_cli.py` patches `get_authenticated_client` with a `MagicMock`; annotations are not enforced at runtime, so those tests are unaffected.
- `ruff check .` clean; `ruff format --check` clean on the touched file (the `Any` import is still needed for the many `dict[str, Any]` signatures in this file, so no unused-import fallout).
- CLI smoke-checked: `python -m yutori.cli.main --help` renders normally.
- 1 file, +3/-3.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YAf2ckWLpYZMsztaiAhreR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-annotation-only change with no logic, auth, or API behavior updates.
> 
> **Overview**
> Tightens three CLI helper annotations from `Any` to `YutoriClient` so type checkers can see the real client surface on every API-calling command.
> 
> `get_authenticated_client`, `cli_client`, and `list_and_render_tasks` now declare the type they already construct and pass. Annotation-only; no runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdfecaff67355c7e9130ce8aaac667c50e01a298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->