### PR TITLE
refactor(navigator): dedupe function-call item construction in parse_n2_tool_calls

### DIFF
--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -495,6 +495,14 @@ def parse_n2_tool_calls(
             args = json.loads(arguments) if isinstance(arguments, str) else arguments
             if not isinstance(args, dict):
                 raise N2ActionValidationError(f"{name} arguments must be an object")
+
+            def finish(
+                translated: list[dict[str, Any]], *, batch_actions: "list[dict[str, Any]] | None" = None
+            ) -> dict[str, Any]:
+                return _function_call_with_execution(
+                    name, args, call_id, translated, batch_actions=batch_actions, execution_deadline=execution_deadline
+                )
+
             if name == "computer_batch":
                 if tool_set not in TOOL_SETS_WITH_BATCH:
                     raise N2ActionValidationError(f"{tool_set} does not expose computer_batch")
@@ -506,28 +514,15 @@ def parse_n2_tool_calls(
                     allow_click_modifiers=allow_click_modifiers,
                     allow_scroll_modifiers=allow_scroll_modifiers,
                 )
-                call_item = _function_call_with_execution(
-                    name,
-                    args,
-                    call_id,
-                    translated,
-                    batch_actions=batch_actions,
-                    execution_deadline=execution_deadline,
-                )
+                call_item = finish(translated, batch_actions=batch_actions)
             elif name in SHELL_COMMAND_TOOL_NAMES:
                 if tool_set not in TOOL_SETS_WITH_SHELL_COMMAND:
                     raise N2ActionValidationError(f"{tool_set} does not expose shell_command")
-                translated = translate_n2_shell_command(args)
-                call_item = _function_call_with_execution(
-                    name, args, call_id, translated, execution_deadline=execution_deadline
-                )
+                call_item = finish(translate_n2_shell_command(args))
             elif name == BASH_TOOL_NAME:
                 if tool_set not in TOOL_SETS_WITH_BASH:
                     raise N2ActionValidationError(f"{tool_set} does not expose bash")
-                translated = translate_n2_bash(args)
-                call_item = _function_call_with_execution(
-                    name, args, call_id, translated, execution_deadline=execution_deadline
-                )
+                call_item = finish(translate_n2_bash(args))
             elif name in FILE_TOOL_NAMES:
                 if tool_set not in TOOL_SETS_WITH_FILE_TOOLS:
                     raise N2ActionValidationError(f"{tool_set} does not expose {name}")
@@ -540,32 +535,25 @@ def parse_n2_tool_calls(
                     "grep": translate_n2_grep,
                     "glob": translate_n2_glob,
                 }
-                translated = translators[name](args)
-                call_item = _function_call_with_execution(
-                    name, args, call_id, translated, execution_deadline=execution_deadline
-                )
+                call_item = finish(translators[name](args))
             elif name == "goto_url":
                 if tool_set not in TOOL_SETS_WITH_BROWSER_NAVIGATION:
                     raise N2ActionValidationError(f"{tool_set} does not expose goto_url")
-                translated = translate_n2_goto_url(args)
-                call_item = _function_call_with_execution(
-                    name, args, call_id, translated, execution_deadline=execution_deadline
-                )
+                call_item = finish(translate_n2_goto_url(args))
             elif name == "screenshot" and tool_set not in TOOL_SETS_WITH_STANDALONE_SCREENSHOT:
                 raise N2ActionValidationError(f"{tool_set} does not expose screenshot")
             elif tool_set == TOOL_SET_COMPUTER_USE_LATEST:
                 raise N2ActionValidationError(f"{tool_set} does not expose {name}")
             else:
-                translated = translate_n2_action(
-                    name,
-                    args,
-                    native_width,
-                    native_height,
-                    allow_click_modifiers=allow_click_modifiers,
-                    allow_scroll_modifiers=allow_scroll_modifiers,
-                )
-                call_item = _function_call_with_execution(
-                    name, args, call_id, translated, execution_deadline=execution_deadline
+                call_item = finish(
+                    translate_n2_action(
+                        name,
+                        args,
+                        native_width,
+                        native_height,
+                        allow_click_modifiers=allow_click_modifiers,
+                        allow_scroll_modifiers=allow_scroll_modifiers,
+                    )
                 )
             output.append(call_item)
         except (json.JSONDecodeError, N2ActionValidationError, TypeError, ValueError) as error:


### PR DESCRIPTION
## Structural issue

`parse_n2_tool_calls`'s tool-name dispatch chain in `yutori/navigator/n2.py` calls `_function_call_with_execution(name, args, call_id, translated, ..., execution_deadline=execution_deadline)` at 6 separate `if`/`elif` branches (`computer_batch`, `shell_command`, `bash`, the file-tool group, `goto_url`, and the fallback single-action `translate_n2_action` path) — 5 of them byte-for-byte identical, and the 6th (`computer_batch`) differing only by an extra `batch_actions` keyword.

## What changed

Extracted a local `finish()` closure — defined right after `args` is parsed, capturing `name`/`args`/`call_id`/`execution_deadline` (all already in scope) — that every branch now calls with just its own `translated` result (and `batch_actions=` for the batch branch). This is a pure "extract common tail into a closure" refactor confined to a single function; the branch-specific validation/translation logic (`translate_n2_batch`, `translate_n2_shell_command`, `translate_n2_bash`, the file-tool dict dispatch, `translate_n2_goto_url`, `translate_n2_action`) is untouched.

1 file changed, +22/-34.

## Why it's safe

- Purely internal — `parse_n2_tool_calls` is not part of the public re-export surface changed here in any signature sense; this touches only its function body.
- No behavior change: each branch still calls `_function_call_with_execution` with the exact same positional/keyword arguments as before (`name, args, call_id, translated`, `batch_actions` defaulting to `None` except in the batch branch, `execution_deadline` threaded through identically).
- Verified:
  - Full suite: `pytest -q -m "not slow"` → 727 passed / 3 skipped / 1 deselected (unchanged from baseline on `main`).
  - Targeted n2 tests: `test_navigator_n2.py`, `test_navigator_n2_harness.py`, `test_navigator_n2_compaction.py`, `test_navigator_n2_cookbooks.py` → 122 passed.
  - `ruff check .` and `ruff format --check yutori/navigator/n2.py` clean.

---
Automated structural-refactor pass (hourly cronjob). Log entry will be appended to `yutori-ai/yutori`'s `.claude/REFACTOR.md` once merged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VSFeUSP86EBqo7WBKZ4JAa)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no signature or argument changes to `_function_call_with_execution`; navigator tool parsing behavior should be identical.
> 
> **Overview**
> **Refactors** `parse_n2_tool_calls` in `n2.py` so every tool branch no longer repeats the same `_function_call_with_execution(...)` tail.
> 
> After arguments are validated, a local **`finish()`** closure captures `name`, `args`, `call_id`, and `execution_deadline`, then each dispatch path (`computer_batch`, shell/bash, file tools, `goto_url`, and the default `translate_n2_action` path) only supplies its translated actions—`computer_batch` still passes **`batch_actions=`**. Validation and translation logic is unchanged; this is structural deduplication only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66593d10f81367827502e30f02acdc987968f19b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->