### PR TITLE
fix(cli): use poetry add for Poetry projects instead of assuming uv add

### DIFF
--- a/tests/test_install_flow.py
+++ b/tests/test_install_flow.py
@@ -187,7 +187,7 @@ def test_hidden_install_ui_alias_dispatches_to_install_flow_command():
         assert label in flow_result.stdout
 
 
-def test_detect_sdk_install_plan_prefers_pyproject(tmp_path: Path, monkeypatch):
+def test_detect_sdk_install_plan_uses_uv_for_pep621_project(tmp_path: Path, monkeypatch):
     (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 
@@ -197,6 +197,90 @@ def test_detect_sdk_install_plan_prefers_pyproject(tmp_path: Path, monkeypatch):
     assert plan.command == ("/usr/bin/uv", "add", "yutori")
     assert plan.default is True
     assert plan.availability_error is None
+
+
+def test_detect_sdk_install_plan_uses_poetry_for_poetry_project(tmp_path: Path, monkeypatch):
+    # No Python range anywhere in the project: Poetry would reject `yutori`
+    # (Requires-Python >=3.9) against its implicit "any Python", so the SDK's
+    # range is stated on the dependency.
+    (tmp_path / "pyproject.toml").write_text("[tool.poetry]\nname='demo'\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("yutori.cli.commands.install_flow._which", return_value="/usr/bin/poetry"),
+        patch("yutori.cli.commands.install_flow._yutori_requires_python", return_value=">=3.9"),
+    ):
+        plan = detect_sdk_install_plan()
+
+    assert plan.reason == "Detected a Poetry project in the current directory."
+    assert plan.command == ("/usr/bin/poetry", "add", "--python", ">=3.9", "yutori")
+    assert plan.default is True
+    assert plan.availability_error is None
+
+
+def test_detect_sdk_install_plan_poetry_project_with_python_range_omits_python_flag(tmp_path: Path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.poetry]\nname = "demo"\n\n[tool.poetry.dependencies]\npython = "^3.11"  # trailing comment\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("yutori.cli.commands.install_flow._which", return_value="/usr/bin/poetry"),
+        patch("yutori.cli.commands.install_flow._yutori_requires_python", return_value=">=3.9"),
+    ):
+        plan = detect_sdk_install_plan()
+
+    assert plan.command == ("/usr/bin/poetry", "add", "yutori")
+
+
+def test_detect_sdk_install_plan_prefers_poetry_for_pep621_project_managed_by_poetry(tmp_path: Path, monkeypatch):
+    # Poetry 2 projects carry both tables; `uv add` would edit [project] and
+    # leave poetry.lock stale, so Poetry wins. `requires-python` counts as a
+    # declared range.
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nrequires-python = ">=3.11"\n\n[tool.poetry]\npackage-mode = false\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("yutori.cli.commands.install_flow._which", return_value="/usr/bin/poetry"),
+        patch("yutori.cli.commands.install_flow._yutori_requires_python", return_value=">=3.9"),
+    ):
+        plan = detect_sdk_install_plan()
+
+    assert plan.reason == "Detected a Poetry project in the current directory."
+    assert plan.command == ("/usr/bin/poetry", "add", "yutori")
+
+
+def test_detect_sdk_install_plan_flags_missing_poetry(tmp_path: Path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text("[tool.poetry]\nname='demo'\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("yutori.cli.commands.install_flow._which", return_value=None),
+        patch("yutori.cli.commands.install_flow._yutori_requires_python", return_value=">=3.9"),
+    ):
+        plan = detect_sdk_install_plan()
+
+    assert plan.command == ("poetry", "add", "--python", ">=3.9", "yutori")
+    assert plan.availability_error == "`poetry` is required for Poetry project installs."
+
+
+def test_detect_sdk_install_plan_does_not_treat_tool_only_pyproject_as_uv_project(tmp_path: Path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text("[tool.ruff]\nline-length=100\n", encoding="utf-8")
+    venv_python = tmp_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    venv_python.chmod(0o755)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / ".venv"))
+
+    with patch("yutori.cli.commands.install_flow.python_has_pip", return_value=True):
+        plan = detect_sdk_install_plan()
+
+    assert plan.command == (str(venv_python), "-m", "pip", "install", "yutori")
 
 
 def test_detect_sdk_install_plan_uses_bootstrap_uv_env_var(tmp_path: Path, monkeypatch):

