### PR TITLE
refactor(tests): consolidate duplicated FakeCompletions test double

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,33 @@
 """Test configuration for Yutori SDK tests."""
 
+from typing import Any
+
 import pytest
 
 from yutori import AsyncYutoriClient, YutoriClient
+
+
+class FakeCompletions:
+    """Scripted chat surface: returns each response in turn, records requests.
+
+    Shared by test_navigator_n2.py and test_navigator_n2_cookbooks.py, which
+    both drive `N2ComputerAgent` against a canned sequence of Chat Completions
+    responses.
+    """
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self.responses = list(responses)
+        self.requests: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.requests.append(kwargs)
+        payload = self.responses.pop(0)
+
+        class _Response:
+            def model_dump(self) -> dict[str, Any]:
+                return payload
+
+        return _Response()
 
 
 @pytest.fixture

--- a/tests/test_navigator_n2.py
+++ b/tests/test_navigator_n2.py
@@ -41,6 +41,8 @@ from yutori.navigator.n2_payload import (
     image_dimensions,
 )
 
+from .conftest import FakeCompletions
+
 
 def _png_data_url(width: int = 200, height: int = 100) -> str:
     buffer = io.BytesIO()
@@ -818,26 +820,6 @@ async def test_typed_text_never_enters_presentation_events():
 # ---------------------------------------------------------------------------
 # The agent loop
 # ---------------------------------------------------------------------------
-
-
-class FakeCompletions:
-    """Scripted chat surface: returns each response in turn, records requests."""
-
-    def __init__(self, responses):
-        self.responses = list(responses)
-        self.requests: list[dict[str, Any]] = []
-
-    async def create(self, **kwargs):
-        self.requests.append(kwargs)
-
-        class _Response:
-            def __init__(self, payload):
-                self._payload = payload
-
-            def model_dump(self):
-                return self._payload
-
-        return _Response(self.responses.pop(0))
 
 
 def _turn(message):

--- a/tests/test_navigator_n2_cookbooks.py
+++ b/tests/test_navigator_n2_cookbooks.py
@@ -21,6 +21,8 @@ from examples.navigator_n2.shared import TOOL_SET_ALIASES, RunGuard, selected_to
 from yutori.navigator import NAVIGATOR_N2_MODEL, TOOL_SET_COMPUTER_USE_LATEST, N2ComputerAgent
 from yutori.navigator.n2_actions import TOOL_SETS_WITH_CLICK_MODIFIERS
 
+from .conftest import FakeCompletions
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -91,22 +93,6 @@ class FakeSandbox:
 
     async def get_dimensions(self) -> tuple[int, int]:
         return 200, 100
-
-
-class FakeCompletions:
-    def __init__(self, responses: list[dict[str, Any]]) -> None:
-        self.responses = list(responses)
-        self.requests: list[dict[str, Any]] = []
-
-    async def create(self, **kwargs: Any) -> Any:
-        self.requests.append(kwargs)
-        payload = self.responses.pop(0)
-
-        class Response:
-            def model_dump(self) -> dict[str, Any]:
-                return payload
-
-        return Response()
 
 
 def _response(message: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

`tests/test_navigator_n2.py` and `tests/test_navigator_n2_cookbooks.py` (both added together in #250) each hand-rolled a byte-for-byte-equivalent `FakeCompletions` scripted chat-completions test double (records requests, replays a canned sequence of responses via `model_dump()`). This moves the shared class into `tests/conftest.py` — the repo's existing home for shared test fixtures/helpers (see `require_examples_extra`) — and imports it from both call sites instead.

Behavior-preserving, test-only change; no production code touched, no public API surface affected.

## Verification

- `ruff check .` — all checks pass
- `ruff format --check` on the three touched files — clean (repo-wide format drift on unrelated files is pre-existing on `main` and untouched here)
- `pytest -q` — 615 passed, 9 skipped (full suite, same as before the change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015z4gcJ7Tuvnwpr9JZczaaL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness consolidation only; behavior of Navigator N2 tests is unchanged.
> 
> **Overview**
> **Deduplicates** the scripted chat-completions test double used by Navigator N2 agent tests: `FakeCompletions` now lives in `tests/conftest.py` instead of being copy-pasted in `test_navigator_n2.py` and `test_navigator_n2_cookbooks.py`.
> 
> The shared helper still records each `create()` call and replays canned responses via `model_dump()`. The conftest version adds typing, a short docstring noting both consumers, and a slightly simplified `_Response` wrapper. Both test modules import it from `.conftest` and drop their local class definitions.
> 
> Test-only refactor; no production or public API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dcdd87b22bcfb5058759e9c69039a54b36d65d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->