### PR TITLE
refactor(navigator): dedupe grep head_limit validation in n2_actions

### DIFF
--- a/yutori/navigator/n2_actions.py
+++ b/yutori/navigator/n2_actions.py
@@ -640,8 +640,10 @@ def _optional_boolean(args: dict[str, Any], field: str, tool_name: str, *, defau
     return value
 
 
-def _optional_nonnegative_integer(args: dict[str, Any], field: str, tool_name: str) -> int | None:
-    value = args.get(field)
+def _optional_nonnegative_integer(
+    args: dict[str, Any], field: str, tool_name: str, *, default: int | None = None
+) -> int | None:
+    value = args.get(field, default)
     if value is not None and (not is_strict_int(value) or value < 0):
         raise N2ActionValidationError(f"{tool_name}.{field} must be a non-negative integer or null")
     return value
@@ -658,9 +660,7 @@ def translate_n2_grep(args: dict[str, Any]) -> list[dict[str, Any]]:
         output_mode = "files_with_matches"
     if output_mode not in {"content", "files_with_matches", "count"}:
         raise N2ActionValidationError("grep.output_mode must be content, files_with_matches, count, or null")
-    head_limit = args.get("head_limit", N2_GREP_DEFAULT_HEAD_LIMIT)
-    if head_limit is not None and (not is_strict_int(head_limit) or head_limit < 0):
-        raise N2ActionValidationError("grep.head_limit must be a non-negative integer or null")
+    head_limit = _optional_nonnegative_integer(args, "head_limit", "grep", default=N2_GREP_DEFAULT_HEAD_LIMIT)
     return [
         internal_file_action(
             "grep_files",


### PR DESCRIPTION
## Summary
- `translate_n2_grep` hand-rolled the same "non-negative integer or null" check that `_optional_nonnegative_integer` already implements for the `-B`/`-A`/`-C` fields, differing only in its custom default (`N2_GREP_DEFAULT_HEAD_LIMIT` vs `None`).
- Gave `_optional_nonnegative_integer` a `default` keyword (mirroring `_optional_boolean`'s existing convention) and routed `head_limit` through it instead of a hand-duplicated inline check.
- No behavior change: identical error message, identical default-substitution semantics (`args.get(field, default)` then the same strict-int/non-negative check).

## Test plan
- [x] `pytest -q` — 661 passed, 9 skipped (pre-existing environment-only skips), no change from baseline
- [x] `ruff check .` — clean
- [x] `ruff format --check .` on the touched file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VodUcizDRNVRNWASwTs1HL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VodUcizDRNVRNWASwTs1HL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal validation refactor in n2 grep translation with no intended semantic change.
> 
> **Overview**
> **Refactors `grep.head_limit` validation** so it goes through `_optional_nonnegative_integer` instead of a one-off inline check in `translate_n2_grep`.
> 
> The helper now accepts an optional **`default`** keyword (same pattern as `_optional_boolean`), using `args.get(field, default)` before the strict non-negative integer check. `head_limit` is passed `default=N2_GREP_DEFAULT_HEAD_LIMIT`; `-B`/`-A`/`-C` keep omitting `default` (still `None` when absent).
> 
> **No intended behavior change**—same default when the field is missing and the same validation rules/error shape for invalid values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f93033cb34800fa5bfce981fd266ac897e88dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->