### PR TITLE
docs: keep n1.5 in Navigator copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The Yutori API provides four main capabilities:
 
 | API           | Description                                                    | SDK Namespace     |
 | ------------- | -------------------------------------------------------------- | ----------------- |
-| **Navigator** | Browser- and computer-use models                            | `client.chat`  |
+| **Navigator** | Browser- and computer-use models (Navigator n1.5, n2)         | `client.chat`  |
 | **Browsing**  | One-time browser automation tasks                              | `client.browsing` |
 | **Research**  | Deep web research using 100+ tools                             | `client.research` |
 | **Scouting**  | Continuous web monitoring on a schedule                        | `client.scouts`   |
@@ -159,7 +159,7 @@ async with AsyncYutoriClient() as client, async_playwright() as p:
 
 This snippet shows a single model call. In practice, you'll run an agent loop: execute the returned actions on the page, capture a fresh screenshot, and call the model again until it returns text with no `tool_calls`. Complete agent loops live in [examples/](examples/).
 
-The SDK defaults to the current browser Navigator model (n1.5). Browser Navigator requests support selectable tool sets, `disable_tools`, and structured JSON output via `json_schema` (returned as `response.parsed_json`). See the [Navigator reference](https://docs.yutori.com/reference/navigator) for model IDs, parameters, and the full action space.
+The SDK defaults to Navigator n1.5 (`n1.5-latest`). Navigator n1.5 requests support selectable tool sets, `disable_tools`, and structured JSON output via `json_schema` (returned as `response.parsed_json`). See the [Navigator reference](https://docs.yutori.com/reference/navigator) for model IDs, parameters, and the full action space.
 
 ### Navigator n2 (computer use)
 
@@ -223,8 +223,8 @@ The `yutori.navigator` subpackage exposes optional helpers for typical agent loo
 | `format_task_with_context(task, ...)`                       | Append location, timezone, and current date to a task message.                                                                           |
 | `format_stop_and_summarize(task)`                           | Ask the model to summarize when hitting max steps or an error.                                                                           |
 | `trimmed_messages_to_fit(messages, max_bytes, keep_recent)` | Drop older screenshots to stay under the API size limit.                                                                                 |
-| `map_key_to_playwright(key)` / `map_keys_individual(keys)`  | Convert Navigator lowercase key names to Playwright format.                                                                              |
-| `yutori.navigator.tools`                                    | Packaged JS reference implementations for browser tool sets (`extract_elements`, `find`, `set_element_value`, `execute_js`).             |
+| `map_key_to_playwright(key)` / `map_keys_individual(keys)`  | Convert Navigator n1.5 lowercase key names to Playwright format.                                                                         |
+| `yutori.navigator.tools`                                    | Packaged JS reference implementations for Navigator n1.5 browser tool sets (`extract_elements`, `find`, `set_element_value`, `execute_js`). |
 | `N2ComputerAgent` / `TOOL_SET_COMPUTER_USE_LATEST`          | The Navigator n2 agent loop and the computer-use tool set it implements (SDK 0.9.2+).                                                    |
 
 
@@ -394,7 +394,7 @@ Run `yutori --help` or `yutori <command> --help` for full options.
 
 ## Examples
 
-See [examples/](examples/) for complete working examples: Navigator n1.5 browser agents and a Navigator n2 computer-use agent on a Daytona desktop.
+See [examples/](examples/) for complete working examples: Navigator n1.5 browser loops, custom tools, and a Navigator n2 computer-use agent on a Daytona desktop.
 
 ## Contributing
 

--- a/examples/navigator_n1_5.py
+++ b/examples/navigator_n1_5.py
@@ -12,13 +12,11 @@ raw request/response payloads in `visualization.html` after the run.
 Custom tools: `navigator_n1_5_custom_tools.py` and `navigator_n1_5_memo.py` subclass
 the `Agent` below, set `self.custom_tools`, and override `_dispatch_custom_tool`.
 
-Key differences from the retired Navigator n1:
-- model: "n1.5-latest" (instead of "n1-latest")
+Navigator n1.5 features:
+- model: "n1.5-latest"
 - tool_set / disable_tools: select which built-in tools the model can use
 - json_schema: request structured output (returned as parsed_json on the response)
-- Renamed actions: hover → mouse_move; key_press param renamed from key_comb → key
-- New actions: middle_click, mouse_down, mouse_up, go_forward, hold_key
-- type no longer has press_enter_after / clear_before_typing
+- Actions include mouse_move, middle_click, mouse_down, mouse_up, go_forward, hold_key, and more
 - Key names are lowercase (e.g. ctrl+c, enter, left) instead of Playwright names
 
 Usage:

--- a/yutori/_async/chat.py
+++ b/yutori/_async/chat.py
@@ -32,11 +32,11 @@ class AsyncChatCompletions:
 
         Args:
             messages: List of messages following OpenAI Chat format.
-            model: Model to use (defaults to the current browser Navigator model).
-            tool_set: Built-in browser Navigator tool set to use, e.g.
+            model: Model to use (default: ``"n1.5-latest"`` -- Navigator n1.5).
+            tool_set: Navigator n1.5 browser tool set to use, e.g.
                 ``"browser_tools_core-20260403"`` or
                 ``"browser_tools_expanded-20260403"``.
-            disable_tools: List of browser tool names to remove
+            disable_tools: List of Navigator n1.5 browser tool names to remove
                 from the selected tool set.
             json_schema: JSON Schema for structured output.
                 When provided, the model returns a ``parsed_json`` field

--- a/yutori/_sync/chat.py
+++ b/yutori/_sync/chat.py
@@ -32,11 +32,11 @@ class ChatCompletions:
 
         Args:
             messages: List of messages following OpenAI Chat format.
-            model: Model to use (defaults to the current browser Navigator model).
-            tool_set: Built-in browser Navigator tool set to use, e.g.
+            model: Model to use (default: ``"n1.5-latest"`` -- Navigator n1.5).
+            tool_set: Navigator n1.5 browser tool set to use, e.g.
                 ``"browser_tools_core-20260403"`` or
                 ``"browser_tools_expanded-20260403"``.
-            disable_tools: List of browser tool names to remove
+            disable_tools: List of Navigator n1.5 browser tool names to remove
                 from the selected tool set.
             json_schema: JSON Schema for structured output.
                 When provided, the model returns a ``parsed_json`` field

--- a/yutori/navigator/__init__.py
+++ b/yutori/navigator/__init__.py
@@ -1,13 +1,13 @@
 """Utilities for building agents with the Yutori Navigator API.
 
-Provides reusable helpers for common browser Navigator and desktop
-computer-use agent loop patterns:
+Provides reusable helpers for common Navigator n1.5 browser and
+Navigator n2 desktop computer-use agent loop patterns:
 
 - Screenshot preparation: capture and encode screenshots as optimized WebP data URLs
 - Coordinate conversion: map the 1000x1000 tool-call space to viewport pixels
 - Payload management: trim old screenshots to stay within API size limits
 - Loop helpers: create trimmed requests without mutating caller state
-- Key mapping: convert Navigator lowercase key names to Playwright-compatible names
+- Key mapping: convert Navigator n1.5 lowercase key names to Playwright-compatible names
 - Model constants: canonical model identifiers and tool set names
 """
 

--- a/yutori/navigator/keys.py
+++ b/yutori/navigator/keys.py
@@ -1,9 +1,10 @@
-"""Key name mapping for the Navigator lowercase key format.
+"""Key name mapping for the Navigator n1.5 lowercase key format.
 
-Navigator returns lowercase key names (e.g. ``ctrl+c``, ``enter``, ``left``)
-while Playwright expects Playwright-style names (e.g. ``Control+c``,
-``Enter``, ``ArrowLeft``).  Use :func:`map_key_to_playwright` to convert
-a full Navigator key expression to a Playwright-compatible string.
+Navigator n1.5 returns lowercase key names (e.g. ``ctrl+c``, ``enter``,
+``left``) while Playwright expects Playwright-style names (e.g.
+``Control+c``, ``Enter``, ``ArrowLeft``). Use :func:`map_key_to_playwright`
+to convert a full Navigator n1.5 key expression to a Playwright-compatible
+string.
 
 Only the Playwright ``key`` name is needed here (not ``code`` / ``keyCode``).
 """
@@ -96,10 +97,10 @@ def _split_into_combos(key_expr: str) -> list[list[str]]:
 
 
 def map_key_to_playwright(key_expr: str) -> list[str]:
-    """Convert a Navigator key expression to a list of Playwright key-press strings.
+    """Convert a Navigator n1.5 key expression to a list of Playwright key-press strings.
 
-    Navigator uses ``+`` for simultaneous combos and spaces for sequential
-    presses.  For example:
+    Navigator n1.5 uses ``+`` for simultaneous combos and spaces for
+    sequential presses. For example:
 
     * ``"ctrl+c"``         → ``["Control+c"]``
     * ``"down down enter"`` → ``["ArrowDown", "ArrowDown", "Enter"]``
@@ -115,7 +116,7 @@ def map_key_to_playwright(key_expr: str) -> list[str]:
 
 
 def map_keys_individual(key_expr: str) -> list[str]:
-    """Convert a Navigator key expression to a flat list of individual Playwright keys.
+    """Convert a Navigator n1.5 key expression to a flat list of individual Playwright keys.
 
     Unlike :func:`map_key_to_playwright`, this never joins keys with ``+``.
     Each token is mapped individually, making the result safe for


### PR DESCRIPTION
Restores Navigator n1.5 in README and public helper docstrings while keeping n1 out of public SDK docs. Also trims the examples README to the n1.5 browser example.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docstring-only changes; no API or runtime behavior is modified.
> 
> **Overview**
> Updates **public documentation and docstrings** so browser Navigator is consistently labeled **Navigator n1.5** (alongside n2), instead of generic “browser Navigator” wording.
> 
> **README** now calls out n1.5 and n2 in the API overview table, states the default model as `n1.5-latest`, and scopes helper-table rows (key mapping, packaged JS tools) to n1.5. The examples blurb mentions n1.5 browser loops and custom tools.
> 
> **SDK docstrings** in `client.chat.completions.create` (sync/async), `yutori.navigator`, and `yutori.navigator.keys` use the same n1.5-specific language for defaults, `tool_set`, and `disable_tools`.
> 
> **`examples/navigator_n1_5.py`** drops the “differences from retired Navigator n1” section and replaces it with a standalone **Navigator n1.5 features** list (no n1 migration copy in that example header).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 039a3b03a94a6a989f809dc863dc4a5cd5a12172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->