### PR TITLE
feat(examples): one-command n2 Daytona example and local-Docker Cua cookbook

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,8 @@ graft examples
 # Cookbook lockfiles are intentionally developer-local; the public cookbook
 # pins its Cua dependency in pyproject.toml and must not inherit a local lock.
 exclude examples/navigator_n2/uv.lock
+# Never package a developer's ignored cookbook environment after they follow
+# the documented `uv sync` setup.
+prune examples/navigator_n2/.venv
 recursive-include yutori/navigator/macos/assets *
 global-exclude __pycache__ *.py[cod]

--- a/README.md
+++ b/README.md
@@ -181,22 +181,22 @@ async with AsyncYutoriClient() as client:
     )
 
     async for step in agent.run("Open Calculator and compute 17 * 23."):
-        for item in step.get("output") or []:
-            if item.get("type") == "message":
-                for part in item.get("content") or []:
-                    if isinstance(part, dict) and part.get("text"):
-                        print(part["text"])
+        ...  # each step yields the model's messages, tool calls, and tool results
 ```
 
-`computer` is your adapter for interfacing with the computer: the loop calls it to capture screenshots and execute the model's actions. See the [Navigator n2 reference](https://docs.yutori.com/reference/n2) for the tools, actions, and coordinate system, and the [API reference](api.md#navigator-n2) for direct `client.chat.completions.create(...)` calls.
+`computer` is your adapter for interfacing with the computer: the loop calls it to execute the model's actions and capture the results — screenshots, command output, file contents.
 
-The complete runnable example is [examples/navigator_n2_daytona.py](examples/navigator_n2_daytona.py) — a compact agent on a disposable [Daytona](https://www.daytona.io) Linux desktop, with the adapter and sandbox lifecycle contained in that one file; [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona) walks through it. After authenticating with `yutori auth login`, run it without installing anything into your project:
+The complete runnable example is [examples/navigator_n2_daytona.py](examples/navigator_n2_daytona.py) — a compact agent on a disposable [Daytona](https://www.daytona.io) Linux desktop, with the adapter and sandbox lifecycle contained in that one file; [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona) walks through it. To run it:
 
 ```bash
-export DAYTONA_API_KEY=...  # https://app.daytona.io
+yutori auth login            # or export YUTORI_API_KEY=...
+export DAYTONA_API_KEY=...   # https://app.daytona.io
+
 uv run https://raw.githubusercontent.com/yutori-ai/yutori-sdk-python/main/examples/navigator_n2_daytona.py \
     "Find the OS version and free disk space of this machine, and save a summary to a file on the desktop"
 ```
+
+See the [Navigator n2 reference](https://docs.yutori.com/reference/n2) for the tools, actions, and coordinate system, and the [API reference](api.md#navigator-n2) for direct `client.chat.completions.create(...)` calls.
 
 <details>
 <summary>Run in local Docker instead (Cua cookbook)</summary>

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ uv sync --python 3.12
 uv run python remote_sandbox.py --auto-approve "Run bash: echo hello-from-n2"
 ```
 
