### PR TITLE
chore: prepare yutori 0.9.4

### DIFF
--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -16,7 +16,7 @@ Authenticate Yutori with yutori auth login or YUTORI_API_KEY. The sandbox exampl
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.3'
+pip install 'yutori[macos]==0.9.4'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -5,11 +5,11 @@ description = "Public Cua cookbooks for stable Yutori Navigator n2"
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "cua==0.1.6",
-    "yutori==0.9.3",
+    "yutori==0.9.4",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.3"]
+macos = ["yutori[macos]==0.9.4"]
 
 [tool.uv.sources]
 yutori = { path = "../..", editable = true }

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.3"
+YUTORI_INSTALLER_VERSION="0.9.4"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.3"
+version = "0.9.4"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/yutori/navigator/macos/assets/provenance.json
+++ b/yutori/navigator/macos/assets/provenance.json
@@ -1,6 +1,6 @@
 {
   "runtime": "yutori.navigator.macos",
-  "sdk_version": "0.9.3",
+  "sdk_version": "0.9.4",
   "overlay_protocol_version": 2,
   "renderer_protocol_version": 3,
   "source": "Public yutori SDK distribution",

--- a/yutori/navigator/macos/transport.py
+++ b/yutori/navigator/macos/transport.py
@@ -88,7 +88,7 @@ class CuaDriverTransport:
                 {
                     "protocolVersion": "2024-11-05",
                     "capabilities": {},
-                    "clientInfo": {"name": "yutori-python-sdk", "version": "0.9.3"},
+                    "clientInfo": {"name": "yutori-python-sdk", "version": "0.9.4"},
                 },
             )
             await self._notify("notifications/initialized")


### PR DESCRIPTION
## Summary
- prepare the next patch version needed to exercise the new manual release workflow
- synchronize embedded macOS metadata, exact cookbook pins, and the generated installer banner

## Validation
- `bash scripts/check_install_sh_fresh.sh`
- `bash -n install.sh`
- `pytest -q tests/test_bash_scripts.py`
- `pytest -m slow tests/test_packaging.py -q`

After merge, create the annotated `v0.9.4` tag and use **Publish yutori to PyPI** → **Run workflow** with that tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-string and dependency pin updates only; no behavioral or API changes in this diff.
> 
> **Overview**
> **Bumps the SDK from 0.9.3 to 0.9.4** across the release surface so the next patch can ship through the manual release workflow.
> 
> The package version in `pyproject.toml` is updated, and the same number is propagated to `install.sh` (`YUTORI_INSTALLER_VERSION`), Navigator n2 cookbook pins and README install line, macOS overlay `provenance.json`, and the MCP `initialize` `clientInfo.version` in `transport.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ece0d97df8fd194fb2d4144f331f343d68c05130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->