### PR TITLE
fix(cli): scope non-interactive skills install, make auth status honest

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ The installer sets these up automatically when Node.js is available. To do it ma
 
 ```bash
 npx add-mcp -n yutori "uvx yutori-mcp"
-npx skills add yutori-ai/yutori-mcp -g
+npx -y skills add yutori-ai/yutori-mcp -g -y -a claude-code
 ```
 
-The first command registers the Yutori MCP server with your editor. The second installs workflow skills for Claude Code and compatible agents.
+The first command registers the Yutori MCP server with your editor. The second installs workflow skills scoped to your client — swap `-a claude-code` for another slug if needed (the skills CLI needs `git` on PATH).
 
 </details>
 
@@ -358,7 +358,7 @@ except APIError as e:
 ```bash
 # Authentication
 yutori auth login      # Log in via browser
-yutori auth status     # Show current auth status
+yutori auth status     # Show whether an API key is configured locally
 yutori auth logout     # Remove saved credentials
 
 # Scouts

--- a/llms.txt
+++ b/llms.txt
@@ -18,12 +18,12 @@ Drive setup yourself. The user's only action is clicking **Allow** in a browser 
 1. Install the CLI, MCP server, and skills in one shot (you run this):
 
     ```bash
-    YUTORI_INSTALL_CLIENT=<client> curl -fsSL https://yutori.com/install.sh | bash
+    curl -fsSL https://yutori.com/install.sh | YUTORI_INSTALL_CLIENT=<client> bash
     ```
 
     Substitute `<client>` with your agent's slug — common values: `claude-code`, `codex`, `cursor`, `vscode`, `claude-desktop`, `gemini-cli`, `zed`, `opencode` (run `npx add-mcp list-agents` for the full list). If `YUTORI_INSTALL_CLIENT` is unset the installer registers MCP for the default set (`claude-code`, `codex`, `cursor`, `gemini-cli`).
 
-    In non-TTY mode the installer does the CLI install via `uv tool install yutori`, registers the Yutori MCP server for the chosen client(s), and installs the six workflow skills (`yutori-scout`, `yutori-research`, `yutori-browse`, `yutori-competitor-watch`, `yutori-api-monitor`, `yutori-login`) at user scope. Auth and verification are skipped — they need a browser and an API key (step 2 below).
+    In non-TTY mode the installer does the CLI install via `uv tool install yutori`, registers the Yutori MCP server for the chosen client(s), and installs the seven workflow skills (`yutori-scout`, `yutori-research`, `yutori-browse`, `yutori-computer-use`, `yutori-competitor-watch`, `yutori-api-monitor`, `yutori-login`) at user scope for the chosen client(s). Auth and verification are skipped — they need a browser and an API key (step 2 below).
 
     If `~/.local/bin` isn't on your PATH yet, invoke `yutori` via `$(uv tool dir --bin)/yutori` or run `export PATH="$(uv tool dir --bin):$PATH"` for the rest of this session.
 
@@ -50,7 +50,7 @@ The installer's status table will say `MCP server: SKIP` or `MCP skills: SKIP` i
 npx add-mcp -y -g -n yutori -a <client> "uvx yutori-mcp"
 
 # Workflow skills
-npx skills add yutori-ai/yutori-mcp -g
+npx -y skills add yutori-ai/yutori-mcp -g -y -a <client>
 ```
 
 If `npx` isn't available, native CLIs work for some clients:
@@ -64,8 +64,8 @@ If `npx` isn't available, native CLIs work for some clients:
 **You run these yourself** once the user confirms `yutori auth login` completed:
 
 ```bash
-yutori auth status     # confirms the API key is saved and valid
-yutori usage           # shows the user their daily quota and active scouts
+yutori auth status     # confirms an API key is configured
+yutori usage           # validates the key and shows daily quota / active scouts
 ```
 
 If both succeed, proceed to **Demonstrate** below. If MCP tools have already loaded in your session (i.e. the coding agent was restarted), `list_api_usage` is an equivalent MCP check.

