### PR TITLE
fix(cli): render HTML task results as text in browse/research get

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,6 +57,13 @@ def test_html_to_text_keeps_table_rows_on_lines_and_separates_cells():
     assert html_to_text(raw) == "Name  Title\nAda  Eng"
 
 
+def test_html_to_text_drops_layout_whitespace_around_pretty_printed_cells():
+    # Server-rendered tables may be pretty-printed with newlines/indentation between
+    # tags; that layout whitespace must not leak into the cell separator/row break.
+    raw = "<table>\n<tr>\n<td>Ada</td><td>Eng</td>\n</tr>\n<tr>\n<td>Grace</td><td>Navy</td>\n</tr>\n</table>"
+    assert html_to_text(raw) == "Ada  Eng\nGrace  Navy"
+
+
 def test_html_to_text_drops_script_and_style_bodies():
     raw = "<p>keep</p><style>p { color: red }</style><script>alert(1)</script><p>this</p>"
     assert html_to_text(raw) == "keep\n\nthis"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner, Result
 
 from yutori import __version__
-from yutori.cli.commands import truncate_for_display
+from yutori.cli.commands import html_to_text, truncate_for_display
 from yutori.cli.main import app
 
 runner = CliRunner()
@@ -29,6 +29,42 @@ def test_truncate_for_display_budget_includes_ellipsis_is_a_hard_cap():
 def test_truncate_for_display_no_truncation_when_within_max_len():
     assert truncate_for_display("short", 47) == "short"
     assert truncate_for_display("short", 47, budget_includes_ellipsis=True) == "short"
+
+
+def test_html_to_text_unwraps_browsing_pre_markdown():
+    # Browsing results come back as entity-escaped markdown inside <pre>.
+    raw = (
+        "<pre>## Summary of Findings\n\n"
+        "| **Links** | &quot;Learn more&quot; \u2192 `https://iana.org/domains/example` |\n"
+        "I&#x27;m done.</pre>"
+    )
+    assert html_to_text(raw) == (
+        '## Summary of Findings\n\n| **Links** | "Learn more" \u2192 `https://iana.org/domains/example` |\nI\'m done.'
+    )
+
+
+def test_html_to_text_flattens_research_article_markup():
+    # Research results are full HTML documents.
+    raw = (
+        "<article>\n  <h3>Title</h3>\n  <p>First <b>bold</b> paragraph.</p>\n"
+        "  <ul><li>one</li><li>two</li></ul>\n<hr/>\n  <p>Last &amp; final.</p>\n</article>"
+    )
+    assert html_to_text(raw) == "Title\n\nFirst bold paragraph.\n\none\ntwo\n\nLast & final."
+
+
+def test_html_to_text_keeps_table_rows_on_lines_and_separates_cells():
+    raw = "<table><tr><th>Name</th><th>Title</th></tr><tr><td>Ada</td><td>Eng</td></tr></table>"
+    assert html_to_text(raw) == "Name  Title\nAda  Eng"
+
+
+def test_html_to_text_drops_script_and_style_bodies():
+    raw = "<p>keep</p><style>p { color: red }</style><script>alert(1)</script><p>this</p>"
+    assert html_to_text(raw) == "keep\n\nthis"
+
+
+def test_html_to_text_leaves_plain_text_alone():
+    for plain in ("No employee info", "a < b and b > c", "set <YOUR_KEY> here", "x &amp; y stays escaped"):
+        assert html_to_text(plain) == plain
 
 
 def _make_client_mock() -> MagicMock:
@@ -413,6 +449,39 @@ def test_browse_get_renders_markup_like_start_url_literally():
 # ---------------------------------------------------------------------------
 # Friendly API error handling: no tracebacks for routine failures.
 # ---------------------------------------------------------------------------
