### PR TITLE
refactor(macos): dedupe capsule label reset in MacOSPresentationController

### DIFF
--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -331,6 +331,17 @@ class MacOSPresentationController:
         left, top, width, height = region
         return left <= x <= left + width and top <= y <= top + height
 
+    def _clear_action_labels(self) -> None:
+        """Reset the capsule's action-status, terminal-command, and active-key labels.
+
+        Shared by the ``reasoning``, ``action_done``, and ``final`` branches of
+        :meth:`present`, each of which clears these three fields immediately
+        before re-rendering the capsule.
+        """
+        self._action_status = ""
+        self._terminal_command = ""
+        self._active_keys = None
+
     async def present(self, event: dict[str, Any]) -> None:
         if not self._status.available or self._stopping:
             return
@@ -340,9 +351,7 @@ class MacOSPresentationController:
                 text = event.get("text")
                 if isinstance(text, str) and text.strip():
                     self._reasoning = text.strip()
-                    self._action_status = ""
-                    self._terminal_command = ""
-                    self._active_keys = None
+                    self._clear_action_labels()
                     await self._render_capsule()
             elif event_type in {"action", "batch_member"}:
                 await self._present_action(event)
@@ -350,15 +359,11 @@ class MacOSPresentationController:
                 if self._batch_is_last:
                     self._queue_active = False
                     self._batch_is_last = False
-                self._action_status = ""
-                self._terminal_command = ""
-                self._active_keys = None
+                self._clear_action_labels()
                 await self._render_capsule()
             elif event_type == "final":
                 self._reasoning = ""
-                self._action_status = ""
-                self._terminal_command = ""
-                self._active_keys = None
+                self._clear_action_labels()
                 await self._render_capsule()
             elif event_type == "shell":
                 shell_event = event.get("event")


### PR DESCRIPTION
## Issue

`MacOSPresentationController.present()` (`yutori/navigator/macos/presentation.py`) hand-duplicated the same three-line reset three times, once each in the `reasoning`, `action_done`, and `final` branches:

```python
self._action_status = ""
self._terminal_command = ""
self._active_keys = None
```

Each branch clears these three capsule label fields immediately before calling `self._render_capsule()`.

## Improvement

Extracted a shared private `_clear_action_labels()` method; all three branches now delegate to it instead of repeating the three assignments inline.

## Why this is safe

- Purely mechanical: the extracted method's body is byte-for-byte the same three assignments, in the same order, that each branch previously inlined. No control flow, ordering, or values changed.
- `MacOSPresentationController` is an internal macOS computer-use presentation controller, not part of the SDK's public API surface documented in the README/`api.md`; `_clear_action_labels` is a private method, not exported anywhere.
- No public API change, no signature change to `present()` or any other method.
- 1 file touched, +14/-9 lines.
- Verified: full suite `pytest -q` — 679 passed / 9 skipped (unchanged from `main`); `tests/test_navigator_macos_presentation.py::test_reasoning_action_and_batch_map_to_renderer_operations` exercises the `reasoning`/`action`/`batch_member` branches through this exact reset path; `ruff check` clean on the touched file; `ruff format --check` reports no diff for this file (the pre-existing repo-wide drift on `main` is unrelated to this change).


---
_Generated by [Claude Code](https://claude.ai/code/session_011FoimJykzu2UpZXXxUwoQw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication in internal macOS presentation code with no API or logic changes.
> 
> **Overview**
> Extracts repeated capsule label resets in `MacOSPresentationController.present()` into a private **`_clear_action_labels()`** helper that clears `_action_status`, `_terminal_command`, and `_active_keys` before re-rendering.
> 
> The **`reasoning`**, **`action_done`**, and **`final`** event branches now call this method instead of inlining the same three assignments. Behavior and call order are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 207b56f672518c4116dbd85b4299aed7a89c6866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->