### PR TITLE
test(examples): pin the Daytona example's default compaction end to end

### DIFF
--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #   "daytona==0.207.0",
-#   "yutori>=0.9.4",
+#   "yutori>=0.9.5",
 # ]
 # ///
 """
@@ -28,6 +28,7 @@ Usage:
         "Find the OS version and free disk space of this machine, and save a summary to a file on the desktop"
 
 Add --record to save a screen recording of the run to n2-daytona-run.mp4.
+Long runs compact automatically (the SDK default); each compaction prints a notice.
 
 Walkthrough: https://docs.yutori.com/reference/n2-daytona
 """
@@ -92,6 +93,13 @@ def _truncate(text: str, max_chars: int = BASH_RESULT_MAX_CHARS) -> str:
 # `exec` is a fresh process. Each command reports where it ended up on this
 # sentinel line and the next one starts there.
 CWD_SENTINEL = "__YUTORI_N2_CWD__"
+
+
+class CompactionNotice:
+    """Print when the SDK's default compactor rewrites the conversation."""
+
+    async def on_compaction(self, info: dict) -> None:
+        print(f"Compacted context: {info['items_before']} -> {info['items_after']} items")
 
 
 class DaytonaComputer:
@@ -226,6 +234,7 @@ async def main(task: str, max_steps: int = MAX_STEPS, record: bool = False) -> N
                     # bash only, so it pins the compatible immutable batch-plus-bash contract.
                     tool_set=TOOL_SET_COMPUTER_USE_BASH_BATCH,
                     max_steps=max_steps,
+                    callbacks=[CompactionNotice()],
                 )
 
                 async for step in agent.run(task):

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -18,7 +18,7 @@ def test_daytona_script_declares_its_uv_environment_inline() -> None:
 
     assert '# requires-python = ">=3.10"' in script
     assert '#   "daytona==0.207.0",' in script
-    assert '#   "yutori>=0.9.4",' in script
+    assert '#   "yutori>=0.9.5",' in script
 
 
 def test_remote_sandbox_cli_accepts_documented_docker_command(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -263,6 +263,126 @@ async def test_daytona_validates_yutori_before_ephemeral_sandbox_and_waits_for_d
     assert "/workspace" in printed
     assert 'RESULT "[1:left_click] OK"' in printed
     assert "base64,secret" not in printed
+
+
+async def test_daytona_example_compacts_long_runs_by_default(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """main() with the real agent: usage past the default trigger is checkpointed
+    (SDK-default compactor, no compactor wiring in the example) and announced."""
+    import base64 as _b64
+    import io as _io
+    import json as _json
+    from unittest.mock import AsyncMock
+
+    from PIL import Image as _Image
+
+    buffer = _io.BytesIO()
+    _Image.new("RGB", (100, 100), (10, 20, 30)).save(buffer, format="PNG")
+    screenshot = f"data:image/png;base64,{_b64.b64encode(buffer.getvalue()).decode()}"
+
+    responses = [
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "act-1",
+                                "function": {
+                                    "name": "computer_batch",
+                                    "arguments": _json.dumps(
+                                        {"actions": [{"action": "left_click", "coordinates": [500, 500]}]}
+                                    ),
+                                },
+                            }
+                        ],
+                    }
+                }
+            ],
+            "usage": {"prompt_tokens": 60_000},  # past the default 53,760 trigger
+            "request_id": "actor-1",
+        },
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": (
+                            "<conversation_compaction_summary>\n## Goal\nsummarize\n</conversation_compaction_summary>"
+                        ),
+                        "tool_calls": [],
+                    }
+                }
+            ],
+            "usage": {"prompt_tokens": 2},
+            "request_id": "compact-1",
+        },
+        {
+            "choices": [{"message": {"content": "done", "tool_calls": []}}],
+            "usage": {"prompt_tokens": 2},
+            "request_id": "actor-2",
+        },
+    ]
+    requests: list[dict] = []
+
+    class FakeCompletions:
+        async def create(self, **kwargs: object) -> dict:
+            requests.append(kwargs)
+            return responses[len(requests) - 1]
+
+    class FakeYutoriClient:
+        def __init__(self) -> None:
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+        async def __aenter__(self) -> "FakeYutoriClient":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            pass
+
+        async def get_usage(self) -> dict:
+            return {}
+
+    fake_sandbox = SimpleNamespace(
+        computer_use=SimpleNamespace(
+            start=AsyncMock(),
+            display=SimpleNamespace(
+                get_info=AsyncMock(return_value=SimpleNamespace(displays=[SimpleNamespace(height=100)]))
+            ),
+            screenshot=SimpleNamespace(
+                take_full_screen=AsyncMock(return_value=SimpleNamespace(screenshot=screenshot))
+            ),
+            mouse=SimpleNamespace(click=AsyncMock()),
+        ),
+        delete=AsyncMock(),
+    )
+
+    class FakeDaytona:
+        async def __aenter__(self) -> "FakeDaytona":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            pass
+
+        async def create(self, _params: object) -> object:
+            return fake_sandbox
+
+    monkeypatch.setattr(navigator_n2_daytona, "AsyncYutoriClient", FakeYutoriClient)
+    monkeypatch.setitem(
+        sys.modules,
+        "daytona",
+        SimpleNamespace(AsyncDaytona=FakeDaytona, CreateSandboxFromSnapshotParams=lambda **kwargs: kwargs),
+    )
+
+    await navigator_n2_daytona.main("long task")
+
+    assert len(requests) == 3, "expected actor -> compaction -> actor"
+    request_text = _json.dumps(requests[2].get("messages", []))
+    assert "working_checkpoint" in request_text, "compacted checkpoint never reached the next actor request"
+    printed = capsys.readouterr().out
+    assert "Compacted context:" in printed
+    assert "done" in printed
 
 
 async def test_daytona_rejected_yutori_key_never_enters_daytona(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
Follow-up to #288 now that **yutori 0.9.5 is on PyPI** (verified: the published wheel's `N2ComputerAgent` defaults to `N2InlineCompactor`; yutori.com/install.sh serves 0.9.5):
- Restores the end-to-end compaction test removed with the old example, adapted to the default-on world: `main()` drives the **real agent** through fake Daytona/Yutori surfaces; an actor turn reporting 60k prompt tokens (past the 53,760 default trigger) is checkpointed, and the next actor request carries the `working_checkpoint`.
- The example gets a `CompactionNotice` callback so the default announces itself (`Compacted context: N -> M items`) — the visibility promise from #288.
- PEP 723 floor bumped to `yutori>=0.9.5` (safe now that it's published; the isolated env resolved 0.9.5 either way).

## Verification
Suite green including the new test; the published 0.9.5 wheel confirmed to default to the inline compactor before this pin bump was pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example and test-only changes; no production SDK or auth paths modified.
> 
> **Overview**
> Pins the **navigator_n2_daytona** example to **`yutori>=0.9.5`** (PEP 723 inline deps and the matching assertion test) so the script matches the SDK where **`N2ComputerAgent`** defaults to inline compaction.
> 
> The example wires a **`CompactionNotice`** callback on the agent so default compactions print **`Compacted context: N -> M items`**, and the module docstring notes that long runs compact automatically.
> 
> Adds **`test_daytona_example_compacts_long_runs_by_default`**, which runs **`main()`** with faked Daytona/Yutori I/O but the **real** agent loop: a turn reporting 60k prompt tokens triggers the default compactor, the follow-up actor request includes **`working_checkpoint`**, and stdout shows the compaction notice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b06b77d9af8c8100f9bd496c32dabb45fe5a18a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->