+
+
+def test_browse_get_renders_html_result_as_text():
+    client = _make_client_mock()
+    client.browsing.get.return_value = {
+        "task_id": "task-123",
+        "status": "succeeded",
+        "result": "<pre>Summary of findings: I&#x27;m trying to find a &quot;Team&quot; page.</pre>",
+    }
+
+    result = _invoke_cli(client, ["browse", "get", "task-123"])
+
+    assert result.exit_code == 0
+    assert "Result:" in result.stdout
+    assert 'Summary of findings: I\'m trying to find a "Team" page.' in result.stdout
+    assert "<pre>" not in result.stdout
+    assert "&#x27;" not in result.stdout
+
+
+def test_research_get_renders_html_result_as_text():
+    client = _make_client_mock()
+    client.research.get.return_value = {
+        "task_id": "research-123",
+        "status": "succeeded",
+        "result": "<article><h3>Heading</h3><p>Body &amp; more.</p></article>",
+    }
+
+    result = _invoke_cli(client, ["research", "get", "research-123"])
+
+    assert result.exit_code == 0
+    assert "Heading" in result.stdout
+    assert "Body & more." in result.stdout
+    assert "<article>" not in result.stdout
 
 
 def test_browse_get_api_error_prints_message_not_traceback():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,6 +64,12 @@ def test_html_to_text_drops_layout_whitespace_around_pretty_printed_cells():
     assert html_to_text(raw) == "Ada  Eng\nGrace  Navy"
 
 
+def test_html_to_text_keeps_significant_space_between_inline_tags():
+    # A whitespace-only text node between two inline tags (e.g. </b> and <i>) is a
+    # real word separator, unlike the layout whitespace around td/th cells above.
+    assert html_to_text("<b>Hello</b> <i>World</i>") == "Hello World"
+
+
 def test_html_to_text_drops_script_and_style_bodies():
     raw = "<p>keep</p><style>p { color: red }</style><script>alert(1)</script><p>this</p>"
     assert html_to_text(raw) == "keep\n\nthis"

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -332,14 +332,14 @@ class _HTMLTextExtractor(HTMLParser):
             self._suppress_layout_ws = True
         else:
             self._request_break(tag)
-            self._suppress_layout_ws = True
 
     def handle_endtag(self, tag: str) -> None:
         if tag in _HTML_SKIPPED_TAGS:
             self._skip_depth = max(0, self._skip_depth - 1)
+        elif tag in _HTML_CELL_TAGS:
+            self._suppress_layout_ws = True
         else:
             self._request_break(tag)
-            self._suppress_layout_ws = True
 
     def handle_data(self, data: str) -> None:
         if self._skip_depth:

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import contextlib
+import re
 from collections.abc import Callable, Iterator
+from html.parser import HTMLParser
 from typing import Any
 
 import httpx
