### PR TITLE
refactor(macos): extract shared parent-death watcher shell fragment

### DIFF
--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -87,10 +87,14 @@ class _BackgroundProcess:
     monitor: "asyncio.Task[None] | None" = None
 
 
-_FOREGROUND_SUPERVISOR = """
-parent_pid=$1
-shell_kind=$2
-(
+# Shared by both supervisor scripts below: a background subshell that polls
+# whether the shell's original parent is still its direct parent (not merely
+# alive — reparented onto init after a crash counts as gone) and force-kills
+# the whole process group the moment it isn't. This is what keeps a spawned
+# foreground/background shell from outliving the Python process that started
+# it. The two supervisors previously hand-duplicated this block; kept in one
+# place so the parent-liveness contract can't drift between them.
+_PARENT_DEATH_WATCHER = """(
   trap 'exit 0' TERM
   while /bin/kill -0 "$parent_pid" 2>/dev/null; do
     current_parent=$(/bin/ps -o ppid= -p "$$" | /usr/bin/tr -d '[:space:]')
@@ -99,7 +103,13 @@ shell_kind=$2
   done
   /bin/kill -KILL 0
 ) &
-watcher=$!
+watcher=$!""".strip()
+
+
+_FOREGROUND_SUPERVISOR = f"""
+parent_pid=$1
+shell_kind=$2
+{_PARENT_DEATH_WATCHER}
 if [ "$shell_kind" = bash ]; then
   /bin/bash --noprofile --norc -s
 else
@@ -112,19 +122,10 @@ exit "$status"
 """.strip()
 
 
-_BACKGROUND_SUPERVISOR = """
+_BACKGROUND_SUPERVISOR = f"""
 parent_pid=$1
 status_path=$2
-(
-  trap 'exit 0' TERM
-  while /bin/kill -0 "$parent_pid" 2>/dev/null; do
-    current_parent=$(/bin/ps -o ppid= -p "$$" | /usr/bin/tr -d '[:space:]')
-    [ "$current_parent" = "$parent_pid" ] || break
-    /bin/sleep 0.2
-  done
-  /bin/kill -KILL 0
-) &
-watcher=$!
+{_PARENT_DEATH_WATCHER}
 /bin/bash --noprofile --norc -s
 status=$?
 printf '%s\\n' "$status" > "$status_path"


### PR DESCRIPTION
## Summary

`_FOREGROUND_SUPERVISOR` and `_BACKGROUND_SUPERVISOR` in `yutori/navigator/macos/computer.py` each hand-duplicated the same 8-line "watch the original parent, force-kill the process group if it goes away" subshell inside their `/bin/sh` supervisor scripts. They differ only in the arguments each shell takes and what happens after the parent's actual work finishes.

Extracted the shared fragment into a new `_PARENT_DEATH_WATCHER` constant and had both supervisor templates interpolate it via an f-string, so the watcher logic can't drift between the foreground and background code paths the way the two subprocess-shutdown call sites already had before #252 (`terminate_process_gracefully`).

No behavior change — this is a pure string-composition refactor.

## Verification

- Imported the module before and after the change and confirmed the runtime string values of both `_FOREGROUND_SUPERVISOR` and `_BACKGROUND_SUPERVISOR` are byte-identical to their pre-refactor originals.
- `pytest -m "not slow"`: 614 passed, 9 skipped, 1 deselected (unchanged from main).
- `pytest tests/test_navigator_macos_computer.py`: 32 passed.
- `ruff check yutori/navigator/macos/computer.py`: clean.
- `ruff format --check`: one pre-existing unrelated format-drift line (~505) confirmed present on `main` before this change and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014CS2jDaRuGYUHqo4Sh11cV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-composition refactor only; supervisor script output is intended to remain byte-identical to pre-refactor values.
> 
> **Overview**
> **Deduplicates** the identical parent-liveness watcher subshell that both `_FOREGROUND_SUPERVISOR` and `_BACKGROUND_SUPERVISOR` embedded in their `/bin/sh` wrapper scripts.
> 
> The shared block is now a single `_PARENT_DEATH_WATCHER` constant (with a short comment on the contract: direct parent must stay the spawning Python process, otherwise the process group is SIGKILLed). Foreground and background supervisors **interpolate** it via f-strings instead of copying eight lines twice.
> 
> **No runtime behavior change**—only how the supervisor shell strings are composed so the watcher logic cannot drift between foreground and background shell paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2be108d455072dad2f4deb330bea1a2472ba3a7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->