### PR TITLE
refactor(macos): share the stdio JSON-RPC subprocess boilerplate

### DIFF
--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from .overlay_build import OVERLAY_PROTOCOL_VERSION, PreparedMacOSOverlay, load_prepared_macos_overlay
-from .process_lifecycle import cancel_and_drain, terminate_process_gracefully
+from .process_lifecycle import cancel_and_drain, drain_stream, spawn_rpc_subprocess, terminate_process_gracefully
 from .types import (
     CancellationLatch,
     MacOSPresentationCapabilities,
@@ -30,7 +30,6 @@ _SHELL_MINIMUM_DWELL_SECONDS = 0.9
 _SHELL_TERMINAL_HOLD_SECONDS = 0.9
 _BACKGROUND_TERMINAL_HOLD_SECONDS = 1.5
 _NORMALIZED_SCALE = 1000
-_RPC_STREAM_LIMIT_BYTES = 32 * 1024 * 1024
 
 _ACTION_STATUS = {
     "left_click": "Click",
@@ -281,15 +280,7 @@ class MacOSPresentationController:
         prepared = self._prepared or load_prepared_macos_overlay(self._cache_directory)
         config = json.dumps({"showStopButton": self._show_stop_button, "enableHotkey": True}, separators=(",", ":"))
         try:
-            self._process = await asyncio.create_subprocess_exec(
-                str(prepared.binary),
-                str(prepared.html),
-                config,
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                limit=_RPC_STREAM_LIMIT_BYTES,
-            )
+            self._process = await spawn_rpc_subprocess(str(prepared.binary), str(prepared.html), config)
             self._ready = asyncio.get_running_loop().create_future()
             self._reader_task = asyncio.create_task(self._read_host())
             self._stderr_task = asyncio.create_task(self._drain_stderr())
@@ -491,12 +482,8 @@ class MacOSPresentationController:
             await self._degrade("host_exited")
 
     async def _drain_stderr(self) -> None:
-        assert self._process is not None and self._process.stderr is not None
-        try:
-            while await self._process.stderr.read(4096):
-                pass
-        except asyncio.CancelledError:
-            pass
+        assert self._process is not None
+        await drain_stream(self._process.stderr)
 
     async def _send_envelope(
         self,

--- a/yutori/navigator/macos/process_lifecycle.py
+++ b/yutori/navigator/macos/process_lifecycle.py
@@ -1,18 +1,57 @@
 """Shared asyncio lifecycle helpers for macOS computer-use subprocesses and tasks.
 
-Both the cua-driver transport and the presentation host manage their own
-``asyncio.subprocess.Process`` and need the same escalating shutdown: close
-stdin, wait, then escalate to ``terminate()`` and finally ``kill()`` if the
-process does not exit in time. They (and the frame-polling and no-progress
-helpers) also repeatedly need to cancel a set of in-flight tasks -- e.g. the
-loser of an ``asyncio.wait(..., return_when=FIRST_COMPLETED)`` race -- and
-await their cancellation before continuing.
+Both the cua-driver transport and the presentation host speak newline-delimited
+JSON-RPC over a long-lived child process, so they spawn it identically (all
+three pipes plus the same oversized stream limit), drain its stderr identically,
+and need the same escalating shutdown: close stdin, wait, then escalate to
+``terminate()`` and finally ``kill()`` if the process does not exit in time.
+They (and the frame-polling and no-progress helpers) also repeatedly need to
+cancel a set of in-flight tasks -- e.g. the loser of an
+``asyncio.wait(..., return_when=FIRST_COMPLETED)`` race -- and await their
+cancellation before continuing.
 """
 
 from __future__ import annotations
 
 import asyncio
 from typing import Any
+
+# Screenshot-bearing JSON-RPC frames routinely exceed asyncio's 64 KiB default,
+# so both stdio peers raise the stream limit to the same ceiling.
+RPC_STREAM_LIMIT_BYTES = 32 * 1024 * 1024
+
+_STDERR_CHUNK_BYTES = 4096
+
+
+async def spawn_rpc_subprocess(*argv: str) -> asyncio.subprocess.Process:
+    """Spawn a newline-delimited JSON-RPC child with all three pipes attached.
+
+    Callers own error translation and the process handle; this only fixes the
+    pipe wiring and stream limit that every stdio RPC peer here shares.
+    """
+    return await asyncio.create_subprocess_exec(
+        *argv,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        limit=RPC_STREAM_LIMIT_BYTES,
+    )
+
+
+async def drain_stream(stream: "asyncio.StreamReader | None") -> None:
+    """Read and discard a piped stream until EOF so the child never blocks on it.
+
+    Returns immediately when the stream is absent, and treats cancellation as an
+    ordinary stop -- this runs as a detached background task whose only job is to
+    keep the pipe from filling up.
+    """
+    if stream is None:
+        return
+    try:
+        while await stream.read(_STDERR_CHUNK_BYTES):
+            pass
+    except asyncio.CancelledError:
+        pass
 
 
 async def cancel_and_drain(*tasks: "asyncio.Task[Any]") -> None:

--- a/yutori/navigator/macos/transport.py
+++ b/yutori/navigator/macos/transport.py
@@ -9,11 +9,10 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
-from .process_lifecycle import cancel_and_drain, terminate_process_gracefully
+from .process_lifecycle import cancel_and_drain, drain_stream, spawn_rpc_subprocess, terminate_process_gracefully
 
 _RPC_TIMEOUT_SECONDS = 30.0
 _PROCESS_EXIT_TIMEOUT_SECONDS = 3.0
-_RPC_STREAM_LIMIT_BYTES = 32 * 1024 * 1024
 
 
 class CuaDriverError(RuntimeError):
@@ -79,14 +78,7 @@ class CuaDriverTransport:
         self._closing = False
         binary = self.binary or find_cua_driver_binary()
         try:
-            self._process = await asyncio.create_subprocess_exec(
-                str(binary),
-                "mcp",
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                limit=_RPC_STREAM_LIMIT_BYTES,
-            )
+            self._process = await spawn_rpc_subprocess(str(binary), "mcp")
         except OSError as error:
             raise CuaDriverConnectionError(f"Failed to start cua-driver: {error}") from error
         self._stderr_task = asyncio.create_task(self._drain_stderr())
@@ -226,10 +218,4 @@ class CuaDriverTransport:
 
     async def _drain_stderr(self) -> None:
         process = self._process
-        if process is None or process.stderr is None:
-            return
-        try:
-            while await process.stderr.read(4096):
-                pass
-        except asyncio.CancelledError:
-            pass
+        await drain_stream(process.stderr if process is not None else None)


### PR DESCRIPTION
## The structural issue

`yutori/navigator/macos/` has two peers that speak newline-delimited JSON-RPC over a long-lived child process:

- `transport.py` — the `cua-driver mcp` session
- `presentation.py` — the AppKit/WebKit overlay host

Each of them hand-rolled the *same three* pieces of that setup, independently:

| Duplicated piece | `transport.py` | `presentation.py` |
| --- | --- | --- |
| `_RPC_STREAM_LIMIT_BYTES = 32 * 1024 * 1024` | L16 | L33 |
| `create_subprocess_exec(..., stdin/stdout/stderr=PIPE, limit=…)` | L82–89 | L284–292 |
| `_drain_stderr()` — read 4096-byte chunks to EOF, swallow `CancelledError` | L227–234 | L493–499 |

The stream-limit constant in particular is the drift-prone one: it is a *protocol* constant (screenshot-bearing RPC frames blow past asyncio's 64 KiB default), duplicated as a private literal in two files with nothing tying the copies together. Raising it in one place and not the other would silently truncate frames on only one of the two channels.

## The change

All three move into `process_lifecycle.py` — the module that already exists for exactly this pair of peers, and whose docstring already names them both:

- `RPC_STREAM_LIMIT_BYTES` — one definition
- `spawn_rpc_subprocess(*argv)` — fixes only the pipe wiring and stream limit; callers keep owning their own argv, error translation, and process handle
- `drain_stream(stream)` — the shared "read and discard until EOF" pump

Net: **-24 lines**, three call sites collapse to one-liners, and the third caller of this module (`computer.py`, `polling.py`) is untouched.

This follows the same path as #252 / #254 / #255 / #256, which consolidated the graceful-shutdown and cancel-and-drain halves of this same module.

## Why it's safe

- **`process_lifecycle` is internal.** It is not re-exported from `yutori/navigator/macos/__init__.py` and is not documented in `api.md`. No public import path, exported name, or signature changes.
- **Spawn is provably identical.** Patching `asyncio.create_subprocess_exec` and driving both `CuaDriverTransport.start()` and `MacOSPresentationController.start()` shows byte-identical argv and kwargs versus the pre-refactor code:
  ```
  ('/tmp/cua-driver', 'mcp')
  ('/tmp/host-bin', '/tmp/overlay.html', '{"showStopButton":true,"enableHotkey":true}')
  kwargs == {stdin: PIPE, stdout: PIPE, stderr: PIPE, limit: 33554432}   # both
  ```
- **`drain_stream` is provably identical.** Verified it issues the same `read(4096)` chunk sizes, stops on the same falsy-chunk EOF, no-ops on a `None` stream, and still absorbs `CancelledError` rather than propagating it.
- **Full suite green**: `pytest -m "not slow"` → 614 passed, 9 skipped (unchanged from `main`); the macOS transport/presentation/computer files specifically → 44 passed. `ruff check .` clean.

One incidental tightening, called out for the reviewer: `presentation._drain_stderr` previously re-read `self._process.stderr` on *every* loop iteration, so it could raise `AttributeError` in the window where `_terminate_process` sets `self._process = None` before cancelling the task. That exception was already being absorbed by `cancel_and_drain(..., return_exceptions=True)`, so it was unobservable — capturing the stream once (which is what `transport.py` already did) just removes the latent raise. No behaviour any caller can see changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUvtranrCVsuVnr2HnsAjx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with behavior-preserving subprocess spawn and stderr drain; no public API changes.
> 
> **Overview**
> **Consolidates duplicated macOS JSON-RPC child-process setup** in `process_lifecycle.py` so the cua-driver transport and presentation overlay host stay in sync on pipe wiring and stream limits.
> 
> Adds shared **`RPC_STREAM_LIMIT_BYTES`**, **`spawn_rpc_subprocess(*argv)`** (stdin/stdout/stderr pipes plus the 32 MiB asyncio limit), and **`drain_stream`**. **`transport.py`** and **`presentation.py`** replace local `_RPC_STREAM_LIMIT_BYTES`, inline `create_subprocess_exec`, and hand-rolled `_drain_stderr` loops with these helpers. The module docstring is updated to describe this shared RPC pattern alongside the existing shutdown/cancel helpers.
> 
> **Presentation stderr draining** now delegates to `drain_stream` on a captured `stderr` reference (aligned with transport), avoiding a latent `AttributeError` if `_process` is cleared mid-loop during teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bf2403b054731f0a6384538aabc64cee909724b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->