### PR TITLE
refactor(http): type _request/_request_kwargs's params/json as dict[str, Any] | None

### DIFF
--- a/yutori/_http.py
+++ b/yutori/_http.py
@@ -180,7 +180,7 @@ class _BaseNamespace(Generic[_ClientT]):
         self._base_url = base_url
         self._headers = build_headers(api_key)
 
-    def _request_kwargs(self, params: Any, json: Any) -> dict[str, Any]:
+    def _request_kwargs(self, params: dict[str, Any] | None, json: dict[str, Any] | None) -> dict[str, Any]:
         kwargs: dict[str, Any] = {"headers": self._headers}
         if params is not None:
             kwargs["params"] = params
@@ -202,8 +202,8 @@ class _SyncBaseNamespace(_BaseNamespace[httpx.Client]):
         method: _HTTPMethod,
         path: str,
         *,
-        params: Any = None,
-        json: Any = None,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         http_method = getattr(self._client, method)
         try:
@@ -224,8 +224,8 @@ class _AsyncBaseNamespace(_BaseNamespace[httpx.AsyncClient]):
         method: _HTTPMethod,
         path: str,
         *,
-        params: Any = None,
-        json: Any = None,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         http_method = getattr(self._client, method)
         try:


### PR DESCRIPTION
## What

`_BaseNamespace._request_kwargs` and both `_SyncBaseNamespace._request`/`_AsyncBaseNamespace._request` took `params`/`json` as `Any`, even though every call site across the `_sync`/`_async` namespaces and `client.py`/`async_client.py` passes either `None` or a `dict[str, Any]` (built by `build_query_params`, `build_payload_with_schema`, or `prepare_scout_update`'s `json` return value).

## Why

Continues the same `Any`-to-concrete-type tightening pattern already applied repeatedly in this codebase (#230, #234, #240, #241, #242, #243). Narrowing these two internal parameters closes off a small gap where a typo'd non-dict value passed as `params`/`json` would only fail at request time (httpx erroring on an unexpected type) instead of at type-check time.

## Why it's safe

No behavior change — annotations are lazily evaluated (`from __future__ import annotations`), so this has zero runtime effect. Scoped to a single file (`yutori/_http.py`), 5 lines changed.

Verification:
- `pytest -m "not slow"`: 476 passed, 16 skipped, 1 deselected (unchanged from before)
- `ruff check .`: clean; the touched lines are `ruff format` clean (two pre-existing, unrelated format-drift spots remain in `handle_response`, as already documented in prior audits — CI does not run `ruff format --check`)
- `mypy --ignore-missing-imports yutori/_http.py`: same 11 pre-existing errors before and after this change (0 new)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WfGyYJMBixbVHSFLZksWV8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only change in a single internal module; no logic, API surface, or runtime behavior changes.
> 
> **Overview**
> Tightens static types on the internal HTTP helpers in `_http.py`: **`_request_kwargs`** and sync/async **`_request`** now declare **`params`** and **`json`** as **`dict[str, Any] | None`** instead of **`Any`**.
> 
> This matches how namespaces already call these methods (query/body values from helpers like **`build_query_params`** / **`build_payload_with_schema`**, or **`None`**). **No runtime behavior change**—only annotations under **`from __future__ import annotations`**—so invalid non-dict values would be caught by type checkers earlier instead of failing inside httpx at request time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd8e6d8f358d733cefa37fc281cddcaffff03a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->