### PR TITLE
docs: document n2 CUA harness setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The Yutori API provides four main capabilities:
 
 | API           | Description                                                    | SDK Namespace     |
 | ------------- | -------------------------------------------------------------- | ----------------- |
-| **Navigator** | Computer-use model family (Navigator n1, Navigator n1.5)       | `client.chat`     |
+| **Navigator** | Browser- and computer-use models (Navigator n1, n1.5, n2 preview) | `client.chat`  |
 | **Browsing**  | One-time browser automation tasks                              | `client.browsing` |
 | **Research**  | Deep web research using 100+ tools                             | `client.research` |
 | **Scouting**  | Continuous web monitoring on a schedule                        | `client.scouts`   |
@@ -118,7 +118,7 @@ The Yutori API provides four main capabilities:
 
 ## Navigator API
 
-The Navigator API hosts Yutori's family of computer-use models for navigating websites. The current public versions are **Navigator n1** (model id `n1-latest`) and **Navigator n1.5** (model id `n1.5-latest`). Capture a screenshot, send it to the model, and execute the returned tool calls. The endpoint follows the OpenAI Chat Completions interface, so `client.chat` is a drop-in OpenAI-compatible client:
+The Navigator API hosts Yutori's visual-control models. **Navigator n1** (`n1-latest`) and **Navigator n1.5** (`n1.5-latest`) control browsers; the gated **Navigator n2** preview (`n2-preview`) controls a complete desktop. Capture a screenshot, send it to the model, and execute the returned tool calls. The endpoint follows the OpenAI Chat Completions interface, so `client.chat` is a drop-in OpenAI-compatible client:
 
 ```python
 from yutori import AsyncYutoriClient
@@ -157,6 +157,30 @@ This snippet shows a single model call. In practice, you'll usually run an agent
 
 The SDK defaults to Navigator n1.5 (`n1.5-latest`). Navigator n1 (`n1-latest`) is still supported for callers that want the older model. Navigator n1.5 adds selectable tool sets, `disable_tools`, and structured JSON output via `json_schema` (returned as `response.parsed_json`). See the [Navigator n1.5 reference](https://docs.yutori.com/reference/n1-5) and [Navigator n1 reference](https://docs.yutori.com/reference/n1) for model IDs, parameters, and the full action space.
 
+### Navigator n2 macOS CUA preview
+
+Navigator n2 is a gated, non-streaming computer-use preview. It does not change the SDK default. Use `model="n2-preview"` with the dated macOS CUA tool set `computer_use_tools-20260815`, exposed by SDK 0.9.2+ as `TOOL_SET_COMPUTER_USE_LATEST`.
+
+For local Mac desktop automation, install **Yutori MCP**. It is the supported installer and MCP server for the n2 CUA harness:
+
+```bash
+uvx yutori-mcp --env dev login
+uvx yutori-mcp computer-use setup
+uvx yutori-mcp computer-use doctor
+uvx yutori-mcp computer-use smoke
+```
+
+This path requires macOS 15+, Python 3.10+, `uvx`, and a dev API key with gated `n2-preview` access. `computer-use setup` installs and starts the pinned `CuaDriver.app` / `cua-driver==0.19.3`, requests Screen Recording and Accessibility permissions, prepares the optional native reasoning overlay, and verifies the SDK-owned runtime (`yutori==0.9.2`) before a task runs.
+
+For direct SDK harness use, first run the MCP setup flow above, or manage `CuaDriver.app` 0.19.3 yourself and run `cua-driver permissions grant`. Then install the published SDK runtime and prepare the optional overlay:
+
+```bash
+python -m pip install 'yutori[macos]>=0.9.2'
+python -c 'from yutori.navigator.macos import prepare_macos_overlay; prepare_macos_overlay()'
+```
+
+The SDK harness exports `N2ComputerAgent` for the agent loop and `yutori.navigator.macos.MacOSComputer` for the native Mac driver. `MacOSComputer` owns the persistent CuaDriver session, capture/input, shell lifecycle, cancellation, recovery, and optional presentation overlay. Local shell execution stays disabled unless the caller explicitly enables it.
+
 ### Agent-loop helpers
 
 The `yutori.navigator` subpackage exposes optional helpers for typical agent loops:
@@ -171,6 +195,7 @@ The `yutori.navigator` subpackage exposes optional helpers for typical agent loo
 | `trimmed_messages_to_fit(messages, max_bytes, keep_recent)` | Drop older screenshots to stay under the API size limit.                                                                                 |
 | `map_key_to_playwright(key)` / `map_keys_individual(keys)`  | Convert Navigator n1.5's lowercase key names to Playwright format.                                                                       |
 | `yutori.navigator.tools`                                    | Packaged JS reference implementations for the Navigator n1.5 expanded tools (`extract_elements`, `find`, `set_element_value`, `execute_js`). |
+| `N2ComputerAgent` / `yutori.navigator.macos.MacOSComputer`  | Published 0.9.2+ helpers for gated Navigator n2 desktop CUA loops.                                                                       |
 
 
 Full helper reference: [api.md](api.md).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/yutori.svg)](https://pypi.org/project/yutori/)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 
-The official Python SDK and CLI for the [Yutori API](https://docs.yutori.com) — build web agents that autonomously execute tasks on the web.
+The official Python SDK and CLI for the [Yutori API](https://docs.yutori.com) — build reliable computer-use agents that browse, research, monitor, and operate computers.
 
 The SDK offers sync and async clients with full type annotations, plus a `yutori` CLI for authentication and managing resources from the terminal.
 
@@ -110,7 +110,7 @@ The Yutori API provides four main capabilities:
 
 | API           | Description                                                    | SDK Namespace     |
 | ------------- | -------------------------------------------------------------- | ----------------- |
-| **Navigator** | Browser- and computer-use models (Navigator n1, n1.5, n2 preview) | `client.chat`  |
+| **Navigator** | Browser- and computer-use models (Navigator n1, n1.5, n2) | `client.chat`  |
 | **Browsing**  | One-time browser automation tasks                              | `client.browsing` |
 | **Research**  | Deep web research using 100+ tools                             | `client.research` |
 | **Scouting**  | Continuous web monitoring on a schedule                        | `client.scouts`   |
@@ -118,7 +118,7 @@ The Yutori API provides four main capabilities:
 
 ## Navigator API
 
-The Navigator API hosts Yutori's visual-control models. **Navigator n1** (`n1-latest`) and **Navigator n1.5** (`n1.5-latest`) control browsers; the gated **Navigator n2** preview (`n2-preview`) controls a complete desktop. Capture a screenshot, send it to the model, and execute the returned tool calls. The endpoint follows the OpenAI Chat Completions interface, so `client.chat` is a drop-in OpenAI-compatible client:
+The Navigator API hosts Yutori's visual-control models. **Navigator n1** (`n1-latest`) and **Navigator n1.5** (`n1.5-latest`) control browsers; **Navigator n2** controls a complete desktop. Capture a screenshot, send it to the model, and execute the returned tool calls. The endpoint follows the OpenAI Chat Completions interface, so `client.chat` is a drop-in OpenAI-compatible client:
 
 ```python
 from yutori import AsyncYutoriClient
