### PR TITLE
fix(ci): don't gate installer release assets on PyPI publish

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -132,7 +132,10 @@ jobs:
 
   release-assets:
     name: Upload release checksums and installers
-    needs: [build, publish]
+    # Keep the public install/uninstall URLs available even if the independent
+    # PyPI publishing job fails. Both jobs consume the exact artifacts produced
+    # by `build`.
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- `release-assets` now depends on `build` only, not `[build, publish]`.
- It already consumes the `python-distributions` and `release-source` artifacts straight from `build` and verifies `SHA256SUMS` itself, so nothing it does needs `publish` to have run — the dependency was purely on `publish`'s *success*.

## Why

On 2026-08-29 the v0.9.3 release workflow failed in `publish` (PyPI Trusted Publishing `invalid-publisher` — the publisher hadn't been registered on PyPI yet). Because `release-assets` was gated on `publish`, it was skipped and the release had zero assets. GitHub marks a release "Latest" at publish time regardless of workflow outcome, and `yutori.com/install.sh` redirects to `releases/latest/download/install.sh`, so `curl -fsSL https://yutori.com/install.sh | bash` returned 404 for everyone until the publisher was registered and the run re-run.

With this change a PyPI failure can no longer take the public installer URL down. `install.sh` installs `yutori` unpinned (`uv tool install --force --upgrade yutori`), so an installer attached to a release whose package didn't reach PyPI degrades to installing the previous published version instead of failing.

## Validation

- `yaml.safe_load` parses the workflow; `jobs.release-assets.needs == "build"`.
- No change to the `build` or `publish` jobs; the artifact handoff and hash verification in `release-assets` are unchanged.
- Workflow-only change; exercised on the next `release: published` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency change; release assets still come from the same verified `build` artifacts, with the tradeoff that installers may be published before PyPI succeeds.
> 
> **Overview**
> **Decouples GitHub release installer assets from PyPI publish success** so a failed `publish` job no longer skips `release-assets`.
> 
> The `release-assets` job’s `needs` list changes from `[build, publish]` to **`build` only**, with comments noting that both jobs already use artifacts from `build` and that keeping `install.sh` / uninstall URLs on the release matters when Trusted Publishing fails. Build, publish, artifact downloads, and hash checks in `release-assets` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b540c1901536af8572fb5d983daf0fc10beb50a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->