### PR TITLE
feat(navigator): public completion_request() for harness-owned wrap-up turns

### DIFF
--- a/tests/test_navigator_n2.py
+++ b/tests/test_navigator_n2.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import copy
 import io
 import json
 import time
@@ -1260,3 +1261,30 @@ def test_converter_preserves_plain_string_assistant_turns():
         ]
     )
     assert {"role": "assistant", "content": "earlier answer"} in messages
+
+
+@pytest.mark.asyncio
+async def test_completion_request_is_public_wrapup_surface() -> None:
+    """completion_request() returns the actor's exact next request — windowed messages,
+    sampling fields, chaining — with optional harness-owned extra messages appended,
+    without advancing the loop or mutating the trajectory."""
+    agent = N2ComputerAgent(
+        computer=FakeComputer(),
+        tool_set=TOOL_SET_COMPUTER_USE_HYBRID_BATCH,
+        completions=FakeCompletions([_turn({"content": "Done.", "tool_calls": []})]),
+        screenshot_delay=0,
+    )
+    async for _step in agent.run("task"):
+        pass
+    before = copy.deepcopy(agent.trajectory)
+    nudge = {"role": "user", "content": [{"type": "text", "text": "Stop here. Summarize."}]}
+    request = agent.completion_request([nudge])
+    assert request["model"] == agent.model
+    assert request["tool_set"] == agent.tool_set
+    assert request["max_completion_tokens"] == agent.max_completion_tokens
+    assert request["messages"][-1] == nudge
+    # the trajectory itself renders just before the nudge, exactly as the loop would send it
+    assert request["messages"][:-1] == agent._prepare_completion_messages(agent.trajectory)
+    assert agent.trajectory == before
+    if agent.last_request_id is not None:
+        assert request["extra_body"]["prev_request_id"] == agent.last_request_id

--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -1280,6 +1280,26 @@ class N2ComputerAgent:
             )
         return completion_messages
 
+    def completion_request(self, extra_messages: "list[dict[str, Any]] | None" = None) -> dict[str, Any]:
+        """The actor's next Chat Completions request for the current trajectory.
+
+        Returns exactly what the loop itself would send — system prompt, image-windowed
+        messages, sampling fields, and request chaining — optionally with ``extra_messages``
+        (chat-format) appended after the trajectory. Useful for harness-owned turns that
+        must not advance the loop or execute tools, such as a step-cap "stop and
+        summarize" wrap-up: send it yourself with the same client,
+        ``await client.chat.completions.create(**agent.completion_request([nudge]))``.
+        The call and its response stay the caller's own; the trajectory is not changed.
+        """
+        request = self._completion_request_kwargs()
+        messages = self._prepare_completion_messages(self.trajectory)
+        if extra_messages:
+            messages = messages + copy.deepcopy(list(extra_messages))
+        request["messages"] = messages
+        if self.last_request_id is not None:
+            request["extra_body"] = {**(request.get("extra_body") or {}), "prev_request_id": self.last_request_id}
+        return request
+
     def _completion_request_kwargs(self) -> dict[str, Any]:
         """Return resolved actor call fields other than messages and chaining."""
 

--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -1280,22 +1280,27 @@ class N2ComputerAgent:
             )
         return completion_messages
 
-    def completion_request(self, extra_messages: "list[dict[str, Any]] | None" = None) -> dict[str, Any]:
+    def completion_request(
+        self, extra_messages: "list[dict[str, Any]] | None" = None, *, items: "list[dict[str, Any]] | None" = None
+    ) -> dict[str, Any]:
         """The actor's next Chat Completions request for the current trajectory.
 
-        Returns exactly what the loop itself would send — system prompt, image-windowed
+        Returns exactly what the loop itself sends — system prompt, image-windowed
         messages, sampling fields, and request chaining — optionally with ``extra_messages``
         (chat-format) appended after the trajectory. Useful for harness-owned turns that
         must not advance the loop or execute tools, such as a step-cap "stop and
         summarize" wrap-up: send it yourself with the same client,
         ``await client.chat.completions.create(**agent.completion_request([nudge]))``.
         The call and its response stay the caller's own; the trajectory is not changed.
+        ``items`` overrides the rendered trajectory (the loop's own steps pass their
+        in-flight working set).
         """
         request = self._completion_request_kwargs()
