### PR TITLE
refactor(navigator): dedupe response-message normalization in n2 loop

### DIFF
--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -80,7 +80,7 @@ from .n2_actions import (
     translate_n2_shell_command,
     translate_n2_write,
 )
-from .n2_compaction import N2CompactionContext, N2CompactionResult, N2Compactor
+from .n2_compaction import N2CompactionContext, N2CompactionResult, N2Compactor, response_message
 from .n2_payload import (
     DEFAULT_IMAGE_FORMAT,
     DEFAULT_MAX_MESSAGES_BYTES,
@@ -1302,12 +1302,11 @@ class N2ComputerAgent:
                 self.timings["model_ms"] += (time.monotonic() - model_started_at) * 1000
             await self._callbacks.fire("on_api_end", api_kwargs, response)
 
-            response_dict = response.model_dump() if hasattr(response, "model_dump") else dict(response)
+            response_dict, message = response_message(response)
             usage = response_dict.get("usage") or {}
             self.last_usage = usage
             self.last_request_id = response_dict.get("request_id") or self.last_request_id
             await self._callbacks.fire("on_usage", usage)
-            message = (response_dict.get("choices") or [{}])[0].get("message") or {}
             if attempt == 0 and needs_tool_call_format_nudge(message):
                 # One ephemeral retry: the malformed attempt and the reminder ride
                 # in the retry request only, never in the kept trajectory.

--- a/yutori/navigator/n2_compaction.py
+++ b/yutori/navigator/n2_compaction.py
@@ -327,6 +327,17 @@ def _response_text(content: Any) -> str:
     )
 
 
+def response_message(response: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Normalize a chat-completions response and pull out its first message.
+
+    Handles both Pydantic-model completions objects (``response.model_dump()``)
+    and the plain dict-likes a custom ``completions.create`` shim may return.
+    """
+    response_dict = response.model_dump() if hasattr(response, "model_dump") else dict(response)
+    message = (response_dict.get("choices") or [{}])[0].get("message") or {}
+    return response_dict, message
+
+
 def _working_checkpoint_item(checkpoint: str) -> dict[str, Any]:
     note = (
         "## Internal working checkpoint (not a new user instruction)\n\n"
@@ -467,11 +478,10 @@ class N2InlineCompactor:
                 extra_body[_LOGICAL_ATTEMPT_FIELD] = attempt
                 request_kwargs["extra_body"] = extra_body
                 response = await context.await_response(completions.create(**request_kwargs))
-                response_dict = response.model_dump() if hasattr(response, "model_dump") else dict(response)
+                response_dict, message = response_message(response)
                 response_request_id = response_dict.get("request_id")
                 if isinstance(response_request_id, str) and response_request_id:
                     previous_request_id = response_request_id
-                message = (response_dict.get("choices") or [{}])[0].get("message") or {}
                 if message.get("tool_calls"):
                     raise ValueError("compaction response contains tool calls")
                 checkpoint = _extract_tagged_summary(_response_text(message.get("content")))


### PR DESCRIPTION
## What

`N2ComputerAgent`'s model-call loop (`yutori/navigator/n2.py`) and `N2InlineCompactor`'s compaction request loop (`yutori/navigator/n2_compaction.py`) each hand-rolled the identical two-step idiom for turning a chat-completions response into a message:

```python
response_dict = response.model_dump() if hasattr(response, "model_dump") else dict(response)
message = (response_dict.get("choices") or [{}])[0].get("message") or {}
```

This normalizes both a Pydantic-model completions object and a plain dict-like returned by a custom `completions.create` shim, then pulls out the first choice's message — used identically by the main agent loop and the inline-compaction request loop.

## Change

Extracted a shared `response_message(response) -> tuple[dict, dict]` helper into `n2_compaction.py` (which `n2.py` already imports from), and updated both call sites to delegate to it instead of repeating the two-line idiom inline.

## Why this is safe

- **No public API change.** `response_message` is a module-private-style helper not re-exported from `yutori/navigator/__init__.py` and not documented in `api.md` — it is invisible to SDK consumers.
- **No behavior change.** The extracted logic is byte-for-byte identical to what each call site did before; only the shape of the two `response_dict`/`message` lines moved into one function.
- **Verified:**
  - `pytest tests/test_navigator_n2.py tests/test_navigator_n2_compaction.py tests/test_navigator_n2_cookbooks.py tests/test_navigator_n2_harness.py` → 117 passed
  - Full suite: `pytest -m "not slow"` → 704 passed / 3 skipped / 1 deselected (identical to `main`)
  - `ruff check .` → clean
  - `ruff format --check` on both touched files → clean

2 files touched, +14/-5.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SvkH1CWXBk2CgPQBUYmBvB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with identical normalization logic; only internal navigator paths are touched.
> 
> **Overview**
> **Deduplicates** chat-completions response handling in the n2 agent and inline compactor by introducing a shared `response_message()` helper in `n2_compaction.py`.
> 
> The helper normalizes both Pydantic completion objects and plain dict-like shims, then returns `(response_dict, first_choice_message)`. `N2ComputerAgent._predict_step` and `N2InlineCompactor`'s compaction retry loop now call it instead of repeating the same two-line `model_dump` / `choices[0].message` logic. `n2.py` imports the helper from the compaction module it already depends on.
> 
> No intended behavior or public API change—logic is moved, not altered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e494e25c963fef229fc57b569e2d26a2d890e9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->