--- a/tests/test_bash_scripts.py
+++ b/tests/test_bash_scripts.py
@@ -12,6 +12,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SH = REPO_ROOT / "install.sh"
 INSTALL_TEMPLATE = REPO_ROOT / "install.sh.template"
 UNINSTALL_SH = REPO_ROOT / "uninstall.sh"
+LLMS_TXT = REPO_ROOT / "llms.txt"
 
 
 # Scripts that must always be present (hand-authored or committed artifact).
@@ -67,6 +68,13 @@ def test_generated_install_sh_syntax() -> None:
     script = _resolve_install_sh()
     result = subprocess.run(["bash", "-n", str(script)], capture_output=True, text=True)
     assert result.returncode == 0, f"bash -n failed:\n{result.stderr}"
+
+
+def test_llms_install_client_variable_is_scoped_to_the_installer() -> None:
+    content = LLMS_TXT.read_text(encoding="utf-8")
+
+    assert "curl -fsSL https://yutori.com/install.sh | YUTORI_INSTALL_CLIENT=<client> bash" in content
+    assert "YUTORI_INSTALL_CLIENT=<client> curl" not in content
 
 
 @pytest.mark.parametrize("script", AUTHORED_SCRIPTS, ids=lambda p: p.name)

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from typer.testing import CliRunner, Result
 
-from yutori.auth.types import LoginResult
+from yutori.auth.types import AuthStatus, LoginResult
 from yutori.cli.main import app
 
 runner = CliRunner()
@@ -99,3 +99,20 @@ def test_auth_login_ignores_placeholder_config_key(monkeypatch):
 
     assert result.exit_code == 0
     assert "Successfully authenticated!" in result.stdout
+
+
+def test_auth_status_distinguishes_configured_from_validated_key() -> None:
+    configured = AuthStatus(
+        authenticated=True,
+        masked_key="yt-...fake",
+        source="env_var",
+    )
+
+    with patch("yutori.cli.commands.auth.get_auth_status", return_value=configured):
+        result = runner.invoke(app, ["auth", "status"])
+
+    assert result.exit_code == 0
+    assert "API key configured" in result.stdout
+    assert "not validated" in result.stdout
+    assert "yutori usage" in result.stdout
+    assert "Authenticated" not in result.stdout

--- a/tests/test_install_flow.py
+++ b/tests/test_install_flow.py
@@ -1278,6 +1278,24 @@ def test_maybe_install_mcp_skills_skips_with_actionable_detail_when_git_is_missi
     fake_interactive.assert_not_called()
 
 
+def test_maybe_install_mcp_skills_git_skip_hint_matches_the_mode(monkeypatch):
+    # The retry hint in the git-missing skip must be the command the current
+    # mode would actually run: a no-TTY user retrying the bare base command
+    # would hit the unanswered-picker no-op again (Bugbot: git skip hint
+    # drops client scoping).
+    monkeypatch.setenv("YUTORI_INSTALL_CLIENT", "codex")
+
+    with patch("yutori.cli.commands.install_flow._which", return_value=None):
+        noninteractive = maybe_install_mcp_skills(Console(), interactive=False)
+        interactive = maybe_install_mcp_skills(Console(), interactive=True)
+
+    assert "-y -a codex" in noninteractive.detail
+    # The interactive hint is the base command (the TTY picker does the
+    # scoping); note "-a" alone would false-match "yutori-ai".
+    assert "-y -a" not in interactive.detail
+    assert "skills add yutori-ai/yutori-mcp -g` to retry." in interactive.detail
+
+
 def test_maybe_install_mcp_server_noninteractive_defaults_to_popular_client_set(monkeypatch):
     # Without YUTORI_INSTALL_CLIENT, non-interactive installs target the
     # small popular default set -- not `--all` (which writes configs for

--- a/tests/test_install_flow.py
+++ b/tests/test_install_flow.py
@@ -1182,7 +1182,12 @@ def test_run_command_catches_generic_oserror_not_just_filenotfound():
     assert "/bin/bad-binary" in result.stderr
 
 
