### PR TITLE
fix(cli): register the MCP server as "yutori", not "uvx"

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Resolution order: explicit `api_key` > `YUTORI_API_KEY` env var > `~/.yutori/con
 The installer sets these up automatically when Node.js is available. To do it manually:
 
 ```bash
-npx add-mcp "uvx yutori-mcp"
+npx add-mcp -n yutori "uvx yutori-mcp"
 npx skills add yutori-ai/yutori-mcp -g
 ```
 

--- a/tests/test_install_flow.py
+++ b/tests/test_install_flow.py
@@ -810,6 +810,23 @@ def test_maybe_install_mcp_server_runs_add_mcp_on_consent():
     assert mock_run.call_args.args[0] == ("/usr/local/bin/npx", *MCP_SERVER_INSTALL_COMMAND[1:])
 
 
+def test_mcp_server_install_command_names_server_yutori():
+    # Regression: the interactive command used to omit `-n`, so add-mcp
+    # inferred the server name from the first word of "uvx yutori-mcp" and
+    # registered it as "uvx" in ~/.claude.json / ~/.codex/config.toml.
+    assert MCP_SERVER_INSTALL_COMMAND[MCP_SERVER_INSTALL_COMMAND.index("-n") + 1] == "yutori"
+    # The target stays a single argv token (add-mcp's quoted command string).
+    assert MCP_SERVER_INSTALL_COMMAND[-1] == "uvx yutori-mcp"
+
+
+def test_interactive_npx_commands_preanswer_npx_package_prompt():
+    # `-y` must sit directly after `npx` so npx consumes it (skipping its
+    # "Need to install the following packages" prompt) instead of forwarding
+    # it to add-mcp/skills.
+    for command in (MCP_SERVER_INSTALL_COMMAND, MCP_SKILLS_INSTALL_COMMAND):
+        assert command[:2] == ("npx", "-y")
+
+
 def test_maybe_install_mcp_server_failure_includes_retry_hint():
     # run_interactive_command inherits stdio so stdout/stderr are None in
     # production. The failure detail should still be useful — a retry hint
@@ -821,7 +838,7 @@ def test_maybe_install_mcp_server_failure_includes_retry_hint():
 
     assert result.status == "failed"
     assert "status 1" in result.detail
-    assert "npx add-mcp" in result.detail
+    assert "add-mcp -n yutori" in result.detail
 
 
 def test_maybe_install_mcp_server_returncode_127_uses_generic_message():
@@ -837,7 +854,7 @@ def test_maybe_install_mcp_server_returncode_127_uses_generic_message():
     assert result.status == "failed"
     assert "status 127" in result.detail
     assert "Could not execute" not in result.detail
-    assert "npx add-mcp" in result.detail
+    assert "add-mcp -n yutori" in result.detail
 
 
 def test_maybe_install_mcp_server_failure_surfaces_timeout():
@@ -848,7 +865,7 @@ def test_maybe_install_mcp_server_failure_surfaces_timeout():
 
     assert result.status == "failed"
     assert "Timed out" in result.detail
-    assert "npx add-mcp" in result.detail
+    assert "add-mcp -n yutori" in result.detail
 
 
 def test_maybe_install_mcp_skills_runs_global_skills_on_consent():

--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -61,11 +61,16 @@ def _slate_line(text: str) -> str:
 VERIFICATION_TASK = "Give me a list of all employees (names and titles) of Yutori."
 VERIFICATION_URL = "https://yutori.com"
 VERIFICATION_MAX_STEPS = 3
-# `add-mcp` takes a single quoted command-string argument. The third tuple
+# `npx -y` answers npx's own "Need to install the following packages" prompt;
+# the user has already confirmed the step and seen the exact package name, so
+# that prompt is a second speed bump rather than a safeguard.
+# `add-mcp` takes a single quoted command-string argument, so the last tuple
 # element is intentionally one argv token, not two (mirrors the README:
-# `npx add-mcp "uvx yutori-mcp"`).
-MCP_SERVER_INSTALL_COMMAND = ("npx", "add-mcp", "uvx yutori-mcp")
-MCP_SKILLS_INSTALL_COMMAND = ("npx", "skills", "add", "yutori-ai/yutori-mcp", "-g")
+# `npx add-mcp -n yutori "uvx yutori-mcp"`). `-n yutori` is required: without
+# it add-mcp infers the server name from the first word of the target and
+# registers the server as "uvx".
+MCP_SERVER_INSTALL_COMMAND = ("npx", "-y", "add-mcp", "-n", "yutori", "uvx yutori-mcp")
+MCP_SKILLS_INSTALL_COMMAND = ("npx", "-y", "skills", "add", "yutori-ai/yutori-mcp", "-g")
 # Default set of clients to register MCP for when YUTORI_INSTALL_CLIENT is
 # unset in non-TTY installs. Covers the most-used coding agents without
 # spraying config files for every one of the ~14 supported clients


### PR DESCRIPTION
## Summary

- Interactive installs ran `npx add-mcp "uvx yutori-mcp"` with no `-n`, so `add-mcp` inferred the server name from the first word of the target and registered it as **`uvx`** — `mcpServers.uvx` in `~/.claude.json`, `[mcp_servers.uvx]` in `~/.codex/config.toml`. The non-interactive path already passed `-n yutori`; this brings the interactive command (`MCP_SERVER_INSTALL_COMMAND`) and the README's manual command in line.
- Both interactive `npx` invocations now pass npx's own `-y`, so users aren't prompted twice per step — once by our "Install …?" confirmation and again by npx's "Need to install the following packages … Ok to proceed?" for `add-mcp` / `skills`.

Observed on a fresh `curl -fsSL https://yutori.com/install.sh | bash` of 0.9.3 today.

## Changes

- `yutori/cli/commands/install_flow.py`: `MCP_SERVER_INSTALL_COMMAND = ("npx", "-y", "add-mcp", "-n", "yutori", "uvx yutori-mcp")`, `MCP_SKILLS_INSTALL_COMMAND = ("npx", "-y", "skills", "add", "yutori-ai/yutori-mcp", "-g")`; comment explains why `-n` is required.
- `README.md`: manual command is now `npx add-mcp -n yutori "uvx yutori-mcp"`.
- `tests/test_install_flow.py`: two regression tests (server name is `yutori`; `-y` sits directly after `npx` so npx consumes it), and the three retry-hint assertions updated for the new argv.

## Not changed

- Non-interactive `add-mcp` command and `llms.txt` — they already used `-n yutori`.
- Existing users who already have a `uvx` entry: clean up with `claude mcp remove uvx` / delete `[mcp_servers.uvx]`; re-running the installer adds the correctly named entry.

## Validation

- `ruff check` clean; `pytest tests/test_install_flow.py`: 83 passed (81 existing + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Installer and docs-only argv changes for MCP registration; behavior fix with regression tests and no auth or API surface changes.
> 
> **Overview**
> Interactive MCP setup now runs **`npx -y add-mcp -n yutori "uvx yutori-mcp"`** (and **`npx -y skills add …`** for workflow skills), fixing a bug where missing **`-n`** caused **`add-mcp`** to register the server as **`uvx`** in editor configs instead of **`yutori`**.
> 
> **`-y`** immediately after **`npx`** skips npx’s package-install prompt after the installer already asked for consent. The README manual steps match the new argv, and tests lock in the server name, target string, **`-y`** placement, and updated failure retry hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f361d2833819489dcca419a81766ae7c05334be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->