--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -26,7 +26,7 @@ import sys
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, metadata, version
 from pathlib import Path
 from typing import Literal
 
@@ -416,6 +416,13 @@ def _yutori_version() -> str:
         return "unknown"
 
 
+def _yutori_requires_python() -> str | None:
+    try:
+        return metadata("yutori").get("Requires-Python") or None
+    except PackageNotFoundError:
+        return None
+
+
 def render_header(console: Console, *, interactive: bool) -> None:
     mode = "Interactive terminal detected." if interactive else "Non-interactive terminal detected."
     # Only used when bash didn't render its own intro (direct
@@ -534,14 +541,71 @@ def inspect_cli_install(env: Mapping[str, str] | None = None) -> tuple[CLIInstal
     return state, StepResult("CLI", "success", detail)
 
 
+def _pyproject_declared_keys(path: Path) -> set[str]:
+    """Return the dotted table headers and simple keys declared by ``path``.
+
+    Table headers appear as-is (``"tool.poetry"``); ``key = value`` lines
+    appear prefixed by their table (``"project.requires-python"``,
+    ``"tool.poetry.dependencies.python"``). The installer supports Python 3.9+,
+    so it cannot rely on stdlib ``tomllib``; this is enough to recognize the
+    canonical project formats and whether they pin a Python range, without
+    parsing arbitrary TOML values.
+    """
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError):
+        return set()
+
+    keys: set[str] = set()
+    table = ""
+    for line in lines:
+        candidate = line.partition("#")[0].strip()
+        if not candidate:
+            continue
+        if candidate.startswith("[") and candidate.endswith("]"):
+            table = "".join(candidate.strip("[]").split()).replace('"', "").replace("'", "")
+            keys.add(table)
+            continue
+        key, separator, _ = candidate.partition("=")
+        key = key.strip().strip("\"'")
+        if separator and key:
+            keys.add(f"{table}.{key}" if table else key)
+    return keys
+
+
 def detect_sdk_install_plan(cwd: Path | None = None, env: Mapping[str, str] | None = None) -> SDKInstallPlan:
     resolved_cwd = cwd or Path.cwd()
     resolved_env = _resolve_env(env)
 
