### PR TITLE
refactor(macos): share cancel-and-drain task cleanup beyond computer.py

### DIFF
--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -25,6 +25,7 @@ from PIL import Image
 from .no_progress import NoProgressWatchdog
 from .polling import FRAME_POLL_ACTION_MAX_MS, frame_poll_wait_budget_ms, poll_until_frame_changes
 from .presentation import MacOSPresentationController
+from .process_lifecycle import cancel_and_drain
 from .sanitize import sanitize_command_preview
 from .transport import (
     CuaDriverConnectionError,
@@ -131,20 +132,6 @@ status=$?
 printf '%s\\n' "$status" > "$status_path"
 wait "$watcher"
 """.strip()
-
-
-async def _cancel_and_drain(*tasks: "asyncio.Task[Any]") -> None:
-    """Cancel any of the given tasks still running, then await all of them.
-
-    Cancelling an already-done task is a no-op, so this is safe whether the
-    tasks are a raced pair (one finished, one not) or an already-pending set.
-    `return_exceptions=True` absorbs each task's `CancelledError`/result so
-    this never raises on the caller's behalf.
-    """
-    for task in tasks:
-        if not task.done():
-            task.cancel()
-    await asyncio.gather(*tasks, return_exceptions=True)
 
 
 def _structured(result: dict[str, Any]) -> dict[str, Any]:
@@ -953,7 +940,7 @@ class MacOSComputer:
                 return operation.result()
             raise asyncio.CancelledError(stopped.result())
         finally:
-            await _cancel_and_drain(operation, stopped)
+            await cancel_and_drain(operation, stopped)
 
     async def _capture_png(self) -> tuple[bytes, int, int]:
         last_error: "Exception | None" = None
@@ -1250,7 +1237,7 @@ class MacOSComputer:
                 await process.wait()
             raise
         finally:
-            await _cancel_and_drain(communication, cancellation)
+            await cancel_and_drain(communication, cancellation)
 
     async def _monitor_background(self, background: _BackgroundProcess) -> None:
         try:
@@ -1321,7 +1308,7 @@ class MacOSComputer:
         done, pending = await asyncio.wait(
             {sleeper, cancellation}, timeout=timeout, return_when=asyncio.FIRST_COMPLETED
         )
-        await _cancel_and_drain(*pending)
+        await cancel_and_drain(*pending)
         if sleeper not in done:
             if cancellation not in done:
                 self.cancellation.request("deadline")

--- a/yutori/navigator/macos/polling.py
+++ b/yutori/navigator/macos/polling.py
@@ -12,6 +12,7 @@ from typing import Literal
 
 from PIL import Image
 
+from .process_lifecycle import cancel_and_drain
 from .types import CancellationLatch, N2Observation
 
 FRAME_SIGNATURE_WIDTH = 160
@@ -89,9 +90,7 @@ async def _sleep_or_cancel(delay: float, cancellation: "CancellationLatch | None
     sleeper = asyncio.create_task(asyncio.sleep(delay))
     cancelled = asyncio.create_task(cancellation.wait())
     done, pending = await asyncio.wait({sleeper, cancelled}, return_when=asyncio.FIRST_COMPLETED)
-    for task in pending:
-        task.cancel()
-    await asyncio.gather(*pending, return_exceptions=True)
+    await cancel_and_drain(*pending)
     return cancelled in done
 
 

--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from .overlay_build import OVERLAY_PROTOCOL_VERSION, PreparedMacOSOverlay, load_prepared_macos_overlay
-from .process_lifecycle import terminate_process_gracefully
+from .process_lifecycle import cancel_and_drain, terminate_process_gracefully
 from .types import (
     CancellationLatch,
     MacOSPresentationCapabilities,
@@ -436,9 +436,7 @@ class MacOSPresentationController:
         if self._stopping:
             return
         self._stopping = True
-        for task in tuple(self._background_removals):
-            task.cancel()
-        await asyncio.gather(*self._background_removals, return_exceptions=True)
+        await cancel_and_drain(*self._background_removals)
         if self._process is not None and self._process.returncode is None and self._fatal_error is None:
             try:
                 await self._send_operation({"op": "destroy"}, allow_stopping=True)
@@ -719,9 +717,7 @@ class MacOSPresentationController:
         sleeper = asyncio.create_task(asyncio.sleep(seconds))
         cancelled = asyncio.create_task(self.cancellation.wait())
         done, pending = await asyncio.wait({sleeper, cancelled}, return_when=asyncio.FIRST_COMPLETED)
-        for task in pending:
-            task.cancel()
-        await asyncio.gather(*pending, return_exceptions=True)
+        await cancel_and_drain(*pending)
         return sleeper in done
 
     def _validate_ready(self, reply: dict[str, Any]) -> MacOSPresentationCapabilities:
@@ -804,8 +800,6 @@ class MacOSPresentationController:
             await terminate_process_gracefully(process, exit_timeout=_PROCESS_EXIT_TIMEOUT_SECONDS, kill_timeout=0.5)
         current = asyncio.current_task()
         tasks = [task for task in (self._reader_task, self._stderr_task) if task is not None and task is not current]
-        for task in tasks:
-            task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
+        await cancel_and_drain(*tasks)
         self._reader_task = None
         self._stderr_task = None

--- a/yutori/navigator/macos/process_lifecycle.py
+++ b/yutori/navigator/macos/process_lifecycle.py
@@ -1,14 +1,32 @@
-"""Shared graceful-shutdown helper for asyncio subprocesses.
+"""Shared asyncio lifecycle helpers for macOS computer-use subprocesses and tasks.
 
 Both the cua-driver transport and the presentation host manage their own
 ``asyncio.subprocess.Process`` and need the same escalating shutdown: close
 stdin, wait, then escalate to ``terminate()`` and finally ``kill()`` if the
-process does not exit in time.
+process does not exit in time. They (and the frame-polling and no-progress
+helpers) also repeatedly need to cancel a set of in-flight tasks -- e.g. the
+loser of an ``asyncio.wait(..., return_when=FIRST_COMPLETED)`` race -- and
+await their cancellation before continuing.
 """
 
 from __future__ import annotations
 
 import asyncio
+from typing import Any
+
+
+async def cancel_and_drain(*tasks: "asyncio.Task[Any]") -> None:
+    """Cancel any of the given tasks still running, then await all of them.
+
+    Cancelling an already-done task is a no-op, so this is safe whether the
+    tasks are a raced pair (one finished, one not) or an already-pending set.
+    `return_exceptions=True` absorbs each task's `CancelledError`/result so
+    this never raises on the caller's behalf.
+    """
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
 
 
 async def terminate_process_gracefully(

--- a/yutori/navigator/macos/transport.py
+++ b/yutori/navigator/macos/transport.py
@@ -9,7 +9,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
-from .process_lifecycle import terminate_process_gracefully
+from .process_lifecycle import cancel_and_drain, terminate_process_gracefully
 
 _RPC_TIMEOUT_SECONDS = 30.0
 _PROCESS_EXIT_TIMEOUT_SECONDS = 3.0
@@ -135,8 +135,7 @@ class CuaDriverTransport:
         if process is not None:
             await terminate_process_gracefully(process, exit_timeout=_PROCESS_EXIT_TIMEOUT_SECONDS)
         if self._stderr_task is not None:
-            self._stderr_task.cancel()
-            await asyncio.gather(self._stderr_task, return_exceptions=True)
+            await cancel_and_drain(self._stderr_task)
             self._stderr_task = None
 
     async def _restart(self) -> None:


### PR DESCRIPTION
## Issue

PR #255 extracted `_cancel_and_drain` inside `computer.py` — cancel any still-running task in a set, then `await asyncio.gather(*tasks, return_exceptions=True)` to drain them — to de-duplicate that idiom across `_await_with_cancellation`, `_communicate`, and `_sleep`.

The same exact 2–3 line idiom was independently duplicated **six more times** across the sibling n2 macOS modules that PR #255 didn't touch:

- `transport.py::CuaDriverTransport.close()` — stderr-task cleanup
- `presentation.py::MacOSPresentationController.stop()` — background-removal task cleanup
- `presentation.py::MacOSPresentationController._sleep()` — sleep/cancellation race cleanup
- `presentation.py::MacOSPresentationController._terminate_process()` — reader/stderr task cleanup
- `polling.py::_sleep_or_cancel()` — sleep/cancellation race cleanup

This is the same duplication mechanism already fixed once in `computer.py`, just unaudited in its siblings.

## Fix

Move `cancel_and_drain(*tasks)` out of `computer.py` (private `_cancel_and_drain`) and into `process_lifecycle.py`, which is already the shared home for asyncio subprocess/task lifecycle helpers (`terminate_process_gracefully`) imported by both `transport.py` and `presentation.py`. Point every call site — including `computer.py`'s original three — at the shared public helper, and add the import to `polling.py` (no existing dependency, no cycle risk: `process_lifecycle.py` only imports `asyncio`).

Net: 5 files touched, -3 lines overall, zero new module-level dependencies beyond the existing `process_lifecycle.py` imports.

## Why this is safe (no behavior change)

- Every call site keeps the exact same sequence: cancel each task still running, then `gather(..., return_exceptions=True)`. Cancelling an already-`done()` task is a documented asyncio no-op, so the two call sites that previously cancelled unconditionally (without checking `.done()`) behave identically under the new helper's `.done()` guard.
- `presentation.py.stop()`'s `for task in tuple(self._background_removals): task.cancel()` defensive-copy is preserved: `cancel_and_drain(*self._background_removals)` unpacks the list into positional args at the call site before the helper runs, so it's snapshotted the same way.
- Not part of the public SDK surface: `cancel_and_drain`/`_cancel_and_drain` was never exported from `yutori/navigator/macos/__init__.py`, and this PR doesn't change `__init__.py` or any public method signature.
- No control-flow, timing, or exception-handling change — purely moving+renaming an internal helper and pointing more call sites at it.

## Verification

- `python -m pytest -m "not slow"` — 614 passed, 9 skipped (full non-slow suite, including all `tests/test_navigator_macos_*.py` files)
- `ruff check .` — all checks passed
- (Pre-existing `ruff format` drift in `computer.py`/`transport.py`, on lines this PR doesn't touch, is untouched — CI only runs `ruff check`, not `ruff format --check`.)


---
_Generated by [Claude Code](https://claude.ai/code/session_018DSWS7uA3ww2AAx2gGZP1o)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor only; asyncio cleanup semantics are preserved across shutdown and cancellation paths with no new dependencies or signature changes.
> 
> **Overview**
> Promotes the **cancel-then-drain** asyncio cleanup helper from a private `_cancel_and_drain` in `computer.py` to shared **`cancel_and_drain`** in `process_lifecycle.py` (alongside `terminate_process_gracefully`), and wires every macOS navigator call site to it.
> 
> **`computer.py`**, **`polling.py`**, **`presentation.py`**, and **`transport.py`** drop duplicated “cancel pending tasks + `gather(..., return_exceptions=True)`” blocks in cancellation races, shell I/O, overlay shutdown, and stderr draining. The helper’s docstring and module description are updated to cover task cleanup as well as subprocess shutdown.
> 
> No public API or control-flow changes—same cancel/drain sequence, with a `.done()` guard before cancel that matches prior behavior for already-finished tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f2b9f6eb87896086349dff5b68b0b131deb4fef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->