### PR TITLE
refactor(macos): extract shared subprocess graceful-shutdown helper

### DIFF
--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from .overlay_build import OVERLAY_PROTOCOL_VERSION, PreparedMacOSOverlay, load_prepared_macos_overlay
+from .process_lifecycle import terminate_process_gracefully
 from .types import (
     CancellationLatch,
     MacOSPresentationCapabilities,
@@ -800,18 +801,7 @@ class MacOSPresentationController:
     async def _terminate_process(self) -> None:
         process, self._process = self._process, None
         if process is not None:
-            if process.stdin is not None:
-                process.stdin.close()
-            if process.returncode is None:
-                try:
-                    await asyncio.wait_for(process.wait(), timeout=_PROCESS_EXIT_TIMEOUT_SECONDS)
-                except asyncio.TimeoutError:
-                    process.terminate()
-                    try:
-                        await asyncio.wait_for(process.wait(), timeout=0.5)
-                    except asyncio.TimeoutError:
-                        process.kill()
-                        await process.wait()
+            await terminate_process_gracefully(process, exit_timeout=_PROCESS_EXIT_TIMEOUT_SECONDS, kill_timeout=0.5)
         current = asyncio.current_task()
         tasks = [task for task in (self._reader_task, self._stderr_task) if task is not None and task is not current]
         for task in tasks:

--- a/yutori/navigator/macos/process_lifecycle.py
+++ b/yutori/navigator/macos/process_lifecycle.py
@@ -1,0 +1,37 @@
+"""Shared graceful-shutdown helper for asyncio subprocesses.
+
+Both the cua-driver transport and the presentation host manage their own
+``asyncio.subprocess.Process`` and need the same escalating shutdown: close
+stdin, wait, then escalate to ``terminate()`` and finally ``kill()`` if the
+process does not exit in time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+async def terminate_process_gracefully(
+    process: asyncio.subprocess.Process,
+    *,
+    exit_timeout: float,
+    kill_timeout: "float | None" = None,
+) -> None:
+    """Close stdin, then escalate wait -> terminate -> kill until the process exits.
+
+    ``kill_timeout`` bounds the wait after ``terminate()`` is sent; it defaults to
+    ``exit_timeout`` when not given.
+    """
+    if process.stdin is not None:
+        process.stdin.close()
+    if process.returncode is None:
+        try:
+            await asyncio.wait_for(process.wait(), timeout=exit_timeout)
+        except asyncio.TimeoutError:
+            process.terminate()
+            resolved_kill_timeout = exit_timeout if kill_timeout is None else kill_timeout
+            try:
+                await asyncio.wait_for(process.wait(), timeout=resolved_kill_timeout)
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()

--- a/yutori/navigator/macos/transport.py
+++ b/yutori/navigator/macos/transport.py
@@ -9,6 +9,8 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
+from .process_lifecycle import terminate_process_gracefully
+
 _RPC_TIMEOUT_SECONDS = 30.0
 _PROCESS_EXIT_TIMEOUT_SECONDS = 3.0
 _RPC_STREAM_LIMIT_BYTES = 32 * 1024 * 1024
@@ -131,18 +133,7 @@ class CuaDriverTransport:
         self._closing = True
         process, self._process = self._process, None
         if process is not None:
-            if process.stdin is not None:
-                process.stdin.close()
-            if process.returncode is None:
-                try:
-                    await asyncio.wait_for(process.wait(), timeout=_PROCESS_EXIT_TIMEOUT_SECONDS)
-                except asyncio.TimeoutError:
-                    process.terminate()
-                    try:
-                        await asyncio.wait_for(process.wait(), timeout=_PROCESS_EXIT_TIMEOUT_SECONDS)
-                    except asyncio.TimeoutError:
-                        process.kill()
-                        await process.wait()
+            await terminate_process_gracefully(process, exit_timeout=_PROCESS_EXIT_TIMEOUT_SECONDS)
         if self._stderr_task is not None:
             self._stderr_task.cancel()
             await asyncio.gather(self._stderr_task, return_exceptions=True)


### PR DESCRIPTION
## Issue

`CuaDriverTransport.close()` (`yutori/navigator/macos/transport.py`) and `MacOSPresentationController._terminate_process()` (`yutori/navigator/macos/presentation.py`) — both added in #250's new n2 macOS computer-use SDK — each hand-rolled the identical close-stdin → wait → terminate → kill escalation over their own `asyncio.subprocess.Process`, ~12 duplicated lines apiece.

The two copies had already drifted from each other: `transport.py` reuses `_PROCESS_EXIT_TIMEOUT_SECONDS` for both the initial wait and the post-`terminate()` wait, while `presentation.py` reuses it for the first wait but hardcodes `0.5` for the second, with no comment explaining the asymmetry. That's exactly the kind of divergence duplicated logic invites over time.

## Improvement

Extracted `terminate_process_gracefully(process, *, exit_timeout, kill_timeout=None)` into a new leaf module, `yutori/navigator/macos/process_lifecycle.py` (a fresh module rather than either existing file, since `transport.py` and `presentation.py` don't currently import from each other and this avoids introducing that edge). Both call sites now delegate to it, passing their existing timeout values unchanged — `presentation.py` explicitly passes `kill_timeout=0.5` to preserve its current behavior exactly. Net: 24 duplicated lines removed, one 20-line shared implementation added.

## Why it's safe

- **Behavior-preserving**: identical close-stdin/wait/terminate/kill sequence, identical timeout values passed at each call site — nothing about the observable shutdown behavior changed.
- **No import-cycle risk**: `process_lifecycle.py` has zero dependencies on `transport.py`/`presentation.py`; both import it, not each other.
- **Test coverage**: neither `tests/test_navigator_macos_transport.py` nor `tests/test_navigator_macos_presentation.py` pins the internal wait/terminate/kill mechanics directly (no `assert_called_with(timeout=...)` on the escalation), so this is a low-risk area to consolidate. Full suite passes: `pytest -m "not slow"` → 663 passed, 3 skipped, 1 deselected (unchanged from before). Also ran the slow `tests/test_packaging.py -m slow` build/wheel test to confirm the new module is correctly packaged.
- **Lint clean**: `ruff check yutori/navigator/macos/` passes; `ruff format --check` is clean on all 3 touched/new files. (A pre-existing, unrelated format-drift line in `transport.py::find_cua_driver_binary` was confirmed present on `main` before this change via `git stash` and is left untouched, per this repo's convention of not smuggling unrelated reformatting into a refactor diff.)

3 files touched (1 new, 2 edited), no call-site or public-API changes outside the two `macos/` internals.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyRxZCuue1LGGRC5C5kv6g)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving internal refactor with no public API changes; shutdown timing at each call site is unchanged.
> 
> **Overview**
> **Pulls duplicated asyncio subprocess teardown into one shared helper** so the cua-driver transport and macOS presentation host stop using copy-pasted close-stdin → wait → `terminate()` → `kill()` blocks.
> 
> Adds `terminate_process_gracefully` in `process_lifecycle.py` and wires `CuaDriverTransport.close()` and `MacOSPresentationController._terminate_process()` to call it. Timeouts stay the same at each site: transport uses only `exit_timeout` (3s for both waits via the default `kill_timeout`), while presentation still passes `kill_timeout=0.5` after the initial 1s wait.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6692611ca0c6ce4f2898ca61af6bf198c299cfd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->