-    if (resolved_cwd / "pyproject.toml").exists():
+    pyproject_path = resolved_cwd / "pyproject.toml"
+    pyproject_keys = _pyproject_declared_keys(pyproject_path) if pyproject_path.exists() else set()
+    if "tool.poetry" in pyproject_keys:
+        poetry_path = _which("poetry", resolved_env)
+        poetry_command = [poetry_path or "poetry", "add"]
+        declares_python_range = bool(
+            {"project.requires-python", "tool.poetry.dependencies.python"} & pyproject_keys
+        )
+        requires_python = _yutori_requires_python()
+        if requires_python and not declares_python_range:
+            # A Poetry project with no Python range of its own is treated by
+            # Poetry as supporting every Python, so it refuses any dependency
+            # that pins one. Stating the SDK's range on this dependency is the
+            # only way `poetry add` succeeds there. Projects that declare a
+            # range resolve fine without it, and shouldn't get a redundant
+            # `python = ...` marker written into their pyproject.
+            poetry_command.extend(("--python", requires_python))
+        poetry_command.append("yutori")
+        return SDKInstallPlan(
+            reason="Detected a Poetry project in the current directory.",
+            command=tuple(poetry_command),
+            default=True,
+            availability_error=None if poetry_path else "`poetry` is required for Poetry project installs.",
+        )
+
+    if "project" in pyproject_keys:
         uv_path = resolve_uv_path(resolved_env)
         return SDKInstallPlan(
-            reason="Detected pyproject.toml in the current directory.",
+            reason="Detected a PEP 621 project in the current directory.",
             command=((uv_path or "uv"), "add", "yutori"),
             default=True,
             availability_error=None if uv_path else "`uv` is required for project installs.",


### PR DESCRIPTION
## Summary

The installer's "Python SDK" step proposed `uv add yutori` for **any** `pyproject.toml`. In a legacy Poetry project (no `[project]` table) that fails:

```
SDK   FAIL   error: Project is missing a `[project]` table; add a `[project]` table to use production dependencies, or run `uv add --dev` instead
```

Seen on a fresh `curl | bash` install of 0.9.3 inside the Yutori monorepo today.

## Changes

`detect_sdk_install_plan` now classifies the file with a small header/key scanner (`_pyproject_declared_keys` — `tomllib` isn't available on 3.9/3.10, and we only need headers and simple keys):

| `pyproject.toml` | Plan |
|---|---|
| has `[tool.poetry]` | `poetry add yutori` — plus `--python <SDK Requires-Python>` **only** when the project declares no Python range (`project.requires-python` / `tool.poetry.dependencies.python`). Without a range, Poetry treats the project as supporting every Python and rejects any dependency that pins one; with one, the flag would just write a redundant `python = …` marker into the user's file. |
| has `[project]` (no Poetry) | `uv add yutori`, unchanged |
| tool-only (e.g. just `[tool.ruff]`) | falls through to active-venv / user-site logic instead of being misclassified as a uv project |

Poetry wins when both tables are present (Poetry 2 projects): `uv add` would edit `[project]` and leave `poetry.lock` stale. Missing `poetry` on PATH is reported as an availability error like the existing uv/pip cases.

## Validation

- `pytest tests/test_install_flow.py`: 88 passed — 7 new/updated tests covering Poetry without a range (`--python` added), Poetry with a range (no flag), Poetry 2 + PEP 621 (Poetry wins, no flag), missing `poetry`, and tool-only pyproject fallback.
- Against the monorepo: the planner yields `poetry add --python '>=3.9' yutori`; `poetry add --dry-run --python '>=3.9' yutori` resolves `yutori (0.9.3)` with no files modified.
- `ruff check` clean.

## Credit

Initial detection logic and tests drafted by Codex during the same investigation; this PR narrows the `--python` flag to projects that actually need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to installer SDK command selection and planning logic, with broad test coverage and no auth or runtime API impact.
> 
> **Overview**
> The install flow’s **Python SDK** step no longer runs `uv add yutori` for every `pyproject.toml`. It now inspects the file with a lightweight `_pyproject_declared_keys` scanner (no full TOML parse on 3.9/3.10) and picks the install command from what’s declared.
> 
> **Poetry** (`[tool.poetry]`) is preferred when present—including Poetry 2 layouts that also have `[project]`—and plans `poetry add yutori`. If the project does not declare a Python range (`requires-python` or `tool.poetry.dependencies.python`), the planner adds `--python` from the installed package’s **Requires-Python** metadata so `poetry add` succeeds; projects that already pin Python omit that flag. Missing `poetry` on PATH surfaces an availability error like the existing uv/pip cases.
> 
> **PEP 621** projects with `[project]` but no Poetry still use `uv add yutori`. **Tool-only** pyprojects (e.g. only `[tool.ruff]`) are no longer treated as uv projects and fall through to virtualenv `pip install` or user-site install as before.
> 
> Tests were expanded/renamed to cover Poetry with and without a Python range, Poetry-over-PEP-621, missing Poetry, and tool-only pyproject fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b2392fb766be276ea005514981cc0e4ec930321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->