### PR TITLE
fix: publish SDK releases atomically

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,8 +1,19 @@
 name: Publish yutori to PyPI
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Annotated vX.Y.Z tag to publish"
+        required: true
+        type: string
+
+# A GitHub Release becomes "latest" as soon as it is published. Build, test,
+# publish to PyPI, and attach every release asset before publishing the release
+# so yutori.com/install.sh can never point at an incomplete release.
+concurrency:
+  group: yutori-release
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -13,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.tag }}
           fetch-depth: 0
 
       - uses: actions/setup-python@v6
@@ -22,12 +33,44 @@ jobs:
 
       - name: Verify annotated release tag and package version
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           test "$(git cat-file -t "refs/tags/$RELEASE_TAG")" = tag
           test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$(git rev-parse HEAD)"
           test "${RELEASE_TAG#v}" != "$RELEASE_TAG"
           test "$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")" = "${RELEASE_TAG#v}"
+
+      - name: Refuse to overwrite a published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from urllib.error import HTTPError
+          from urllib.parse import quote
+          from urllib.request import Request, urlopen
+
+          repository = os.environ["GITHUB_REPOSITORY"]
+          tag = quote(os.environ["RELEASE_TAG"], safe="")
+          request = Request(
+              f"https://api.github.com/repos/{repository}/releases/tags/{tag}",
+              headers={"Authorization": f"Bearer {os.environ['GH_TOKEN']}"},
+          )
+          try:
+              with urlopen(request, timeout=30) as response:
+                  release = json.load(response)
+          except HTTPError as error:
+              if error.code == 404:
+                  raise SystemExit(0)
+              raise
+
+          if not release["draft"]:
+              raise SystemExit(
+                  "Refusing to overwrite a published release; repair it separately or create a new release tag."
+              )
+          PY
 
       - name: Install build tools
         run: pip install build twine
@@ -50,7 +93,7 @@ jobs:
 
       - name: Record public source provenance
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           python - <<'PY'
           import hashlib
@@ -122,7 +165,43 @@ jobs:
           mkdir packages
           cp dist/*.tar.gz dist/*.whl packages/
 
+      - name: Check whether PyPI already has these distributions
+        id: pypi-release
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          from urllib.error import HTTPError
+          from urllib.request import urlopen
+
+          expected = {}
+          for line in Path("dist/SHA256SUMS").read_text(encoding="utf-8").splitlines():
+              digest, filename = line.split(maxsplit=1)
+              expected[filename.removeprefix("*")] = digest
+
+          version = os.environ["RELEASE_TAG"].removeprefix("v")
+          try:
+              with urlopen(f"https://pypi.org/pypi/yutori/{version}/json", timeout=30) as response:
+                  release = json.load(response)
+          except HTTPError as error:
+              if error.code != 404:
+                  raise
+              state = "missing"
+          else:
+              actual = {file["filename"]: file["digests"]["sha256"] for file in release["urls"]}
+              if actual != expected:
+                  raise SystemExit(f"PyPI yutori {version} does not match the verified distributions")
+              state = "matching"
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              print(f"state={state}", file=output)
+          PY
+
       - name: Publish with PyPI Trusted Publishing
+        if: steps.pypi-release.outputs.state == 'missing'
         # release/v1, pinned to an immutable commit. This action creates and
         # uploads PyPI attestations for the same distribution bytes by default.
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
@@ -170,11 +249,28 @@ jobs:
           sha256sum source/install.sh > source/install.sh.sha256
           sha256sum source/uninstall.sh > source/uninstall.sh.sha256
 
+      - name: Verify release assets
+        run: |
+          for file in \
+            dist/SHA256SUMS \
+            dist/RELEASE-PROVENANCE.json \
+            source/install.sh \
+            source/install.sh.sha256 \
+            source/uninstall.sh \
+            source/uninstall.sh.sha256; do
+            test -s "$file"
+          done
+
       - name: Upload release assets
         # Pinned to a commit SHA: this third-party action runs with
         # contents:write and uploads the curl|sh installer artifacts.
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
+          tag_name: ${{ inputs.tag }}
+          name: yutori ${{ inputs.tag }}
+          generate_release_notes: true
+          draft: true
+          fail_on_unmatched_files: true
           files: |
             dist/SHA256SUMS
             dist/RELEASE-PROVENANCE.json
@@ -182,3 +278,9 @@ jobs:
             source/install.sh.sha256
             source/uninstall.sh
             source/uninstall.sh.sha256
+
+      - name: Publish release after verified assets upload
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,15 @@ Thank you for your interest in contributing to the Yutori Python SDK!
 4. Run tests and linting
 5. Submit a pull request
 
+## Releases
+
+Before the first release, register PyPI Trusted Publishing for GitHub Actions with owner `yutori-ai`, repository
+`yutori-sdk-python`, workflow `publish_to_pypi.yml`, and environment `pypi`. Then push an annotated `vX.Y.Z` tag and
+run **Publish yutori to PyPI** from the GitHub Actions UI with that tag as its input. The workflow builds and tests the
+exact tag, publishes it to PyPI, uploads every installer asset to a draft GitHub release, and only then publishes the
+release. Do not publish a GitHub release manually or dispatch the workflow for an already-published release:
+`yutori.com/install.sh` follows the latest published release.
+
 ## Reporting Issues
 
 Please report issues at https://github.com/yutori-ai/yutori-sdk-python/issues


### PR DESCRIPTION
## Summary
- publish tagged SDK releases through an explicit manual workflow, creating a GitHub release only after PyPI succeeds
- keep releases draft until all installer assets and checksums are verified; serialize releases and reject overwriting published releases
- make retries hash-aware and document the required PyPI Trusted Publisher settings

## Validation
- parsed the workflow YAML and checked its release invariants
- ran `bash scripts/check_install_sh_fresh.sh`
- verified the repaired `https://yutori.com/install.sh` returns 200 and the v0.9.3 installer parses with Bash

## Operational result
The corrected PyPI publisher configuration allowed GitHub Actions attempt 3 to publish yutori 0.9.3 successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release and PyPI publishing orchestration and GitHub release timing; mistakes could still affect install.sh consumers, but guards reduce overwrite and incomplete-release exposure.
> 
> **Overview**
> **Replaces release-on-publish automation** with a **manual** `workflow_dispatch` that takes an annotated `vX.Y.Z` tag, so publishing is explicit and ordered instead of racing GitHub’s “latest” release semantics.
> 
> The workflow now **serializes** releases (`yutori-release` concurrency), **blocks** reruns against an already-published GitHub release, and **skips PyPI upload** when the version is already on PyPI with matching artifact SHA256s (or fails if hashes differ). Installer/checksum assets are **verified**, uploaded to a **draft** release for that tag, then the release is **published last** via `gh release edit` so `yutori.com/install.sh` never points at a partial release.
> 
> **CONTRIBUTING.md** adds a **Releases** section covering PyPI Trusted Publishing setup and the “tag + dispatch workflow, don’t publish manually” process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a22d66a9f43cf9b877d4ac9421ad3fec34d4ce6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->