### PR TITLE
feat(examples): stop-and-summarize turn at the step cap, harness parity

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -78,7 +78,7 @@ uv run python remote_sandbox.py --auto-approve \
 
 A computer-use agent using third-party [Daytona](https://www.daytona.io) infrastructure. `N2ComputerAgent` runs the loop, while this Yutori-maintained example provides a compact `DaytonaComputer` adapter plus sandbox lifecycle wiring. It intentionally uses the immutable batch-plus-bash tool set. The ephemeral sandbox is deleted, with deletion confirmation requested, when the run ends.
 
-The script declares Python 3.10+, Yutori SDK 0.9.4 or newer, and the tested Daytona version as inline metadata. `uv` installs them into an isolated environment automatically:
+The script declares Python 3.10+, the Yutori SDK, and the tested Daytona version as inline metadata; `uv` installs them into an isolated environment automatically. If the run hits the step cap, the example takes one summarize-only turn (no tool execution) and prints the model's summary of progress before exiting:
 
 ```bash
 export DAYTONA_API_KEY=...   # https://app.daytona.io

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -43,7 +43,7 @@ docker info
 uv run python remote_sandbox.py "Open Calculator and compute 17 * 23"
 ~~~
 
-The script prints a `Watch the desktop live: http://localhost:<port>/vnc.html` link at startup — open it in a browser to follow the agent's actions on the sandbox's noVNC viewer.
+The script prints a `Watch the desktop live: http://localhost:<port>/vnc.html` link at startup — open it in a browser to follow the agent's actions on the sandbox's noVNC viewer. If a run hits `--max-steps`, the entrypoints take one summarize-only turn (no tool execution) and print the model's summary of progress before exiting.
 
 This cookbook intentionally does not expose Cua cloud. Cua's current cloud path uses Fleet pools and provider-owned credentials rather than the retired image-based VM API in the pinned Python package; follow [Cua's current CLI documentation](https://cua.ai/docs/reference/cua-cli/cli-reference) if you need that infrastructure.
 

--- a/examples/navigator_n2/local_macos.py
+++ b/examples/navigator_n2/local_macos.py
@@ -5,32 +5,33 @@ from __future__ import annotations
 import argparse
 import asyncio
 
+from yutori import AsyncYutoriClient
 from yutori.auth import require_api_key
 from yutori.navigator import NAVIGATOR_N2_MODEL, N2ComputerAgent
 from yutori.navigator.macos import MacOSComputer
 from yutori.navigator.n2_actions import TOOL_SETS_WITH_CLICK_MODIFIERS
 
 try:
-    from .shared import RunGuard, add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
+    from .shared import add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
 except ImportError:
-    from shared import RunGuard, add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
+    from shared import add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
 
 
 async def main(args: argparse.Namespace) -> None:
-    guard = RunGuard(args.max_steps)
     tool_set = selected_tool_set(args.tool_set)
-    async with MacOSComputer(allow_local_shell=True) as computer:
+    client = AsyncYutoriClient(api_key=require_api_key())
+    async with client, MacOSComputer(allow_local_shell=True) as computer:
         async with N2ComputerAgent(
             computer=computer,
-            api_key=require_api_key(),
+            completions=client.chat.completions,
             model=NAVIGATOR_N2_MODEL,
             tool_set=tool_set,
-            callbacks=[guard],
+            max_steps=args.max_steps,
             action_confirmation_callback=build_confirmation_callback(args.auto_approve, always_confirm_shell=True),
             supports_click_modifiers=tool_set in TOOL_SETS_WITH_CLICK_MODIFIERS,
             supports_scroll_modifiers=False,
         ) as agent:
-            await run_agent(agent, args.task, guard)
+            await run_agent(agent, args.task, completions=client.chat.completions)
 
 
 def parse_args() -> argparse.Namespace:

--- a/examples/navigator_n2/remote_sandbox.py
+++ b/examples/navigator_n2/remote_sandbox.py
@@ -5,15 +5,16 @@ from __future__ import annotations
 import argparse
 import asyncio
 
+from yutori import AsyncYutoriClient
 from yutori.auth import require_api_key
 from yutori.navigator import NAVIGATOR_N2_MODEL, N2ComputerAgent
 
 try:
     from .cua_adapter import CuaSandboxComputer
-    from .shared import RunGuard, add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
+    from .shared import add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
 except ImportError:
     from cua_adapter import CuaSandboxComputer
-    from shared import RunGuard, add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
+    from shared import add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
 
 
 def _watch_url(sandbox) -> "str | None":
@@ -36,22 +37,22 @@ async def main(args: argparse.Namespace) -> None:
     # Resolve every Yutori-owned input before third-party infrastructure can be allocated.
     api_key = require_api_key()
     tool_set = selected_tool_set(args.tool_set)
-    guard = RunGuard(args.max_steps)
-    async with Sandbox.ephemeral(Image.linux(kind="container"), local=True) as sandbox:
-        watch = _watch_url(sandbox)
-        if watch:
-            print(f"Watch the desktop live: {watch}")
-        computer = CuaSandboxComputer(sandbox)
-        async with N2ComputerAgent(
-            computer=computer,
-            api_key=api_key,
-            model=NAVIGATOR_N2_MODEL,
-            tool_set=tool_set,
-            callbacks=[guard],
-            action_confirmation_callback=build_confirmation_callback(args.auto_approve, always_confirm_shell=False),
-            supports_click_modifiers=True,
-        ) as agent:
-            await run_agent(agent, args.task, guard)
+    async with AsyncYutoriClient(api_key=api_key) as client:
+        async with Sandbox.ephemeral(Image.linux(kind="container"), local=True) as sandbox:
+            watch = _watch_url(sandbox)
+            if watch:
+                print(f"Watch the desktop live: {watch}")
+            computer = CuaSandboxComputer(sandbox)
+            async with N2ComputerAgent(
+                computer=computer,
+                completions=client.chat.completions,
+                model=NAVIGATOR_N2_MODEL,
+                tool_set=tool_set,
+                max_steps=args.max_steps,
+                action_confirmation_callback=build_confirmation_callback(args.auto_approve, always_confirm_shell=False),
+                supports_click_modifiers=True,
+            ) as agent:
+                await run_agent(agent, args.task, completions=client.chat.completions)
 
 
 def parse_args() -> argparse.Namespace:

--- a/examples/navigator_n2/shared.py
+++ b/examples/navigator_n2/shared.py
@@ -19,6 +19,7 @@ from yutori.navigator import (
     TOOL_SET_COMPUTER_USE_HYBRID,
     TOOL_SET_COMPUTER_USE_HYBRID_BATCH,
     TOOL_SET_COMPUTER_USE_LATEST,
+    format_stop_and_summarize,
 )
 
 CONFIRMATION_DENIED_OUTPUT = "[ERROR] Action was not confirmed by the user."
@@ -129,8 +130,28 @@ def _text_items(response: dict[str, Any]) -> list[str]:
     return texts
 
 
-async def run_agent(agent: Any, task: str, guard: RunGuard) -> None:
-    """Run the public SDK loop and print text plus non-image tool results."""
+async def stop_and_summarize(agent: Any, completions: Any, task: str) -> "str | None":
+    """One summarize-only completion after the step cap — no tool execution.
+
+    Mirrors the served harness's step-cap wrap-up: the stop-and-summarize nudge
+    is appended to the actor's exact next request (`agent.completion_request`),
+    and the call is made by the caller, so a tool-call reply is never executed.
+    Returns the model's visible text, or None if it answered with none.
+    """
+    nudge = {"role": "user", "content": [{"type": "text", "text": format_stop_and_summarize(task)}]}
+    response = await completions.create(**agent.completion_request([nudge]))
+    data = response.model_dump() if hasattr(response, "model_dump") else dict(response)
+    message = ((data.get("choices") or [{}])[0]).get("message") or {}
+    text = message.get("content")
+    return text if isinstance(text, str) and text.strip() else None
+
+
+async def run_agent(agent: Any, task: str, *, completions: Any) -> None:
+    """Run the public SDK loop and print text plus non-image tool results.
+
+    At the loop's own step cap (``stopped_by == "max_steps"``) one final
+    summarize-only turn is taken and printed before raising.
+    """
     async for response in agent.run(task):
         for text in _text_items(response):
             print(text)
@@ -143,5 +164,8 @@ async def run_agent(agent: Any, task: str, guard: RunGuard) -> None:
                     print(output)
                 elif isinstance(output, dict) and output.get("result") is not None:
                     print(f"RESULT {json.dumps(output['result'], sort_keys=True)}")
-    if guard.limit_reached:
-        raise RuntimeError(f"Stopped after the configured {guard.max_steps} model steps")
+    if agent.stopped_by == "max_steps":
+        summary = await stop_and_summarize(agent, completions, task)
+        if summary:
+            print(f"Step cap reached; the model's summary of progress so far:\n{summary}")
+        raise RuntimeError(f"Stopped after {agent.max_steps} model steps (summary above)")

--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -42,7 +42,7 @@ import shlex
 import uuid
 
 from yutori import AsyncYutoriClient
-from yutori.navigator import TOOL_SET_COMPUTER_USE_BASH_BATCH, N2ComputerAgent
+from yutori.navigator import TOOL_SET_COMPUTER_USE_BASH_BATCH, N2ComputerAgent, format_stop_and_summarize
 
 # Any snapshot carrying Daytona's computer-use bundle. This one is a bare XFCE
 # desktop at 1024x768; build your own to give the model a browser or an editor.
@@ -261,8 +261,17 @@ async def main(task: str, max_steps: int = MAX_STEPS, record: bool = False) -> N
                 finally:
                     await sandbox.delete(wait=True)
 
-    if agent.stopped_by == "max_steps":
-        raise RuntimeError(f"Stopped after {max_steps} steps")
+        if agent.stopped_by == "max_steps":
+            # One summarize-only completion — sent by this harness itself via the
+            # actor's exact next request, so a tool-call reply is never executed.
+            # The sandbox is already deleted; only the Yutori client is needed.
+            nudge = {"role": "user", "content": [{"type": "text", "text": format_stop_and_summarize(task)}]}
+            response = await client.chat.completions.create(**agent.completion_request([nudge]))
+            data = response.model_dump() if hasattr(response, "model_dump") else dict(response)
+            summary = (((data.get("choices") or [{}])[0]).get("message") or {}).get("content")
+            if isinstance(summary, str) and summary.strip():
+                print(f"Step cap reached; the model's summary of progress so far:\n{summary}")
+            raise RuntimeError(f"Stopped after {max_steps} steps (summary above)")
 
 
 if __name__ == "__main__":

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -118,7 +118,7 @@ async def test_remote_sandbox_wires_local_container_runtime(monkeypatch: pytest.
         async def __aexit__(self, *_args: object) -> None:
             pass
 
-    async def fake_run_agent(_agent: object, task: str, _guard: object) -> None:
+    async def fake_run_agent(_agent: object, task: str, *, completions: object) -> None:
         seen["task"] = task
 
     monkeypatch.setitem(sys.modules, "cua", SimpleNamespace(Image=FakeImage, Sandbox=FakeSandbox))
@@ -383,6 +383,104 @@ async def test_daytona_example_compacts_long_runs_by_default(
     printed = capsys.readouterr().out
     assert "Compacted context:" in printed
     assert "done" in printed
+
+
+async def test_shared_stop_and_summarize_returns_visible_text_only() -> None:
+    from examples.navigator_n2 import shared
+
+    class FakeAgent:
+        def completion_request(self, extra_messages=None):
+            assert extra_messages and "Stop here." in extra_messages[0]["content"][0]["text"]
+            return {"model": "n2", "messages": [{"role": "user", "content": "history"}, *extra_messages]}
+
+    class FakeCompletions:
+        def __init__(self, message: dict) -> None:
+            self._message = message
+
+        async def create(self, **kwargs: object) -> dict:
+            assert kwargs["model"] == "n2"
+            return {"choices": [{"message": self._message}]}
+
+    summary = await shared.stop_and_summarize(FakeAgent(), FakeCompletions({"content": "did X, found Y"}), "task")
+    assert summary == "did X, found Y"
+    # A tool-call reply with no visible text yields None (keeps the pre-cap answer).
+    empty = await shared.stop_and_summarize(FakeAgent(), FakeCompletions({"content": "", "tool_calls": [{}]}), "task")
+    assert empty is None
+
+
+async def test_daytona_step_cap_takes_one_summarize_only_turn(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    wrapup_requests: list[dict] = []
+
+    class FakeCompletions:
+        async def create(self, **kwargs: object) -> object:
+            wrapup_requests.append(kwargs)
+            return {"choices": [{"message": {"content": "summary: reached step 2 of 5"}}]}
+
+    class FakeYutoriClient:
+        def __init__(self) -> None:
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+        async def __aenter__(self) -> "FakeYutoriClient":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            pass
+
+        async def get_usage(self) -> dict:
+            return {}
+
+    class FakeSandbox:
+        async def delete(self, wait: bool = False) -> None:
+            pass
+
+    class FakeDaytona:
+        async def __aenter__(self) -> "FakeDaytona":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            pass
+
+        async def create(self, _params: object) -> FakeSandbox:
+            return FakeSandbox()
+
+    class FakeComputer:
+        def __init__(self, _sandbox: object) -> None:
+            pass
+
+        async def start(self) -> None:
+            pass
+
+    class FakeAgent:
+        stopped_by = "max_steps"
+
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        async def run(self, _task: str):
+            if False:  # pragma: no cover - empty async generator
+                yield {}
+
+        def completion_request(self, extra_messages=None):
+            assert "Stop here." in extra_messages[0]["content"][0]["text"]
+            return {"messages": [*extra_messages]}
+
+    monkeypatch.setattr(navigator_n2_daytona, "AsyncYutoriClient", FakeYutoriClient)
+    monkeypatch.setattr(navigator_n2_daytona, "DaytonaComputer", FakeComputer)
+    monkeypatch.setattr(navigator_n2_daytona, "N2ComputerAgent", FakeAgent)
+    monkeypatch.setitem(
+        sys.modules,
+        "daytona",
+        SimpleNamespace(AsyncDaytona=FakeDaytona, CreateSandboxFromSnapshotParams=lambda **kwargs: kwargs),
+    )
+
+    with pytest.raises(RuntimeError, match="summary above"):
+        await navigator_n2_daytona.main("long task", max_steps=2)
+
+    assert len(wrapup_requests) == 1
+    printed = capsys.readouterr().out
+    assert "summary: reached step 2 of 5" in printed
 
 
 async def test_daytona_rejected_yutori_key_never_enters_daytona(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
At `stopped_by == "max_steps"`, all three example entrypoints (Daytona example, cookbook local-macOS and Docker-sandbox) now take **one summarize-only turn**: the stop-and-summarize nudge is appended to the actor's exact next request via the public `completion_request()` (#274) and sent by the example itself — so a tool-call reply is never executed — then the model's summary of progress is printed before the example exits non-zero.

Notes:
- The nudge text is the SDK's existing `format_stop_and_summarize()`.
- Only visible message content is used; a tool-call reply with empty content keeps the pre-cap output.
- The cookbook entrypoints migrate from the `RunGuard` callback to the loop's native `max_steps` policy so `stopped_by` reports `"max_steps"`; `RunGuard` remains exported. They now construct `AsyncYutoriClient` explicitly so the wrap-up shares the run's client; `require_api_key()` still resolves before any sandbox allocation (ordering tests unchanged and passing).

## Verification
- `756 passed, 3 skipped`; ruff clean. New tests: `stop_and_summarize` visible-text-only contract, and a Daytona `main()` step-cap path test (one wrap-up request, summary printed, non-zero exit).
- **Live**: a Daytona run capped at `--max-steps 1` on a multi-step task stopped at the cap, took exactly one summarize-only completion, printed a genuine progress summary ("Completed: collected OS/disk data via shell… Not yet done: writing the Desktop file"), exited non-zero, and left zero sandboxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW