### PR TITLE
refactor(navigator): share word-form punctuation key names

### DIFF
--- a/yutori/navigator/_key_symbols.py
+++ b/yutori/navigator/_key_symbols.py
@@ -1,0 +1,27 @@
+"""Shared word-form punctuation key names, used by both key-mapping schemes.
+
+``keys.py`` (Navigator n1.5 -> Playwright) and ``n2_actions.py`` (Navigator n2
+-> the SDK's internal key vocabulary) each need to recognize spelled-out
+punctuation key names like ``"comma"`` or ``"bracketleft"``. Both target
+vocabularies represent punctuation as the literal character itself, so the
+two modules' tables were identical by coincidence rather than by import --
+this module is the single source of truth those tables merge in, so a fix or
+addition can't update one and silently miss the other.
+"""
+
+from __future__ import annotations
+
+PUNCTUATION_KEY_NAMES: dict[str, str] = {
+    "minus": "-",
+    "plus": "+",
+    "equal": "=",
+    "comma": ",",
+    "period": ".",
+    "slash": "/",
+    "backslash": "\\",
+    "semicolon": ";",
+    "quote": "'",
+    "backquote": "`",
+    "bracketleft": "[",
+    "bracketright": "]",
+}

--- a/yutori/navigator/keys.py
+++ b/yutori/navigator/keys.py
@@ -11,6 +11,8 @@ Only the Playwright ``key`` name is needed here (not ``code`` / ``keyCode``).
 
 from __future__ import annotations
 
+from ._key_symbols import PUNCTUATION_KEY_NAMES
+
 _KEY_MAP: dict[str, str] = {
     # Modifier keys
     "ctrl": "Control",
@@ -50,18 +52,7 @@ _KEY_MAP: dict[str, str] = {
     # Function keys
     **{f"f{i}": f"F{i}" for i in range(1, 13)},
     # Word-form punctuation
-    "plus": "+",
-    "minus": "-",
-    "equal": "=",
-    "comma": ",",
-    "period": ".",
-    "slash": "/",
-    "backslash": "\\",
-    "semicolon": ";",
-    "quote": "'",
-    "backquote": "`",
-    "bracketleft": "[",
-    "bracketright": "]",
+    **PUNCTUATION_KEY_NAMES,
     # Lock keys
     "capslock": "CapsLock",
     "numlock": "NumLock",

--- a/yutori/navigator/n2_actions.py
+++ b/yutori/navigator/n2_actions.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import copy
 from typing import Any
 
+from ._key_symbols import PUNCTUATION_KEY_NAMES
 from .models import (
     TOOL_SET_COMPUTER_USE,
     TOOL_SET_COMPUTER_USE_BASH_BATCH,
@@ -177,21 +178,6 @@ _MODIFIER_ALIASES = {
 # model was never taught to ask for.
 MODIFIABLE_ACTIONS = frozenset({"left_click", "double_click", "triple_click", "middle_click", "right_click", "scroll"})
 
-_PUNCTUATION_KEYS = {
-    "minus": "-",
-    "plus": "+",
-    "equal": "=",
-    "comma": ",",
-    "period": ".",
-    "slash": "/",
-    "backslash": "\\",
-    "semicolon": ";",
-    "quote": "'",
-    "backquote": "`",
-    "bracketleft": "[",
-    "bracketright": "]",
-}
-
 _KEY_ALIASES = {
     "meta": "cmd",
     "command": "cmd",
@@ -206,7 +192,7 @@ _KEY_ALIASES = {
     "arrowdown": "down",
     "arrowleft": "left",
     "arrowright": "right",
-    **_PUNCTUATION_KEYS,
+    **PUNCTUATION_KEY_NAMES,
 }
 
 _ACTION_FIELDS = {


### PR DESCRIPTION
## What

`yutori/navigator/keys.py` (maps Navigator n1.5's lowercase key names to Playwright key names) and `yutori/navigator/n2_actions.py` (maps Navigator n2 key expressions to the SDK's internal key vocabulary) each hand-maintained their own copy of the same 12-entry table of spelled-out punctuation names (`"comma"`, `"bracketleft"`, `"semicolon"`, ...) mapped to the literal character. The two tables were identical, but nothing tied them together — a typo fix or a new punctuation alias added to one could silently miss the other, and a reviewer diffing one file has no signal that a twin exists elsewhere.

This extracts the table into a new private module, `yutori/navigator/_key_symbols.py`, and has both `keys.py` and `n2_actions.py` merge it in via `**PUNCTUATION_KEY_NAMES` — the same dict-composition style `n2_actions.py` already used internally for `_KEY_ALIASES`.

## Why this is safe

- **No behavior change.** I verified programmatically that the two original dicts were exactly equal (same keys, same values) before extracting them, so both call sites produce bit-for-bit identical dictionaries after the change.
- **No public API impact.** `_KEY_MAP` and the old `_PUNCTUATION_KEYS` were both private, unexported module-level dicts (`yutori/navigator/__init__.py` only re-exports the public functions `map_key_to_playwright`, `map_keys_individual`, and the `translate_n2_*` helpers — never these internal tables). No test references them by name either.
- **Verified**: full test suite (`pytest -m "not slow"`) passes — 684 passed, 9 skipped (pre-existing, unrelated), 1 deselected (slow marker) — and `ruff check` / `ruff format --check` pass on all changed files.
- **Small, focused diff**: 3 files, one of which is a small new module containing only the shared constant.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfooK3BTwiLhxbP8M15eoZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of private mapping tables with no behavior change to key translation or exported APIs.
> 
> **Overview**
> **Centralizes spelled-out punctuation key aliases** (`"comma"`, `"bracketleft"`, etc.) in a new private module `_key_symbols.py` as `PUNCTUATION_KEY_NAMES`, instead of maintaining identical 12-entry tables in both `keys.py` (n1.5 → Playwright) and `n2_actions.py` (n2 → SDK key vocabulary).
> 
> Both mappers now merge that constant into their private dicts (`_KEY_MAP` and `_KEY_ALIASES`) via `**PUNCTUATION_KEY_NAMES`, matching the composition style `n2_actions` already used. **No runtime or public API change** — the extracted table matches what both files had before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1caf91d2e1a5b6f422e5a2be97c13e1db9ab5200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->