@@ -157,20 +157,21 @@ This snippet shows a single model call. In practice, you'll usually run an agent
 
 The SDK defaults to Navigator n1.5 (`n1.5-latest`). Navigator n1 (`n1-latest`) is still supported for callers that want the older model. Navigator n1.5 adds selectable tool sets, `disable_tools`, and structured JSON output via `json_schema` (returned as `response.parsed_json`). See the [Navigator n1.5 reference](https://docs.yutori.com/reference/n1-5) and [Navigator n1 reference](https://docs.yutori.com/reference/n1) for model IDs, parameters, and the full action space.
 
-### Navigator n2 macOS CUA preview
+### Navigator n2 macOS CUA
 
-Navigator n2 is a gated, non-streaming computer-use preview. It does not change the SDK default. Use `model="n2-preview"` with the dated macOS CUA tool set `computer_use_tools-20260815`, exposed by SDK 0.9.2+ as `TOOL_SET_COMPUTER_USE_LATEST`.
+Navigator n2 is a non-streaming computer-use model. It does not change the SDK default. Use `model="n2"` and pass an explicit dated tool set; the current macOS CUA surface is `computer_use_tools-20260815`, exposed by SDK 0.9.2+ as `TOOL_SET_COMPUTER_USE_LATEST`.
 
 For local Mac desktop automation, install **Yutori MCP**. It is the supported installer and MCP server for the n2 CUA harness:
 
 ```bash
-uvx yutori-mcp --env dev login
+uvx yutori-mcp login
 uvx yutori-mcp computer-use setup
 uvx yutori-mcp computer-use doctor
 uvx yutori-mcp computer-use smoke
+uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the result." --app Calculator
 ```
 
-This path requires macOS 15+, Python 3.10+, `uvx`, and a dev API key with gated `n2-preview` access. `computer-use setup` installs and starts the pinned `CuaDriver.app` / `cua-driver==0.19.3`, requests Screen Recording and Accessibility permissions, prepares the optional native reasoning overlay, and verifies the SDK-owned runtime (`yutori==0.9.2`) before a task runs.
+This path requires macOS 15+, Python 3.10+, `uvx`, and a Yutori API key with computer-use access. `computer-use setup` installs and starts the pinned `CuaDriver.app` / `cua-driver==0.19.3`, requests Screen Recording and Accessibility permissions, prepares the optional native reasoning overlay, and verifies the SDK-owned runtime (`yutori==0.9.2`) before a task runs.
 
 For direct SDK harness use, first run the MCP setup flow above, or manage `CuaDriver.app` 0.19.3 yourself and run `cua-driver permissions grant`. Then install the published SDK runtime and prepare the optional overlay:
 
@@ -195,7 +196,7 @@ The `yutori.navigator` subpackage exposes optional helpers for typical agent loo
 | `trimmed_messages_to_fit(messages, max_bytes, keep_recent)` | Drop older screenshots to stay under the API size limit.                                                                                 |
 | `map_key_to_playwright(key)` / `map_keys_individual(keys)`  | Convert Navigator n1.5's lowercase key names to Playwright format.                                                                       |
 | `yutori.navigator.tools`                                    | Packaged JS reference implementations for the Navigator n1.5 expanded tools (`extract_elements`, `find`, `set_element_value`, `execute_js`). |
-| `N2ComputerAgent` / `yutori.navigator.macos.MacOSComputer`  | Published 0.9.2+ helpers for gated Navigator n2 desktop CUA loops.                                                                       |
+| `N2ComputerAgent` / `yutori.navigator.macos.MacOSComputer`  | Published 0.9.2+ helpers for Navigator n2 desktop CUA loops.                                                                             |
 
 
 Full helper reference: [api.md](api.md).

--- a/api.md
+++ b/api.md
@@ -7,7 +7,8 @@ A dense reference to everything the Yutori Python SDK and CLI expose. The [READM
 | Import | Purpose |
 |--------|---------|
 | `yutori` | Clients (`YutoriClient`, `AsyncYutoriClient`) and exceptions (`APIError`, `APIConnectionError`, `AuthenticationError`, `YutoriSDKError`) |
-| `yutori.navigator` | Agent-loop helpers for the Navigator API (Navigator n1 / Navigator n1.5 chat completions) |
+| `yutori.navigator` | Agent-loop helpers for the Navigator API (Navigator n1 / Navigator n1.5 / gated Navigator n2 preview chat completions) |
+| `yutori.navigator.macos` | Published 0.9.2+ macOS CUA harness for Navigator n2 preview loops |
 | `yutori.navigator.tools` | Packaged JavaScript reference implementations for the Navigator n1.5 expanded browser tools |
 
 All SDK calls go through `YutoriClient` / `AsyncYutoriClient`. The Navigator helpers are optional and do not change the shape of `client.chat.completions.create(...)`.
@@ -54,7 +55,7 @@ YutoriClient(
 
 | Attribute | Class | Purpose |
 |-----------|-------|---------|
-| `client.chat` | `ChatNamespace` | Navigator API (Navigator n1 / Navigator n1.5) chat completions |
+| `client.chat` | `ChatNamespace` | Navigator API (Navigator n1 / Navigator n1.5 / gated Navigator n2 preview) chat completions |
 | `client.browsing` | `BrowsingNamespace` | One-time browser automation |
 | `client.research` | `ResearchNamespace` | One-time deep web research |
 | `client.scouts` | `ScoutsNamespace` | Continuous monitoring scouts |
@@ -94,9 +95,11 @@ Importable from `yutori.navigator`. Prefer these over hard-coded strings so upgr
 from yutori.navigator import (
     NAVIGATOR_N1_MODEL,
     NAVIGATOR_N1_5_MODEL,
+    NAVIGATOR_N2_PREVIEW_MODEL,
     NAVIGATOR_COORDINATE_SCALE,
     TOOL_SET_CORE,
     TOOL_SET_EXPANDED,
+    TOOL_SET_COMPUTER_USE_LATEST,
 )
 ```
 
@@ -104,19 +107,21 @@ from yutori.navigator import (
 |----------|-------|-------|
 | `NAVIGATOR_N1_MODEL` | `"n1-latest"` | Alias for the latest stable Navigator n1 model. |
 | `NAVIGATOR_N1_5_MODEL` | `"n1.5-latest"` | Alias for the latest stable Navigator n1.5 model (current default). |
+| `NAVIGATOR_N2_PREVIEW_MODEL` | `"n2-preview"` | Gated preview identifier for the Navigator n2 computer-use model. |
 | `TOOL_SET_CORE` | `"browser_tools_core-20260403"` | Default Navigator n1.5 tool set — 18 coordinate-based browser tools. |
 | `TOOL_SET_EXPANDED` | `"browser_tools_expanded-20260403"` | Core tools + `extract_elements`, `find`, `set_element_value`, `execute_js`. |
+| `TOOL_SET_COMPUTER_USE_LATEST` | `"computer_use_tools-20260815"` | Current Navigator n2 macOS CUA surface: `computer_batch`, `screenshot`, `bash`, and held click/scroll modifiers. |
 | `NAVIGATOR_COORDINATE_SCALE` | `1000` | The normalized action space is `NAVIGATOR_COORDINATE_SCALE × NAVIGATOR_COORDINATE_SCALE`. |
 
 `N1_MODEL`, `N1_5_MODEL`, and `N1_COORDINATE_SCALE` are still importable from the same module as deprecated aliases of the `NAVIGATOR_*` constants and may be removed in a future release.
 
-For pinned versions (e.g. `n1-20260203`, `n1-experimental-20260309`) see [docs.yutori.com/reference/n1](https://docs.yutori.com/reference/n1) and [docs.yutori.com/reference/n1-5](https://docs.yutori.com/reference/n1-5).
+For pinned versions (e.g. `n1-20260203`, `n1-experimental-20260309`) see [docs.yutori.com/reference/n1](https://docs.yutori.com/reference/n1) [docs.yutori.com/reference/n1-5](https://docs.yutori.com/reference/n1-5), and [docs.yutori.com/reference/n2](https://docs.yutori.com/reference/n2).
 
 ## Namespaces
 
 ### `client.chat` — Navigator API
 
-OpenAI-compatible pixels-to-actions chat completions. Works with both Navigator n1 and Navigator n1.5 models.
+OpenAI-compatible pixels-to-actions chat completions. Works with Navigator n1, Navigator n1.5, and gated Navigator n2 preview models.
 
 | Method | HTTP | Endpoint | Returns |
 |--------|------|----------|---------|
@@ -174,6 +179,32 @@ parsed = getattr(response, "parsed_json", None)
 | Click modifiers | — | `ref`, `modifier` |
 | Extra actions | — | `hold_key`, `middle_click`, `mouse_down`, `mouse_up`, `go_forward` |
 | `type` extras | `press_enter_after`, `clear_before_typing` | — |
+
+#### Navigator n2 preview
+
+Navigator n2 is a gated, non-streaming desktop computer-use preview. It does not change the SDK default. Use `model=NAVIGATOR_N2_PREVIEW_MODEL` and pass an explicit dated tool set. The current macOS CUA surface is `TOOL_SET_COMPUTER_USE_LATEST` (`"computer_use_tools-20260815"`).
+
+The n2 surface rejects caller-provided `tools`, `disable_tools`, `json_schema`, `response_format`, and non-auto `tool_choice`. The server preserves every screenshot in the two newest image-bearing messages, strips older image parts while preserving non-image history, and bills output plus reasoning tokens as output-class tokens.
+
+For local macOS desktop execution, install Yutori MCP. It is the supported all-in-one installer and MCP server for the n2 CUA harness:
+
+```bash
+uvx yutori-mcp --env dev login
+uvx yutori-mcp computer-use setup
+uvx yutori-mcp computer-use doctor
+uvx yutori-mcp computer-use smoke
+```
+
+Dependencies for that path are macOS 15+, Python 3.10+, `uvx`, a dev API key with `n2-preview` access, `yutori-mcp`, the SDK-owned runtime (`yutori==0.9.2`), `CuaDriver.app` / `cua-driver==0.19.3`, Screen Recording and Accessibility permissions, and optionally Xcode Command Line Tools for the native reasoning overlay. `computer-use setup` installs the pinned CuaDriver app and prompts for the macOS permissions.
+
+For direct SDK harness use, first run the MCP setup flow above, or manage `CuaDriver.app` 0.19.3 yourself and run `cua-driver permissions grant`. Then install the published macOS extra and prepare the optional overlay:
+
+```bash
+python -m pip install 'yutori[macos]>=0.9.2'
+python -c 'from yutori.navigator.macos import prepare_macos_overlay; prepare_macos_overlay()'
+```
+
+`N2ComputerAgent` runs the agent loop. `yutori.navigator.macos.MacOSComputer` owns the persistent CuaDriver session, native capture/input, local shell lifecycle, cancellation, recovery, and optional presentation overlay. Local shell execution remains disabled unless the caller explicitly enables it.
 
 ### `client.browsing` — Browsing API
 
@@ -439,7 +470,10 @@ Opt-in helpers for custom agent loops. They do **not** change the shape of `clie
 ```python
 from yutori.navigator import (
     # Models / tool sets
-    NAVIGATOR_N1_MODEL, NAVIGATOR_N1_5_MODEL, TOOL_SET_CORE, TOOL_SET_EXPANDED, NAVIGATOR_COORDINATE_SCALE,
+    NAVIGATOR_N1_MODEL, NAVIGATOR_N1_5_MODEL, NAVIGATOR_N2_PREVIEW_MODEL,
+    TOOL_SET_CORE, TOOL_SET_EXPANDED, TOOL_SET_COMPUTER_USE_LATEST, NAVIGATOR_COORDINATE_SCALE,
+    # Navigator n2 loop helpers
+    N2ComputerAgent, parse_n2_tool_calls, execute_n2_computer_call, retain_n2_image_window,
     # Screenshots
     aplaywright_screenshot_to_data_url, playwright_screenshot_to_data_url, screenshot_to_data_url,
     # Coordinates
@@ -456,6 +490,17 @@ from yutori.navigator import (
     extract_text_content, RunHooksBase,
 )
 ```
+
+### macOS CUA harness
+
+Importable from published SDK 0.9.2+:
+
+```python
+from yutori.navigator import N2ComputerAgent, NAVIGATOR_N2_PREVIEW_MODEL, TOOL_SET_COMPUTER_USE_LATEST
+from yutori.navigator.macos import MacOSComputer, check_macos_overlay, prepare_macos_overlay
+```
+
+`MacOSComputer` is the native CUA executor for macOS. It sends screenshots to the n2 loop, executes CuaDriver actions in the same capture coordinate space, manages foreground/background shell commands, watches for target crashes, and can show the branded reasoning/action overlay. It requires macOS, Python 3.10+, `yutori[macos]>=0.9.2`, and `cua-driver==0.19.3`.
 
 ### Screenshot helpers
 
@@ -631,6 +676,7 @@ Optional extras:
 |-------|----------|---------|
 | `dev` | `pytest`, `pytest-asyncio`, `ruff`, `build` | Development tooling. |
 | `examples` | `loguru`, `playwright`, `pydantic`, `tenacity` | Running the `examples/` scripts. Pydantic is also the library to install if you want to pass Pydantic models to `output_schema=`. |
+| `macos` | `cua-driver==0.19.3` | Native macOS CUA driver for gated Navigator n2 preview loops in published SDK 0.9.2+. |
 
 ## Error handling example
 

--- a/api.md
+++ b/api.md
@@ -7,8 +7,8 @@ A dense reference to everything the Yutori Python SDK and CLI expose. The [READM
 | Import | Purpose |
 |--------|---------|
 | `yutori` | Clients (`YutoriClient`, `AsyncYutoriClient`) and exceptions (`APIError`, `APIConnectionError`, `AuthenticationError`, `YutoriSDKError`) |
-| `yutori.navigator` | Agent-loop helpers for the Navigator API (Navigator n1 / Navigator n1.5 / gated Navigator n2 preview chat completions) |
-| `yutori.navigator.macos` | Published 0.9.2+ macOS CUA harness for Navigator n2 preview loops |
+| `yutori.navigator` | Agent-loop helpers for the Navigator API (Navigator n1 / Navigator n1.5 / Navigator n2 chat completions) |
+| `yutori.navigator.macos` | Published 0.9.2+ macOS CUA harness for Navigator n2 loops |
 | `yutori.navigator.tools` | Packaged JavaScript reference implementations for the Navigator n1.5 expanded browser tools |
 
 All SDK calls go through `YutoriClient` / `AsyncYutoriClient`. The Navigator helpers are optional and do not change the shape of `client.chat.completions.create(...)`.
@@ -55,7 +55,7 @@ YutoriClient(
 
 | Attribute | Class | Purpose |
 |-----------|-------|---------|
-| `client.chat` | `ChatNamespace` | Navigator API (Navigator n1 / Navigator n1.5 / gated Navigator n2 preview) chat completions |
+| `client.chat` | `ChatNamespace` | Navigator API (Navigator n1 / Navigator n1.5 / Navigator n2) chat completions |
 | `client.browsing` | `BrowsingNamespace` | One-time browser automation |
 | `client.research` | `ResearchNamespace` | One-time deep web research |
 | `client.scouts` | `ScoutsNamespace` | Continuous monitoring scouts |
@@ -95,7 +95,6 @@ Importable from `yutori.navigator`. Prefer these over hard-coded strings so upgr
 from yutori.navigator import (
     NAVIGATOR_N1_MODEL,
     NAVIGATOR_N1_5_MODEL,
-    NAVIGATOR_N2_PREVIEW_MODEL,
     NAVIGATOR_COORDINATE_SCALE,
     TOOL_SET_CORE,
     TOOL_SET_EXPANDED,
@@ -107,7 +106,6 @@ from yutori.navigator import (
 |----------|-------|-------|
 | `NAVIGATOR_N1_MODEL` | `"n1-latest"` | Alias for the latest stable Navigator n1 model. |
 | `NAVIGATOR_N1_5_MODEL` | `"n1.5-latest"` | Alias for the latest stable Navigator n1.5 model (current default). |
-| `NAVIGATOR_N2_PREVIEW_MODEL` | `"n2-preview"` | Gated preview identifier for the Navigator n2 computer-use model. |
 | `TOOL_SET_CORE` | `"browser_tools_core-20260403"` | Default Navigator n1.5 tool set — 18 coordinate-based browser tools. |
 | `TOOL_SET_EXPANDED` | `"browser_tools_expanded-20260403"` | Core tools + `extract_elements`, `find`, `set_element_value`, `execute_js`. |
 | `TOOL_SET_COMPUTER_USE_LATEST` | `"computer_use_tools-20260815"` | Current Navigator n2 macOS CUA surface: `computer_batch`, `screenshot`, `bash`, and held click/scroll modifiers. |
@@ -121,7 +119,7 @@ For pinned versions (e.g. `n1-20260203`, `n1-experimental-20260309`) see [docs.y
 
 ### `client.chat` — Navigator API
 
-OpenAI-compatible pixels-to-actions chat completions. Works with Navigator n1, Navigator n1.5, and gated Navigator n2 preview models.
+OpenAI-compatible pixels-to-actions chat completions. Works with Navigator n1, Navigator n1.5, and Navigator n2 models.
 
 | Method | HTTP | Endpoint | Returns |
 |--------|------|----------|---------|
@@ -180,22 +178,23 @@ parsed = getattr(response, "parsed_json", None)
 | Extra actions | — | `hold_key`, `middle_click`, `mouse_down`, `mouse_up`, `go_forward` |
 | `type` extras | `press_enter_after`, `clear_before_typing` | — |
 
-#### Navigator n2 preview
+#### Navigator n2
 
-Navigator n2 is a gated, non-streaming desktop computer-use preview. It does not change the SDK default. Use `model=NAVIGATOR_N2_PREVIEW_MODEL` and pass an explicit dated tool set. The current macOS CUA surface is `TOOL_SET_COMPUTER_USE_LATEST` (`"computer_use_tools-20260815"`).
+Navigator n2 is a non-streaming desktop computer-use model. It does not change the SDK default. Use `model="n2"` and pass an explicit dated tool set. The current macOS CUA surface is `TOOL_SET_COMPUTER_USE_LATEST` (`"computer_use_tools-20260815"`).
 
 The n2 surface rejects caller-provided `tools`, `disable_tools`, `json_schema`, `response_format`, and non-auto `tool_choice`. The server preserves every screenshot in the two newest image-bearing messages, strips older image parts while preserving non-image history, and bills output plus reasoning tokens as output-class tokens.
 
 For local macOS desktop execution, install Yutori MCP. It is the supported all-in-one installer and MCP server for the n2 CUA harness:
 
 ```bash
-uvx yutori-mcp --env dev login
+uvx yutori-mcp login
 uvx yutori-mcp computer-use setup
 uvx yutori-mcp computer-use doctor
 uvx yutori-mcp computer-use smoke
+uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the result." --app Calculator
 ```
 
-Dependencies for that path are macOS 15+, Python 3.10+, `uvx`, a dev API key with `n2-preview` access, `yutori-mcp`, the SDK-owned runtime (`yutori==0.9.2`), `CuaDriver.app` / `cua-driver==0.19.3`, Screen Recording and Accessibility permissions, and optionally Xcode Command Line Tools for the native reasoning overlay. `computer-use setup` installs the pinned CuaDriver app and prompts for the macOS permissions.
+Dependencies for that path are macOS 15+, Python 3.10+, `uvx`, a Yutori API key with computer-use access, `yutori-mcp`, the SDK-owned runtime (`yutori==0.9.2`), `CuaDriver.app` / `cua-driver==0.19.3`, Screen Recording and Accessibility permissions, and optionally Xcode Command Line Tools for the native reasoning overlay. `computer-use setup` installs the pinned CuaDriver app and prompts for the macOS permissions.
 
 For direct SDK harness use, first run the MCP setup flow above, or manage `CuaDriver.app` 0.19.3 yourself and run `cua-driver permissions grant`. Then install the published macOS extra and prepare the optional overlay:
 
@@ -470,7 +469,7 @@ Opt-in helpers for custom agent loops. They do **not** change the shape of `clie
 ```python
 from yutori.navigator import (
     # Models / tool sets
-    NAVIGATOR_N1_MODEL, NAVIGATOR_N1_5_MODEL, NAVIGATOR_N2_PREVIEW_MODEL,
+    NAVIGATOR_N1_MODEL, NAVIGATOR_N1_5_MODEL,
     TOOL_SET_CORE, TOOL_SET_EXPANDED, TOOL_SET_COMPUTER_USE_LATEST, NAVIGATOR_COORDINATE_SCALE,
     # Navigator n2 loop helpers
     N2ComputerAgent, parse_n2_tool_calls, execute_n2_computer_call, retain_n2_image_window,
@@ -496,7 +495,7 @@ from yutori.navigator import (
 Importable from published SDK 0.9.2+:
 
 ```python
-from yutori.navigator import N2ComputerAgent, NAVIGATOR_N2_PREVIEW_MODEL, TOOL_SET_COMPUTER_USE_LATEST
+from yutori.navigator import N2ComputerAgent, TOOL_SET_COMPUTER_USE_LATEST
 from yutori.navigator.macos import MacOSComputer, check_macos_overlay, prepare_macos_overlay
 ```
 
@@ -676,7 +675,7 @@ Optional extras:
 |-------|----------|---------|
 | `dev` | `pytest`, `pytest-asyncio`, `ruff`, `build` | Development tooling. |
 | `examples` | `loguru`, `playwright`, `pydantic`, `tenacity` | Running the `examples/` scripts. Pydantic is also the library to install if you want to pass Pydantic models to `output_schema=`. |
-| `macos` | `cua-driver==0.19.3` | Native macOS CUA driver for gated Navigator n2 preview loops in published SDK 0.9.2+. |
+| `macos` | `cua-driver==0.19.3` | Native macOS CUA driver for Navigator n2 loops in published SDK 0.9.2+. |
 
 ## Error handling example
 

--- a/llms.txt
+++ b/llms.txt
@@ -107,9 +107,9 @@ If they decline, skip the Scout demo and end with a recap of Research + Browsing
 
 ## Navigator API
 
-Navigator is Yutori's computer-use model (model id `n1.5-latest`). It is an **OpenAI Chat Completions-compatible endpoint**: you send a screenshot of a web page plus a task instruction, and the model returns **browser actions** as tool calls (`left_click`, `type`, `scroll`, `goto_url`, …). You execute those actions in your own browser (e.g. Playwright), append the results, capture a fresh screenshot, and call again — an **agent loop** — until the model returns a text response with no tool calls.
+Navigator is Yutori's visual-control model family. Navigator n1.5 (model id `n1.5-latest`) controls browsers. The gated Navigator n2 preview (model id `n2-preview`) controls a complete desktop through a CUA harness. Both use the **OpenAI Chat Completions-compatible endpoint**: you send a screenshot plus a task instruction, and the model returns actions as tool calls. You execute those actions, append the results, capture a fresh screenshot, and call again - an **agent loop** - until the model returns a text response with no tool calls.
 
-There is no `yutori` CLI command for Navigator; it is called from Python via `client.chat.completions.create(...)`, which is a drop-in OpenAI-compatible client.
+There is no `yutori` CLI command for browser Navigator loops; call them from Python via `client.chat.completions.create(...)`, which is a drop-in OpenAI-compatible client. For macOS n2 CUA, prefer the MCP preview installer/tool unless the user explicitly wants to build a direct SDK harness.
 
 ### Minimal single call
 
@@ -162,6 +162,29 @@ Pass these as keyword args to `client.chat.completions.create(...)`:
 | `temperature` | Sampling temperature (default 0.3). |
 
 The core action space covers clicks, scroll, type, key press, drag, mouse move/down/up, navigation (`goto_url`, `go_back`, `go_forward`, `refresh`), `wait`, and `hold_key`. Coordinates are in a normalized 1000×1000 space — use `denormalize_coordinates(coords, width, height)` to map to viewport pixels. For the full action reference, see <https://docs.yutori.com/reference/n1-5>. For the SDK and CLI reference, see the link at the bottom of this file.
+
+### Navigator n2 / macOS CUA preview
+
+Use this only for users with gated dev access who want local Mac desktop automation. Install Yutori MCP; it is the supported installer and MCP server for the n2 CUA harness:
+
+```bash
+uvx yutori-mcp --env dev login
+uvx yutori-mcp computer-use setup
+uvx yutori-mcp computer-use doctor
+uvx yutori-mcp computer-use smoke
+```
+
+Dependencies: macOS 15+, Python 3.10+, `uvx`, a dev API key with `n2-preview` access, `yutori-mcp`, the SDK-owned runtime (`yutori==0.9.2`), `CuaDriver.app` / `cua-driver==0.19.3`, Screen Recording and Accessibility permissions, and optionally Xcode Command Line Tools for the native reasoning overlay. `computer-use setup` installs the pinned CuaDriver app and prompts for permissions.
+
+Then expose the MCP server with `uvx yutori-mcp --env dev`; the `run_computer_use_task` tool appears only on macOS against dev. It controls the visible foreground desktop, sends visible desktop content to Yutori's dev model endpoint, and should run while the user is not touching the Mac.
+
+Direct SDK harness use is available in published SDK 0.9.2+ after the pinned CuaDriver app has been installed and permissioned by `yutori-mcp computer-use setup` or an equivalent manual install:
+
+```bash
+python -m pip install 'yutori[macos]>=0.9.2'
+```
+
+Use `model="n2-preview"` with `tool_set="computer_use_tools-20260815"` (or SDK constants `NAVIGATOR_N2_PREVIEW_MODEL` and `TOOL_SET_COMPUTER_USE_LATEST`). The SDK exports `N2ComputerAgent` and `yutori.navigator.macos.MacOSComputer`; `MacOSComputer` owns the CuaDriver session, native capture/input, optional local shell lifecycle, cancellation, recovery, and presentation overlay. Local shell execution stays disabled unless explicitly enabled.
 
 For SDK/API integration details, use:
 

--- a/llms.txt
+++ b/llms.txt
@@ -107,9 +107,9 @@ If they decline, skip the Scout demo and end with a recap of Research + Browsing
 
 ## Navigator API
 
-Navigator is Yutori's visual-control model family. Navigator n1.5 (model id `n1.5-latest`) controls browsers. The gated Navigator n2 preview (model id `n2-preview`) controls a complete desktop through a CUA harness. Both use the **OpenAI Chat Completions-compatible endpoint**: you send a screenshot plus a task instruction, and the model returns actions as tool calls. You execute those actions, append the results, capture a fresh screenshot, and call again - an **agent loop** - until the model returns a text response with no tool calls.
+Navigator is Yutori's visual-control model family. Navigator n1.5 (model id `n1.5-latest`) controls browsers. Navigator n2 (model id `n2`) controls a complete desktop through a CUA harness. Both use the **OpenAI Chat Completions-compatible endpoint**: you send a screenshot plus a task instruction, and the model returns actions as tool calls. You execute those actions, append the results, capture a fresh screenshot, and call again - an **agent loop** - until the model returns a text response with no tool calls.
 
-There is no `yutori` CLI command for browser Navigator loops; call them from Python via `client.chat.completions.create(...)`, which is a drop-in OpenAI-compatible client. For macOS n2 CUA, prefer the MCP preview installer/tool unless the user explicitly wants to build a direct SDK harness.
+There is no `yutori` CLI command for browser Navigator loops; call them from Python via `client.chat.completions.create(...)`, which is a drop-in OpenAI-compatible client. For macOS n2 CUA, prefer the MCP installer/tool unless the user explicitly wants to build a direct SDK harness.
 
 ### Minimal single call
 
@@ -163,20 +163,21 @@ Pass these as keyword args to `client.chat.completions.create(...)`:
 
 The core action space covers clicks, scroll, type, key press, drag, mouse move/down/up, navigation (`goto_url`, `go_back`, `go_forward`, `refresh`), `wait`, and `hold_key`. Coordinates are in a normalized 1000×1000 space — use `denormalize_coordinates(coords, width, height)` to map to viewport pixels. For the full action reference, see <https://docs.yutori.com/reference/n1-5>. For the SDK and CLI reference, see the link at the bottom of this file.
 
-### Navigator n2 / macOS CUA preview
+### Navigator n2 / macOS CUA
 
-Use this only for users with gated dev access who want local Mac desktop automation. Install Yutori MCP; it is the supported installer and MCP server for the n2 CUA harness:
+For local Mac desktop automation, install Yutori MCP; it is the supported installer and MCP server for the n2 CUA harness:
 
 ```bash
-uvx yutori-mcp --env dev login
+uvx yutori-mcp login
 uvx yutori-mcp computer-use setup
 uvx yutori-mcp computer-use doctor
 uvx yutori-mcp computer-use smoke
+uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the result." --app Calculator
 ```
 
-Dependencies: macOS 15+, Python 3.10+, `uvx`, a dev API key with `n2-preview` access, `yutori-mcp`, the SDK-owned runtime (`yutori==0.9.2`), `CuaDriver.app` / `cua-driver==0.19.3`, Screen Recording and Accessibility permissions, and optionally Xcode Command Line Tools for the native reasoning overlay. `computer-use setup` installs the pinned CuaDriver app and prompts for permissions.
+Dependencies: macOS 15+, Python 3.10+, `uvx`, a Yutori API key with computer-use access, `yutori-mcp`, the SDK-owned runtime (`yutori==0.9.2`), `CuaDriver.app` / `cua-driver==0.19.3`, Screen Recording and Accessibility permissions, and optionally Xcode Command Line Tools for the native reasoning overlay. `computer-use setup` installs the pinned CuaDriver app and prompts for permissions.
 
-Then expose the MCP server with `uvx yutori-mcp --env dev`; the `run_computer_use_task` tool appears only on macOS against dev. It controls the visible foreground desktop, sends visible desktop content to Yutori's dev model endpoint, and should run while the user is not touching the Mac.
+Then expose the MCP server with `uvx yutori-mcp`; the `run_computer_use_task` tool appears on macOS. It controls the visible foreground desktop, sends visible desktop content to Yutori, and should run while the user is not touching the Mac.
 
 Direct SDK harness use is available in published SDK 0.9.2+ after the pinned CuaDriver app has been installed and permissioned by `yutori-mcp computer-use setup` or an equivalent manual install:
 
@@ -184,7 +185,7 @@ Direct SDK harness use is available in published SDK 0.9.2+ after the pinned Cua
 python -m pip install 'yutori[macos]>=0.9.2'
 ```
 
-Use `model="n2-preview"` with `tool_set="computer_use_tools-20260815"` (or SDK constants `NAVIGATOR_N2_PREVIEW_MODEL` and `TOOL_SET_COMPUTER_USE_LATEST`). The SDK exports `N2ComputerAgent` and `yutori.navigator.macos.MacOSComputer`; `MacOSComputer` owns the CuaDriver session, native capture/input, optional local shell lifecycle, cancellation, recovery, and presentation overlay. Local shell execution stays disabled unless explicitly enabled.
+Use `model="n2"` with `tool_set="computer_use_tools-20260815"` (or SDK constant `TOOL_SET_COMPUTER_USE_LATEST`). The SDK exports `N2ComputerAgent` and `yutori.navigator.macos.MacOSComputer`; `MacOSComputer` owns the CuaDriver session, native capture/input, optional local shell lifecycle, cancellation, recovery, and presentation overlay. Local shell execution stays disabled unless explicitly enabled.
 
 For SDK/API integration details, use:
 


### PR DESCRIPTION
## Summary
- document the n2 macOS CUA preview and supported yutori-mcp install path
- list required local dependencies including cua-driver and TCC permissions
- point direct SDK users at the published n2 harness exports and macOS overlay prep

## Validation
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation updates with no runtime or API behavior changes in this diff.
> 
> **Overview**
> This PR **extends the SDK docs** (`README.md`, `api.md`, `llms.txt`) for **Navigator n2** desktop computer-use alongside existing browser Navigator (n1 / n1.5). Positioning and API overview tables now describe n2 as full-desktop control; the default chat model stays **n1.5-latest**.
> 
> **Navigator n2 / macOS CUA** sections document the supported **`yutori-mcp computer-use`** flow (login, setup, doctor, smoke, run), pinned **`cua-driver==0.19.3`**, macOS 15+, TCC permissions, and SDK **0.9.2+** with `yutori[macos]`. Direct harness users get `model="n2"`, **`TOOL_SET_COMPUTER_USE_LATEST`** (`computer_use_tools-20260815`), **`N2ComputerAgent`**, and **`yutori.navigator.macos.MacOSComputer`** / overlay prep. **`api.md`** adds n2 chat constraints (rejected params, image-window behavior), new navigator imports, the **`macos`** optional extra, and a link to the n2 API reference. **`llms.txt`** tells coding agents to prefer MCP for n2 unless building a direct SDK loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6a53b0417c0e932bb34bd7ab65332bacdb01316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->