### PR TITLE
refactor(http): type _BaseNamespace's client param as httpx.Client/AsyncClient

### DIFF
--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 import httpx
 
 from ._schema import resolve_output_schema
 from .exceptions import APIConnectionError, APIError, AuthenticationError
+
+_ClientT = TypeVar("_ClientT", httpx.Client, httpx.AsyncClient)
 
 
 def build_headers(api_key: str) -> dict[str, str]:
@@ -161,7 +163,7 @@ def _to_connection_error(exc: httpx.HTTPError) -> APIConnectionError:
     return APIConnectionError(message)
 
 
-class _BaseNamespace:
+class _BaseNamespace(Generic[_ClientT]):
     """Shared base for SDK namespace classes (sync and async).
 
     Stores the HTTP client, base URL, and a precomputed auth header dict
@@ -169,7 +171,7 @@ class _BaseNamespace:
     of rebuilding headers on every request.
     """
 
-    def __init__(self, client: Any, base_url: str, api_key: str) -> None:
+    def __init__(self, client: _ClientT, base_url: str, api_key: str) -> None:
         self._client = client
         self._base_url = base_url
         self._headers = build_headers(api_key)
@@ -183,7 +185,7 @@ class _BaseNamespace:
         return kwargs
 
 
-class _SyncBaseNamespace(_BaseNamespace):
+class _SyncBaseNamespace(_BaseNamespace[httpx.Client]):
     """Sync namespace base with a shared request helper.
 
     Centralizes the ``self._client.<method>(url, headers=..., ...)`` +
@@ -210,7 +212,7 @@ class _SyncBaseNamespace(_BaseNamespace):
         return handle_response(response)
 
 
-class _AsyncBaseNamespace(_BaseNamespace):
+class _AsyncBaseNamespace(_BaseNamespace[httpx.AsyncClient]):
     """Async counterpart of :class:`_SyncBaseNamespace`."""
 
     async def _request(


### PR DESCRIPTION
`_BaseNamespace.__init__` took `client: Any`, even though the two concrete subclasses always pass exactly one of `httpx.Client` (`_SyncBaseNamespace`) or `httpx.AsyncClient` (`_AsyncBaseNamespace`). This makes `_BaseNamespace` generic over the client type (`Generic[_ClientT]` bound to `httpx.Client | httpx.AsyncClient`), so `self._client` is concretely typed in each subclass instead of `Any`.

This continues the `Any`-to-concrete-type tightening pattern from #234–#240 (typing the shared client helpers).

No behavior change — this is purely a type-annotation change; `Generic` subscripting has no runtime effect beyond storing the parameter.

**Verification:**
- `pytest -m "not slow"`: 476 passed, 16 skipped (same as before the change)
- `ruff check .`: all checks passed
- Manual sanity check instantiating both `_SyncBaseNamespace(httpx.Client(), ...)` and `_AsyncBaseNamespace(httpx.AsyncClient(), ...)` to confirm no runtime regression


---
_Generated by [Claude Code](https://claude.ai/code/session_01BqJiZpBkfz7qKgJ2ohL8AU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only refactor on internal SDK helpers; no changes to request handling, auth, or public APIs.
> 
> **Overview**
> **Tightens static typing** on the shared HTTP namespace helpers in `_http.py` by replacing `client: Any` with a generic bound to `httpx.Client` or `httpx.AsyncClient`.
> 
> `_BaseNamespace` is now `Generic[_ClientT]`, and `_SyncBaseNamespace` / `_AsyncBaseNamespace` specialize it so `self._client` is concretely typed in sync vs async code paths. **No runtime or API behavior change**—only type-checker visibility for the same request boilerplate used by scout/research/browsing namespaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f393b91eb63ec0b9d6fa451886842763e1e0bc70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->