### PR TITLE
docs(api.md): sync browsing.create params with today's docstring update

### DIFF
--- a/api.md
+++ b/api.md
@@ -233,8 +233,8 @@ task = client.browsing.create(
 **Parameters:**
 - `task` (`str`): Natural language description of the browsing task.
 - `start_url` (`str`): URL to start browsing from.
-- `max_steps` (`int`, optional): Maximum agent steps (1–100).
-- `agent` (`str`, optional): `"navigator-n1.5-latest"` (default) or `"claude-sonnet-4-5-computer-use-2025-01-24"`.
+- `max_steps` (`int`, optional): Maximum agent steps.
+- `agent` (`str`, optional): Optional agent/model override for the browsing task.
 - `require_auth` (`bool`, optional): Use an auth-optimized browser for login flows.
 - `browser` (`str`, optional): `"cloud"` (default) or `"local"` for Yutori Local with the user's logged-in desktop sessions.
 - `output_schema`: See [Structured output](#structured-output).


### PR DESCRIPTION
## Day-over-day pattern

Today (2026-08-26), `#246` ("docs: update SDK positioning and Navigator copy") deliberately edited the `browsing.create` docstrings in both `yutori/_async/browsing.py` and `yutori/_sync/browsing.py`, under the explicit sub-message "docs: remove max-step cap guidance":

```diff
-            max_steps: Maximum agent steps (1-100).
-            agent: Agent to use ("navigator-n1-latest" or
-                   "claude-sonnet-4-5-computer-use-2025-01-24").
+            max_steps: Maximum agent steps.
+            agent: Optional agent/model override for the browsing task.
```

`api.md` — the hand-maintained parameter reference that mirrors these same docstrings — wasn't touched in that commit, and still read:

```
- `max_steps` (`int`, optional): Maximum agent steps (1–100).
- `agent` (`str`, optional): `"navigator-n1-latest"` (default) or `"claude-sonnet-4-5-computer-use-2025-01-24"`.
```

That's now stale on both counts: the 1–100 cap was intentionally documented away, and the literal two-value agent list no longer matches the source docstring's generic override wording.

## What this PR does

Doc-only, two lines: brings `api.md` back in sync with the docstrings it mirrors.

```diff
- `max_steps` (`int`, optional): Maximum agent steps (1–100).
- `agent` (`str`, optional): `"navigator-n1-latest"` (default) or `"claude-sonnet-4-5-computer-use-2025-01-24"`.
+ `max_steps` (`int`, optional): Maximum agent steps.
+ `agent` (`str`, optional): Optional agent/model override for the browsing task.
```

Confirmed no other stray `1–100` / literal agent-list references remain in `api.md`.

cc @ksk002 (Kaushik Kasi) as author of `#246`, for review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hand-maintained API reference text only; no code, auth, or data-path changes.
> 
> **Overview**
> Updates the **`browsing.create`** parameter reference in `api.md` so it matches the SDK docstrings from the earlier docstring refresh (not updated in that change).
> 
> **`max_steps`** no longer documents a **1–100** step cap. **`agent`** no longer lists fixed default/model strings; it is described as an optional agent/model override for the task.
> 
> Documentation-only; no runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1380ace32e8d9dc3924bacd96f759acafa7769aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->