### PR TITLE
refactor(navigator): dedupe hold_key/wait duration validation in n2_actions

### DIFF
--- a/yutori/navigator/n2_actions.py
+++ b/yutori/navigator/n2_actions.py
@@ -360,6 +360,13 @@ def native_point(value: Any, path: str, width: int, height: int) -> "tuple[int, 
     )
 
 
+def _validate_wait_seconds(duration: Any, field: str) -> "int | float":
+    """Validate a ``hold_key``/``wait`` duration: a number in [0, N2_MAX_WAIT_SECONDS]."""
+    if isinstance(duration, bool) or not isinstance(duration, (int, float)) or not 0 <= duration <= N2_MAX_WAIT_SECONDS:
+        raise N2ActionValidationError(f"{field} must be between 0 and {N2_MAX_WAIT_SECONDS} seconds")
+    return duration
+
+
 def _validate_fields(action: str, args: dict[str, Any]) -> None:
     if action not in _ACTION_FIELDS:
         raise N2ActionValidationError(f"unsupported n2 action: {action}")
@@ -483,23 +490,11 @@ def translate_n2_action(
             raise N2ActionValidationError("hold_key.key must name exactly one key")
         if "duration" not in args:
             return [internal("hold_key_until_next_action", key=sequence[0][0])]
-        duration = args["duration"]
-        if (
-            isinstance(duration, bool)
-            or not isinstance(duration, (int, float))
-            or not 0 <= duration <= N2_MAX_WAIT_SECONDS
-        ):
-            raise N2ActionValidationError(f"hold_key.duration must be between 0 and {N2_MAX_WAIT_SECONDS} seconds")
+        duration = _validate_wait_seconds(args["duration"], "hold_key.duration")
         return [internal("hold_key", key=sequence[0][0], ms=round(float(duration) * 1000))]
 
     if action == "wait":
-        duration = args.get("duration", N2_DEFAULT_WAIT_SECONDS)
-        if (
-            isinstance(duration, bool)
-            or not isinstance(duration, (int, float))
-            or not 0 <= duration <= N2_MAX_WAIT_SECONDS
-        ):
-            raise N2ActionValidationError(f"wait.duration must be between 0 and {N2_MAX_WAIT_SECONDS} seconds")
+        duration = _validate_wait_seconds(args.get("duration", N2_DEFAULT_WAIT_SECONDS), "wait.duration")
         return [internal("wait", ms=round(float(duration) * 1000))]
 
     if action == "screenshot":


### PR DESCRIPTION
## What

`translate_n2_action` in `yutori/navigator/n2_actions.py` validates the `hold_key` and `wait` action's `duration` argument with the identical numeric-range check — bool-excluded `int`/`float` in `[0, N2_MAX_WAIT_SECONDS]` — differing only in the field name baked into the error message (`hold_key.duration` vs `wait.duration`) and the default value used when `duration` is absent (only `wait` has one; `hold_key` treats a missing `duration` as "hold until the next action").

Extracted the shared check into `_validate_wait_seconds(duration, field) -> int | float`; both call sites now delegate to it.

## Why

The two validation blocks were byte-for-byte identical apart from the field name in the message — a duplicated pattern with real drift risk (the two independently-maintained bound checks could silently diverge on a future edit to one but not the other, e.g. a widened range or a `bool` exclusion fix).

## Why it's safe

- **No behavior change.** The extracted logic is exactly what each site did before, including the exact error message text (`f"{field} must be between 0 and {N2_MAX_WAIT_SECONDS} seconds"` reproduces both `"hold_key.duration must be ..."` and `"wait.duration must be ..."` verbatim).
- **Scoped to one file**, no call-site changes elsewhere — `translate_n2_action`'s public behavior and signature are unchanged.
- **Verified:**
  - Targeted n2 tests (`test_navigator_n2.py`, `test_navigator_n2_cookbooks.py`, `test_navigator_n2_harness.py`, `test_navigator_n2_compaction.py`): 121 passed.
  - Full suite (`pytest -m "not slow"`): 659 passed, 9 skipped, 1 deselected — matches `main`.
  - `ruff check .` and `ruff format --check yutori/navigator/n2_actions.py`: clean.

This is a pure structural refactor with no functional change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PAuTfxfMJgwUpMeUtnkvuC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure structural deduplication in n2 action translation with no intended behavior or API changes; existing n2 tests cover the validated paths.
> 
> **Overview**
> Consolidates identical **`hold_key.duration`** and **`wait.duration`** checks in `translate_n2_action` into a shared **`_validate_wait_seconds(duration, field)`** helper in `n2_actions.py`.
> 
> Both action branches now call that helper (with the same field-specific error labels and **`wait`**’s default when **`duration`** is omitted). Validation rules are unchanged: non-bool **`int`/`float`** in **`[0, N2_MAX_WAIT_SECONDS]`**, with **`hold_key`** still using **`hold_key_until_next_action`** when **`duration`** is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 645a1535f3730c24da1f0210def8d5678863c881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->