### PR TITLE
refactor(macos): extract shared _spawn_supervised_shell helper

### DIFF
--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -1083,6 +1083,40 @@ class MacOSComputer:
         if not self.allow_local_shell:
             raise PermissionError("Local shell execution requires allow_local_shell=True")
 
+    async def _spawn_supervised_shell(
+        self,
+        argv: "Sequence[str]",
+        *,
+        cwd: "str | None",
+        stdout: Any,
+        task_id: str,
+        preview: str,
+        run_in_background: bool,
+        on_start_failure: "Callable[[], None] | None" = None,
+    ) -> asyncio.subprocess.Process:
+        """Spawn one parent-death-supervised shell, presenting cancel/failure identically for both shell kinds."""
+        try:
+            self.cancellation.raise_if_cancelled()
+            return await asyncio.create_subprocess_exec(
+                *argv,
+                cwd=cwd,
+                env=_shell_environment(),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=stdout,
+                stderr=asyncio.subprocess.STDOUT,
+                start_new_session=True,
+            )
+        except asyncio.CancelledError:
+            await self._present_shell(ShellPresentationEvent(task_id, preview, run_in_background, "cancelled"))
+            if on_start_failure is not None:
+                on_start_failure()
+            raise
+        except Exception:
+            await self._present_shell(ShellPresentationEvent(task_id, preview, run_in_background, "failed"))
+            if on_start_failure is not None:
+                on_start_failure()
+            raise
+
     async def _run_foreground_shell(
         self,
         command: str,
@@ -1100,28 +1134,14 @@ class MacOSComputer:
         task_id = f"shell-{uuid.uuid4().hex[:8]}"
         await self._present_shell(ShellPresentationEvent(task_id, preview, False, "starting"))
         started_at = time.monotonic()
-        try:
-            self.cancellation.raise_if_cancelled()
-            process = await asyncio.create_subprocess_exec(
-                "/bin/sh",
-                "-c",
-                _FOREGROUND_SUPERVISOR,
-                "yutori-shell",
-                str(os.getpid()),
-                "bash" if bash else "sh",
-                cwd=cwd,
-                env=_shell_environment(),
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-                start_new_session=True,
-            )
-        except asyncio.CancelledError:
-            await self._present_shell(ShellPresentationEvent(task_id, preview, False, "cancelled"))
-            raise
-        except Exception:
-            await self._present_shell(ShellPresentationEvent(task_id, preview, False, "failed"))
-            raise
+        process = await self._spawn_supervised_shell(
+            ["/bin/sh", "-c", _FOREGROUND_SUPERVISOR, "yutori-shell", str(os.getpid()), "bash" if bash else "sh"],
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            task_id=task_id,
+            preview=preview,
+            run_in_background=False,
+        )
         self._foreground_processes.add(process)
         await self._present_shell(ShellPresentationEvent(task_id, preview, False, "running"))
         try:
@@ -1152,30 +1172,15 @@ class MacOSComputer:
         status_path = output_path.with_suffix(".status")
         log_file = os.fdopen(descriptor, "wb")
         try:
-            try:
-                self.cancellation.raise_if_cancelled()
-                process = await asyncio.create_subprocess_exec(
-                    "/bin/sh",
-                    "-c",
-                    _BACKGROUND_SUPERVISOR,
-                    "yutori-background",
-                    str(os.getpid()),
-                    str(status_path),
-                    cwd=self._bash_cwd,
-                    env=_shell_environment(),
-                    stdin=asyncio.subprocess.PIPE,
-                    stdout=log_file,
-                    stderr=asyncio.subprocess.STDOUT,
-                    start_new_session=True,
-                )
-            except asyncio.CancelledError:
-                await self._present_shell(ShellPresentationEvent(task_id, preview, True, "cancelled"))
-                output_path.unlink(missing_ok=True)
-                raise
-            except Exception:
-                await self._present_shell(ShellPresentationEvent(task_id, preview, True, "failed"))
-                output_path.unlink(missing_ok=True)
-                raise
+            process = await self._spawn_supervised_shell(
+                ["/bin/sh", "-c", _BACKGROUND_SUPERVISOR, "yutori-background", str(os.getpid()), str(status_path)],
+                cwd=self._bash_cwd,
+                stdout=log_file,
+                task_id=task_id,
+                preview=preview,
+                run_in_background=True,
+                on_start_failure=lambda: output_path.unlink(missing_ok=True),
+            )
         finally:
             log_file.close()
         try:


### PR DESCRIPTION
## Structural issue

`yutori/navigator/macos/computer.py`'s `_run_foreground_shell` and `_run_background_shell` each hand-duplicated the same ~15-line block: spawn a parent-death-supervised `asyncio.create_subprocess_exec` child (identical `stdin=PIPE`/`stderr=STDOUT`/`start_new_session=True` wiring), and on `asyncio.CancelledError`/`Exception` present a `ShellPresentationEvent` (`"cancelled"`/`"failed"`) before re-raising. Only the argv, `cwd`, the `stdout` target (a pipe vs. a log file), and an extra temp-file cleanup on the background path actually differed.

This is the same shape as the recently-landed `#252`/`#254`/`#258` extractions in this same file/package (shared subprocess graceful-shutdown, parent-death-watcher shell fragment, stdio JSON-RPC boilerplate) — this is simply the next duplicated instance of that pattern within `computer.py` itself.

## Fix

Extracted `_spawn_supervised_shell(argv, *, cwd, stdout, task_id, preview, run_in_background, on_start_failure=None)`, which owns the spawn + cancel/failure presentation scaffolding. Both call sites now just pass their differing argv/cwd/stdout (and the background path's `on_start_failure=lambda: output_path.unlink(missing_ok=True)` cleanup callback).

## Why it's safe

- Purely internal: `_spawn_supervised_shell` and both call sites are private (`_`-prefixed) methods on `MacOSComputer`. No public API change.
- Behaviour-preserving: identical `argv`, identical subprocess kwargs, and the identical `ShellPresentationEvent` sequence on success/cancel/failure for both shell kinds — verified by diff, not just intent.
- Full test suite passes: `615 passed, 9 skipped` (including the foreground/background shell integration tests in `tests/test_navigator_macos_computer.py`, which spawn real subprocesses and assert on the exact event sequences and process-group lifecycle).
- `ruff check .` clean. (`ruff format --check` flags pre-existing, unrelated drift on this file predating this change — not introduced or touched here.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MTHU3PqSCGK6epgAMSUxm7)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor in macOS local shell spawning with behavior preserved; no auth or external API changes.
> 
> **Overview**
> **Deduplicates** parent-death-supervised shell startup in `MacOSComputer` by pulling the shared `create_subprocess_exec` path and cancel/failure `ShellPresentationEvent` handling into private **`_spawn_supervised_shell`**.
> 
> **`_run_foreground_shell`** and **`_run_background_shell`** now only pass their differing argv, `cwd`, stdout target (pipe vs log file), and the background-only **`on_start_failure`** cleanup that deletes the temp log on spawn failure. Subprocess kwargs, cancellation checks, and presentation on `"cancelled"` / `"failed"` at start time are unchanged—this is an internal refactor with no public API change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3f97159e04917e359dbb371791c993e1a73683b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->