-        messages = self._prepare_completion_messages(self.trajectory)
+        # Historical merge order: callers should not pass ``messages`` through
+        # completion_kwargs, but it previously won if they did.
+        request.setdefault("messages", self._prepare_completion_messages(self.trajectory if items is None else items))
         if extra_messages:
-            messages = messages + copy.deepcopy(list(extra_messages))
-        request["messages"] = messages
+            request["messages"] = list(request["messages"]) + copy.deepcopy(list(extra_messages))
         if self.last_request_id is not None:
             request["extra_body"] = {**(request.get("extra_body") or {}), "prev_request_id": self.last_request_id}
         return request
@@ -1324,7 +1329,8 @@ class N2ComputerAgent:
         return await _await_model_response(self.computer, awaitable)
 
     async def _predict_step(self, items: list[dict[str, Any]]) -> dict[str, Any]:
-        completion_messages = self._prepare_completion_messages(items)
+        api_kwargs = self.completion_request(items=items)
+        completion_messages = api_kwargs["messages"]
 
         latest_url = latest_image_url(completion_messages)
         if latest_url is None:
@@ -1342,11 +1348,6 @@ class N2ComputerAgent:
                 native_width, native_height = await self._resolve_native_size()
             else:
                 native_width, native_height = image_dimensions(latest_url)
-
-        api_kwargs = self._completion_request_kwargs()
-        # Preserve the historical merge order: callers should not pass
-        # ``messages`` through completion_kwargs, but it previously won if they did.
-        api_kwargs.setdefault("messages", completion_messages)
 
         for attempt in (0, 1):
             if self.last_request_id is not None:


### PR DESCRIPTION
## Summary

Adds one public method to `N2ComputerAgent`:

**`completion_request(extra_messages=None)`** — returns the actor's exact next Chat Completions request (system prompt, image-windowed messages, sampling fields, `prev_request_id` chaining), optionally with caller-supplied chat messages appended. It does not advance the loop, execute tools, or mutate the trajectory.

## Why

A harness sometimes needs one more model turn that must never execute tools — e.g. the praxis eval harness's step-cap "stop and summarize" wrap-up, whose text becomes the scored answer. `resume()` is the wrong vehicle (it re-enters the loop, so a tool-call reply gets executed). Before this, the eval mirror harness (yutori#12808) reached into `_prepare_completion_messages`/`_resolve_completions`; it now composes the wrap-up entirely on public surface:

```python
nudge = {"role": "user", "content": [{"type": "text", "text": STOP_AND_SUMMARIZE}]}
response = await client.chat.completions.create(**agent.completion_request([nudge]))
```

## Testing

- New test: request carries model/tool_set/max_completion_tokens, renders the trajectory exactly as the loop would, appends the extra message, leaves the trajectory untouched.
- Full suite: 661 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQn7mTTxR8tBuK7G4SSiKE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public API addition with internal refactor to a shared code path; no change to tool execution or trajectory semantics during normal runs.
> 
> **Overview**
> Adds **`completion_request()`** on `N2ComputerAgent` so harnesses can obtain the **same** Chat Completions kwargs the loop would send—system prompt, image-windowed messages, sampling fields, and `prev_request_id` chaining—with optional chat-format **`extra_messages`** appended and **`items`** overriding the trajectory slice. The method does **not** advance the loop, run tools, or change **`trajectory`**.
> 
> **`_predict_step`** now builds its API call via **`completion_request(items=items)`** instead of duplicating message prep and kwargs assembly.
> 
> New test **`test_completion_request_is_public_wrapup_surface`** checks model/tool_set/token limits, trajectory rendering parity with the loop, nudge append, trajectory immutability, and chaining when **`last_request_id`** is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb968e78e5be4f89926af359f9eeb7f1e11f6cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->