### PR TITLE
refactor(navigator): dedupe frame-poll settle logic in MacOSComputer

### DIFF
--- a/tests/test_navigator_macos_computer.py
+++ b/tests/test_navigator_macos_computer.py
@@ -16,6 +16,7 @@ from typing import Any
 import pytest
 from PIL import Image
 
+import yutori.navigator.macos.computer as computer_module
 from yutori.navigator.macos.computer import (
     MacOSActionRefusedError,
     MacOSComputer,
@@ -23,8 +24,9 @@ from yutori.navigator.macos.computer import (
     MacOSTargetCrashedError,
     MacOSUncertainActionError,
 )
+from yutori.navigator.macos.polling import FramePollResult
 from yutori.navigator.macos.transport import CuaDriverToolError, CuaDriverUncertainActionError
-from yutori.navigator.macos.types import MacOSPresentationStatus
+from yutori.navigator.macos.types import MacOSPresentationStatus, N2Observation
 
 
 def _png(width: int = 2560, height: int = 1600) -> bytes:
@@ -716,3 +718,89 @@ asyncio.run(main())
             os.killpg(supervisor_pid, signal.SIGKILL)
         except ProcessLookupError:
             pass
+
+
+def _frame(capture_id: int = 1) -> N2Observation:
+    return N2Observation(
+        capture_id=capture_id,
+        native_width=100,
+        native_height=100,
+        encoded_width=100,
+        encoded_height=100,
+        media_type="image/webp",
+        encoded_bytes=b"frame-bytes",
+    )
+
+
+def _poll_result(*, outcome: str, last_frame: object, waited_ms: int = 0, capture_ms: int = 0) -> FramePollResult:
+    return FramePollResult(
+        outcome=outcome,
+        waited_ms=waited_ms,
+        polls=1,
+        capture_ms=capture_ms,
+        last_frame=last_frame,
+        changed_fraction=None,
+    )
+
+
+async def test_wait_for_change_banks_polling_time_and_returns_the_changed_frame(monkeypatch):
+    computer = MacOSComputer(FakeTransport(), owns_transport=False, presentation=False)
+    changed_frame = _frame(2)
+
+    async def fake_poll(**kwargs: Any) -> FramePollResult:
+        return _poll_result(outcome="changed", last_frame=changed_frame, waited_ms=900, capture_ms=300)
+
+    monkeypatch.setattr(computer_module, "poll_until_frame_changes", fake_poll)
+
+    result = await computer.wait_for_change(500, _frame(1))
+
+    assert result is changed_frame
+    assert computer.timings["polling_ms"] == 600
+
+
+async def test_wait_for_change_falls_back_to_a_fresh_screenshot_when_the_poll_yields_no_frame(monkeypatch):
+    computer = MacOSComputer(FakeTransport(), owns_transport=False, presentation=False)
+    fresh_frame = _frame(3)
+
+    async def fake_poll(**kwargs: Any) -> FramePollResult:
+        return _poll_result(outcome="undiffable", last_frame=None)
+
+    async def fake_screenshot() -> N2Observation:
+        return fresh_frame
+
+    monkeypatch.setattr(computer_module, "poll_until_frame_changes", fake_poll)
+    monkeypatch.setattr(computer, "screenshot", fake_screenshot)
+
+    assert await computer.wait_for_change(500, _frame(1)) is fresh_frame
+
+
+async def test_poll_after_action_returns_the_reference_first_frame_when_the_poll_yields_no_frame(monkeypatch):
+    computer = MacOSComputer(FakeTransport(), owns_transport=False, presentation=False)
+    first_frame = _frame(4)
+
+    async def fake_poll(**kwargs: Any) -> FramePollResult:
+        return _poll_result(outcome="exhausted", last_frame=None)
+
+    async def unexpected_screenshot() -> N2Observation:
+        raise AssertionError("poll_after_action must not take a fresh screenshot of its own")
+
+    monkeypatch.setattr(computer_module, "poll_until_frame_changes", fake_poll)
+    monkeypatch.setattr(computer, "screenshot", unexpected_screenshot)
+
+    result = await computer.poll_after_action("left_click", _frame(1), first_frame)
+
+    assert result is first_frame
+
+
+async def test_wait_for_change_raises_on_an_aborted_poll(monkeypatch):
+    computer = MacOSComputer(FakeTransport(), owns_transport=False, presentation=False)
+
+    async def fake_poll(**kwargs: Any) -> FramePollResult:
+        return _poll_result(outcome="aborted", last_frame=None)
+
+    monkeypatch.setattr(computer_module, "poll_until_frame_changes", fake_poll)
+    computer.cancellation.request("operator_stop")
+    await asyncio.sleep(0)
+
+    with pytest.raises(asyncio.CancelledError, match="operator_stop"):
+        await computer.wait_for_change(500, _frame(1))

--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -23,7 +23,7 @@ from typing import Any, Literal
 from PIL import Image
 
 from .no_progress import NoProgressWatchdog
-from .polling import FRAME_POLL_ACTION_MAX_MS, frame_poll_wait_budget_ms, poll_until_frame_changes
+from .polling import FRAME_POLL_ACTION_MAX_MS, FramePollResult, frame_poll_wait_budget_ms, poll_until_frame_changes
 from .presentation import MacOSPresentationController
 from .process_lifecycle import cancel_and_drain
 from .sanitize import sanitize_command_preview
@@ -559,12 +559,7 @@ class MacOSComputer:
             deadline=self.execution_deadline,
             cancellation=self.cancellation,
         )
