### PR TITLE
refactor(http): narrow _request's method param to a Literal of the four dispatched HTTP verbs

### DIFF
--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 
 import httpx
 
@@ -10,6 +10,10 @@ from ._schema import resolve_output_schema
 from .exceptions import APIConnectionError, APIError, AuthenticationError
 
 _ClientT = TypeVar("_ClientT", httpx.Client, httpx.AsyncClient)
+
+# The only httpx.Client/AsyncClient methods any namespace ever dispatches
+# through _BaseNamespace._request()'s getattr(self._client, method) call.
+_HTTPMethod = Literal["get", "post", "patch", "delete"]
 
 
 def build_headers(api_key: str) -> dict[str, str]:
@@ -108,7 +112,7 @@ def resolve_scout_status_endpoint(status: str) -> str:
 
 def prepare_scout_update(
     scout_id: str, status: str | None, payload: dict[str, Any]
-) -> tuple[str, str, dict[str, Any] | None]:
+) -> tuple[Literal["post", "patch"], str, dict[str, Any] | None]:
     """Resolve ``(method, path, json)`` for a ``scouts.update()`` call.
 
     Centralizes the mutual-exclusion rule between ``status`` and field
@@ -195,7 +199,7 @@ class _SyncBaseNamespace(_BaseNamespace[httpx.Client]):
 
     def _request(
         self,
-        method: str,
+        method: _HTTPMethod,
         path: str,
         *,
         params: Any = None,
@@ -217,7 +221,7 @@ class _AsyncBaseNamespace(_BaseNamespace[httpx.AsyncClient]):
 
     async def _request(
         self,
-        method: str,
+        method: _HTTPMethod,
         path: str,
         *,
         params: Any = None,


### PR DESCRIPTION
`_SyncBaseNamespace._request()`/`_AsyncBaseNamespace._request()` (`yutori/_http.py`) took `method: str`, even though `getattr(self._client, method)` is only ever called with one of four literal strings (`"get"`, `"post"`, `"patch"`, `"delete"`) — confirmed across all 12 call sites in `_sync/`/`_async/` namespaces and `client.py`/`async_client.py`. Added a private `_HTTPMethod = Literal["get", "post", "patch", "delete"]` alias and typed both `_request()` overrides and `prepare_scout_update()`'s return type with it (the latter only ever returns `"post"` or `"patch"`), so a typo'd HTTP verb string is now a static type error instead of a silent runtime `AttributeError` from `getattr()`.

Continues the same `Any`/`str`-to-concrete-type tightening pattern as #230, #234, #240, #241. No behavior change — `Literal` has zero runtime effect and every existing call site already passes one of these four strings. `_request` is a private (leading-underscore) internal method, not part of the public SDK surface.

**Verification:**
- `pytest tests/ -m "not slow"`: 476 passed, 16 skipped, 1 deselected — identical to baseline
- `ruff check .`: all checks passed
- `mypy --ignore-missing-imports yutori/_http.py`: no new errors (6 pre-existing errors surfaced only from unrelated imported files, `navigator/images.py` and `auth/credentials.py`)
- Confirmed via grep that no test calls `_request()` directly with a non-literal method string


---
_Generated by [Claude Code](https://claude.ai/code/session_01UNp1qd4G67kz4mMxt5Z6u3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing-only refactor on private HTTP helpers with no logic or public API changes.
> 
> **Overview**
> Introduces a private **`_HTTPMethod`** type (`Literal["get", "post", "patch", "delete"]`) and uses it on **`_SyncBaseNamespace._request`**, **`_AsyncBaseNamespace._request`**, and the method slot of **`prepare_scout_update`**’s return type (`Literal["post", "patch"]` only).
> 
> This tightens typing around **`getattr(self._client, method)`** so invalid HTTP verb strings are caught by static type checkers instead of failing at runtime with **`AttributeError`**. **No runtime behavior change** — existing call sites already pass those four literals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1628c64c0ef3c09b1c134f8b8930c1f8c06b1394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->