@@ -27,6 +29,7 @@ __all__ = [
     "cli_client",
     "format_interval",
     "get_authenticated_client",
+    "html_to_text",
     "print_aligned_fields",
     "print_creation_result",
     "print_optional_field",
@@ -263,13 +266,115 @@ def print_task_get_header(console: Console, task_type: str, task_id: str, result
     print_rejection_reason(console, result)
 
 
+# Matches an opening or closing HTML tag. A bare "<" in prose ("a < b",
+# "<YOUR_KEY>" is *not* matched because the tag name must be followed by a
+# closing ">" on the same run) keeps plain-text results untouched.
+_HTML_TAG_RE = re.compile(r"<(?:/?[A-Za-z][A-Za-z0-9-]*)(?:\s[^<>]*)?/?>")
+# Block-level tags separate paragraphs (blank line between) when the document
+# is read as text; line-level tags start a new line. Inline tags (<b>, <code>,
+# <a>, ...) are dropped, keeping only their content.
+_HTML_PARAGRAPH_TAGS = frozenset(
+    {
+        "article",
+        "blockquote",
+        "div",
+        "footer",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "header",
+        "hr",
+        "ol",
+        "p",
+        "pre",
+        "section",
+        "table",
+        "ul",
+    }
+)
+_HTML_LINE_TAGS = frozenset({"br", "li", "tr"})
+_HTML_CELL_TAGS = frozenset({"td", "th"})
+_HTML_SKIPPED_TAGS = frozenset({"script", "style"})
+
+
+class _HTMLTextExtractor(HTMLParser):
+    """Collect an HTML document's text with block structure turned into line breaks.
+
+    Breaks are recorded as *pending* rather than written immediately: adjacent
+    boundaries (``</li><li>``, ``</h3>\n  <p>``) collapse to the larger request
+    instead of stacking, and the indentation whitespace between tags is
+    dropped while a break is pending. Whitespace inside content -- markdown in
+    a ``<pre>`` block, say -- is kept verbatim.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._chunks: list[str] = []
+        self._pending_breaks = 0
+        self._skip_depth = 0
+
+    def _request_break(self, tag: str) -> None:
+        if tag in _HTML_PARAGRAPH_TAGS:
+            self._pending_breaks = max(self._pending_breaks, 2)
+        elif tag in _HTML_LINE_TAGS:
+            self._pending_breaks = max(self._pending_breaks, 1)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in _HTML_SKIPPED_TAGS:
+            self._skip_depth += 1
+        elif tag in _HTML_CELL_TAGS:
+            if self._chunks and not self._pending_breaks:
+                self._chunks.append("  ")  # separate cells on the same row
+        else:
+            self._request_break(tag)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in _HTML_SKIPPED_TAGS:
+            self._skip_depth = max(0, self._skip_depth - 1)
+        else:
+            self._request_break(tag)
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth:
+            return
+        if self._pending_breaks and not data.strip():
+            return  # layout whitespace between tags
+        if self._chunks and self._pending_breaks:
+            self._chunks.append("\n" * self._pending_breaks)
+        self._pending_breaks = 0
+        self._chunks.append(data)
+
+    def text(self) -> str:
+        return "".join(self._chunks).strip()
+
+
+def html_to_text(text: str) -> str:
+    """Render task-result HTML as terminal text; return non-HTML input unchanged.
+
+    The API stores task results as HTML for the web dashboard: browsing
+    results arrive as entity-escaped markdown inside ``<pre>``, research
+    results as full ``<article>`` markup. In a terminal that shows up as
+    literal ``<pre>`` and ``&#x27;``. Unescape entities, keep one line per
+    block element, and drop the tags themselves.
+    """
+    if not _HTML_TAG_RE.search(text):
+        return text
+    extractor = _HTMLTextExtractor()
+    extractor.feed(text)
+    extractor.close()
+    return extractor.text()
+
+
 def print_task_result_output(console: Console, result: dict[str, Any], *, max_length: int = 2000) -> None:
-    """Print the ``result``/``output`` body of a task, truncated to ``max_length`` chars."""
+    """Print the ``result``/``output`` body of a task as text, truncated to ``max_length`` chars."""
     output = result.get("result") or result.get("output")
     if not output:
         return
     console.print("\n[bold]Result:[/bold]")
-    text = str(output)
+    text = html_to_text(str(output))
     if len(text) > max_length:
         text = text[:max_length] + "\n... (truncated)"
     console.print(text, markup=False)

--- a/yutori/cli/commands/__init__.py
+++ b/yutori/cli/commands/__init__.py
@@ -315,6 +315,7 @@ class _HTMLTextExtractor(HTMLParser):
         self._chunks: list[str] = []
         self._pending_breaks = 0
         self._skip_depth = 0
+        self._suppress_layout_ws = False
 
     def _request_break(self, tag: str) -> None:
         if tag in _HTML_PARAGRAPH_TAGS:
@@ -328,23 +329,27 @@ class _HTMLTextExtractor(HTMLParser):
         elif tag in _HTML_CELL_TAGS:
             if self._chunks and not self._pending_breaks:
                 self._chunks.append("  ")  # separate cells on the same row
+            self._suppress_layout_ws = True
         else:
             self._request_break(tag)
+            self._suppress_layout_ws = True
 
     def handle_endtag(self, tag: str) -> None:
         if tag in _HTML_SKIPPED_TAGS:
             self._skip_depth = max(0, self._skip_depth - 1)
         else:
             self._request_break(tag)
+            self._suppress_layout_ws = True
 
     def handle_data(self, data: str) -> None:
         if self._skip_depth:
             return
-        if self._pending_breaks and not data.strip():
-            return  # layout whitespace between tags
+        if (self._pending_breaks or self._suppress_layout_ws) and not data.strip():
+            return  # layout whitespace between tags, including around td/th cells
         if self._chunks and self._pending_breaks:
             self._chunks.append("\n" * self._pending_breaks)
         self._pending_breaks = 0
+        self._suppress_layout_ws = False
         self._chunks.append(data)
 
     def text(self) -> str:


### PR DESCRIPTION
## Summary

`yutori browse get` and `yutori research get` printed the API's `result` field verbatim. The API stores results as **HTML** for the web dashboard — browsing results as entity-escaped markdown inside `<pre>`, research results as full `<article>` markup — so terminals showed:

```
Result:
<pre>Summary of findings: I&#x27;m trying to find … an &quot;About&quot; or &quot;Team&quot; link …
```

The installer's verification summary reads the CLI's output and inherited the same noise (seen on today's fresh 0.9.3 install).

## Changes

- New `html_to_text()` in `yutori/cli/commands/__init__.py` (stdlib `html.parser`, no new deps): unescapes entities, emits one line per block element (`p`, `h1–h6`, `li`, `pre`, `br`, `hr`, `tr`, …), drops inline tags and `<script>`/`<style>` bodies, collapses gaps to one blank line. Input with no HTML tags is returned unchanged, so plain-text results and prose containing `<` (`a < b`, `<YOUR_KEY>`) are untouched.
- `print_task_result_output` runs the result through it before the 2000-char truncation, so the cap applies to visible text.

After (same task, via this branch):

```
Result:
Summary of findings: I'm trying to find a list of all Yutori employees (names
and titles) from the Yutori website (https://yutori.com/). … where an
"About" or "Team" link might be. …
```

## Not changed

- The API payload — the dashboard depends on HTML there; this is presentation in the terminal only.
- Markdown inside browsing results is shown as markdown text, not rendered (tables/bold stay as `|`/`**`). Rendering via `rich.markdown.Markdown` is a possible follow-up, but research results aren't markdown, so it would need per-task-type handling.

## Validation

- 7 new tests in `tests/test_cli.py`: browsing `<pre>` markdown unwrap, research `<article>` flattening (incl. indentation whitespace between tags), `<script>`/`<style>` dropping, plain-text passthrough, table cell separation, and end-to-end `browse get` / `research get` through the Typer app.
- Full fast suite green; `ruff check` clean.
- Live: `browse get` on today's verification task renders the text above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal-only presentation change with no API or auth impact; plain-text results are unchanged when no HTML tags are detected.
> 
> **Overview**
> **`browse get` and `research get`** no longer print API `result` HTML literally in the terminal. A new **`html_to_text()`** helper (stdlib `html.parser`) converts dashboard HTML into readable text before the existing 2000-character truncation in **`print_task_result_output`**.
> 
> The converter unescapes entities, maps block/line tags to line breaks, strips **`script`**/**`style`**, formats table cells with spacing, and **passes through** strings that do not look like HTML (e.g. `a < b`, `<YOUR_KEY>`). Browsing **`<pre>`** markdown and research **`<article>`** markup are flattened to plain text; markdown is not rendered.
> 
> Tests cover **`html_to_text`** edge cases and end-to-end **`browse get`** / **`research get`** CLI output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d13af8f9bacd30da5a5ecba4fa7d07b974e38b66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->