-        self.add_polling_time(max(0, result.waited_ms - result.capture_ms))
-        if result.outcome == "aborted":
-            self.cancellation.raise_if_cancelled()
-        if isinstance(result.last_frame, N2Observation):
-            return result.last_frame
-        return await self.screenshot()
+        return await self._settle_frame_poll(result)
 
     async def poll_after_action(
         self,
@@ -595,10 +590,25 @@ class MacOSComputer:
             deadline=self.execution_deadline,
             cancellation=self.cancellation,
         )
+        return await self._settle_frame_poll(result, fallback=first_frame)
+
+    async def _settle_frame_poll(
+        self, result: FramePollResult, *, fallback: "N2Observation | None" = None
+    ) -> N2Observation:
+        """Bank a completed poll's time/cancellation and resolve its frame.
+
+        A missing ``fallback`` means the caller had no frame of its own to fall
+        back to (:meth:`wait_for_change`'s blind wait), so a fresh capture
+        stands in instead.
+        """
         self.add_polling_time(max(0, result.waited_ms - result.capture_ms))
         if result.outcome == "aborted":
             self.cancellation.raise_if_cancelled()
-        return result.last_frame if isinstance(result.last_frame, N2Observation) else first_frame
+        if isinstance(result.last_frame, N2Observation):
+            return result.last_frame
+        if fallback is not None:
+            return fallback
+        return await self.screenshot()
 
     async def run_shell_command(
         self,


### PR DESCRIPTION
## What
`MacOSComputer.wait_for_change()` and `MacOSComputer.poll_after_action()` each banked the same completed poll's timing/cancellation bookkeeping and picked the same frame to return, differing only in their fallback when the poll yields no usable frame (a fresh screenshot vs. the caller's own reference frame).

Extracted `_settle_frame_poll(result, *, fallback=None)` and updated both call sites to delegate to it.

## Why this is an improvement
Removes duplicated poll-result handling (`add_polling_time`, `cancellation.raise_if_cancelled` on `"aborted"`, and the `isinstance(result.last_frame, N2Observation)` frame selection) that was copy-pasted across the two methods, with only the fallback branch differing.

## Why it's safe
- No behavior change — `wait_for_change()` passes no `fallback` (preserving its "take a fresh screenshot" behavior), `poll_after_action()` passes `fallback=first_frame` (preserving its "return the reference frame" behavior).
- Both methods were previously untested for this logic; added 4 new characterization tests pinning the exact previous behavior for both call sites (changed-frame return, no-frame-falls-back-to-screenshot, no-frame-falls-back-to-first_frame, aborted-poll raises).
- 2 files touched.
- `pytest tests/test_navigator_macos_computer.py` → 36 passed (32 pre-existing + 4 new).
- `ruff check` clean on both changed files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LqEgaHyht5JFs5QgodY9J4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of macOS navigator frame-poll handling with characterization tests; intended behavior is unchanged.
> 
> **Overview**
> **`MacOSComputer`** now routes completed frame polls through a shared **`_settle_frame_poll`** helper instead of duplicating timing, cancellation, and frame-selection logic in **`wait_for_change`** and **`poll_after_action`**.
> 
> Both methods still call **`poll_until_frame_changes`** with the same modes and budgets as before; only the post-poll handling is centralized. **`wait_for_change`** omits **`fallback`**, so a poll with no usable frame still triggers a fresh **`screenshot`**. **`poll_after_action`** passes **`fallback=first_frame`**, so it still returns the caller’s reference frame without an extra capture.
> 
> Four new tests in **`test_navigator_macos_computer.py`** mock **`poll_until_frame_changes`** to lock in changed-frame return, screenshot vs. first-frame fallbacks, polling time banking, and **`CancelledError`** on aborted polls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 539074f87c37934e4524f7625af2ac2b1618eb22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->