### PR TITLE
refactor(cli): share non-interactive client scoping between MCP steps

### DIFF
--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -806,6 +806,23 @@ def _run_npx_step(
     return StepResult(name, "failed", f"{reason} {_manual_retry_hint(display_command)}")
 
 
+def _resolve_noninteractive_clients() -> tuple[str, ...]:
+    """Clients to scope a non-interactive install to.
+
+    Honors ``YUTORI_INSTALL_CLIENT`` (single target) when set, otherwise
+    falls back to the small :data:`DEFAULT_NONINTERACTIVE_MCP_CLIENTS` set.
+    Shared by the MCP-server and MCP-skills steps so a change to one client
+    list can't drift from the other.
+    """
+    client = os.environ.get("YUTORI_INSTALL_CLIENT", "").strip()
+    return (client,) if client else DEFAULT_NONINTERACTIVE_MCP_CLIENTS
+
+
+def _client_agent_flags(clients: Sequence[str]) -> tuple[str, ...]:
+    """Flatten ``("claude-code", "codex")`` into ``("-a", "claude-code", "-a", "codex")``."""
+    return tuple(flag for slug in clients for flag in ("-a", slug))
+
+
 def maybe_install_mcp_server(
     console: Console,
     *,
@@ -830,17 +847,10 @@ def maybe_install_mcp_server(
 
     if not interactive:
         client = os.environ.get("YUTORI_INSTALL_CLIENT", "").strip()
+        clients = _resolve_noninteractive_clients()
         base = ("npx", "add-mcp", "-y", "-g", "-n", "yutori")
-        if client:
-            noninteractive_command = (*base, "-a", client, "uvx yutori-mcp")
-        else:
-            # Flatten ("claude-code", "codex", ...) -> ("-a", "claude-code", "-a", "codex", ...)
-            agent_flags = tuple(
-                flag
-                for slug in DEFAULT_NONINTERACTIVE_MCP_CLIENTS
-                for flag in ("-a", slug)
-            )
-            noninteractive_command = (*base, *agent_flags, "uvx yutori-mcp")
+        noninteractive_command = (*base, *_client_agent_flags(clients), "uvx yutori-mcp")
+        if not client:
             default_list = ", ".join(DEFAULT_NONINTERACTIVE_MCP_CLIENTS)
             success_detail = (
                 f"Registered Yutori MCP for the default client set ({default_list}). "
@@ -877,10 +887,8 @@ def maybe_install_mcp_skills(
     noninteractive_command: Sequence[str] | None = None
     success_detail = "Installed Yutori workflow skills at user scope."
     if not interactive:
-        client = os.environ.get("YUTORI_INSTALL_CLIENT", "").strip()
-        clients = (client,) if client else DEFAULT_NONINTERACTIVE_MCP_CLIENTS
-        agent_flags = tuple(flag for slug in clients for flag in ("-a", slug))
-        noninteractive_command = (*MCP_SKILLS_INSTALL_COMMAND, "-y", *agent_flags)
+        clients = _resolve_noninteractive_clients()
+        noninteractive_command = (*MCP_SKILLS_INSTALL_COMMAND, "-y", *_client_agent_flags(clients))
         success_detail = (
             f"Installed Yutori workflow skills at user scope for: {', '.join(clients)}. "
             "Set YUTORI_INSTALL_CLIENT=<slug> to scope to one client."


### PR DESCRIPTION
## Structural issue

`maybe_install_mcp_server` and `maybe_install_mcp_skills` in `yutori/cli/commands/install_flow.py` each independently implemented the same "resolve which clients a non-interactive install targets" logic:

1. Read `YUTORI_INSTALL_CLIENT` from the environment, falling back to `DEFAULT_NONINTERACTIVE_MCP_CLIENTS`.
2. Flatten the resulting client list into `("-a", slug, "-a", slug, ...)` argv flags.

This duplication was introduced by #282, which added the skills-step scoping to deliberately mirror the MCP-server step's existing behavior — but re-derived the logic inline rather than sharing it, so a future change to the client-resolution rule (e.g. adding a new default client) could update one call site and silently miss the other.

## Fix

Extracted two small private helpers:
- `_resolve_noninteractive_clients() -> tuple[str, ...]` — the env-var-with-fallback resolution.
- `_client_agent_flags(clients) -> tuple[str, ...]` — the `-a`-flag flattening.

Both `maybe_install_mcp_server` and `maybe_install_mcp_skills` now call these instead of re-implementing the logic. `maybe_install_mcp_server` still branches on whether `YUTORI_INSTALL_CLIENT` was explicitly set to pick its success-detail message (unchanged from before).

## Why it's safe

- **No public API change**: `install_flow.py` backs the hidden `yutori __install_flow` subcommand and is explicitly documented as "not part of the public surface" (module docstring) — nothing here is imported by SDK users.
- **No behavior change**: the resulting argv tuples and success-detail strings are byte-for-byte identical to before for every case (`YUTORI_INSTALL_CLIENT` set vs. unset), verified by direct comparison of the extracted logic against the two original inline implementations.
- **Verified**: full suite `pytest -q -m "not slow"` → 733 passed / 3 skipped / 1 deselected, identical to the pre-refactor baseline (matches the count reported by the immediately-preceding #282 commit). `ruff check .` clean on the touched file. (`ruff format` reports pre-existing, unrelated drift elsewhere in this file — none of it in the lines this PR touches — already documented in this repo's refactor log as CI not running `ruff format --check`.)
- **Scoped**: single file, +22/-14.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NUBVcAW63XfE2aoyXBDYw1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor in the hidden install flow with no intended behavior or public API change.
> 
> **Overview**
> **Deduplicates** how non-interactive MCP server and skills installs pick target agents, so the two steps cannot drift.
> 
> Adds **`_resolve_noninteractive_clients()`** (honor `YUTORI_INSTALL_CLIENT`, else `DEFAULT_NONINTERACTIVE_MCP_CLIENTS`) and **`_client_agent_flags()`** (client slugs → repeated `-a` argv pairs). **`maybe_install_mcp_server`** and **`maybe_install_mcp_skills`** build their no-TTY `npx` commands through those helpers instead of inlining the same env read and flag flattening.
> 
> **Behavior is unchanged**: same argv tuples and success-detail messaging, including the MCP-server branch that only expands the default-client hint when `YUTORI_INSTALL_CLIENT` is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6424a71bcd962949d16e4be39df68173c6d8e04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->