### PR TITLE
docs: update SDK positioning and Navigator copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/yutori.svg)](https://pypi.org/project/yutori/)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 
-The official Python SDK and CLI for the [Yutori API](https://docs.yutori.com) — build reliable computer-use agents that browse, research, monitor, and operate computers.
+The official Python SDK and CLI for the [Yutori API](https://docs.yutori.com) — build agents that monitor, research, and browse the web as well as operate computers with [Yutori](https://yutori.com/api).
 
 The SDK offers sync and async clients with full type annotations, plus a `yutori` CLI for authentication and managing resources from the terminal.
 
@@ -110,7 +110,7 @@ The Yutori API provides four main capabilities:
 
 | API           | Description                                                    | SDK Namespace     |
 | ------------- | -------------------------------------------------------------- | ----------------- |
-| **Navigator** | Browser- and computer-use models (Navigator n1, n1.5, n2) | `client.chat`  |
+| **Navigator** | Browser- and computer-use models                            | `client.chat`  |
 | **Browsing**  | One-time browser automation tasks                              | `client.browsing` |
 | **Research**  | Deep web research using 100+ tools                             | `client.research` |
 | **Scouting**  | Continuous web monitoring on a schedule                        | `client.scouts`   |
@@ -118,7 +118,7 @@ The Yutori API provides four main capabilities:
 
 ## Navigator API
 
-The Navigator API hosts Yutori's visual-control models. **Navigator n1** (`n1-latest`) and **Navigator n1.5** (`n1.5-latest`) control browsers; **Navigator n2** controls a complete desktop. Capture a screenshot, send it to the model, and execute the returned tool calls. The endpoint follows the OpenAI Chat Completions interface, so `client.chat` is a drop-in OpenAI-compatible client:
+The Navigator API hosts Yutori's visual-control models. Browser Navigator models control webpages; **Navigator n2** controls a complete desktop. Capture a screenshot, send it to the model, and execute the returned tool calls. The endpoint follows the OpenAI Chat Completions interface, so `client.chat` is a drop-in OpenAI-compatible client:
 
 ```python
 from yutori import AsyncYutoriClient
@@ -155,7 +155,7 @@ async with AsyncYutoriClient() as client, async_playwright() as p:
 
 This snippet shows a single model call. In practice, you'll usually run an agent loop: execute the returned actions on the page, capture a fresh screenshot, and call the model again until it emits `stop`. Complete agent loops live in [examples/](examples/).
 
-The SDK defaults to Navigator n1.5 (`n1.5-latest`). Navigator n1 (`n1-latest`) is still supported for callers that want the older model. Navigator n1.5 adds selectable tool sets, `disable_tools`, and structured JSON output via `json_schema` (returned as `response.parsed_json`). See the [Navigator n1.5 reference](https://docs.yutori.com/reference/n1-5) and [Navigator n1 reference](https://docs.yutori.com/reference/n1) for model IDs, parameters, and the full action space.
+The SDK defaults to the current browser Navigator model. Browser Navigator requests support selectable tool sets, `disable_tools`, and structured JSON output via `json_schema` (returned as `response.parsed_json`). See the [Navigator reference](https://docs.yutori.com/reference/navigator) for model IDs, parameters, and the full action space.
 
 ### Navigator n2 macOS CUA
 
@@ -194,8 +194,8 @@ The `yutori.navigator` subpackage exposes optional helpers for typical agent loo
 | `format_task_with_context(task, ...)`                       | Append location, timezone, and current date to a task message.                                                                           |
 | `format_stop_and_summarize(task)`                           | Ask the model to summarize when hitting max steps or an error.                                                                           |
 | `trimmed_messages_to_fit(messages, max_bytes, keep_recent)` | Drop older screenshots to stay under the API size limit.                                                                                 |
-| `map_key_to_playwright(key)` / `map_keys_individual(keys)`  | Convert Navigator n1.5's lowercase key names to Playwright format.                                                                       |
-| `yutori.navigator.tools`                                    | Packaged JS reference implementations for the Navigator n1.5 expanded tools (`extract_elements`, `find`, `set_element_value`, `execute_js`). |
+| `map_key_to_playwright(key)` / `map_keys_individual(keys)`  | Convert Navigator lowercase key names to Playwright format.                                                                              |
+| `yutori.navigator.tools`                                    | Packaged JS reference implementations for browser tool sets (`extract_elements`, `find`, `set_element_value`, `execute_js`).             |
 | `N2ComputerAgent` / `yutori.navigator.macos.MacOSComputer`  | Published 0.9.2+ helpers for Navigator n2 desktop CUA loops.                                                                             |
 
 
@@ -365,7 +365,7 @@ Run `yutori --help` or `yutori <command> --help` for full options.
 
 ## Examples
 
-See [examples/](examples/) for complete working examples, including Navigator agent loops for both Navigator n1 and Navigator n1.5.
+See [examples/](examples/) for complete working examples, including Navigator browser loops and n2 computer-use helpers.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ python -c 'from yutori.navigator.macos import prepare_macos_overlay; prepare_mac
 
 The SDK harness exports `N2ComputerAgent` for the agent loop and `yutori.navigator.macos.MacOSComputer` for the native Mac driver. `MacOSComputer` owns the persistent CuaDriver session, capture/input, shell lifecycle, cancellation, recovery, and optional presentation overlay. Local shell execution stays disabled unless the caller explicitly enables it.
 
+For longer n2 runs, prefer compacting or summarizing older screenshots and tool results so the conversation stays within `max_context_len`; do not rely on an artificial 100-step cap.
+
 ### Agent-loop helpers
 
 The `yutori.navigator` subpackage exposes optional helpers for typical agent loops:

--- a/yutori/_async/browsing.py
+++ b/yutori/_async/browsing.py
@@ -58,8 +58,7 @@ class AsyncBrowsingNamespace(_AsyncBaseNamespace):
             task: Natural language description of the browsing task.
             start_url: URL to start browsing from.
             max_steps: Maximum agent steps (1-100).
-            agent: Agent to use ("navigator-n1-latest" or
-                   "claude-sonnet-4-5-computer-use-2025-01-24").
+            agent: Optional agent/model override for the browsing task.
             require_auth: Use auth-optimized browser for login flows.
             browser: "cloud" (default) or "local" to use the desktop app with
                      the user's logged-in sessions.

--- a/yutori/_async/browsing.py
+++ b/yutori/_async/browsing.py
@@ -57,7 +57,7 @@ class AsyncBrowsingNamespace(_AsyncBaseNamespace):
         Args:
             task: Natural language description of the browsing task.
             start_url: URL to start browsing from.
-            max_steps: Maximum agent steps (1-100).
+            max_steps: Maximum agent steps.
             agent: Optional agent/model override for the browsing task.
             require_auth: Use auth-optimized browser for login flows.
             browser: "cloud" (default) or "local" to use the desktop app with

--- a/yutori/_async/chat.py
+++ b/yutori/_async/chat.py
@@ -32,13 +32,13 @@ class AsyncChatCompletions:
 
         Args:
             messages: List of messages following OpenAI Chat format.
-            model: Model to use (default: ``"n1.5-latest"`` — Navigator n1.5).
-            tool_set: (Navigator n1.5 only) Built-in tool set to use, e.g.
+            model: Model to use (defaults to the current browser Navigator model).
+            tool_set: Built-in browser Navigator tool set to use, e.g.
                 ``"browser_tools_core-20260403"`` or
                 ``"browser_tools_expanded-20260403"``.
-            disable_tools: (Navigator n1.5 only) List of tool names to remove
+            disable_tools: List of browser tool names to remove
                 from the selected tool set.
-            json_schema: (Navigator n1.5 only) JSON Schema for structured output.
+            json_schema: JSON Schema for structured output.
                 When provided, the model returns a ``parsed_json`` field
                 on the response.
             **kwargs: Additional parameters (e.g., temperature).

--- a/yutori/_sync/browsing.py
+++ b/yutori/_sync/browsing.py
@@ -58,8 +58,7 @@ class BrowsingNamespace(_SyncBaseNamespace):
             task: Natural language description of the browsing task.
             start_url: URL to start browsing from.
             max_steps: Maximum agent steps (1-100).
-            agent: Agent to use ("navigator-n1-latest" or
-                   "claude-sonnet-4-5-computer-use-2025-01-24").
+            agent: Optional agent/model override for the browsing task.
             require_auth: Use auth-optimized browser for login flows.
             browser: "cloud" (default) or "local" to use the desktop app with
                      the user's logged-in sessions.

--- a/yutori/_sync/browsing.py
+++ b/yutori/_sync/browsing.py
@@ -57,7 +57,7 @@ class BrowsingNamespace(_SyncBaseNamespace):
         Args:
             task: Natural language description of the browsing task.
             start_url: URL to start browsing from.
-            max_steps: Maximum agent steps (1-100).
+            max_steps: Maximum agent steps.
             agent: Optional agent/model override for the browsing task.
             require_auth: Use auth-optimized browser for login flows.
             browser: "cloud" (default) or "local" to use the desktop app with

--- a/yutori/_sync/chat.py
+++ b/yutori/_sync/chat.py
@@ -32,13 +32,13 @@ class ChatCompletions:
 
         Args:
             messages: List of messages following OpenAI Chat format.
-            model: Model to use (default: ``"n1.5-latest"`` — Navigator n1.5).
-            tool_set: (Navigator n1.5 only) Built-in tool set to use, e.g.
+            model: Model to use (defaults to the current browser Navigator model).
+            tool_set: Built-in browser Navigator tool set to use, e.g.
                 ``"browser_tools_core-20260403"`` or
                 ``"browser_tools_expanded-20260403"``.
-            disable_tools: (Navigator n1.5 only) List of tool names to remove
+            disable_tools: List of browser tool names to remove
                 from the selected tool set.
-            json_schema: (Navigator n1.5 only) JSON Schema for structured output.
+            json_schema: JSON Schema for structured output.
                 When provided, the model returns a ``parsed_json`` field
                 on the response.
             **kwargs: Additional parameters (e.g., temperature).

--- a/yutori/async_client.py
+++ b/yutori/async_client.py
@@ -78,10 +78,8 @@ class AsyncYutoriClient(_AsyncBaseNamespace):
         Returns:
             Dictionary with ``num_active_scouts``, ``active_scout_ids``,
             ``rate_limits``, ``navigator_rate_limits``, and ``activity``
-            counts. The response also includes ``n1_rate_limits`` and
-            ``activity.n1_calls`` as deprecated aliases of
-            ``navigator_rate_limits`` / ``navigator_calls`` and will be
-            removed in a future release; prefer the ``navigator_*`` names.
+            counts. The response may also include deprecated legacy aliases
+            for navigator usage fields; prefer the ``navigator_*`` names.
         """
         return await self._request("get", "/usage", params=build_query_params(period=period))
 

--- a/yutori/cli/commands/usage.py
+++ b/yutori/cli/commands/usage.py
@@ -84,7 +84,7 @@ def usage(
                 gate_on_status_available=True,
             )
 
-        # Navigator API rate limits (falls back to the deprecated ``n1_rate_limits`` key on older servers)
+        # Fall back to the deprecated legacy key on older servers.
         navigator_limits = data.get("navigator_rate_limits") or data.get("n1_rate_limits") or {}
         if navigator_limits:
             _print_rate_limits(
@@ -100,7 +100,7 @@ def usage(
             p = activity.get("period", period)
             console.print(f"\n  [bold]Activity ({p})[/bold]")
 
-            # `navigator_calls` is the canonical key; `n1_calls` is the deprecated alias.
+            # `navigator_calls` is the canonical key; keep the legacy fallback for older servers.
             navigator_calls = activity.get("navigator_calls", activity.get("n1_calls", 0))
             table = Table(show_header=True, padding=(0, 2))
             table.add_column("Metric")

--- a/yutori/client.py
+++ b/yutori/client.py
@@ -68,10 +68,8 @@ class YutoriClient(_SyncBaseNamespace):
         Returns:
             Dictionary with ``num_active_scouts``, ``active_scout_ids``,
             ``rate_limits``, ``navigator_rate_limits``, and ``activity``
-            counts. The response also includes ``n1_rate_limits`` and
-            ``activity.n1_calls`` as deprecated aliases of
-            ``navigator_rate_limits`` / ``navigator_calls`` and will be
-            removed in a future release; prefer the ``navigator_*`` names.
+            counts. The response may also include deprecated legacy aliases
+            for navigator usage fields; prefer the ``navigator_*`` names.
         """
         return self._request("get", "/usage", params=build_query_params(period=period))
 

--- a/yutori/navigator/__init__.py
+++ b/yutori/navigator/__init__.py
@@ -1,13 +1,13 @@
 """Utilities for building agents with the Yutori Navigator API.
 
-Provides reusable helpers for common patterns in Navigator n1 and
-Navigator n1.5 agent loops:
+Provides reusable helpers for common browser Navigator and desktop
+computer-use agent loop patterns:
 
 - Screenshot preparation: capture and encode screenshots as optimized WebP data URLs
 - Coordinate conversion: map the 1000x1000 tool-call space to viewport pixels
 - Payload management: trim old screenshots to stay within API size limits
 - Loop helpers: create trimmed requests without mutating caller state
-- Key mapping: convert Navigator n1.5 lowercase key names to Playwright-compatible names
+- Key mapping: convert Navigator lowercase key names to Playwright-compatible names
 - Model constants: canonical model identifiers and tool set names
 """
 

--- a/yutori/navigator/keys.py
+++ b/yutori/navigator/keys.py
@@ -1,9 +1,9 @@
-"""Key name mapping for the Navigator n1.5 lowercase key format.
+"""Key name mapping for the Navigator lowercase key format.
 
-Navigator n1.5 returns lowercase key names (e.g. ``ctrl+c``, ``enter``, ``left``)
+Navigator returns lowercase key names (e.g. ``ctrl+c``, ``enter``, ``left``)
 while Playwright expects Playwright-style names (e.g. ``Control+c``,
 ``Enter``, ``ArrowLeft``).  Use :func:`map_key_to_playwright` to convert
-a full Navigator n1.5 key expression to a Playwright-compatible string.
+a full Navigator key expression to a Playwright-compatible string.
 
 Only the Playwright ``key`` name is needed here (not ``code`` / ``keyCode``).
 """
@@ -96,9 +96,9 @@ def _split_into_combos(key_expr: str) -> list[list[str]]:
 
 
 def map_key_to_playwright(key_expr: str) -> list[str]:
-    """Convert a Navigator n1.5 key expression to a list of Playwright key-press strings.
+    """Convert a Navigator key expression to a list of Playwright key-press strings.
 
-    Navigator n1.5 uses ``+`` for simultaneous combos and spaces for sequential
+    Navigator uses ``+`` for simultaneous combos and spaces for sequential
     presses.  For example:
 
     * ``"ctrl+c"``         → ``["Control+c"]``
@@ -115,7 +115,7 @@ def map_key_to_playwright(key_expr: str) -> list[str]:
 
 
 def map_keys_individual(key_expr: str) -> list[str]:
-    """Convert a Navigator n1.5 key expression to a flat list of individual Playwright keys.
+    """Convert a Navigator key expression to a flat list of individual Playwright keys.
 
     Unlike :func:`map_key_to_playwright`, this never joins keys with ``+``.
     Each token is mapped individually, making the result safe for

--- a/yutori/navigator/models.py
+++ b/yutori/navigator/models.py
@@ -1,10 +1,4 @@
-"""Model identifiers and tool set constants for the Navigator API.
-
-The Navigator API hosts a family of computer-use models. Current public
-versions are Navigator n1 and Navigator n1.5. The API model ID strings
-(``n1-latest`` / ``n1.5-latest``) are unchanged — only the user-facing
-naming was updated.
-"""
+"""Model identifiers and tool set constants for the Navigator API."""
 
 from __future__ import annotations
 
@@ -13,17 +7,17 @@ from __future__ import annotations
 # ---------------------------------------------------------------------------
 
 NAVIGATOR_N1_MODEL = "n1-latest"
-"""Alias for the latest stable Navigator n1 model."""
+"""Deprecated browser Navigator model identifier."""
 
 NAVIGATOR_N1_5_MODEL = "n1.5-latest"
-"""Alias for the latest stable Navigator n1.5 model (current default)."""
+"""Current default browser Navigator model identifier."""
 
 # Back-compat aliases. Prefer the ``NAVIGATOR_*`` names above.
 N1_MODEL = NAVIGATOR_N1_MODEL
 N1_5_MODEL = NAVIGATOR_N1_5_MODEL
 
 # ---------------------------------------------------------------------------
-# Tool sets (Navigator n1.5 only)
+# Browser Navigator tool sets
 # ---------------------------------------------------------------------------
 
 TOOL_SET_CORE = "browser_tools_core-20260403"

--- a/yutori/navigator/payload.py
+++ b/yutori/navigator/payload.py
@@ -5,7 +5,7 @@ step because every tool response includes a new screenshot. These utilities
 help keep the total payload under the API's size limit by selectively removing
 old screenshots while preserving recent context.
 
-Adapted from the n1-brightdata project (https://github.com/meirk-brd/n1-brightdata).
+Adapted from Yutori's earlier browser-agent tooling.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Updates the README positioning to say agents monitor, research, and browse the web as well as operate computers with Yutori. Also removes deprecated Navigator n1/n1.5 mentions from public SDK docs and docstrings while keeping compatibility symbols untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docstring-only changes with no API or default behavior modifications in the diff.
> 
> **Overview**
> **Repositions public README and SDK docstrings** away from Navigator n1/n1.5 naming toward generic **browser Navigator** vs **Navigator n2** desktop CUA, while leaving model constants (`n1-latest`, `n1.5-latest`) and back-compat aliases in code.
> 
> The README intro and API overview now describe agents that monitor, research, browse, and operate computers; Navigator sections point to the unified [Navigator reference](https://docs.yutori.com/reference/navigator) instead of per-version pages. **n2 guidance** adds a note to compact older screenshots/tool results for `max_context_len` rather than assuming a 100-step cap.
> 
> **Browsing** `create` docstrings drop the documented `max_steps` (1–100) bound and enumerated `agent` values, describing them as generic limits/overrides. **Chat** `completions.create` docstrings no longer label `tool_set`, `disable_tools`, and `json_schema` as n1.5-only. **Usage** client/CLI docs soften specifics on deprecated `n1_*` response keys while keeping `navigator_*` as canonical.
> 
> Navigator subpackage module docs (`__init__`, `keys`, `models`, `payload`) align with the same naming; `NAVIGATOR_N1_MODEL` is documented as deprecated in `models.py` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f92cff181b534f096d03cb3b0129f018c36fdf55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->