-def test_maybe_install_mcp_skills_runs_noninteractively_without_tty():
+def test_maybe_install_mcp_skills_runs_noninteractively_without_tty(monkeypatch):
+    # Without YUTORI_INSTALL_CLIENT, the no-TTY skills install answers the
+    # picker with `-y` but scopes it to the same default client set as the
+    # MCP-server step -- a bare `-y` would install symlink scaffolding for
+    # every one of the skills CLI's ~70 supported agents.
+    monkeypatch.delenv("YUTORI_INSTALL_CLIENT", raising=False)
     captured: dict[str, tuple[str, ...]] = {}
 
     with (
@@ -1194,9 +1199,83 @@ def test_maybe_install_mcp_skills_runs_noninteractively_without_tty():
 
     assert result.status == "success"
     fake_interactive.assert_not_called()
-    # Same argv as MCP_SKILLS_INSTALL_COMMAND, just with npx resolved to its
-    # absolute path -- `skills add ... -g` is already non-interactive.
-    assert captured["argv"] == ("/usr/local/bin/npx", *MCP_SKILLS_INSTALL_COMMAND[1:])
+    assert captured["argv"] == (
+        "/usr/local/bin/npx",
+        "-y",
+        "skills",
+        "add",
+        "yutori-ai/yutori-mcp",
+        "-g",
+        "-y",
+        "-a",
+        "claude-code",
+        "-a",
+        "codex",
+        "-a",
+        "cursor",
+        "-a",
+        "gemini-cli",
+    )
+    # Success detail should name the targeted clients and how to scope.
+    assert "claude-code" in result.detail
+    assert "YUTORI_INSTALL_CLIENT" in result.detail
+
+
+def test_maybe_install_mcp_skills_noninteractive_scopes_to_yutori_install_client(monkeypatch):
+    monkeypatch.setenv("YUTORI_INSTALL_CLIENT", "codex")
+    captured: dict[str, tuple[str, ...]] = {}
+
+    with (
+        patch("yutori.cli.commands.install_flow.resolve_npx_path", return_value="/usr/local/bin/npx"),
+        patch("yutori.cli.commands.install_flow.run_command", side_effect=_capturing_run_command(captured)),
+    ):
+        result = maybe_install_mcp_skills(Console(), interactive=False)
+
+    assert result.status == "success"
+    assert captured["argv"] == (
+        "/usr/local/bin/npx",
+        "-y",
+        "skills",
+        "add",
+        "yutori-ai/yutori-mcp",
+        "-g",
+        "-y",
+        "-a",
+        "codex",
+    )
+
+
+def test_maybe_install_mcp_skills_interactive_keeps_the_agent_picker():
+    # On a TTY the skills CLI's own agent picker is the scoping mechanism, so
+    # the interactive argv must not carry the picker-suppressing `-y` or any
+    # `-a` flags.
+    success = _completed_process(0, "", "")
+
+    with _patched_npx_install(run_result=success) as (_, mock_run):
+        result = maybe_install_mcp_skills(Console(), interactive=True)
+
+    assert result.status == "success"
+    argv = mock_run.call_args.args[0]
+    assert argv[-1] == "-g"
+    assert "-a" not in argv
+
+
+def test_maybe_install_mcp_skills_skips_with_actionable_detail_when_git_is_missing():
+    # The skills CLI clones its repository with git; without git it dies
+    # inside npx with a bare `spawn git ENOENT`. The step must skip with a
+    # real explanation instead, in both modes, before any npx invocation.
+    with (
+        patch("yutori.cli.commands.install_flow._which", return_value=None),
+        patch("yutori.cli.commands.install_flow.run_command") as fake_run,
+        patch("yutori.cli.commands.install_flow.run_interactive_command") as fake_interactive,
+    ):
+        result = maybe_install_mcp_skills(Console(), interactive=False)
+
+    assert result.status == "skipped"
+    assert "git" in result.detail
+    assert "skills add yutori-ai/yutori-mcp" in result.detail
+    fake_run.assert_not_called()
+    fake_interactive.assert_not_called()
 
 
 def test_maybe_install_mcp_server_noninteractive_defaults_to_popular_client_set(monkeypatch):

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -320,7 +320,7 @@ def run_login_flow(
                 f"Login succeeded and an API key was created, but saving it to "
                 f"{get_config_path()} failed: {e}. Fix the path and run "
                 f"'yutori auth login' again, or set YUTORI_API_KEY to a key from "
-                f"https://platform.yutori.com/settings.",
+                f"https://platform.yutori.com (Settings -> API Keys).",
                 auth_url=auth_url,
                 api_key=api_key,
             )

--- a/yutori/auth/flow.py
+++ b/yutori/auth/flow.py
@@ -320,7 +320,7 @@ def run_login_flow(
                 f"Login succeeded and an API key was created, but saving it to "
                 f"{get_config_path()} failed: {e}. Fix the path and run "
                 f"'yutori auth login' again, or set YUTORI_API_KEY to a key from "
-                f"https://platform.yutori.com (Settings -> API Keys).",
+                f"https://platform.yutori.com (-> API Keys).",
                 auth_url=auth_url,
                 api_key=api_key,
             )

--- a/yutori/cli/commands/auth.py
+++ b/yutori/cli/commands/auth.py
@@ -36,7 +36,7 @@ def login() -> None:
         raise typer.Exit(1)
 
     if get_stored_api_key() is not None:
-        console.print("[yellow]You are already authenticated.[/yellow]")
+        console.print("[yellow]An API key is already configured.[/yellow]")
         console.print("Run [bold]yutori auth logout[/bold] first to re-authenticate.")
         raise typer.Exit(1)
 
@@ -69,7 +69,7 @@ def logout() -> None:
 
 @app.command()
 def status() -> None:
-    """Show current authentication status."""
+    """Show whether an API key is configured locally."""
     auth_status = get_auth_status()
 
     if not auth_status.authenticated:
@@ -77,10 +77,12 @@ def status() -> None:
         console.print("Run [bold]yutori auth login[/bold] to authenticate.")
         raise typer.Exit(1)
 
-    console.print("[green]Authenticated[/green]")
+    console.print("[green]API key configured[/green] [yellow](not validated)[/yellow]")
     console.print(f"  API Key: {auth_status.masked_key}")
 
     if auth_status.source == "config_file":
         console.print(f"  Source: {auth_status.config_path}")
     elif auth_status.source == "env_var":
         console.print("  Source: YUTORI_API_KEY environment variable")
+
+    console.print("Run [bold]yutori usage[/bold] to validate this key against the API.")

--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -70,6 +70,13 @@ VERIFICATION_MAX_STEPS = 3
 # it add-mcp infers the server name from the first word of the target and
 # registers the server as "uvx".
 MCP_SERVER_INSTALL_COMMAND = ("npx", "-y", "add-mcp", "-n", "yutori", "uvx yutori-mcp")
+# The leading `-y` belongs to npx (it answers npx's own package-install
+# prompt). The skills CLI's `-y` is deliberately NOT part of the base command:
+# on a TTY the user should get the CLI's agent picker, while non-interactive
+# installs append `-y` plus explicit `-a <slug>` scoping in
+# maybe_install_mcp_skills -- a bare `-y` auto-confirms the picker for every
+# supported agent and sprays skill directories for ~70 agents the user never
+# installed.
 MCP_SKILLS_INSTALL_COMMAND = ("npx", "-y", "skills", "add", "yutori-ai/yutori-mcp", "-g")
 # Default set of clients to register MCP for when YUTORI_INSTALL_CLIENT is
 # unset in non-TTY installs. Covers the most-used coding agents without
@@ -862,18 +869,43 @@ def maybe_install_mcp_skills(
     interactive: bool,
     env: Mapping[str, str] | None = None,
 ) -> StepResult:
+    # The skills CLI clones its skill repository with git. Without git the
+    # step would die inside npx with a bare `spawn git ENOENT`, so surface an
+    # actionable skip here instead.
+    if _which("git", _resolve_env(env)) is None:
+        return StepResult(
+            "MCP skills",
+            "skipped",
+            "git is not on PATH and the skills CLI clones its skill repository with git. "
+            f"Install git, then retry. {_manual_retry_hint(MCP_SKILLS_INSTALL_COMMAND)}",
+        )
+
+    # In non-TTY mode the skills CLI's agent picker is answered with `-y`,
+    # which alone would install for every supported agent (~70 directories of
+    # symlink scaffolding under $HOME). Scope it with the same client
+    # selection the MCP-server step uses: YUTORI_INSTALL_CLIENT when set,
+    # otherwise the small default client set.
+    noninteractive_command: Sequence[str] | None = None
+    success_detail = "Installed Yutori workflow skills at user scope."
+    if not interactive:
+        client = os.environ.get("YUTORI_INSTALL_CLIENT", "").strip()
+        clients = (client,) if client else DEFAULT_NONINTERACTIVE_MCP_CLIENTS
+        agent_flags = tuple(flag for slug in clients for flag in ("-a", slug))
+        noninteractive_command = (*MCP_SKILLS_INSTALL_COMMAND, "-y", *agent_flags)
+        success_detail = (
+            f"Installed Yutori workflow skills at user scope for: {', '.join(clients)}. "
+            "Set YUTORI_INSTALL_CLIENT=<slug> to scope to one client."
+        )
+
     return _run_npx_step(
         console,
         name="MCP skills",
         title="Yutori workflow skills",
         description="Installs slash-command workflow skills globally via the skills CLI.",
         command=MCP_SKILLS_INSTALL_COMMAND,
-        # `npx skills add ... -g` doesn't prompt, so the same argv works in
-        # both modes -- only the wrapper's confirm prompt and stdio-handling
-        # differ between interactive and non-interactive paths.
-        noninteractive_command=MCP_SKILLS_INSTALL_COMMAND,
+        noninteractive_command=noninteractive_command,
         confirm_question="Install Yutori workflow skills globally?",
-        success_detail="Installed Yutori workflow skills at user scope.",
+        success_detail=success_detail,
         interactive=interactive,
         env=env,
     )
@@ -893,7 +925,11 @@ def maybe_authenticate(console: Console, *, interactive: bool) -> tuple[StepResu
             print_prompt_block(console, "Authentication", "No interactive terminal detected.")
             console.print(_slate_line("Skipping auth. To finish setting up:"))
             console.print(_slate_line("  - Run `yutori auth login` on a machine with a browser"))
-            console.print(_slate_line("  - Or set YUTORI_API_KEY (get one at https://platform.yutori.com/settings)"))
+            console.print(
+                _slate_line(
+                    "  - Or set YUTORI_API_KEY (create one at https://platform.yutori.com under Settings -> API Keys)"
+                )
+            )
             return (
                 StepResult(
                     "Auth",

--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -930,7 +930,7 @@ def maybe_authenticate(console: Console, *, interactive: bool) -> tuple[StepResu
             console.print(_slate_line("  - Run `yutori auth login` on a machine with a browser"))
             console.print(
                 _slate_line(
-                    "  - Or set YUTORI_API_KEY (create one at https://platform.yutori.com under Settings -> API Keys)"
+                    "  - Or set YUTORI_API_KEY (create one at https://platform.yutori.com (-> API Keys))"
                 )
             )
             return (

--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -869,17 +869,6 @@ def maybe_install_mcp_skills(
     interactive: bool,
     env: Mapping[str, str] | None = None,
 ) -> StepResult:
-    # The skills CLI clones its skill repository with git. Without git the
-    # step would die inside npx with a bare `spawn git ENOENT`, so surface an
-    # actionable skip here instead.
-    if _which("git", _resolve_env(env)) is None:
-        return StepResult(
-            "MCP skills",
-            "skipped",
-            "git is not on PATH and the skills CLI clones its skill repository with git. "
-            f"Install git, then retry. {_manual_retry_hint(MCP_SKILLS_INSTALL_COMMAND)}",
-        )
-
     # In non-TTY mode the skills CLI's agent picker is answered with `-y`,
     # which alone would install for every supported agent (~70 directories of
     # symlink scaffolding under $HOME). Scope it with the same client
@@ -895,6 +884,20 @@ def maybe_install_mcp_skills(
         success_detail = (
             f"Installed Yutori workflow skills at user scope for: {', '.join(clients)}. "
             "Set YUTORI_INSTALL_CLIENT=<slug> to scope to one client."
+        )
+
+    # The skills CLI clones its skill repository with git. Without git the
+    # step would die inside npx with a bare `spawn git ENOENT`, so surface an
+    # actionable skip here instead. The retry hint must show the command this
+    # mode would actually run: hinting the bare base command at a no-TTY user
+    # would reproduce the unanswered-picker no-op it exists to prevent.
+    if _which("git", _resolve_env(env)) is None:
+        retry_command = MCP_SKILLS_INSTALL_COMMAND if interactive else noninteractive_command
+        return StepResult(
+            "MCP skills",
+            "skipped",
+            "git is not on PATH and the skills CLI clones its skill repository with git. "
+            f"Install git, then retry. {_manual_retry_hint(retry_command)}",
         )
 
     return _run_npx_step(


### PR DESCRIPTION
## Summary
- **Skills step**: non-interactive installs used to report `MCP skills OK` while installing nothing (unanswered picker, exit 0); the naive `-y` fix would spray ~55 agent dot-dirs / ~395 symlinks into a fresh `$HOME`. Now: `-y` **plus** `-a <slug>` scoping using the same client selection as the MCP-server step (`YUTORI_INSTALL_CLIENT` or the default four). Interactive installs keep the CLI's own picker. A missing `git` (the skills CLI clones with it) now yields an actionable skip instead of `spawn git ENOENT`.
- **auth status**: says "API key configured (not validated)" and points at `yutori usage` for real validation — it never validated the key, and llms.txt claimed it did.
- **llms.txt/README**: `curl … | YUTORI_INSTALL_CLIENT=<client> bash` (the old leading-assignment form scoped the var to curl and never reached the installer; regression-tested), manual skills commands scoped with `-a`, skill count corrected to seven, stale `platform.yutori.com/settings` deep links reworded.

## Validation
- Pristine `node:22-bookworm-slim`: scoped argv installs 7 skills into `~/.agents` + the chosen client only; all four default slugs accepted; the old spray repro (55 dirs / 395 symlinks) does not occur.
- Gitless container: step now skips with install-git instructions; previously `spawn git ENOENT`, exit 1.
- Fake key: `yutori auth status` → configured-not-validated; `yutori usage` → 401, exit 1. Real key: exit 0.
- `733 passed, 3 skipped`; ruff clean.

## Notes
These fixes reach published users only with the next SDK release (0.9.4 predates them). The auth-status wording and llms.txt fixes were authored by a Codex pass; this PR adds the skills scoping, the git precheck, and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly installer/docs UX and clearer CLI messaging; skills scoping reduces accidental home-directory side effects without touching API auth or payment paths.
> 
> **Overview**
> **Non-interactive MCP skills** no longer rely on a bare `npx skills add … -g` (which could exit 0 without installing or, with only `-y`, litter the home directory for dozens of agents). The installer now appends the skills CLI’s `-y` plus `-a <slug>` flags using the same rules as the MCP server step: `YUTORI_INSTALL_CLIENT` when set, otherwise the default four coding agents. **Interactive** installs still run the base command so the skills CLI’s agent picker works. If **`git` is missing**, the step skips up front with a retry command that matches the current mode instead of failing inside npx.
> 
> **`yutori auth status`** is reframed as *API key configured (not validated)* and directs users to **`yutori usage`** for a live check; login/logout copy is aligned so “configured locally” is not confused with a verified session.
> 
> **README / `llms.txt`** fix the broken `YUTORI_INSTALL_CLIENT` pipe form (`curl … | YUTORI_INSTALL_CLIENT=… bash`), document scoped manual skills installs (`-y -a`), list seven workflow skills, and split verify steps so status vs usage responsibilities are accurate. Stale **platform.yutori.com/settings** links are reworded to point at API Keys. Tests cover the docs regression, auth status output, skills argv scoping, git skip hints, and interactive vs non-interactive behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 718cd9e9070062c0ed9064c681ee0e7653e1e62f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->