### PR TITLE
docs(api.md): document completion_request() public method

### DIFF
--- a/api.md
+++ b/api.md
@@ -558,6 +558,10 @@ For another policy, implement `N2Compactor.compact(...)`. Existing compactors ma
 `N2CompactionResult` to advance the request chain. A new `run()` resets usage and optional compactor state;
 `resume()` continues both.
 
+### Harness-owned completion requests
+
+`agent.completion_request(extra_messages=None, *, items=None)` returns the actor's exact next Chat Completions request as a `dict` — system prompt, windowed messages, sampling fields, tool set, and request chaining — without advancing the loop or mutating the trajectory. Pass `extra_messages` (a list of chat-format dicts) to append harness-owned messages after the trajectory, for example a step-cap "stop and summarize" probe: `await client.chat.completions.create(**agent.completion_request([nudge]))`. The call and its response stay the caller's own; the trajectory is not changed. `items` overrides the rendered trajectory (the loop's own steps pass their in-flight working set). Requires SDK 0.9.4+.
+
 ### Screenshot helpers
 
 | Helper | Signature | Description |


### PR DESCRIPTION
## Summary

- Document `completion_request()` in the Navigator n2 loop section of `api.md`
- Added in #274 (SDK 0.9.4+), the method was tested and mentioned in the preamble but never appeared in the API reference

The method returns the actor's exact next Chat Completions request without advancing the loop — used by harness-owned wrap-up turns such as step-cap stop-and-summarize probes.

## Context

Daily docs-drift cronjob: reviewed all commits merged to main in the last 24 hours and found this public API method was undocumented.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbzekJn7SHJkQ1jip3kiAz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime or API behavior is modified.
> 
> **Overview**
> Adds a **Harness-owned completion requests** subsection to the Navigator n2 loop docs in `api.md`, documenting `N2ComputerAgent.completion_request()` (SDK 0.9.4+).
> 
> The new text explains that the method returns the actor’s next Chat Completions payload as a `dict` without running a loop turn or changing the trajectory, and how to use `extra_messages` (e.g. step-cap stop-and-summarize via `create(**agent.completion_request([nudge]))`) and optional `items` to override the rendered trajectory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64c7b35da6a52b8b98e36734c3ac3ed7f3589742. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->