### PR TITLE
refactor(macos): extract shared cancel-and-drain task cleanup helper

### DIFF
--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -133,6 +133,20 @@ wait "$watcher"
 """.strip()
 
 
+async def _cancel_and_drain(*tasks: "asyncio.Task[Any]") -> None:
+    """Cancel any of the given tasks still running, then await all of them.
+
+    Cancelling an already-done task is a no-op, so this is safe whether the
+    tasks are a raced pair (one finished, one not) or an already-pending set.
+    `return_exceptions=True` absorbs each task's `CancelledError`/result so
+    this never raises on the caller's behalf.
+    """
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
 def _structured(result: dict[str, Any]) -> dict[str, Any]:
     value = result.get("structuredContent") or result.get("structured_content") or {}
     return value if isinstance(value, dict) else {}
@@ -939,10 +953,7 @@ class MacOSComputer:
                 return operation.result()
             raise asyncio.CancelledError(stopped.result())
         finally:
-            for task in (operation, stopped):
-                if not task.done():
-                    task.cancel()
-            await asyncio.gather(operation, stopped, return_exceptions=True)
+            await _cancel_and_drain(operation, stopped)
 
     async def _capture_png(self) -> tuple[bytes, int, int]:
         last_error: "Exception | None" = None
@@ -1239,10 +1250,7 @@ class MacOSComputer:
                 await process.wait()
             raise
         finally:
-            for task in (communication, cancellation):
-                if not task.done():
-                    task.cancel()
-            await asyncio.gather(communication, cancellation, return_exceptions=True)
+            await _cancel_and_drain(communication, cancellation)
 
     async def _monitor_background(self, background: _BackgroundProcess) -> None:
         try:
@@ -1313,9 +1321,7 @@ class MacOSComputer:
         done, pending = await asyncio.wait(
             {sleeper, cancellation}, timeout=timeout, return_when=asyncio.FIRST_COMPLETED
         )
-        for task in pending:
-            task.cancel()
-        await asyncio.gather(*pending, return_exceptions=True)
+        await _cancel_and_drain(*pending)
         if sleeper not in done:
             if cancellation not in done:
                 self.cancellation.request("deadline")


### PR DESCRIPTION
## Issue

`MacOSComputer._await_with_cancellation` and `MacOSComputer._communicate` (`yutori/navigator/macos/computer.py`, part of the new n2 macOS computer-use SDK added in #250) each hand-duplicated the identical task-cleanup idiom in their `finally` blocks:

```python
for task in (a, b):
    if not task.done():
        task.cancel()
await asyncio.gather(a, b, return_exceptions=True)
```

`_sleep`'s pending-task cleanup was a near-identical variant operating over an already-filtered `pending` set from `asyncio.wait()`:

```python
for task in pending:
    task.cancel()
await asyncio.gather(*pending, return_exceptions=True)
```

This is the same class of drift-prone duplication that #252 (shared subprocess graceful-shutdown helper) and #254 (shared parent-death-watcher shell fragment) already fixed elsewhere in this same new module.

## Improvement

Extracted a module-level `_cancel_and_drain(*tasks)` helper; all three sites now delegate to it.

## Why it's safe

- **Behavior-preserving**: cancelling an already-done task is a no-op (`Task.cancel()` returns `False`, does nothing), so the helper is correct for both the raced two-task case (one task may already be done) and `_sleep`'s already-filtered `pending` set (every task there is still running, by construction of `asyncio.wait`'s return value). `return_exceptions=True` absorbs each task's result/`CancelledError` exactly as before.
- **No public API change**: `_cancel_and_drain` and all three call sites are private (`_`-prefixed); nothing about `MacOSComputer`'s public surface changes.
- **Test coverage**: `tests/test_navigator_macos_computer.py` exercises exactly these cleanup paths — Stop-cancellation of in-flight driver actions/captures/waits, outer `asyncio.Task.cancel()` during a driver action, and foreground-shell timeout/cancellation killing the process group.

Verified:
- `pytest -m "not slow"`: 614 passed, 9 skipped, 1 deselected — identical to the baseline recorded in the immediately-prior PR (#254) on this same file.
- `pytest tests/test_navigator_macos_computer.py`: 32 passed.
- `ruff check yutori/navigator/macos/computer.py`: clean.
- `ruff format --check`: confirmed the one flagged line is pre-existing drift already present on `main` before this change (checked via `git stash`), left untouched per this repo's convention of not smuggling unrelated reformatting into a refactor diff.

1 file touched (+17/-11), no call-site changes outside the three internal cleanup blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017FHypGoG3o1CzdpnNYH6Gc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of asyncio cleanup with behavior-preserving semantics; cancellation, shell I/O, and sleep paths are covered by existing macOS computer tests.
> 
> **Overview**
> Introduces a module-level **`_cancel_and_drain`** helper in `computer.py` that cancels any still-running asyncio tasks and awaits them with `return_exceptions=True`, so cleanup does not leak `CancelledError` to callers.
> 
> **`_await_with_cancellation`**, **`_communicate`**, and **`_sleep`** now call this helper instead of duplicating the cancel-then-`gather` pattern in their `finally` / post-`wait` blocks. Behavior is unchanged: safe when one task in a race is already done, and when cleaning up `asyncio.wait`'s `pending` set.
> 
> Private API only; no change to `MacOSComputer`'s public surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b021cc1a163de437f0341e7ad7a495ce1065f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->