### PR TITLE
refactor(exceptions): type APIError.response as httpx.Response

### DIFF
--- a/yutori/exceptions.py
+++ b/yutori/exceptions.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+import httpx
 
 
 class YutoriSDKError(Exception):
@@ -20,7 +20,7 @@ class APIConnectionError(YutoriSDKError):
 class APIError(YutoriSDKError):
     """Raised when the Yutori API returns a non-successful or unusable response."""
 
-    def __init__(self, message: str, status_code: int, response: Any | None = None):
+    def __init__(self, message: str, status_code: int, response: httpx.Response | None = None):
         super().__init__(message)
         self.message = message
         self.status_code = status_code


### PR DESCRIPTION
## What

`APIError.__init__()` (`yutori/exceptions.py`) declared `response: Any | None = None`, even though all 3 raise sites — every branch of `yutori/_http.py::handle_response()` (redirect, 4xx/5xx status, non-JSON 2xx body) — pass the `httpx.Response` they just received, and no test or call site ever constructs an `APIError` with anything else.

Tightened the annotation to `response: httpx.Response | None = None`.

## Why it's an improvement

`APIError` is a public exception (`except APIError as e: ...`) that SDK consumers catch and can inspect via `e.response`. The `Any` annotation erased type checking on that attribute for every downstream user, not just internal call sites — a caller doing `e.response.status_code` got no type help and no protection against a typo like `e.response.staus_code`.

This continues the same `Any`/`str`-to-concrete-type tightening pattern already merged in #230, #234, #240, #241, and #242.

## Why it's safe

- **Zero runtime effect**: `exceptions.py` has `from __future__ import annotations`, so annotations are lazily-evaluated strings — no behavior change at all.
- **`httpx` is already a hard dependency** imported throughout the package (`_http.py`, `client.py`, `async_client.py`, `auth/flow.py`), so this introduces no new dependency or import-cycle risk.
- **No public API break**: the constructor signature's runtime behavior (positional/keyword args, defaults) is unchanged — only the static type annotation narrowed from `Any` to the type every real caller already passes.
- **Verified no divergent construction**: grepped every `APIError(...)` call site in `yutori/` and `tests/` — all pass either an `httpx.Response` or nothing (the `None` default).

## Verification

- `pytest -m "not slow"`: 476 passed, 16 skipped, 1 deselected — identical to baseline.
- `ruff check .` / `ruff format --check yutori/exceptions.py`: clean.
- `mypy --ignore-missing-imports yutori/exceptions.py`: 0 errors before and after.
- Manual smoke check: `APIError("msg", 500, httpx.Response(500))` constructs and stringifies correctly, `type(e.response)` is `httpx.Response`.

🤖 Generated with automated hourly refactor cronjob (Claude)


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5SrmyMFrBJAWuLXCswRiT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only change in a public exception type with no runtime or behavioral impact.
> 
> **Overview**
> Narrows the static type of **`APIError.response`** from `Any | None` to **`httpx.Response | None`**, matching what **`handle_response()`** in `_http.py` always passes when raising. Adds an **`httpx`** import and drops unused **`typing.Any`**.
> 
> This is **typing-only** (`from __future__ import annotations`); runtime behavior and the public constructor are unchanged. SDK users who **`except APIError`** and read **`e.response`** get accurate type checking on attributes like **`status_code`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a80e5fdb30191783fff7d5453fa77daf79659a49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->