### PR TITLE
refactor(examples): dedupe stderr-append logic in cua_sandbox.py

### DIFF
--- a/examples/navigator_n2/cua_sandbox.py
+++ b/examples/navigator_n2/cua_sandbox.py
@@ -172,13 +172,16 @@ else:
 """
 
 
+def _append_stream(base: str, addition: str) -> str:
+    """Append a second output stream to the first, inserting a newline only where one is missing."""
+    if not addition:
+        return base
+    return f"{base}{'' if not base or base.endswith(chr(10)) else chr(10)}{addition}"
+
+
 def _result_output(result: Any) -> str:
     """Join Cua's separate stdout and stderr streams without losing either."""
-    output = str(getattr(result, "stdout", "") or "")
-    stderr = str(getattr(result, "stderr", "") or "")
-    if stderr:
-        output = f"{output}{'' if not output or output.endswith(chr(10)) else chr(10)}{stderr}"
-    return output
+    return _append_stream(str(getattr(result, "stdout", "") or ""), str(getattr(result, "stderr", "") or ""))
 
 
 def _truncate(text: str, max_chars: int = BASH_RESULT_MAX_CHARS) -> str:
@@ -372,9 +375,7 @@ class CuaSandboxComputer:
         body, marker, new_cwd = stdout.rpartition(f"\n{sentinel}")
         if marker:
             self._bash_cwd = new_cwd.strip() or cwd
-            stderr = str(getattr(result, "stderr", "") or "")
-            if stderr:
-                body = f"{body}{'' if not body or body.endswith(chr(10)) else chr(10)}{stderr}"
+            body = _append_stream(body, str(getattr(result, "stderr", "") or ""))
             return _format_shell_output(body, int(getattr(result, "returncode", 0) or 0))
         return _shell_result(result)
 


### PR DESCRIPTION
## What

`examples/navigator_n2/cua_sandbox.py` (the reference n2 computer-use handler, split out of `remote_sandbox.py` in #251) had the same "append a second output stream to the first, inserting a newline only where one is missing" expression hand-duplicated in two places:

- `_result_output()`'s `if stderr: ...` block
- `run_bash_command()`'s cwd-marker success branch (`if marker: ...`)

Both built the identical `f"{base}{'' if not base or base.endswith(chr(10)) else chr(10)}{addition}"` expression to join Cua's separate stdout/stderr streams.

## Why this is an improvement

Same drift risk as any hand-duplicated non-trivial expression: a future tweak to the join logic (e.g. a different separator, or handling a trailing-newline edge case) could easily be applied to one call site and not the other. Extracted a single `_append_stream(base, addition)` helper; both sites now delegate to it.

## Why it's safe

- Purely mechanical extraction — the helper's body is the exact same expression, just parameterized.
- Both call sites now produce byte-identical output to before (traced through by hand; also covered by `test_public_cua_adapter_preserves_bash_cwd_when_the_command_fails` in `tests/test_navigator_n2_cookbooks.py`, which exercises the exact stderr-append branch in `run_bash_command`).
- Example/reference code only, not part of the published `yutori` package's public API surface — zero impact on SDK consumers.
- 1 file changed, 9 insertions / 8 deletions.
- Full suite: 685 passed / 3 skipped / 1 deselected (`pytest -m "not slow"`), unchanged from baseline. `ruff check .` and `ruff format --check` on the touched file both clean.

## Test plan

- [x] `pytest -m "not slow"` — 685 passed, 3 skipped, 1 deselected (baseline-identical)
- [x] `pytest tests/test_navigator_n2_cookbooks.py` — 9 passed, including the stderr-append regression test
- [x] `ruff check .` — clean
- [x] `ruff format --check examples/navigator_n2/cua_sandbox.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aicpeFTAXmKePWwnPqT1H

---
_Generated by [Claude Code](https://claude.ai/code/session_018aicpeFTAXmKePWwnPqT1H)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor in example-only reference code with no logic change; existing cookbook tests cover the bash stderr-append path.
> 
> **Overview**
> Extracts a shared **`_append_stream(base, addition)`** helper in `examples/navigator_n2/cua_sandbox.py` so stdout/stderr joining (newline only when missing) lives in one place instead of being copy-pasted.
> 
> **`_result_output`** and the **`run_bash_command`** cwd-sentinel success path now call that helper; behavior is unchanged—same join rules, same n2 shell output formatting downstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7376c9b134eb1a1bc2fa8e7e1cfab54d1d819e99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->