### PR TITLE
refactor(navigator): dedupe unknown-field validation in n2_actions

### DIFF
--- a/yutori/navigator/n2_actions.py
+++ b/yutori/navigator/n2_actions.py
@@ -380,9 +380,7 @@ def _validate_wait_seconds(duration: Any, field: str) -> "int | float":
 def _validate_fields(action: str, args: dict[str, Any]) -> None:
     if action not in _ACTION_FIELDS:
         raise N2ActionValidationError(f"unsupported n2 action: {action}")
-    unknown = set(args) - _ACTION_FIELDS[action]
-    if unknown:
-        raise N2ActionValidationError(f"{action} received unsupported field(s): {', '.join(sorted(unknown))}")
+    _tool_arguments(args, action, _ACTION_FIELDS[action])
 
 
 def translate_n2_action(


### PR DESCRIPTION
## What

`yutori/navigator/n2_actions.py::_validate_fields()` (used by `translate_n2_action` for click/scroll/type/drag/key/wait/etc.) hand-rolled its own "unknown fields → sorted, comma-joined error" check, duplicating logic that `_tool_arguments()` already implements and that seven other functions in the same file (`translate_n2_read`, `translate_n2_write`, `translate_n2_edit`, `translate_n2_grep`, `translate_n2_glob`, `translate_n2_shell_command`, `translate_n2_bash`) already delegate to.

```python
# before
def _validate_fields(action: str, args: dict[str, Any]) -> None:
    if action not in _ACTION_FIELDS:
        raise N2ActionValidationError(f"unsupported n2 action: {action}")
    unknown = set(args) - _ACTION_FIELDS[action]
    if unknown:
        raise N2ActionValidationError(f"{action} received unsupported field(s): {', '.join(sorted(unknown))}")

# after
def _validate_fields(action: str, args: dict[str, Any]) -> None:
    if action not in _ACTION_FIELDS:
        raise N2ActionValidationError(f"unsupported n2 action: {action}")
    _tool_arguments(args, action, _ACTION_FIELDS[action])
```

## Why it's an improvement

This is the same "unknown-field check against an allowlist, raise a formatted error" pattern that #272/#273/#275 already extracted for adjacent validation logic in this file. `_validate_fields` was the one call site still hand-rolling it instead of reusing the existing `_tool_arguments` helper.

## Why it's safe

- **Byte-identical error message**: `_tool_arguments`'s error format is `f"{tool_name} received unsupported field(s): {', '.join(sorted(unknown))}"` — with `tool_name=action`, this is exactly what `_validate_fields` produced before.
- **No new behavior**: `_tool_arguments` also does an `isinstance(args, dict)` check, but `_validate_fields` is only ever called from `translate_n2_action` after `args` has already been confirmed to be a `dict` (line ~399), so that check is a no-op here.
- **Purely internal**: neither function is re-exported from `yutori/navigator/__init__.py` or documented in `api.md` — zero public-surface change on this published PyPI package.
- **Verified**: full suite `pytest -m "not slow"` — 660 passed / 9 skipped / 1 deselected, identical before and after the change (confirmed via `git stash`). `ruff check` and `ruff format --check` clean on the touched file. Existing tests that assert on this exact error text (`tests/test_navigator_n2.py`, substring match on `"unsupported field"`) still pass.

1 file changed, +1/-3.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3U8TAP4d94xoAttbz79HY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor in navigator validation with no intended behavior or public API change.
> 
> **Overview**
> **`_validate_fields`** in `n2_actions.py` no longer hand-rolls allowlist checks for extra action arguments. It now calls **`_tool_arguments`**, matching how `translate_n2_read`, shell/bash, grep/glob, and the other translators already validate tool envelopes.
> 
> Unsupported-action handling is unchanged; only the “unknown field(s)” path is centralized. Error text stays the same shape (`{action} received unsupported field(s): …`) because `_tool_arguments` uses the same `tool_name` and sorted field list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c766426d450f477c792ea872e22f00b80cd8f45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->