+The script prints a `Watch the desktop live:` URL at startup — open it in a browser to follow along.
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The complete runnable example is [examples/navigator_n2_daytona.py](examples/nav
 ```bash
 export DAYTONA_API_KEY=...  # https://app.daytona.io
 uv run https://raw.githubusercontent.com/yutori-ai/yutori-sdk-python/main/examples/navigator_n2_daytona.py \
-    "Write 'hello from n2' to /tmp/demo.txt with bash, then open a terminal from the dock and cat the file"
+    "Find the OS version and free disk space of this machine, and save a summary to a file on the desktop"
 ```
 
 <details>
@@ -238,7 +238,7 @@ The `yutori.navigator` subpackage exposes optional helpers for typical agent loo
 | `map_key_to_playwright(key)` / `map_keys_individual(keys)`  | Convert Navigator n1.5 lowercase key names to Playwright format.                                                                         |
 | `yutori.navigator.tools`                                    | Packaged JS reference implementations for Navigator n1.5 browser tool sets (`extract_elements`, `find`, `set_element_value`, `execute_js`). |
 | `N2ComputerAgent` / `TOOL_SET_COMPUTER_USE_LATEST`          | The stable Navigator n2 agent loop and current computer-use tool set (SDK 0.9.3+).                                                       |
-| `N2InlineCompactor` / `N2Compactor`                         | Opt-in context compaction on current main; the inline implementation is not included in published SDK 0.9.4.                          |
+| `N2InlineCompactor` / `N2Compactor`                         | Opt-in context compaction for long n2 trajectories, and the protocol for a custom history rewrite policy.                          |
 
 
 Full helper reference: [api.md](api.md).

--- a/README.md
+++ b/README.md
@@ -186,7 +186,17 @@ async with AsyncYutoriClient() as client:
                         print(part["text"])
 ```
 
-`computer` is any adapter with async screenshot and input methods; shell and file methods are optional. [examples/navigator_n2_daytona.py](examples/navigator_n2_daytona.py) is a complete agent on a sandbox [Daytona](https://www.daytona.io) Linux desktop, with everything Daytona-specific in one small adapter class. It also shows how to attach `N2InlineCompactor`, the opt-in Praxis-compatible policy for long trajectories; [Building agents with n2](https://docs.yutori.com/reference/n2-daytona) walks through the harness. For direct `client.chat.completions.create(...)` calls and request fields, see the [API reference](api.md#navigator-n2).
+`computer` is any adapter with async screenshot and input methods; shell and file methods are optional. The [Cua cookbook](examples/navigator_n2/README.md) runs the full current tool set in local Docker. [examples/navigator_n2_daytona.py](examples/navigator_n2_daytona.py) is a compact hosted example using third-party [Daytona](https://www.daytona.io) infrastructure, with the Yutori-maintained adapter and lifecycle contained in that file; [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona) walks through it. For direct `client.chat.completions.create(...)` calls and request fields, see the [API reference](api.md#navigator-n2).
+
+After authenticating with `yutori auth login`, run the Daytona example without installing its dependencies into your project:
+
+```bash
+export DAYTONA_API_KEY=...  # https://app.daytona.io
+uv run https://raw.githubusercontent.com/yutori-ai/yutori-sdk-python/main/examples/navigator_n2_daytona.py \
+    "Write 'hello from n2' to /tmp/demo.txt, then open a terminal and cat the file"
+```
+
+The script declares Python 3.10+ and its pinned Daytona dependency inline, so `uv` creates the isolated environment automatically.
 
 <details>
 <summary>Drive your own local Mac</summary>
@@ -221,7 +231,7 @@ The `yutori.navigator` subpackage exposes optional helpers for typical agent loo
 | `map_key_to_playwright(key)` / `map_keys_individual(keys)`  | Convert Navigator n1.5 lowercase key names to Playwright format.                                                                         |
 | `yutori.navigator.tools`                                    | Packaged JS reference implementations for Navigator n1.5 browser tool sets (`extract_elements`, `find`, `set_element_value`, `execute_js`). |
 | `N2ComputerAgent` / `TOOL_SET_COMPUTER_USE_LATEST`          | The stable Navigator n2 agent loop and current computer-use tool set (SDK 0.9.3+).                                                       |
-| `N2InlineCompactor` / `N2Compactor`                         | Opt-in Praxis-compatible context compaction, or the protocol for a custom n2 history rewrite policy.                                  |
+| `N2InlineCompactor` / `N2Compactor`                         | Opt-in context compaction on current main; the inline implementation is not included in published SDK 0.9.4.                          |
 
 
 Full helper reference: [api.md](api.md).
@@ -390,7 +400,7 @@ Run `yutori --help` or `yutori <command> --help` for full options.
 
 ## Examples
 
-See [examples/](examples/) for complete working examples: Navigator n1.5 browser loops, custom tools, and a Navigator n2 computer-use agent on a Daytona desktop.
+See [examples/](examples/) for complete working examples: Navigator n1.5 browser loops, custom tools, and Navigator n2 on local Docker or Daytona infrastructure.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ The [Cua cookbook](examples/navigator_n2/README.md) runs the full current tool s
 ```bash
 cd examples/navigator_n2
 uv sync --python 3.12
-uv run python remote_sandbox.py --auto-approve "Run bash: echo hello-from-n2"
+uv run python remote_sandbox.py --auto-approve "Open Calculator and compute 17 * 23"
 ```
 
 The script prints a `Watch the desktop live:` URL at startup — open it in a browser to follow along.

--- a/README.md
+++ b/README.md
@@ -161,9 +161,11 @@ This snippet shows a single model call. In practice, you'll run an agent loop: e
 
 The SDK defaults to Navigator n1.5 (`n1.5-latest`). Navigator n1.5 requests support selectable tool sets, `disable_tools`, and structured JSON output via `json_schema` (returned as `response.parsed_json`). See the [Navigator reference](https://docs.yutori.com/reference/navigator) for model IDs, parameters, and the full action space.
 
+If you'd rather not manage browser infrastructure, use the **Browsing API** below, which runs the Navigator n1.5 on Yutori's cloud browser.
+
 ### Navigator n2 (computer use)
 
-Navigator n2 operates a full desktop. It answers with `computer_batch` calls — an ordered sequence of GUI actions, answered with one screenshot taken after the last one — and `bash` calls, answered with the command's output. Implement the computer environment, then pass it to the SDK's agent loop:
+Navigator n2 operates a full desktop. It produces `computer_batch` calls — an ordered sequence of GUI actions — and `bash` calls. You implement the computer environment, and pass the output of the actions to the SDK's agent loop:
 
 ```python
 from yutori import AsyncYutoriClient
@@ -186,17 +188,28 @@ async with AsyncYutoriClient() as client:
                         print(part["text"])
 ```
 
-`computer` is any adapter with async screenshot and input methods; shell and file methods are optional. The [Cua cookbook](examples/navigator_n2/README.md) runs the full current tool set in local Docker. [examples/navigator_n2_daytona.py](examples/navigator_n2_daytona.py) is a compact hosted example using third-party [Daytona](https://www.daytona.io) infrastructure, with the Yutori-maintained adapter and lifecycle contained in that file; [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona) walks through it. For direct `client.chat.completions.create(...)` calls and request fields, see the [API reference](api.md#navigator-n2).
+`computer` is your adapter for interfacing with the computer: the loop calls it to capture screenshots and execute the model's actions. See the [Navigator n2 reference](https://docs.yutori.com/reference/n2) for the tools, actions, and coordinate system, and the [API reference](api.md#navigator-n2) for direct `client.chat.completions.create(...)` calls.
 
-After authenticating with `yutori auth login`, run the Daytona example without installing its dependencies into your project:
+The complete runnable example is [examples/navigator_n2_daytona.py](examples/navigator_n2_daytona.py) — a compact agent on a disposable [Daytona](https://www.daytona.io) Linux desktop, with the adapter and sandbox lifecycle contained in that one file; [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona) walks through it. After authenticating with `yutori auth login`, run it without installing anything into your project:
 
 ```bash
 export DAYTONA_API_KEY=...  # https://app.daytona.io
 uv run https://raw.githubusercontent.com/yutori-ai/yutori-sdk-python/main/examples/navigator_n2_daytona.py \
-    "Write 'hello from n2' to /tmp/demo.txt, then open a terminal and cat the file"
+    "Write 'hello from n2' to /tmp/demo.txt with bash, then open a terminal from the dock and cat the file"
 ```
 
-The script declares Python 3.10+ and its pinned Daytona dependency inline, so `uv` creates the isolated environment automatically.
+<details>
+<summary>Run in local Docker instead (Cua cookbook)</summary>
+
+The [Cua cookbook](examples/navigator_n2/README.md) runs the full current tool set (`computer_batch`, `edit`, `read`, `write`, `bash`) in a disposable local Docker container — no cloud credential needed:
+
+```bash
+cd examples/navigator_n2
+uv sync --python 3.12
+uv run python remote_sandbox.py --auto-approve "Run bash: echo hello-from-n2"
+```
+
+</details>
 
 <details>
 <summary>Drive your own local Mac</summary>
@@ -209,12 +222,6 @@ uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the r
 ```
 
 </details>
-
-See the [Navigator n2 reference](https://docs.yutori.com/reference/n2) for the tools, actions, coordinate system, and request fields.
-
-The SDK also accepts the immutable `computer_use_tools-20260818` browser set for replay. It is not a desktop set: its
-extra `goto_url` call requires a computer handler that implements `async goto_url(url: str)`. The bundled desktop and
-public Cua sandbox adapters deliberately return a recoverable unsupported-environment result for that browser-only call.
 
 ### Agent-loop helpers
 
@@ -235,8 +242,6 @@ The `yutori.navigator` subpackage exposes optional helpers for typical agent loo
 
 
 Full helper reference: [api.md](api.md).
-
-If you'd rather not manage browser infrastructure, use the **Browsing API** below, which runs the Navigator on Yutori's cloud browser.
 
 ## Browsing API
 

--- a/api.md
+++ b/api.md
@@ -113,6 +113,8 @@ from yutori.navigator import (
 
 `N1_MODEL`, `N1_5_MODEL`, and `N1_COORDINATE_SCALE` are still importable from the same module as deprecated aliases of the `NAVIGATOR_*` constants and may be removed in a future release.
 
+**Replay note.** The SDK also accepts the immutable `computer_use_tools-20260818` browser set for replaying recorded trajectories. It is not a desktop set: its extra `goto_url` call requires a computer handler that implements `async goto_url(url: str)`. The bundled desktop and public Cua sandbox adapters deliberately return a recoverable unsupported-environment result for that browser-only call.
+
 For pinned versions (e.g. `n1.5-20260428`) see [docs.yutori.com/reference/n1-5](https://docs.yutori.com/reference/n1-5) and [docs.yutori.com/reference/n2](https://docs.yutori.com/reference/n2).
 
 ## Namespaces

--- a/api.md
+++ b/api.md
@@ -108,7 +108,7 @@ from yutori.navigator import (
 | `TOOL_SET_CORE` | `"browser_tools_core-20260403"` | Default Navigator n1.5 tool set — 18 coordinate-based browser tools. |
 | `TOOL_SET_EXPANDED` | `"browser_tools_expanded-20260403"` | Core tools + `extract_elements`, `find`, `set_element_value`, `execute_js`. |
 | `NAVIGATOR_N2_MODEL` | `"n2"` | Stable Navigator n2 model identifier and `N2ComputerAgent` default. |
-| `TOOL_SET_COMPUTER_USE_LATEST` | `"computer_use_tools-20260825"` | Current n2 tool set: `computer_batch`, `edit`, `read`, `write`, and `bash`. It supports all 15 batch primitives, including held mouse/key actions and screenshot. |
+| `TOOL_SET_COMPUTER_USE_LATEST` | `"computer_use_tools-20260825"` | Current n2 tool set: `computer_batch`, `edit`, `read`, `write`, and `bash`. A batch contains up to 20 actions drawn from 15 action types, including held mouse/key actions and screenshot. |
 | `NAVIGATOR_COORDINATE_SCALE` | `1000` | The normalized action space is `NAVIGATOR_COORDINATE_SCALE × NAVIGATOR_COORDINATE_SCALE`. |
 
 `N1_MODEL`, `N1_5_MODEL`, and `N1_COORDINATE_SCALE` are still importable from the same module as deprecated aliases of the `NAVIGATOR_*` constants and may be removed in a future release.
@@ -190,7 +190,7 @@ response = client.chat.completions.create(
 )
 ```
 
-`N2ComputerAgent` (0.9.3+) runs this loop against any computer adapter — see [Navigator n2 loop](#navigator-n2-loop). [`examples/navigator_n2_daytona.py`](examples/navigator_n2_daytona.py) is a complete agent on a Daytona sandbox desktop built on it; [Yutori MCP](https://github.com/yutori-ai/yutori-mcp) drives a local Mac (`uvx yutori-mcp computer-use setup`). Model reference: [docs.yutori.com/reference/n2](https://docs.yutori.com/reference/n2).
+`N2ComputerAgent` (0.9.3+) runs this loop against any computer adapter — see [Navigator n2 loop](#navigator-n2-loop). The [Cua cookbook](examples/navigator_n2/README.md) runs the full current tool set in local Docker. [`examples/navigator_n2_daytona.py`](examples/navigator_n2_daytona.py) is a compact agent using third-party Daytona infrastructure; [Yutori MCP](https://github.com/yutori-ai/yutori-mcp) drives a local Mac (`uvx yutori-mcp computer-use setup`). Model reference: [docs.yutori.com/reference/n2](https://docs.yutori.com/reference/n2).
 
 ### `client.browsing` — Browsing API
 
@@ -459,7 +459,7 @@ from yutori.navigator import (
     NAVIGATOR_N1_5_MODEL,
     TOOL_SET_CORE, TOOL_SET_EXPANDED, TOOL_SET_COMPUTER_USE_LATEST, NAVIGATOR_COORDINATE_SCALE,
     # Navigator n2 loop helpers
-    N2ComputerAgent, N2CompactionContext, N2CompactionResult, N2Compactor, N2InlineCompactor,
+    N2ComputerAgent, N2Compactor,
     parse_n2_tool_calls, execute_n2_computer_call, retain_n2_image_window,
     # Screenshots
     aplaywright_screenshot_to_data_url, playwright_screenshot_to_data_url, screenshot_to_data_url,
@@ -480,16 +480,18 @@ from yutori.navigator import (
 
 ### Navigator n2 loop
 
+`N2ComputerAgent` and the basic `run()` loop were added in SDK 0.9.3. The `resume()`, `stopped_by`, tool-owned result, and loop-policy APIs documented below require SDK 0.9.4+.
+
 Imports:
 
 ```python
-from yutori.navigator import N2ComputerAgent, N2InlineCompactor, TOOL_SET_COMPUTER_USE_LATEST
+from yutori.navigator import N2ComputerAgent, TOOL_SET_COMPUTER_USE_LATEST
 from yutori.navigator.macos import MacOSComputer  # macOS only; needs the `macos` extra
 ```
 
 `N2ComputerAgent(*, computer, tool_set=TOOL_SET_COMPUTER_USE_LATEST, completions=None, api_key=None, base_url=None, model="n2", instructions=None, callbacks=None, action_confirmation_callback=None, presentation=None, screenshot_delay=0.5, execution_deadline=None, temperature=None, supports_click_modifiers=False, supports_scroll_modifiers=None, **loop_policies)` drives one n2 conversation. `run(task)` is an async generator yielding `{"output": [...], "usage": {...}}` per model turn and per executed call; it ends when the model answers with text and no tool calls, a callback's `on_run_continue` returns `False`, or a budget is spent — `agent.stopped_by` says which; `resume(message)` continues the same conversation. Pass `completions=client.chat.completions` or an `api_key` (the agent then owns its own `AsyncYutoriClient`; close it with `aclose()` or the async context manager). The default model is stable `n2`; no preview SDK alias is exported.
 
-`computer` is any object with the async handler surface `screenshot`, `click`, `double_click`, `scroll`, `type`, `keypress`, `drag`, `move`, `wait`, and optionally `run_bash_command`. `MacOSComputer` is the native macOS implementation — CuaDriver session, capture/input, shell lifecycle, cancellation, recovery, and the optional presentation overlay. It is what Yutori MCP runs; local shell execution stays off unless the caller enables it.
+`computer` is any object with the async base-handler surface `screenshot`, `click`, `double_click`, `scroll`, `type`, `keypress`, `drag`, `move`, and `wait`. Current tools additionally call `run_bash_command`, `read_file`, `write_file`, and `edit_file`; durationless held keys require `key_down` and `key_up`. Set `supports_click_modifiers` or `supports_scroll_modifiers` only when the adapter can keep a modifier down for that whole gesture. `MacOSComputer` is the native macOS implementation — CuaDriver session, capture/input, shell lifecycle, cancellation, recovery, and the optional presentation overlay. It is what Yutori MCP runs; local shell execution stays off unless the caller enables it.
 
 ### Loop policies
 
@@ -512,9 +514,11 @@ The keywords:
 | `max_steps` / `agent_timeout_seconds` | `None` | Turn and wall-clock budgets per `run()`/`resume()` call (`stopped_by == "max_steps"` / `"timeout"`). |
 | `compactor` | `None` | An `N2Compactor`, called before each model request and the context-limit guard. Return a replacement trajectory to compact the context. |
 
-Adapter hooks: a file handler (`read_file` and friends) may return `{"text": ..., "image_url": "data:..."}` so a `read` of an image file shows the model the image as well as the text; any computer handler that declares a `model_action=` keyword parameter receives the model's own call (`{"action": name, **arguments}`) alongside the translated arguments. Shell and file handlers own their result text end to end — see the reference implementations in `examples/navigator_n2/cua_sandbox.py` and `examples/navigator_n2_daytona.py` for the formats n2 expects (`Exit code N` headers, `cat -n` line numbering, `[... output truncated, N more chars ...]` caps).
+Adapter hooks: a file handler (`read_file` and friends) may return `{"text": ..., "image_url": "data:..."}` so a `read` of an image file shows the model the image as well as the text; any computer handler that declares a `model_action=` keyword parameter receives the model's own call (`{"action": name, **arguments}`) alongside the translated arguments. Shell and file handlers own their result text end to end — see the reference implementations in `examples/navigator_n2/cua_adapter.py` and `examples/navigator_n2_daytona.py` for the formats n2 expects (`Exit code N` headers, `cat -n` line numbering, `[... output truncated, N more chars ...]` caps).
 
 ### N2 context compaction
+
+`N2InlineCompactor`, `N2CompactionContext`, and `N2CompactionResult` are available on the current main branch but are not included in the published 0.9.4 package. Use a source checkout until a later SDK release includes them.
 
 `N2InlineCompactor` implements the usage-triggered, tail-retaining compaction policy used by Yutori's Praxis
 harness. It preserves the initial user request, replaces older turns with a model-written working checkpoint,

--- a/examples/README.md
+++ b/examples/README.md
@@ -83,7 +83,7 @@ The script declares Python 3.10+, Yutori SDK 0.9.4 or newer, and the tested Dayt
 ```bash
 export DAYTONA_API_KEY=...   # https://app.daytona.io
 uv run examples/navigator_n2_daytona.py \
-    "Write 'hello from n2' to /tmp/demo.txt, then open a terminal and cat the file"
+    "Write 'hello from n2' to /tmp/demo.txt with bash, then open a terminal from the dock and cat the file"
 ```
 
 Pass `--record` to capture the desktop during the run; the video is downloaded to `n2-daytona-run.mp4` before the sandbox is deleted.

--- a/examples/README.md
+++ b/examples/README.md
@@ -71,7 +71,7 @@ The [public Cua cookbook](navigator_n2/README.md) runs Navigator n2 with the com
 cd examples/navigator_n2
 uv sync --python 3.12
 uv run python remote_sandbox.py --auto-approve \
-    "Run bash: echo hello-from-n2"
+    "Open Calculator and compute 17 * 23"
 ```
 
 ## navigator_n2_daytona.py

--- a/examples/README.md
+++ b/examples/README.md
@@ -63,16 +63,27 @@ The example implements a `MemoToolSuite` with three custom tools:
 - `add_options` - Add new options to an existing question
 - `list_records` - List all recorded questions and options in JSONL format
 
-## navigator_n2_daytona.py
+## navigator_n2/
 
-A computer-use agent: Navigator n2 driving a disposable [Daytona](https://www.daytona.io) Linux desktop. `N2ComputerAgent` from `yutori.navigator` runs the loop — it sends the task, executes the returned `computer_batch` and `bash` calls through a `DaytonaComputer` adapter, and sends the results back until the model answers with text. `N2InlineCompactor` shows how a harness can replace old turns with a working checkpoint before the context fills. The Daytona-specific code remains only the adapter class; swap it to drive a different desktop. The sandbox is deleted when the run ends.
-
-Needs Python 3.10+, the latest `yutori`, and a Daytona API key; it is not part of the `examples` extra:
+The [public Cua cookbook](navigator_n2/README.md) runs Navigator n2 with the complete current tool set in a local Docker container; its dedicated Python 3.12 environment keeps Cua's dependencies separate from the other examples.
 
 ```bash
-pip install 'yutori>=0.9.3' daytona
-export DAYTONA_API_KEY=...   # https://app.daytona.io
-python examples/navigator_n2_daytona.py "Write 'hello from n2' to /tmp/demo.txt, then open a terminal and cat the file"
+cd examples/navigator_n2
+uv sync --python 3.12
+uv run python remote_sandbox.py --auto-approve \
+    "Run bash: echo hello-from-n2"
 ```
 
-To drive your own Mac instead, use [Yutori MCP](https://github.com/yutori-ai/yutori-mcp) (`uvx yutori-mcp computer-use setup`). Walkthrough: [Building agents with n2](https://docs.yutori.com/reference/n2-daytona).
+## navigator_n2_daytona.py
+
+A computer-use agent using third-party [Daytona](https://www.daytona.io) infrastructure. `N2ComputerAgent` runs the loop, while this Yutori-maintained example provides a compact `DaytonaComputer` adapter plus sandbox lifecycle wiring. It intentionally uses the immutable batch-plus-bash tool set. The ephemeral sandbox is deleted, with deletion confirmation requested, when the run ends.
+
+The script declares Python 3.10+, Yutori SDK 0.9.4 or newer, and the tested Daytona version as inline metadata. `uv` installs them into an isolated environment automatically:
+
+```bash
+export DAYTONA_API_KEY=...   # https://app.daytona.io
+uv run examples/navigator_n2_daytona.py \
+    "Write 'hello from n2' to /tmp/demo.txt, then open a terminal and cat the file"
+```
+
+To drive your own Mac instead, use [Yutori MCP](https://github.com/yutori-ai/yutori-mcp) (`uvx yutori-mcp computer-use setup`). Walkthrough: [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona).

--- a/examples/README.md
+++ b/examples/README.md
@@ -83,7 +83,7 @@ The script declares Python 3.10+, Yutori SDK 0.9.4 or newer, and the tested Dayt
 ```bash
 export DAYTONA_API_KEY=...   # https://app.daytona.io
 uv run examples/navigator_n2_daytona.py \
-    "Write 'hello from n2' to /tmp/demo.txt with bash, then open a terminal from the dock and cat the file"
+    "Find the OS version and free disk space of this machine, and save a summary to a file on the desktop"
 ```
 
 Pass `--record` to capture the desktop during the run; the video is downloaded to `n2-daytona-run.mp4` before the sandbox is deleted.

--- a/examples/README.md
+++ b/examples/README.md
@@ -86,4 +86,6 @@ uv run examples/navigator_n2_daytona.py \
     "Write 'hello from n2' to /tmp/demo.txt, then open a terminal and cat the file"
 ```
 
+Pass `--record` to capture the desktop during the run; the video is downloaded to `n2-daytona-run.mp4` before the sandbox is deleted.
+
 To drive your own Mac instead, use [Yutori MCP](https://github.com/yutori-ai/yutori-mcp) (`uvx yutori-mcp computer-use setup`). Walkthrough: [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona).

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -43,6 +43,8 @@ docker info
 uv run python remote_sandbox.py "Open Calculator and compute 17 * 23"
 ~~~
 
+The script prints a `Watch the desktop live: http://localhost:<port>/vnc.html` link at startup — open it in a browser to follow the agent's actions on the sandbox's noVNC viewer.
+
 This cookbook intentionally does not expose Cua cloud. Cua's current cloud path uses Fleet pools and provider-owned credentials rather than the retired image-based VM API in the pinned Python package; follow [Cua's current CLI documentation](https://cua.ai/docs/reference/cua-cli/cli-reference) if you need that infrastructure.
 
 The adapter supports the five current n2 tools: `computer_batch`, `edit`, `read`, `write`, and `bash`. It executes normalized coordinates against the sandbox's native screen, preserves a bash working directory, and uses Cua key-down/key-up primitives to keep modifiers attached to their click or scroll gesture.

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -1,15 +1,27 @@
 # Navigator n2 with public Cua
 
-These runnable cookbooks use the public Python SDK loop, stable model id n2, and the public Cua 0.1.6 package. They do not import an agent package or source code from another repository.
+These runnable cookbooks use the public Python SDK loop, stable model id n2, and public Cua packages. They do not import an agent package or source code from another repository. Cua provides the local Docker runtime; the adapter and n2 loop in this repository are maintained by Yutori.
 
-The cookbook environment is separate because Cua 0.1.6 requires Python 3.12 or 3.13. Its dependency is pinned in pyproject.toml, and the SDK source is used from this checkout while developing the release.
+The cookbook environment is separate because Cua 0.1.6 requires Python 3.12 or 3.13. The tested Cua dependencies are pinned in pyproject.toml, and the SDK source is used from this checkout.
+
+On minimal Debian or Ubuntu images (including `python:3.12-slim`), install the compiler and Linux input headers that Cua's `evdev` dependency builds against:
+
+~~~bash
+apt-get update && apt-get install -y --no-install-recommends build-essential linux-libc-dev
+~~~
 
 ~~~bash
 cd examples/navigator_n2
 uv sync --python 3.12
 ~~~
 
-Authenticate Yutori with yutori auth login or YUTORI_API_KEY. The sandbox example additionally requires normal Cua cloud authentication (CUA_API_KEY or its login flow). The Yutori key remains on the host and is never copied into the sandbox.
+Authenticate Yutori in this environment, or set `YUTORI_API_KEY`:
+
+~~~bash
+yutori auth login
+~~~
+
+No Cua cloud credential is used. The Yutori key remains on the host and is never copied into the container.
 
 ## Local macOS
 
@@ -22,15 +34,18 @@ uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 
 The local runtime can execute bash and file tools only because the example explicitly enables its local-shell option. Every local shell command remains confirmable even with --auto-approve.
 
-## Disposable sandbox
+## Disposable Linux sandbox
 
-The remote entrypoint adapts public Cua Sandbox mouse, keyboard, screenshot, and shell interfaces to N2ComputerAgent. It uses a disposable Linux desktop and destroys it when the process exits.
+The sandbox entrypoint adapts public Cua mouse, keyboard, screenshot, shell, and file interfaces to `N2ComputerAgent`. It creates a disposable Linux desktop in local Docker and destroys it when the process exits. Confirm Docker Desktop or Docker Engine is running, then run:
 
 ~~~bash
+docker info
 uv run python remote_sandbox.py "Open Calculator and compute 17 * 23"
 ~~~
 
-The adapter supports the five current n2 tools: computer_batch, edit, read, write, and bash. It executes normalized coordinates against the sandbox’s native screen, preserves a bash working directory, and uses Cua key-down/key-up primitives to keep modifiers attached to their click or scroll gesture.
+This cookbook intentionally does not expose Cua cloud. Cua's current cloud path uses Fleet pools and provider-owned credentials rather than the retired image-based VM API in the pinned Python package; follow [Cua's current CLI documentation](https://cua.ai/docs/reference/cua-cli/cli-reference) if you need that infrastructure.
+
+The adapter supports the five current n2 tools: `computer_batch`, `edit`, `read`, `write`, and `bash`. It executes normalized coordinates against the sandbox's native screen, preserves a bash working directory, and uses Cua key-down/key-up primitives to keep modifiers attached to their click or scroll gesture.
 
 ## Tool sets
 
@@ -54,4 +69,4 @@ Both examples always send an explicit immutable tool-set id. The default alias i
 uv run python remote_sandbox.py --tool-set gui "Open Calculator and compute 17 * 23"
 ~~~
 
-The public n2 reference documents the current five tools, all 15 batch actions, screenshot compression, and the single-result-per-tool-call rule: https://docs.yutori.com/reference/n2
+The public n2 reference documents the current five tools, all 15 batch action types, the 20-action batch limit, screenshot compression, and the single-result-per-tool-call rule: https://docs.yutori.com/reference/n2

--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -129,10 +129,12 @@ if operation == "read":
     data = path.read_bytes()
     suffix = path.suffix.lower()
     if suffix in IMAGE_SUFFIXES:
+        record_fingerprint(path, data)
         print("__YUTORI_IMAGE__")
         print(base64.b64encode(data).decode())
         raise SystemExit(0)
     if suffix == ".pdf":
+        record_fingerprint(path, data)
         done(f"[pdf file: {path.name} - {len(data)} bytes; binary content not shown]")
     if suffix == ".ipynb":
         try:

--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -1,4 +1,4 @@
-"""The Cua-sandbox computer handler for Navigator n2 — the reference tool implementations.
+"""The Cua computer handler for Navigator n2 — the reference tool implementations.
 
 ``CuaSandboxComputer`` implements the full handler surface `N2ComputerAgent` calls
 (GUI primitives, ``run_bash_command`` with a persistent working directory, and the

--- a/examples/navigator_n2/cua_sandbox.py
+++ b/examples/navigator_n2/cua_sandbox.py
@@ -16,23 +16,17 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import io
 import json
 import shlex
 import uuid
 from collections.abc import Awaitable, Callable, Sequence
-from pathlib import PurePosixPath
 from typing import Any
+
+from PIL import Image
 
 BASH_RESULT_MAX_CHARS = 30_000
 
-_IMAGE_MIME_TYPES = {
-    ".png": "image/png",
-    ".jpg": "image/jpeg",
-    ".jpeg": "image/jpeg",
-    ".gif": "image/gif",
-    ".webp": "image/webp",
-    ".bmp": "image/bmp",
-}
 
 _FILE_TOOL_SCRIPT = r"""
 from pathlib import Path
@@ -103,32 +97,6 @@ def check_read_before_edit(path, display, data):
         return f"ERROR: {display} changed since you last read it - read it again before editing."
     return None
 
-def image_dimensions(data):
-    try:
-        if data[:8] == b"\x89PNG\r\n\x1a\n":
-            return struct.unpack(">II", data[16:24])
-        if data[:6] in (b"GIF87a", b"GIF89a"):
-            return struct.unpack("<HH", data[6:10])
-        if data[:2] == b"BM":
-            width, height = struct.unpack("<ii", data[18:26])
-            return width, abs(height)
-        if data[:2] == b"\xff\xd8":
-            index = 2
-            while index + 9 < len(data):
-                if data[index] != 0xFF:
-                    index += 1
-                    continue
-                marker = data[index + 1]
-                if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
-                    height, width = struct.unpack(">HH", data[index + 5 : index + 9])
-                    return width, height
-                index += 2 + struct.unpack(">H", data[index + 2 : index + 4])[0]
-        if data[:4] == b"RIFF" and data[8:12] == b"WEBP" and data[12:16] == b"VP8X":
-            return (int.from_bytes(data[24:27], "little") + 1, int.from_bytes(data[27:30], "little") + 1)
-    except Exception:
-        pass
-    return None
-
 def edit_snippet(text, anchor, extra_lines):
     lines = text.split("\n")
     line_no = text[: max(anchor, 0)].count("\n") + 1
@@ -161,8 +129,7 @@ if operation == "read":
     data = path.read_bytes()
     suffix = path.suffix.lower()
     if suffix in IMAGE_SUFFIXES:
-        dims = image_dimensions(data)
-        print("__YUTORI_IMAGE__ " + (f"{dims[0]}x{dims[1]}" if dims else "?"))
+        print("__YUTORI_IMAGE__")
         print(base64.b64encode(data).decode())
         raise SystemExit(0)
     if suffix == ".pdf":
@@ -340,6 +307,31 @@ def _shell_result(result: Any) -> str:
     )
 
 
+_IMAGE_VIEW_MAX_EDGE = 1568
+
+
+def _render_image_result(file_path: str, data: bytes) -> "dict[str, str] | str":
+    """Return an image read as visible image content: a note with the source
+    dimensions plus the image itself, downscaled to a 1568-px max edge and
+    WEBP-encoded — the same bounds the loop applies to screenshots."""
+    try:
+        image = Image.open(io.BytesIO(data))
+        image.load()
+        width, height = image.size
+        scale = min(1.0, _IMAGE_VIEW_MAX_EDGE / max(width, height)) if max(width, height) else 1.0
+        shown = image.resize((max(1, int(width * scale)), max(1, int(height * scale)))) if scale < 1.0 else image
+        if shown.mode not in ("RGB", "RGBA", "L"):
+            shown = shown.convert("RGB")
+        buffer = io.BytesIO()
+        shown.save(buffer, format="WEBP", quality=90)
+    except Exception as error:  # noqa: BLE001 - not a decodable image
+        return f"ERROR: {file_path} is not a readable image: {error}"
+    note = f"Loaded image {file_path} ({width}x{height})" + (
+        f", shown downscaled to {shown.size[0]}x{shown.size[1]}" if shown.size != (width, height) else ""
+    )
+    return {"text": note, "image_url": "data:image/webp;base64," + base64.b64encode(buffer.getvalue()).decode()}
+
+
 def _python_command(script: str, *arguments: str) -> str:
     return "python3 -c " + shlex.quote(script) + "".join(f" {shlex.quote(argument)}" for argument in arguments)
 
@@ -505,7 +497,8 @@ class CuaSandboxComputer:
         sentinel = f"__YUTORI_N2_BASH_CWD_{uuid.uuid4().hex}__"
         wrapped = f"{prefix}{command}\n__yutori_rc=$?\nprintf '\\n{sentinel}%s' \"$PWD\"\nexit $__yutori_rc"
         # The n2 bash contract: the timeout is clamped to [0, 600] and an expiry is a
-        # NORMAL result the model can react to, never a raised failure envelope.
+        # NORMAL result the model can react to, never a raised failure envelope. (The
+        # sandbox API discards partial output on expiry, so the result is the bare line.)
         timeout_s = max(0.0, min(float(120.0 if timeout is None else timeout), 600.0))
         if timeout_s == 0:
             return "Command timed out after 0s"
@@ -528,11 +521,8 @@ class CuaSandboxComputer:
             raise ValueError("read.offset must be a positive 1-based line number")
         output = await self._run_file_tool("read", file_path=file_path, offset=offset, limit=limit)
         if output.startswith("__YUTORI_IMAGE__"):
-            header, _, encoded = output.partition("\n")
-            dims = header.split(" ", 1)[1].strip() if " " in header else "?"
-            note = f"Loaded image {file_path}" + (f" ({dims})" if dims != "?" else "")
-            mime = _IMAGE_MIME_TYPES.get(PurePosixPath(file_path).suffix.lower(), "image/png")
-            return {"text": note, "image_url": f"data:{mime};base64,{encoded.strip()}"}
+            _, _, encoded = output.partition("\n")
+            return _render_image_result(file_path, base64.b64decode(encoded.strip()))
         return output.rstrip("\n")
 
     async def write_file(self, file_path: str, content: str) -> str:

--- a/examples/navigator_n2/cua_sandbox.py
+++ b/examples/navigator_n2/cua_sandbox.py
@@ -3,10 +3,13 @@
 ``CuaSandboxComputer`` implements the full handler surface `N2ComputerAgent` calls
 (GUI primitives, ``run_bash_command`` with a persistent working directory, and the
 ``read``/``write``/``edit``/``grep``/``glob`` file tools) on the public ``cua`` sandbox
-API, rendering every result in the format n2 expects: ``Exit code N`` headers,
-``(Bash completed with no output)``, ``cat -n`` line numbering, the edit tool's exact
-error strings, and the 30k ``[... output truncated, N more chars ...]`` cap. Copy or
-adapt this module when building a handler for your own environment.
+API, rendering every result in the exact format n2 expects:
+``Exit code N`` headers, ``(Bash completed with no output)``, ``Command timed out after
+Xs`` as a normal result, ``cat -n`` line numbering with the ``[... output truncated,
+N more chars ...]`` caps, image reads returned as visible image content, the
+sha256-fingerprint read-before-edit gate, and every expected tool error as a plain
+``ERROR: ...`` result rather than a raised failure envelope. Copy or adapt this module
+when building a handler for your own environment.
 """
 
 from __future__ import annotations
@@ -22,34 +25,116 @@ from typing import Any
 
 BASH_RESULT_MAX_CHARS = 30_000
 
+_IMAGE_MIME_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+}
+
 _FILE_TOOL_SCRIPT = r"""
 from pathlib import Path
 import base64
 import fnmatch
 import glob
+import hashlib
 import json
 import os
 import re
+import struct
 import sys
 
 arguments = json.loads(base64.b64decode(sys.argv[1]).decode())
 cwd = Path(arguments["cwd"])
+STATE = Path("/tmp/.yutori-n2-read-fingerprints.json")
+READ_MAX = 256 * 1024
+GREP_MAX = 20000
+MAX_COLUMNS = 500
+VCS_EXCLUDES = {".git", ".svn", ".hg", ".bzr", ".jj", ".sl"}
+IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
+
+def done(text):
+    print(text)
+    raise SystemExit(0)
+
+def truncate(text, limit):
+    if limit is None or len(text) <= limit:
+        return text
+    return text[:limit] + f"\n\n[... output truncated, {len(text) - limit} more chars ...]"
 
 def resolve(value):
     path = Path(value).expanduser()
     return path if path.is_absolute() else cwd / path
 
-def read_text(path):
-    data = path.read_bytes()
-    if data.startswith(b"\xef\xbb\xbf"):
-        return data.decode("utf-8-sig")
-    if data.startswith((b"\xff\xfe", b"\xfe\xff")):
-        return data.decode("utf-16")
-    return data.decode("utf-8")
+def detect_encoding(head):
+    if not head:
+        return "utf-8"
+    if head[:2] in (b"\xff\xfe", b"\xfe\xff"):
+        return "utf-16"
+    if head[:3] == b"\xef\xbb\xbf":
+        return "utf-8-sig"
+    return "utf-8"
+
+def decode_text(data):
+    return data.decode(detect_encoding(data[:4096]), "replace").replace("\r\n", "\n")
 
 def write_text(path, content):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
+
+def load_fingerprints():
+    try:
+        return json.loads(STATE.read_text())
+    except Exception:
+        return {}
+
+def record_fingerprint(path, data):
+    fingerprints = load_fingerprints()
+    fingerprints[str(path)] = hashlib.sha256(data).hexdigest()
+    STATE.write_text(json.dumps(fingerprints))
+
+def check_read_before_edit(path, display, data):
+    seen = load_fingerprints().get(str(path))
+    if seen is None:
+        return f"ERROR: you must read {display} before editing it (read it, then edit)."
+    if seen != hashlib.sha256(data).hexdigest():
+        return f"ERROR: {display} changed since you last read it - read it again before editing."
+    return None
+
+def image_dimensions(data):
+    try:
+        if data[:8] == b"\x89PNG\r\n\x1a\n":
+            return struct.unpack(">II", data[16:24])
+        if data[:6] in (b"GIF87a", b"GIF89a"):
+            return struct.unpack("<HH", data[6:10])
+        if data[:2] == b"BM":
+            width, height = struct.unpack("<ii", data[18:26])
+            return width, abs(height)
+        if data[:2] == b"\xff\xd8":
+            index = 2
+            while index + 9 < len(data):
+                if data[index] != 0xFF:
+                    index += 1
+                    continue
+                marker = data[index + 1]
+                if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+                    height, width = struct.unpack(">HH", data[index + 5 : index + 9])
+                    return width, height
+                index += 2 + struct.unpack(">H", data[index + 2 : index + 4])[0]
+        if data[:4] == b"RIFF" and data[8:12] == b"WEBP" and data[12:16] == b"VP8X":
+            return (int.from_bytes(data[24:27], "little") + 1, int.from_bytes(data[27:30], "little") + 1)
+    except Exception:
+        pass
+    return None
+
+def edit_snippet(text, anchor, extra_lines):
+    lines = text.split("\n")
+    line_no = text[: max(anchor, 0)].count("\n") + 1
+    lo = max(1, line_no - 4)
+    hi = min(len(lines), line_no + 4 + extra_lines)
+    return "\n".join(f"{i:>6}\t{lines[i - 1]}" for i in range(lo, hi + 1))
 
 def mtime_key(path):
     return -path.stat().st_mtime, str(path)
@@ -61,45 +146,89 @@ def search_files(root):
         return []
     files = []
     for directory, child_directories, filenames in os.walk(root):
-        child_directories[:] = [name for name in child_directories if name not in {".git", ".hg", ".svn"}]
+        child_directories[:] = [name for name in child_directories if name not in VCS_EXCLUDES]
         files.extend(Path(directory, filename) for filename in filenames)
     return files
 
 operation = arguments["operation"]
 if operation == "read":
-    path = resolve(arguments["file_path"])
+    display = arguments["file_path"]
+    path = resolve(display)
+    if path.is_dir():
+        done(f"ERROR: path is a directory, not a file: {display}")
+    if not path.is_file():
+        done(f"ERROR: file does not exist: {display}")
+    data = path.read_bytes()
+    suffix = path.suffix.lower()
+    if suffix in IMAGE_SUFFIXES:
+        dims = image_dimensions(data)
+        print("__YUTORI_IMAGE__ " + (f"{dims[0]}x{dims[1]}" if dims else "?"))
+        print(base64.b64encode(data).decode())
+        raise SystemExit(0)
+    if suffix == ".pdf":
+        done(f"[pdf file: {path.name} - {len(data)} bytes; binary content not shown]")
+    if suffix == ".ipynb":
+        try:
+            nb = json.loads(data.decode("utf-8", "replace"))
+        except json.JSONDecodeError as exc:
+            done(f"ERROR: {display} is not valid JSON/.ipynb: {exc}")
+        parts = []
+        for idx, cell in enumerate(nb.get("cells", [])):
+            src = cell.get("source", "")
+            if isinstance(src, list):
+                src = "".join(src)
+            parts.append(f"# -- Cell {idx} [{cell.get('cell_type', 'code')}] --\n{src}")
+        record_fingerprint(path, data)
+        done(truncate("\n\n".join(parts) if parts else "[notebook has no cells]", READ_MAX))
+    record_fingerprint(path, data)
+    if not data:
+        done("[file exists but is empty]")
     offset, limit = arguments["offset"], arguments["limit"]
-    for number, line in enumerate(read_text(path).splitlines()[offset - 1 : offset - 1 + limit], offset):
-        print(f"{number:6}\t{line}")
+    lines = decode_text(data).split("\n")
+    start = max(0, offset - 1) if offset else 0
+    window = lines[start : start + max(0, limit)]
+    done(truncate("\n".join(f"{start + i + 1:>6}\t{line}" for i, line in enumerate(window)), READ_MAX))
 elif operation == "write":
-    path = resolve(arguments["file_path"])
+    display = arguments["file_path"]
+    path = resolve(display)
     existed = path.exists()
     write_text(path, arguments["content"])
-    print("updated" if existed else "created")
+    record_fingerprint(path, arguments["content"].encode("utf-8"))
+    if existed:
+        done(f"The file {display} has been updated successfully.")
+    done(f"File created successfully at: {display}")
 elif operation == "edit":
-    path = resolve(arguments["file_path"])
+    display = arguments["file_path"]
+    path = resolve(display)
     old, new = arguments["old_string"], arguments["new_string"]
     if old == new:
-        raise SystemExit("ERROR: old_string and new_string are identical.")
-    if not old:
+        done("ERROR: old_string and new_string are identical.")
+    if old == "":
         if path.exists():
-            raise SystemExit(
-                f"ERROR: cannot create {path}: it already exists (use a non-empty old_string to edit, "
-                "or write to overwrite)."
+            done(
+                f"ERROR: cannot create {display}: it already exists "
+                "(use a non-empty old_string to edit, or write to overwrite)."
             )
         write_text(path, new)
-        print("created")
-    else:
-        text = path.read_text(encoding="utf-8")
-        matches = text.count(old)
-        if not matches:
-            raise SystemExit("ERROR: old_string not found in file (it must match exactly, including whitespace).")
-        if matches > 1 and not arguments["replace_all"]:
-            raise SystemExit(
-                f"ERROR: old_string is not unique ({matches} occurrences). Add context or pass replace_all=true."
-            )
-        write_text(path, text.replace(old, new, -1 if arguments["replace_all"] else 1))
-        print(matches if arguments["replace_all"] else 1)
+        record_fingerprint(path, new.encode("utf-8"))
+        done(f"File created successfully at: {display}")
+    if not path.is_file():
+        done(f"ERROR: file does not exist: {display}")
+    data = path.read_bytes()
+    stale = check_read_before_edit(path, display, data)
+    if stale is not None:
+        done(stale)
+    text = data.decode("utf-8", "replace")
+    count = text.count(old)
+    if count == 0:
+        done("ERROR: old_string not found in file (it must match exactly, including whitespace).")
+    if count > 1 and not arguments["replace_all"]:
+        done(f"ERROR: old_string is not unique ({count} occurrences). Add context or pass replace_all=true.")
+    new_text = text.replace(old, new) if arguments["replace_all"] else text.replace(old, new, 1)
+    write_text(path, new_text)
+    record_fingerprint(path, new_text.encode("utf-8"))
+    anchor = new_text.find(new) if new else text.find(old)
+    done(f"The file {display} has been updated successfully:\n{edit_snippet(new_text, anchor, new.count(chr(10)))}")
 elif operation == "grep":
     root = resolve(arguments["path"] or arguments["cwd"])
     flags = re.MULTILINE | (re.IGNORECASE if arguments["ignore_case"] else 0)
@@ -108,7 +237,7 @@ elif operation == "grep":
     try:
         regex = re.compile(arguments["pattern"], flags)
     except re.error as error:
-        raise SystemExit(f"invalid regex: {error}")
+        done(f"ERROR: invalid regex: {error}")
     files, counts, content = [], [], []
     show_numbers = (
         arguments["output_mode"] == "content"
@@ -132,23 +261,29 @@ elif operation == "grep":
             text = path.read_text(encoding="utf-8", errors="replace")
         except (OSError, UnicodeError):
             continue
-        lines = text.splitlines() or [text]
-        matches = [index for index, line in enumerate(lines) if regex.search(line)]
-        if arguments["multiline"] and regex.search(text):
-            matches = [0]
-        if not matches:
+        if arguments["multiline"]:
+            hits = [(0, text[:MAX_COLUMNS])] if regex.search(text) else []
+            lines = text.splitlines() or [text]
+        else:
+            lines = text.splitlines()
+            hits = [(index, line[:MAX_COLUMNS]) for index, line in enumerate(lines) if regex.search(line)]
+        if not hits:
             continue
         files.append(path)
-        counts.append(f"{path}:{len(matches)}")
+        counts.append(f"{path}:{len(hits)}")
         if arguments["output_mode"] != "content":
             continue
         emitted = set()
-        for index in matches:
+        for index, hit_line in hits:
+            if arguments["multiline"]:
+                prefix = f"{path}:{index + 1}:" if show_numbers else f"{path}:"
+                content.append(prefix + hit_line)
+                continue
             for line_index in range(max(0, index - before), min(len(lines), index + after + 1)):
                 if line_index not in emitted:
                     emitted.add(line_index)
                     prefix = f"{path}:{line_index + 1}:" if show_numbers else f"{path}:"
-                    content.append(prefix + lines[line_index])
+                    content.append(prefix + lines[line_index][:MAX_COLUMNS])
     if arguments["output_mode"] == "files_with_matches":
         output = sorted(map(str, files), key=lambda value: mtime_key(Path(value)))
     elif arguments["output_mode"] == "count":
@@ -156,7 +291,7 @@ elif operation == "grep":
     else:
         output = content
     limit = arguments["head_limit"]
-    print("\n".join(output if limit in (None, 0) else output[:limit]))
+    done(truncate("\n".join(output if limit in (None, 0) else output[:limit]), GREP_MAX))
 elif operation == "glob":
     root = resolve(arguments["path"] or arguments["cwd"])
     pattern = arguments["pattern"]
@@ -166,7 +301,7 @@ elif operation == "glob":
     output = [str(path) for path in matches[:100]]
     if len(matches) > 100:
         output.append(f"[... truncated to first 100 of {len(matches)} matches ...]")
-    print("\n".join(output))
+    done("\n".join(output))
 else:
     raise SystemExit(f"Unknown file operation: {operation}")
 """
@@ -215,7 +350,6 @@ class CuaSandboxComputer:
     def __init__(self, sandbox: Any) -> None:
         self.sandbox = sandbox
         self._bash_cwd: str | None = None
-        self._file_snapshots: set[str] = set()
         self._pointer: tuple[int, int] | None = None
         self._left_mouse_down = False
 
@@ -370,7 +504,17 @@ class CuaSandboxComputer:
 
         sentinel = f"__YUTORI_N2_BASH_CWD_{uuid.uuid4().hex}__"
         wrapped = f"{prefix}{command}\n__yutori_rc=$?\nprintf '\\n{sentinel}%s' \"$PWD\"\nexit $__yutori_rc"
-        result = await self.sandbox.shell.run(wrapped, timeout=max(1, int(timeout) if timeout else 600))
+        # The n2 bash contract: the timeout is clamped to [0, 600] and an expiry is a
+        # NORMAL result the model can react to, never a raised failure envelope.
+        timeout_s = max(0.0, min(float(120.0 if timeout is None else timeout), 600.0))
+        if timeout_s == 0:
+            return "Command timed out after 0s"
+        try:
+            result = await self.sandbox.shell.run(wrapped, timeout=timeout_s)
+        except Exception as error:  # noqa: BLE001 - classify sandbox timeouts below
+            if "timeout" in type(error).__name__.lower() or "timed out" in str(error).lower():
+                return f"Command timed out after {timeout_s:g}s"
+            raise
         stdout = str(getattr(result, "stdout", "") or "")
         body, marker, new_cwd = stdout.rpartition(f"\n{sentinel}")
         if marker:
@@ -379,19 +523,20 @@ class CuaSandboxComputer:
             return _format_shell_output(body, int(getattr(result, "returncode", 0) or 0))
         return _shell_result(result)
 
-    async def read_file(self, file_path: str, offset: int = 1, limit: int = 2_000) -> str:
+    async def read_file(self, file_path: str, offset: int = 1, limit: int = 2_000) -> "str | dict[str, str]":
         if offset < 1:
             raise ValueError("read.offset must be a positive 1-based line number")
         output = await self._run_file_tool("read", file_path=file_path, offset=offset, limit=limit)
-        self._file_snapshots.add(await self._file_key(file_path))
-        return output.rstrip() or "[file exists but is empty]"
+        if output.startswith("__YUTORI_IMAGE__"):
+            header, _, encoded = output.partition("\n")
+            dims = header.split(" ", 1)[1].strip() if " " in header else "?"
+            note = f"Loaded image {file_path}" + (f" ({dims})" if dims != "?" else "")
+            mime = _IMAGE_MIME_TYPES.get(PurePosixPath(file_path).suffix.lower(), "image/png")
+            return {"text": note, "image_url": f"data:{mime};base64,{encoded.strip()}"}
+        return output.rstrip("\n")
 
     async def write_file(self, file_path: str, content: str) -> str:
-        state = (await self._run_file_tool("write", file_path=file_path, content=content)).strip()
-        self._file_snapshots.add(await self._file_key(file_path))
-        if state == "created":
-            return f"File created successfully at: {file_path}"
-        return f"The file {file_path} has been updated successfully."
+        return (await self._run_file_tool("write", file_path=file_path, content=content)).rstrip("\n")
 
     async def edit_file(
         self,
@@ -400,21 +545,15 @@ class CuaSandboxComputer:
         new_string: str,
         replace_all: bool = False,
     ) -> str:
-        file_key = await self._file_key(file_path)
-        if old_string and file_key not in self._file_snapshots:
-            raise RuntimeError(f"Read or write {file_path} before editing it.")
-        replacements = await self._run_file_tool(
-            "edit",
-            file_path=file_path,
-            old_string=old_string,
-            new_string=new_string,
-            replace_all=replace_all,
-        )
-        if old_string == "":
-            self._file_snapshots.add(file_key)
-            return f"File created successfully at: {file_path}"
-        del replacements
-        return f"The file {file_path} has been updated successfully."
+        return (
+            await self._run_file_tool(
+                "edit",
+                file_path=file_path,
+                old_string=old_string,
+                new_string=new_string,
+                replace_all=replace_all,
+            )
+        ).rstrip("\n")
 
     async def grep_files(
         self,
@@ -446,11 +585,11 @@ class CuaSandboxComputer:
             head_limit=head_limit,
             multiline=multiline,
         )
-        return output.rstrip() or "No matches found."
+        return output.rstrip("\n") or "No matches found."
 
     async def glob_files(self, pattern: str, path: str | None = None) -> str:
         output = await self._run_file_tool("glob", pattern=pattern, path=path)
-        return output.rstrip() or "No files found."
+        return output.rstrip("\n") or "No files found."
 
     async def _working_directory(self) -> str:
         if self._bash_cwd is None:
@@ -462,17 +601,16 @@ class CuaSandboxComputer:
             raise RuntimeError("Sandbox shell did not report a working directory.")
         return self._bash_cwd
 
-    async def _file_key(self, file_path: str) -> str:
-        path = PurePosixPath(file_path)
-        return str(path if path.is_absolute() else PurePosixPath(await self._working_directory()) / path)
-
     async def _run_file_tool(self, operation: str, **arguments: Any) -> str:
         payload = {"operation": operation, "cwd": await self._working_directory(), **arguments}
         encoded = base64.b64encode(json.dumps(payload).encode()).decode()
-        return await self._run_python(_FILE_TOOL_SCRIPT, encoded)
-
-    async def _run_python(self, script: str, *arguments: str) -> str:
-        result = await self.sandbox.shell.run(_python_command(script, *arguments), timeout=30)
+        # Search tools get longer budgets (120s grep / 60s glob); plain file I/O stays short.
+        timeout = {"grep": 120, "glob": 60}.get(operation, 30)
+        result = await self.sandbox.shell.run(_python_command(_FILE_TOOL_SCRIPT, encoded), timeout=timeout)
         if int(getattr(result, "returncode", 0) or 0) != 0:
-            raise RuntimeError(_shell_result(result))
+            # n2 expects unexpected failures as a plain ``ERROR: ...``
+            # tool result the model can react to, never a raised failure envelope.
+            detail = str(getattr(result, "stderr", "") or "").strip().splitlines()
+            reason = detail[-1] if detail else f"{operation} failed with exit code {getattr(result, 'returncode', '?')}"
+            return f"ERROR: {reason}"
         return str(getattr(result, "stdout", "") or "")

--- a/examples/navigator_n2/cua_sandbox.py
+++ b/examples/navigator_n2/cua_sandbox.py
@@ -181,6 +181,13 @@ elif operation == "edit":
         done(f"File created successfully at: {display}")
     if not path.is_file():
         done(f"ERROR: file does not exist: {display}")
+    # NOTE: the decode/match/anchor semantics below deliberately reproduce the served
+    # n2 edit tool exactly — replace-mode decoding (invalid bytes become U+FFFD on
+    # write-back), matching against the raw text (read output is CRLF-normalized for
+    # display, the edit match is not), and anchoring the snippet on the first
+    # occurrence of new_string. Reproducing them byte-for-byte is the point of this
+    # reference implementation; "improving" them here would make results diverge
+    # from what n2 sees elsewhere.
     data = path.read_bytes()
     stale = check_read_before_edit(path, display, data)
     if stale is not None:

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -5,6 +5,10 @@ description = "Public Cua cookbooks for stable Yutori Navigator n2"
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "cua==0.1.6",
+    # Newest cua-cli needs cua-sandbox>=0.1.28, whose API-key path can no longer
+    # create image-based cloud VMs. 0.1.17 keeps the local Docker runtime working;
+    # uv then resolves cua-cli back to 0.1.13, the newest release without that floor.
+    "cua-sandbox==0.1.17",
     "yutori==0.9.4",
 ]
 

--- a/examples/navigator_n2/remote_sandbox.py
+++ b/examples/navigator_n2/remote_sandbox.py
@@ -16,6 +16,20 @@ except ImportError:
     from shared import RunGuard, add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
 
 
+def _watch_url(sandbox) -> "str | None":
+    """Browser URL for the sandbox's noVNC viewer, when the runtime exposes one.
+
+    Reads the pinned cua-sandbox runtime's connection info (private attribute,
+    stable for the exact version pinned in pyproject.toml).
+    """
+    info = getattr(sandbox, "_runtime_info", None)
+    port = getattr(info, "vnc_port", None)
+    if not port:
+        return None
+    host = getattr(info, "host", None) or "localhost"
+    return f"http://{host}:{port}/vnc.html"
+
+
 async def main(args: argparse.Namespace) -> None:
     from cua import Image, Sandbox
 
@@ -24,6 +38,9 @@ async def main(args: argparse.Namespace) -> None:
     tool_set = selected_tool_set(args.tool_set)
     guard = RunGuard(args.max_steps)
     async with Sandbox.ephemeral(Image.linux(kind="container"), local=True) as sandbox:
+        watch = _watch_url(sandbox)
+        if watch:
+            print(f"Watch the desktop live: {watch}")
         computer = CuaSandboxComputer(sandbox)
         async with N2ComputerAgent(
             computer=computer,

--- a/examples/navigator_n2/remote_sandbox.py
+++ b/examples/navigator_n2/remote_sandbox.py
@@ -1,4 +1,4 @@
-"""Run stable Navigator n2 in a disposable public Cua sandbox."""
+"""Run stable Navigator n2 in a disposable local Docker Linux sandbox."""
 
 from __future__ import annotations
 
@@ -9,24 +9,27 @@ from yutori.auth import require_api_key
 from yutori.navigator import NAVIGATOR_N2_MODEL, N2ComputerAgent
 
 try:
-    from .cua_sandbox import CuaSandboxComputer
+    from .cua_adapter import CuaSandboxComputer
     from .shared import RunGuard, add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
 except ImportError:
-    from cua_sandbox import CuaSandboxComputer
+    from cua_adapter import CuaSandboxComputer
     from shared import RunGuard, add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
 
 
 async def main(args: argparse.Namespace) -> None:
     from cua import Image, Sandbox
 
+    # Resolve every Yutori-owned input before third-party infrastructure can be allocated.
+    api_key = require_api_key()
+    tool_set = selected_tool_set(args.tool_set)
     guard = RunGuard(args.max_steps)
-    async with Sandbox.ephemeral(Image.linux()) as sandbox:
+    async with Sandbox.ephemeral(Image.linux(kind="container"), local=True) as sandbox:
         computer = CuaSandboxComputer(sandbox)
         async with N2ComputerAgent(
             computer=computer,
-            api_key=require_api_key(),
+            api_key=api_key,
             model=NAVIGATOR_N2_MODEL,
-            tool_set=selected_tool_set(args.tool_set),
+            tool_set=tool_set,
             callbacks=[guard],
             action_confirmation_callback=build_confirmation_callback(args.auto_approve, always_confirm_shell=False),
             supports_click_modifiers=True,

--- a/examples/navigator_n2/shared.py
+++ b/examples/navigator_n2/shared.py
@@ -113,7 +113,7 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--auto-approve",
         action="store_true",
-        help="Approve actions without prompting. Local shell commands still prompt.",
+        help="Approve environment actions without prompting. Host shell commands may still require confirmation.",
     )
     parser.add_argument("--max-steps", type=int, default=30, help="Maximum model turns (default: 30)")
 

--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -29,6 +29,8 @@ Usage:
     uv run examples/navigator_n2_daytona.py \\
         "Write 'hello from n2' to /tmp/demo.txt, then open a terminal and cat the file"
 
+Add --record to save a screen recording of the run to n2-daytona-run.mp4.
+
 Walkthrough: https://docs.yutori.com/reference/n2-daytona
 """
 
@@ -50,6 +52,9 @@ SNAPSHOT = "daytonaio/sandbox:0.6.0"
 # One `keyboard.type` call longer than this is silently cut off by the sandbox.
 TYPE_CHUNK_MAX_CHARS = 500
 
+# Where --record saves the screen recording after the run.
+RECORDING_PATH = "n2-daytona-run.mp4"
+
 # The n2 `bash` tool caps one result at this many characters.
 BASH_RESULT_MAX_CHARS = 30_000
 MAX_STEPS = 30
@@ -70,6 +75,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=_positive_int,
         default=MAX_STEPS,
         help=f"Maximum model turns (default: {MAX_STEPS})",
+    )
+    parser.add_argument(
+        "--record",
+        action="store_true",
+        help=f"Record the sandbox screen and save the video to {RECORDING_PATH} when the run ends.",
     )
     return parser.parse_args(argv)
 
@@ -195,7 +205,7 @@ class DaytonaComputer:
         return output or "(Bash completed with no output)"
 
 
-async def main(task: str, max_steps: int = MAX_STEPS) -> None:
+async def main(task: str, max_steps: int = MAX_STEPS, record: bool = False) -> None:
     # Validate the Yutori credential before entering or allocating third-party infrastructure.
     async with AsyncYutoriClient() as client:
         await client.get_usage()
@@ -204,9 +214,12 @@ async def main(task: str, max_steps: int = MAX_STEPS) -> None:
 
         async with AsyncDaytona() as daytona:
             sandbox = await daytona.create(CreateSandboxFromSnapshotParams(snapshot=SNAPSHOT, ephemeral=True))
+            recording = None
             try:
                 computer = DaytonaComputer(sandbox)
                 await computer.start()
+                if record:
+                    recording = await sandbox.computer_use.recording.start(label="yutori-n2")
                 agent = N2ComputerAgent(
                     computer=computer,
                     completions=client.chat.completions,
@@ -232,7 +245,14 @@ async def main(task: str, max_steps: int = MAX_STEPS) -> None:
                             elif isinstance(output, dict) and output.get("result") is not None:
                                 print(f"RESULT {json.dumps(output['result'], sort_keys=True)}")
             finally:
-                await sandbox.delete(wait=True)
+                try:
+                    if recording is not None:
+                        stopped = await sandbox.computer_use.recording.stop(recording.id)
+                        await sandbox.computer_use.recording.download(recording.id, RECORDING_PATH)
+                        seconds = stopped.duration_seconds or 0
+                        print(f"Saved screen recording ({seconds:.0f}s) to {RECORDING_PATH}")
+                finally:
+                    await sandbox.delete(wait=True)
 
     if agent.stopped_by == "max_steps":
         raise RuntimeError(f"Stopped after {max_steps} steps")
@@ -240,4 +260,4 @@ async def main(task: str, max_steps: int = MAX_STEPS) -> None:
 
 if __name__ == "__main__":
     cli_args = parse_args()
-    asyncio.run(main(cli_args.task, max_steps=cli_args.max_steps))
+    asyncio.run(main(cli_args.task, max_steps=cli_args.max_steps, record=cli_args.record))

--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -9,25 +9,23 @@
 """
 A computer-use agent: Navigator n2 driving a disposable Daytona Linux desktop.
 
-Daytona is third-party infrastructure. This Yutori-maintained example owns the
-n2 adapter and lifecycle wiring that connect it to the Yutori SDK.
-
 Navigator n2 looks at a full-screen screenshot and answers with tool calls — a
 `computer_batch` of GUI actions, or a `bash` command. `N2ComputerAgent`, the
 SDK's n2 agent loop, executes each call through a small adapter, sends the
 result back (a fresh screenshot for the batch, the output for bash), and asks
 again until the model answers with text.
 
-The provider integration is contained in this example, primarily in
-`DaytonaComputer` plus the sandbox lifecycle in `main`. Swap those pieces for
-your own environment to drive a different desktop.
+Daytona is third-party infrastructure; this Yutori-maintained example contains
+the whole integration — the `DaytonaComputer` adapter plus the sandbox
+lifecycle in `main`. Swap those pieces for your own environment to drive a
+different desktop.
 
 Usage:
     yutori auth login                         # or export YUTORI_API_KEY=...
     export DAYTONA_API_KEY=...                # https://app.daytona.io
 
     uv run examples/navigator_n2_daytona.py \\
-        "Write 'hello from n2' to /tmp/demo.txt, then open a terminal and cat the file"
+        "Write 'hello from n2' to /tmp/demo.txt with bash, then open a terminal from the dock and cat the file"
 
 Add --record to save a screen recording of the run to n2-daytona-run.mp4.
 

--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -25,7 +25,7 @@ Usage:
     export DAYTONA_API_KEY=...                # https://app.daytona.io
 
     uv run examples/navigator_n2_daytona.py \\
-        "Write 'hello from n2' to /tmp/demo.txt with bash, then open a terminal from the dock and cat the file"
+        "Find the OS version and free disk space of this machine, and save a summary to a file on the desktop"
 
 Add --record to save a screen recording of the run to n2-daytona-run.mp4.
 

--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "daytona==0.207.0",
+#   "yutori>=0.9.4",
+# ]
+# ///
 """
 A computer-use agent: Navigator n2 driving a disposable Daytona Linux desktop.
+
+Daytona is third-party infrastructure. This Yutori-maintained example owns the
+n2 adapter and lifecycle wiring that connect it to the Yutori SDK.
 
 Navigator n2 looks at a full-screen screenshot and answers with tool calls — a
 `computer_batch` of GUI actions, or a `bash` command. `N2ComputerAgent`, the
@@ -8,32 +18,30 @@ SDK's n2 agent loop, executes each call through a small adapter, sends the
 result back (a fresh screenshot for the batch, the output for bash), and asks
 again until the model answers with text.
 
-Everything Daytona-specific lives in `DaytonaComputer`. Swap it for your own
-adapter to drive a different desktop. `N2InlineCompactor` demonstrates how a
-harness can compact long trajectories without putting conversation policy in
-the computer adapter.
+The provider integration is contained in this example, primarily in
+`DaytonaComputer` plus the sandbox lifecycle in `main`. Swap those pieces for
+your own environment to drive a different desktop.
 
 Usage:
-    pip install yutori daytona                # Python 3.10+
     yutori auth login                         # or export YUTORI_API_KEY=...
     export DAYTONA_API_KEY=...                # https://app.daytona.io
 
-    python examples/navigator_n2_daytona.py \\
+    uv run examples/navigator_n2_daytona.py \\
         "Write 'hello from n2' to /tmp/demo.txt, then open a terminal and cat the file"
 
-Watch the run: `await sandbox.get_preview_link(6080)` returns a noVNC URL.
 Walkthrough: https://docs.yutori.com/reference/n2-daytona
 """
 
 from __future__ import annotations
 
+import argparse
 import asyncio
+import json
 import shlex
-import sys
 import uuid
 
 from yutori import AsyncYutoriClient
-from yutori.navigator import TOOL_SET_COMPUTER_USE_BASH_BATCH, N2ComputerAgent, N2InlineCompactor
+from yutori.navigator import TOOL_SET_COMPUTER_USE_BASH_BATCH, N2ComputerAgent
 
 # Any snapshot carrying Daytona's computer-use bundle. This one is a bare XFCE
 # desktop at 1024x768; build your own to give the model a browser or an editor.
@@ -45,6 +53,25 @@ TYPE_CHUNK_MAX_CHARS = 500
 # The n2 `bash` tool caps one result at this many characters.
 BASH_RESULT_MAX_CHARS = 30_000
 MAX_STEPS = 30
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run stable Navigator n2 on third-party Daytona infrastructure.")
+    parser.add_argument("task", help="Task for stable Navigator n2")
+    parser.add_argument(
+        "--max-steps",
+        type=_positive_int,
+        default=MAX_STEPS,
+        help=f"Maximum model turns (default: {MAX_STEPS})",
+    )
+    return parser.parse_args(argv)
 
 
 def _truncate(text: str, max_chars: int = BASH_RESULT_MAX_CHARS) -> str:
@@ -168,49 +195,49 @@ class DaytonaComputer:
         return output or "(Bash completed with no output)"
 
 
-async def main(task: str) -> None:
-    from daytona import AsyncDaytona, CreateSandboxFromSnapshotParams
+async def main(task: str, max_steps: int = MAX_STEPS) -> None:
+    # Validate the Yutori credential before entering or allocating third-party infrastructure.
+    async with AsyncYutoriClient() as client:
+        await client.get_usage()
 
-    # These defaults match Yutori's Praxis harness. Implement N2Compactor
-    # yourself when your harness needs a different trigger or rewrite policy.
-    # If no complete recent turn fits, the compactor restores the latest frame
-    # after its checkpoint so the next actor request still sees the desktop.
-    compactor = N2InlineCompactor(
-        trigger_input_tokens=53_760,
-        keep_last_n_turns=5,
-        tail_token_budget=16_384,
-    )
-    # The client resolves credentials up front: a missing key must not cost a desktop.
-    async with AsyncYutoriClient() as client, AsyncDaytona() as daytona:
-        sandbox = await daytona.create(CreateSandboxFromSnapshotParams(snapshot=SNAPSHOT))
-        try:
-            computer = DaytonaComputer(sandbox)
-            await computer.start()
-            agent = N2ComputerAgent(
-                computer=computer,
-                completions=client.chat.completions,
-                model="n2",
-                # Daytona does not expose current n2 file tools, so this example
-                # explicitly replays the compatible 20260812 batch-plus-bash set.
-                tool_set=TOOL_SET_COMPUTER_USE_BASH_BATCH,
-                compactor=compactor,
-                max_steps=MAX_STEPS,
-            )
+        from daytona import AsyncDaytona, CreateSandboxFromSnapshotParams
 
-            async for step in agent.run(task):
-                for item in step.get("output") or []:
-                    if item.get("type") == "message":
-                        for part in item.get("content") or []:
-                            if isinstance(part, dict) and part.get("text"):
-                                print(part["text"])
-                    elif item.get("type") == "function_call":
-                        print(f"ACTION {item.get('name')}: {item.get('arguments')}")
-        finally:
-            await sandbox.delete()
+        async with AsyncDaytona() as daytona:
+            sandbox = await daytona.create(CreateSandboxFromSnapshotParams(snapshot=SNAPSHOT, ephemeral=True))
+            try:
+                computer = DaytonaComputer(sandbox)
+                await computer.start()
+                agent = N2ComputerAgent(
+                    computer=computer,
+                    completions=client.chat.completions,
+                    model="n2",
+                    # This compact Yutori-maintained adapter intentionally implements GUI and
+                    # bash only, so it pins the compatible immutable batch-plus-bash contract.
+                    tool_set=TOOL_SET_COMPUTER_USE_BASH_BATCH,
+                    max_steps=max_steps,
+                )
+
+                async for step in agent.run(task):
+                    for item in step.get("output") or []:
+                        if item.get("type") == "message":
+                            for part in item.get("content") or []:
+                                if isinstance(part, dict) and part.get("text"):
+                                    print(part["text"])
+                        elif item.get("type") == "function_call":
+                            print(f"ACTION {item.get('name')}: {item.get('arguments')}")
+                        elif item.get("type") == "function_call_output":
+                            output = item.get("output")
+                            if isinstance(output, str):
+                                print(output)
+                            elif isinstance(output, dict) and output.get("result") is not None:
+                                print(f"RESULT {json.dumps(output['result'], sort_keys=True)}")
+            finally:
+                await sandbox.delete(wait=True)
 
     if agent.stopped_by == "max_steps":
-        raise RuntimeError(f"Stopped after {MAX_STEPS} steps")
+        raise RuntimeError(f"Stopped after {max_steps} steps")
 
 
 if __name__ == "__main__":
-    asyncio.run(main(sys.argv[1]))
+    cli_args = parse_args()
+    asyncio.run(main(cli_args.task, max_steps=cli_args.max_steps))

--- a/llms.txt
+++ b/llms.txt
@@ -109,7 +109,7 @@ If they decline, skip the Scout demo and end with a recap of Research + Browsing
 
 Navigator is Yutori's visual-control model family. Navigator n1.5 (model id `n1.5-latest`) controls browsers. Navigator n2 (model id `n2`) controls a complete desktop through a CUA harness. Both use the **OpenAI Chat Completions-compatible endpoint**: you send a screenshot plus a task instruction, and the model returns actions as tool calls. You execute those actions, append the results, capture a fresh screenshot, and call again - an **agent loop** - until the model returns a text response with no tool calls.
 
-There is no `yutori` CLI command for Navigator loops; call them from Python via `client.chat.completions.create(...)`, which is a drop-in OpenAI-compatible client. For n2, use Yutori MCP to drive a local Mac; to build your own n2 agent, start from `examples/navigator_n2_daytona.py`.
+There is no `yutori` CLI command for Navigator loops; call them from Python via `client.chat.completions.create(...)`, which is a drop-in OpenAI-compatible client. For n2, use Yutori MCP to drive a local Mac. To build your own n2 agent, use `examples/navigator_n2/` for local Docker or `examples/navigator_n2_daytona.py` for a separate third-party Daytona integration.
 
 ### Minimal single call
 
@@ -165,9 +165,10 @@ The core action space covers clicks, scroll, type, key press, drag, mouse move/d
 
 ### Navigator n2 (computer use)
 
-Navigator n2 operates a full desktop. `N2ComputerAgent` defaults to `model="n2"`; pin the current tool set with `tool_set=TOOL_SET_COMPUTER_USE_LATEST` (`"computer_use_tools-20260825"`). It exposes `computer_batch`, `edit`, `read`, `write`, and `bash`. A batch holds up to 15 GUI primitives, runs sequentially against one observed frame, stops at its first error, and receives one screenshot result. n2 is non-streaming and rejects caller-provided `tools`, `disable_tools`, `json_schema`, `response_format`, and non-auto `tool_choice`. Send the full conversation; the server keeps images only in the two newest image-bearing messages.
+Navigator n2 operates a full desktop. `N2ComputerAgent` defaults to `model="n2"`; pin the current tool set with `tool_set=TOOL_SET_COMPUTER_USE_LATEST` (`"computer_use_tools-20260825"`). It exposes `computer_batch`, `edit`, `read`, `write`, and `bash`. A batch holds up to 20 actions drawn from 15 GUI action types, runs sequentially against one observed frame, stops at its first error, and receives one screenshot result. n2 is non-streaming and rejects caller-provided `tools`, `disable_tools`, `json_schema`, `response_format`, and non-auto `tool_choice`. Send the full conversation; the server keeps images only in the two newest image-bearing messages.
 
-- **Sandboxed Linux desktop:** [`examples/navigator_n2_daytona.py`](https://github.com/yutori-ai/yutori-sdk-python/blob/main/examples/navigator_n2_daytona.py) is a complete agent — the SDK's `N2ComputerAgent` runs the loop, `N2InlineCompactor` checkpoints long trajectories, and a `DaytonaComputer` adapter runs the actions. `pip install yutori daytona` (Python 3.10+) plus a `DAYTONA_API_KEY`. It explicitly pins the older `20260812` surface because Daytona's adapter does not implement the current file tools. Walkthrough: <https://docs.yutori.com/reference/n2-daytona>.
+- **Local Docker:** [`examples/navigator_n2/`](https://github.com/yutori-ai/yutori-sdk-python/tree/main/examples/navigator_n2) implements the full current tool set in a disposable local container.
+- **Third-party Daytona desktop:** [`examples/navigator_n2_daytona.py`](https://github.com/yutori-ai/yutori-sdk-python/blob/main/examples/navigator_n2_daytona.py) is a compact hosted example. The SDK runs the loop; a Yutori-maintained `DaytonaComputer` adapter and lifecycle wiring execute actions on Daytona. The script declares Python 3.10+, `yutori>=0.9.4`, and `daytona==0.207.0` as inline dependencies, so run it with `uv run examples/navigator_n2_daytona.py "<task>"` plus a `DAYTONA_API_KEY`. This compact adapter intentionally pins the immutable `20260812` batch-plus-bash surface. Walkthrough: <https://docs.yutori.com/reference/n2-daytona>.
 - **Local Mac:** install Yutori MCP and run
 
 ```bash
@@ -177,7 +178,7 @@ uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the r
 
 `uvx yutori-mcp` then exposes the `run_computer_use_task` MCP tool on macOS. It controls the visible foreground desktop and sends what is on screen to Yutori, so run it while the user is not touching the Mac.
 
-`N2ComputerAgent` (SDK 0.9.3+) drives any adapter with the async handler surface `screenshot`, `click`, `double_click`, `scroll`, `type`, `keypress`, `drag`, `move`, `wait`, and optional `bash` and file handlers. `yutori.navigator.macos.MacOSComputer` is the native Mac adapter Yutori MCP uses (`pip install 'yutori[macos]'`). It encodes full-screen observations as compressed WebP and enforces the 10 MB request budget. Model reference: <https://docs.yutori.com/reference/n2>.
+`N2ComputerAgent` drives any adapter with the async base-handler surface `screenshot`, `click`, `double_click`, `scroll`, `type`, `keypress`, `drag`, `move`, and `wait`. Current tools additionally call `run_bash_command`, `read_file`, `write_file`, and `edit_file`; durationless held keys require `key_down` and `key_up`. `yutori.navigator.macos.MacOSComputer` is the native Mac adapter Yutori MCP uses (`pip install 'yutori[macos]'`). It encodes full-screen observations as compressed WebP and enforces the 10 MB request budget. Model reference: <https://docs.yutori.com/reference/n2>.
 
 For SDK/API integration details, use:
 

--- a/tests/test_navigator_n2_cookbooks.py
+++ b/tests/test_navigator_n2_cookbooks.py
@@ -446,6 +446,16 @@ def test_cua_file_tools_match_the_n2_tool_contract(tmp_path: Path) -> None:
     png = b"\x89PNG\r\n\x1a\n" + b"\x00\x00\x00\rIHDR" + struct.pack(">IIBBBBB", 64, 48, 8, 6, 0, 0, 0)
     (tmp_path / "img.png").write_bytes(png)
     assert run(**read_args, file_path="img.png").splitlines()[0] == "__YUTORI_IMAGE__"
+    # Image and PDF reads must record fingerprints too, or a later edit of the
+    # same path loops forever on the read-before-edit gate (Bugbot, PR #281).
+    assert not run(
+        operation="edit", file_path="img.png", old_string="nope", new_string="x", replace_all=False
+    ).startswith("ERROR: you must read")
+    (tmp_path / "doc.pdf").write_bytes(b"%PDF-1.4 stub")
+    assert run(**read_args, file_path="doc.pdf").startswith("[pdf file: doc.pdf - ")
+    assert not run(
+        operation="edit", file_path="doc.pdf", old_string="nope", new_string="x", replace_all=False
+    ).startswith("ERROR: you must read")
 
     # Grep clamps columns at 500 and skips all six VCS directories.
     (tmp_path / ".hg").mkdir()

--- a/tests/test_navigator_n2_cookbooks.py
+++ b/tests/test_navigator_n2_cookbooks.py
@@ -459,10 +459,10 @@ def test_cua_file_tools_match_the_n2_tool_contract(tmp_path: Path) -> None:
     (tmp_path / "empty.txt").write_text("", encoding="utf-8")
     assert run(**read_args, file_path="empty.txt") == "[file exists but is empty]"
 
-    # Image reads surface dimensions for the host to render as visible image content.
+    # Image reads hand raw bytes to the host, which renders visible image content.
     png = b"\x89PNG\r\n\x1a\n" + b"\x00\x00\x00\rIHDR" + struct.pack(">IIBBBBB", 64, 48, 8, 6, 0, 0, 0)
     (tmp_path / "img.png").write_bytes(png)
-    assert run(**read_args, file_path="img.png").splitlines()[0] == "__YUTORI_IMAGE__ 64x48"
+    assert run(**read_args, file_path="img.png").splitlines()[0] == "__YUTORI_IMAGE__"
 
     # Grep clamps columns at 500 and skips all six VCS directories.
     (tmp_path / ".hg").mkdir()
@@ -486,3 +486,32 @@ def test_cua_file_tools_match_the_n2_tool_contract(tmp_path: Path) -> None:
     (wide_hit,) = [line for line in grep_output.splitlines() if "wide.txt" in line]
     assert len(wide_hit.split(":", 2)[2]) <= 500
     assert ".hg" not in grep_output
+
+
+def test_cua_read_file_returns_visible_image_content() -> None:
+    """`read` on an image must reach the model as image content: a note with the
+    source dimensions plus a WEBP data URL bounded to the 1568-px max edge."""
+    import asyncio
+    import io as _io
+
+    from PIL import Image as _Image
+
+    from examples.navigator_n2.cua_sandbox import CuaSandboxComputer
+
+    buffer = _io.BytesIO()
+    _Image.new("RGB", (2000, 500), (200, 30, 30)).save(buffer, format="PNG")
+    encoded = base64.b64encode(buffer.getvalue()).decode()
+
+    class _Shell:
+        async def run(self, command: str, timeout: int = 30) -> SimpleNamespace:
+            if command.strip() == "pwd":
+                return SimpleNamespace(stdout="/root\n", stderr="", returncode=0)
+            return SimpleNamespace(stdout=f"__YUTORI_IMAGE__\n{encoded}\n", stderr="", returncode=0)
+
+    computer = CuaSandboxComputer(SimpleNamespace(shell=_Shell()))
+    result = asyncio.run(computer.read_file("shot.png"))
+    assert isinstance(result, dict)
+    assert result["text"] == "Loaded image shot.png (2000x500), shown downscaled to 1568x392"
+    assert result["image_url"].startswith("data:image/webp;base64,")
+    with _Image.open(_io.BytesIO(base64.b64decode(result["image_url"].split(",", 1)[1]))) as shown:
+        assert shown.size == (1568, 392)

--- a/tests/test_navigator_n2_cookbooks.py
+++ b/tests/test_navigator_n2_cookbooks.py
@@ -290,7 +290,9 @@ def test_public_cua_file_tool_script_executes_without_shell_interpolation(tmp_pa
         new_string="after",
         replace_all=False,
     )
-    assert edit_output.strip() == "1"
+    # The n2 edit contract: the success line plus a cat -n snippet of the edited region.
+    assert edit_output.startswith("The file draft.txt has been updated successfully:\n")
+    assert "     1\tafter" in edit_output
     assert (tmp_path / "draft.txt").read_text(encoding="utf-8") == "after"
 
     glob_output = run(**common, operation="glob", pattern="*.txt", path=str(tmp_path))
@@ -406,3 +408,81 @@ async def test_public_cua_adapter_preserves_bash_cwd_when_the_command_fails() ->
 
     assert computer._bash_cwd == "/next-workspace"
     assert output == "Exit code 7\ncommand output\ncommand error"
+
+
+def test_cua_file_tools_match_the_n2_tool_contract(tmp_path: Path) -> None:
+    """Pin the exact tool-result strings n2 expects, so the reference adapter
+    cannot drift from the documented tool contract."""
+    import struct
+
+    def run(**arguments: Any) -> str:
+        encoded = base64.b64encode(json.dumps({"cwd": str(tmp_path), **arguments}).encode()).decode()
+        result = subprocess.run(
+            [sys.executable, "-c", _FILE_TOOL_SCRIPT, encoded],
+            check=True,  # expected tool errors are printed results, exit 0
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.rstrip("\n")
+
+    read_args = {"operation": "read", "offset": 1, "limit": 2_000}
+    # Pre-checks return their messages as plain results, never raised errors.
+    assert run(**read_args, file_path="nope.txt") == "ERROR: file does not exist: nope.txt"
+    assert run(**read_args, file_path=".") == "ERROR: path is a directory, not a file: ."
+
+    # The read-before-edit gate: sha256 fingerprints, both messages.
+    target = tmp_path / "a.txt"
+    target.write_text("hello world\nline two\n", encoding="utf-8")
+    edit_args = {"operation": "edit", "file_path": "a.txt", "replace_all": False}
+    assert (
+        run(**edit_args, old_string="hello", new_string="hi")
+        == "ERROR: you must read a.txt before editing it (read it, then edit)."
+    )
+    assert run(**read_args, file_path="a.txt").startswith("     1\thello world")
+    edited = run(**edit_args, old_string="hello", new_string="hi")
+    assert edited.startswith("The file a.txt has been updated successfully:\n")
+    assert "     1\thi world" in edited  # cat -n snippet of the edited region
+    target.write_text(target.read_text(encoding="utf-8") + "more\n", encoding="utf-8")
+    assert (
+        run(**edit_args, old_string="world", new_string="globe")
+        == "ERROR: a.txt changed since you last read it - read it again before editing."
+    )
+
+    # Ambiguity and empty-file renders.
+    dup = tmp_path / "b.txt"
+    dup.write_text("x y x\n", encoding="utf-8")
+    run(**read_args, file_path="b.txt")
+    assert (
+        run(operation="edit", file_path="b.txt", old_string="x", new_string="z", replace_all=False)
+        == "ERROR: old_string is not unique (2 occurrences). Add context or pass replace_all=true."
+    )
+    (tmp_path / "empty.txt").write_text("", encoding="utf-8")
+    assert run(**read_args, file_path="empty.txt") == "[file exists but is empty]"
+
+    # Image reads surface dimensions for the host to render as visible image content.
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00\x00\x00\rIHDR" + struct.pack(">IIBBBBB", 64, 48, 8, 6, 0, 0, 0)
+    (tmp_path / "img.png").write_bytes(png)
+    assert run(**read_args, file_path="img.png").splitlines()[0] == "__YUTORI_IMAGE__ 64x48"
+
+    # Grep clamps columns at 500 and skips all six VCS directories.
+    (tmp_path / ".hg").mkdir()
+    (tmp_path / ".hg" / "hidden.txt").write_text("needle\n", encoding="utf-8")
+    (tmp_path / "wide.txt").write_text("A" * 600 + "needle\n", encoding="utf-8")
+    grep_output = run(
+        operation="grep",
+        pattern="needle",
+        path=None,
+        glob=None,
+        file_type=None,
+        output_mode="content",
+        ignore_case=False,
+        show_line_numbers=None,
+        before_context=None,
+        after_context=None,
+        context=None,
+        head_limit=250,
+        multiline=False,
+    )
+    (wide_hit,) = [line for line in grep_output.splitlines() if "wide.txt" in line]
+    assert len(wide_hit.split(":", 2)[2]) <= 500
+    assert ".hg" not in grep_output

--- a/tests/test_navigator_n2_cookbooks.py
+++ b/tests/test_navigator_n2_cookbooks.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock
 import pytest
 from PIL import Image
 
-from examples.navigator_n2.cua_sandbox import _FILE_TOOL_SCRIPT, CuaSandboxComputer, _format_shell_output
+from examples.navigator_n2.cua_adapter import _FILE_TOOL_SCRIPT, CuaSandboxComputer, _format_shell_output
 from examples.navigator_n2.shared import TOOL_SET_ALIASES, RunGuard, selected_tool_set
 from examples.navigator_n2_daytona import CWD_SENTINEL, DaytonaComputer
 from yutori.navigator import (
@@ -25,7 +25,6 @@ from yutori.navigator import (
     TOOL_SET_COMPUTER_USE_BASH_BATCH,
     TOOL_SET_COMPUTER_USE_LATEST,
     N2ComputerAgent,
-    N2InlineCompactor,
 )
 from yutori.navigator.n2_actions import TOOL_SETS_WITH_CLICK_MODIFIERS
 
@@ -119,7 +118,7 @@ def test_every_ported_example_is_importable_without_its_optional_runtime() -> No
         assert importlib.import_module(name)
 
 
-async def test_daytona_example_runs_through_compaction_end_to_end() -> None:
+async def test_daytona_adapter_runs_with_public_agent_loop_end_to_end() -> None:
     screenshot = f"data:image/png;base64,{_screenshot_base64()}"
     sandbox = SimpleNamespace(
         computer_use=SimpleNamespace(
@@ -166,65 +165,49 @@ async def test_daytona_example_runs_through_compaction_end_to_end() -> None:
                 "request_id": "actor-1",
             },
             {
-                "choices": [
-                    {
-                        "message": {
-                            "content": (
-                                "<conversation_compaction_summary>\n"
-                                "## Goal\nList the files\n"
-                                "</conversation_compaction_summary>"
-                            ),
-                            "tool_calls": [],
-                        }
-                    }
-                ],
-                "usage": {"prompt_tokens": 2},
-                "request_id": "compact-1",
-            },
-            {
                 "choices": [{"message": {"content": "done", "tool_calls": []}}],
                 "usage": {"prompt_tokens": 1},
                 "request_id": "actor-2",
             },
         ]
     )
-    compactor = N2InlineCompactor(
-        trigger_input_tokens=1,
-        keep_last_n_turns=0,
-        retry_delay_seconds=0,
-    )
     agent = N2ComputerAgent(
         computer=computer,
         completions=completions,
         tool_set=TOOL_SET_COMPUTER_USE_BASH_BATCH,
-        compactor=compactor,
     )
 
     steps = [step async for step in agent.run("list files")]
 
     assert steps[-1]["message"]["content"] == "done"
-    assert compactor.compaction_count == 1
     sandbox.process.exec.assert_not_awaited()
     assert sandbox.computer_use.screenshot.take_full_screen.await_count == 2
     assert completions.requests[1]["extra_body"]["prev_request_id"] == "actor-1"
-    assert completions.requests[2]["extra_body"]["prev_request_id"] == "compact-1"
-    assert (
-        "<working_checkpoint>\n## Goal\nList the files" in completions.requests[2]["messages"][1]["content"][0]["text"]
-    )
-    restored = completions.requests[2]["messages"][2]
-    assert restored["role"] == "user"
-    assert [part["type"] for part in restored["content"]] == ["image_url"]
+    tool_result = completions.requests[1]["messages"][-1]
+    assert tool_result["role"] == "tool"
+    assert [part["type"] for part in tool_result["content"]] == ["text", "image_url"]
 
 
-def test_cookbook_uses_a_public_pinned_cua_dependency() -> None:
+def test_cookbook_uses_pinned_public_runtime_dependencies() -> None:
+    root_project = (ROOT / "pyproject.toml").read_text()
     project = (ROOT / "examples" / "navigator_n2" / "pyproject.toml").read_text()
     readme = (ROOT / "examples" / "navigator_n2" / "README.md").read_text()
+    version_match = re.search(r'^version = "([^"]+)"$', root_project, re.MULTILINE)
 
+    assert version_match is not None
+    sdk_version = version_match.group(1)
     assert '"cua==0.1.6"' in project
+    assert '"cua-sandbox==0.1.17"' in project
+    assert f'"yutori=={sdk_version}"' in project
+    assert f'"yutori[macos]=={sdk_version}"' in project
     assert "cua-agent" not in project
     assert "git =" not in project
     assert "private" not in readme.lower()
     assert "n2-preview" not in readme
+
+
+def test_cookbook_adapter_does_not_shadow_cua_sandbox_package() -> None:
+    assert not (ROOT / "examples" / "navigator_n2" / "cua_sandbox.py").exists()
 
 
 def test_cookbook_aliases_include_current_and_historical_n2_tool_sets() -> None:

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -142,6 +142,13 @@ async def test_remote_sandbox_wires_local_container_runtime(monkeypatch: pytest.
     assert seen["sandbox-closed"] is True
 
 
+def test_remote_sandbox_watch_url_comes_from_the_runtime_info() -> None:
+    info = SimpleNamespace(host="localhost", vnc_port=54423)
+    assert remote_sandbox._watch_url(SimpleNamespace(_runtime_info=info)) == "http://localhost:54423/vnc.html"
+    assert remote_sandbox._watch_url(SimpleNamespace(_runtime_info=None)) is None
+    assert remote_sandbox._watch_url(SimpleNamespace()) is None
+
+
 def test_daytona_cli_record_flag_is_optional_and_order_safe() -> None:
     assert navigator_n2_daytona.parse_args(["task"]).record is False
     assert navigator_n2_daytona.parse_args(["--record", "task"]).record is True

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -142,6 +142,13 @@ async def test_remote_sandbox_wires_local_container_runtime(monkeypatch: pytest.
     assert seen["sandbox-closed"] is True
 
 
+def test_daytona_cli_record_flag_is_optional_and_order_safe() -> None:
+    assert navigator_n2_daytona.parse_args(["task"]).record is False
+    assert navigator_n2_daytona.parse_args(["--record", "task"]).record is True
+    args = navigator_n2_daytona.parse_args(["task", "--record"])
+    assert args.record is True and args.task == "task"
+
+
 def test_daytona_cli_help_is_safe_without_optional_runtime(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as exit_info:
         navigator_n2_daytona.parse_args(["--help"])

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -1,0 +1,280 @@
+"""Credential-free tests for the public n2 example entrypoints."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from examples import navigator_n2_daytona
+from examples.navigator_n2 import remote_sandbox
+
+
+def test_daytona_script_declares_its_uv_environment_inline() -> None:
+    script = Path(navigator_n2_daytona.__file__).read_text(encoding="utf-8")
+
+    assert '# requires-python = ">=3.10"' in script
+    assert '#   "daytona==0.207.0",' in script
+    assert '#   "yutori>=0.9.4",' in script
+
+
+def test_remote_sandbox_cli_accepts_documented_docker_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["remote_sandbox.py", "Open Calculator"])
+
+    args = remote_sandbox.parse_args()
+
+    assert args.task == "Open Calculator"
+
+
+async def test_remote_sandbox_resolves_yutori_key_before_allocation(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeImage:
+        @staticmethod
+        def linux(**_kwargs: object) -> object:
+            return object()
+
+    class FakeSandbox:
+        @staticmethod
+        def ephemeral(*_args: object, **_kwargs: object) -> object:
+            pytest.fail("sandbox allocation started before Yutori authentication")
+
+    monkeypatch.setitem(sys.modules, "cua", SimpleNamespace(Image=FakeImage, Sandbox=FakeSandbox))
+
+    def missing_api_key() -> str:
+        raise RuntimeError("missing Yutori key")
+
+    monkeypatch.setattr(remote_sandbox, "require_api_key", missing_api_key)
+    args = argparse.Namespace(
+        max_steps=1,
+        task="test",
+        tool_set="latest",
+        auto_approve=False,
+    )
+
+    with pytest.raises(RuntimeError, match="missing Yutori key"):
+        await remote_sandbox.main(args)
+
+
+async def test_remote_sandbox_rejects_tool_set_before_allocation(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeImage:
+        @staticmethod
+        def linux(**_kwargs: object) -> object:
+            return object()
+
+    class FakeSandbox:
+        @staticmethod
+        def ephemeral(*_args: object, **_kwargs: object) -> object:
+            pytest.fail("sandbox allocation started before tool-set validation")
+
+    monkeypatch.setitem(sys.modules, "cua", SimpleNamespace(Image=FakeImage, Sandbox=FakeSandbox))
+    monkeypatch.setattr(remote_sandbox, "require_api_key", lambda: "test-yutori-key")
+    args = argparse.Namespace(
+        max_steps=1,
+        task="test",
+        tool_set="not-a-tool-set",
+        auto_approve=False,
+    )
+
+    with pytest.raises(ValueError, match="unknown tool set"):
+        await remote_sandbox.main(args)
+
+
+async def test_remote_sandbox_wires_local_container_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+    fake_sandbox = object()
+
+    class FakeImage:
+        @staticmethod
+        def linux(**kwargs: object) -> object:
+            seen["image"] = kwargs
+            return "linux-image"
+
+    class FakeEphemeral:
+        async def __aenter__(self) -> object:
+            return fake_sandbox
+
+        async def __aexit__(self, *_args: object) -> None:
+            seen["sandbox-closed"] = True
+
+    class FakeSandbox:
+        @staticmethod
+        def ephemeral(image: object, **kwargs: object) -> FakeEphemeral:
+            seen["ephemeral"] = (image, kwargs)
+            return FakeEphemeral()
+
+    class FakeComputer:
+        def __init__(self, sandbox: object) -> None:
+            seen["computer-sandbox"] = sandbox
+
+    class FakeAgent:
+        def __init__(self, **kwargs: object) -> None:
+            seen["agent"] = kwargs
+
+        async def __aenter__(self) -> "FakeAgent":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            pass
+
+    async def fake_run_agent(_agent: object, task: str, _guard: object) -> None:
+        seen["task"] = task
+
+    monkeypatch.setitem(sys.modules, "cua", SimpleNamespace(Image=FakeImage, Sandbox=FakeSandbox))
+    monkeypatch.setattr(remote_sandbox, "require_api_key", lambda: "test-yutori-key")
+    monkeypatch.setattr(remote_sandbox, "CuaSandboxComputer", FakeComputer)
+    monkeypatch.setattr(remote_sandbox, "N2ComputerAgent", FakeAgent)
+    monkeypatch.setattr(remote_sandbox, "run_agent", fake_run_agent)
+    args = argparse.Namespace(
+        max_steps=2,
+        task="test",
+        tool_set="latest",
+        auto_approve=True,
+    )
+
+    await remote_sandbox.main(args)
+
+    assert seen["image"] == {"kind": "container"}
+    assert seen["ephemeral"] == ("linux-image", {"local": True})
+    assert seen["computer-sandbox"] is fake_sandbox
+    assert seen["task"] == "test"
+    assert seen["sandbox-closed"] is True
+
+
+def test_daytona_cli_help_is_safe_without_optional_runtime(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        navigator_n2_daytona.parse_args(["--help"])
+
+    assert exit_info.value.code == 0
+    help_text = capsys.readouterr().out
+    assert "task" in help_text
+    assert "--max-steps" in help_text
+
+
+@pytest.mark.parametrize("argv", [[], ["--max-steps", "0", "test"]])
+def test_daytona_cli_rejects_incomplete_or_invalid_input(argv: list[str]) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        navigator_n2_daytona.parse_args(argv)
+
+    assert exit_info.value.code == 2
+
+
+async def test_daytona_validates_yutori_before_ephemeral_sandbox_and_waits_for_delete(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    events: list[str] = []
+    seen: dict[str, object] = {}
+
+    class FakeYutoriClient:
+        def __init__(self) -> None:
+            self.chat = SimpleNamespace(completions=object())
+
+        async def __aenter__(self) -> "FakeYutoriClient":
+            events.append("yutori-enter")
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            events.append("yutori-exit")
+
+        async def get_usage(self) -> None:
+            events.append("yutori-validated")
+
+    class FakeSandbox:
+        async def delete(self, *, wait: bool = False) -> None:
+            seen["delete-wait"] = wait
+            events.append("sandbox-delete")
+
+    class FakeDaytona:
+        async def __aenter__(self) -> "FakeDaytona":
+            events.append("daytona-enter")
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            events.append("daytona-exit")
+
+        async def create(self, params: object) -> FakeSandbox:
+            seen["sandbox-params"] = params
+            events.append("sandbox-create")
+            return FakeSandbox()
+
+    class FakeComputer:
+        def __init__(self, _sandbox: FakeSandbox) -> None:
+            pass
+
+        async def start(self) -> None:
+            events.append("computer-start")
+
+    class FakeAgent:
+        stopped_by = "final_answer"
+
+        def __init__(self, **kwargs: object) -> None:
+            seen["agent-kwargs"] = kwargs
+
+        async def run(self, _task: str):
+            yield {"output": [{"type": "function_call", "name": "bash", "arguments": '{"command":"pwd"}'}]}
+            yield {"output": [{"type": "function_call_output", "output": "/workspace"}]}
+            yield {
+                "output": [
+                    {
+                        "type": "function_call_output",
+                        "output": {"result": "[1:left_click] OK", "image_url": "data:image/png;base64,secret"},
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(navigator_n2_daytona, "AsyncYutoriClient", FakeYutoriClient)
+    monkeypatch.setattr(navigator_n2_daytona, "DaytonaComputer", FakeComputer)
+    monkeypatch.setattr(navigator_n2_daytona, "N2ComputerAgent", FakeAgent)
+    monkeypatch.setitem(
+        sys.modules,
+        "daytona",
+        SimpleNamespace(
+            AsyncDaytona=FakeDaytona,
+            CreateSandboxFromSnapshotParams=lambda **kwargs: kwargs,
+        ),
+    )
+
+    await navigator_n2_daytona.main("test", max_steps=2)
+
+    assert events.index("yutori-validated") < events.index("daytona-enter")
+    assert events.index("yutori-validated") < events.index("sandbox-create")
+    assert seen["sandbox-params"] == {"snapshot": navigator_n2_daytona.SNAPSHOT, "ephemeral": True}
+    assert seen["agent-kwargs"]["max_steps"] == 2
+    assert seen["delete-wait"] is True
+    assert events[-3:] == ["sandbox-delete", "daytona-exit", "yutori-exit"]
+    printed = capsys.readouterr().out
+    assert 'ACTION bash: {"command":"pwd"}' in printed
+    assert "/workspace" in printed
+    assert 'RESULT "[1:left_click] OK"' in printed
+    assert "base64,secret" not in printed
+
+
+async def test_daytona_rejected_yutori_key_never_enters_daytona(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeYutoriClient:
+        async def __aenter__(self) -> "FakeYutoriClient":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            pass
+
+        async def get_usage(self) -> None:
+            raise RuntimeError("invalid Yutori key")
+
+    class FakeDaytona:
+        def __init__(self) -> None:
+            pytest.fail("Daytona initialized before Yutori authentication succeeded")
+
+    monkeypatch.setattr(navigator_n2_daytona, "AsyncYutoriClient", FakeYutoriClient)
+    monkeypatch.setitem(
+        sys.modules,
+        "daytona",
+        SimpleNamespace(
+            AsyncDaytona=FakeDaytona,
+            CreateSandboxFromSnapshotParams=lambda **kwargs: kwargs,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="invalid Yutori key"):
+        await navigator_n2_daytona.main("test")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -153,11 +153,14 @@ def test_built_distributions_include_packaged_assets(tmp_path: Path) -> None:
         shutil.copytree(
             ROOT / "examples",
             src_dir / "examples",
-            ignore=shutil.ignore_patterns("__pycache__", "uv.lock"),
+            ignore=shutil.ignore_patterns("__pycache__", "uv.lock", ".venv"),
         )
         (src_dir / "examples" / "navigator_n2" / "uv.lock").write_text(
             "developer-local lockfile\n", encoding="utf-8"
         )
+        cookbook_venv = src_dir / "examples" / "navigator_n2" / ".venv"
+        cookbook_venv.mkdir()
+        (cookbook_venv / "sentinel.txt").write_text("must not be packaged\n", encoding="utf-8")
         for fname in ("pyproject.toml", "README.md", "LICENSE", "MANIFEST.in"):
             shutil.copy2(ROOT / fname, src_dir / fname)
 
@@ -187,10 +190,16 @@ def test_built_distributions_include_packaged_assets(tmp_path: Path) -> None:
     ):
         assert f"{sdist_root}/{required}" in sdist_names, f"sdist missing {required}"
     for source_path in (ROOT / "examples" / "navigator_n2").rglob("*"):
-        if source_path.is_file() and "__pycache__" not in source_path.parts and source_path.name != "uv.lock":
+        if (
+            source_path.is_file()
+            and ".venv" not in source_path.parts
+            and "__pycache__" not in source_path.parts
+            and source_path.name != "uv.lock"
+        ):
             required = source_path.relative_to(ROOT).as_posix()
             assert f"{sdist_root}/{required}" in sdist_names, f"sdist missing {required}"
     assert f"{sdist_root}/examples/navigator_n2/uv.lock" not in sdist_names
+    assert not any("/examples/navigator_n2/.venv/" in name for name in sdist_names)
 
     wheels = sorted(dist_dir.glob("yutori-*.whl"))
     assert wheels, "expected build to produce a wheel"

--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -1068,7 +1068,7 @@ class N2ComputerAgent:
     (``screenshot``, ``click``, ``double_click``, ``scroll``, ``type``,
     ``keypress``, ``drag``, ``move``, ``wait``, and optionally the shell/file
     tools: ``run_bash_command``, ``read_file``, ``write_file``, ``edit_file``
-    — see ``examples/navigator_n2/cua_sandbox.py`` for the reference
+    — see ``examples/navigator_n2/cua_adapter.py`` for the reference
     implementation). ``completions`` is a
     chat-completions surface such as ``AsyncYutoriClient().chat.completions``;
     when omitted, the agent owns an ``AsyncYutoriClient`` built from


### PR DESCRIPTION
## Summary

Ships the stable **n2 examples and docs** in their final reviewed state. This PR currently also carries #280's commits (merged in so the combined state could be tested and CI-validated); once #280 lands on main, this diff collapses to the changes below.

### Daytona example — one-command run, recording, safer lifecycle
- `examples/navigator_n2_daytona.py` declares its environment via **PEP 723 inline metadata** (Python 3.10+, `daytona==0.207.0`, `yutori>=0.9.4`), so `uv run <file-or-raw-URL> "<task>"` provisions an isolated env automatically. The README's raw-URL command becomes valid the moment this merges — README and script land together deliberately.
- argparse (`--help` is safe and creates nothing; `--max-steps`), tool results printed, Yutori credential validated via `get_usage()` **before** any Daytona allocation, sandbox `ephemeral=True` + `delete(wait=True)`.
- **`--record`**: starts Daytona's Computer Use screen recording and downloads the video to `n2-daytona-run.mp4` before the sandbox is deleted.
- Example task is outcome-oriented (the model chooses GUI vs bash on its own).

### Cua cookbook — rename, local Docker, live watching
- **Why the rename** `cua_sandbox.py` → `cua_adapter.py`: the module name collided with the third-party `cua_sandbox` package that `cua` itself imports. Running `remote_sandbox.py` from the cookbook directory put the example first on `sys.path`, so `import cua` failed with `ImportError: cannot import name 'CloudTransport' from 'cua_sandbox'` — the cookbook could not run at all as documented. The module content is unchanged by the rename, and #280's `test_cookbook_adapter_does_not_shadow_cua_sandbox_package` asserts the old filename stays gone.
- Local Docker is the supported sandbox runtime (`cua-sandbox==0.1.17` pinned with rationale — newer cua-sandbox retires the image-based cloud path); evdev build prerequisites documented for minimal Debian images.
- **Watch URL**: the cookbook prints `Watch the desktop live: http://localhost:<port>/vnc.html` at startup (the container's noVNC viewer), so a browser can follow the agent's actions in real time.
- Fingerprint fix for #280's read-before-edit gate (image/PDF reads never recorded fingerprints → `edit` after `read` looped forever); regression test added, flagged on #280.

### Docs
README/api.md/llms.txt n2 sections rewritten around the two example paths (Daytona first, Docker cookbook and local Mac in dropdowns); batch wording corrected (up to 20 actions of 15 action types); the `20260812` pin documented; unreleased compaction APIs marked main-only in api.md; adapter handler surface documented; `MANIFEST.in` prunes a developer-local cookbook `.venv`.

## Verification
- **Daytona, live**: documented one-command flow ran end to end repeatedly (fastest 19.8 s / 2 turns); `--record` produced a valid 16 s MP4; zero sandboxes left after every run.
- **Local Docker (cua_adapter), live**: cookbook quick command completed with only a Yutori key; the printed noVNC URL serves the live desktop; no leftover containers. **Reproduced manually in review** (not just by CI/automation).
- Remote `uv run <url>` flow proven by serving this exact file over HTTP (uv built the 73-package isolated env from the inline metadata).
- Linux: `uv sync` + import verified on `python:3.12-slim` with the documented apt line.
- Suite: `743 passed, 3 skipped` (includes #280's exact-string contract tests, unmodified); ruff clean; Bugbot findings addressed (fingerprint gate) with regression tests.

## Provenance & landing order
Base changes authored by a Codex pass (2026-08-30), split, independently re-verified, and extended in review. Prefer landing **#280 first**, exactly as tested there; this PR then rebases to its own changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to examples, documentation, packaging manifests, and tests; no production SDK API behavior changes beyond a docstring path update.
> 
> **Overview**
> **Navigator n2 examples and docs** are reorganized around two paths: **local Docker** via the Cua cookbook (`examples/navigator_n2/`) and **third-party Daytona** (`navigator_n2_daytona.py`), with README, `api.md`, `llms.txt`, and examples README updated accordingly (batch limits: up to **20** actions from **15** types; replay `20260818` note moved into `api.md`; compaction APIs called out as main-only).
> 
> **Cua cookbook** switches the sandbox to **local Docker** (`Sandbox.ephemeral(..., local=True)`), pins **`cua-sandbox==0.1.17`**, renames **`cua_sandbox.py` → `cua_adapter.py`** to avoid shadowing the `cua_sandbox` package, prints a **noVNC watch URL**, and resolves Yutori auth/tool-set **before** container allocation. **`cua_adapter`** records read fingerprints on **image/PDF** reads so edit-after-read does not loop on the gate.
> 
> **Daytona example** adds **PEP 723** inline deps for `uv run`, **argparse** (`--max-steps`, `--record` → `n2-daytona-run.mp4`), validates credentials via **`get_usage()`** before allocating sandboxes, uses **ephemeral** sandboxes and **`delete(wait=True)`**, and drops **`N2InlineCompactor`** from the demo.
> 
> **Packaging/tests:** `MANIFEST.in` **prunes** `examples/navigator_n2/.venv`; new **`test_navigator_n2_entrypoints.py`** and expanded cookbook/packaging tests cover lifecycle and CLI contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7879b0b409cb22ec2498ac00fbcfbf2b6592abd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->