### PR TITLE
refactor(examples): dedupe response-message parsing in n2 stop_and_summarize

### DIFF
--- a/examples/navigator_n2/shared.py
+++ b/examples/navigator_n2/shared.py
@@ -21,6 +21,7 @@ from yutori.navigator import (
     TOOL_SET_COMPUTER_USE_LATEST,
     format_stop_and_summarize,
 )
+from yutori.navigator.n2_compaction import response_message
 
 CONFIRMATION_DENIED_OUTPUT = "[ERROR] Action was not confirmed by the user."
 SHELL_TOOL_NAMES = frozenset({"bash", "shell_command", "run_command"})
@@ -140,8 +141,7 @@ async def stop_and_summarize(agent: Any, completions: Any, task: str) -> "str | 
     """
     nudge = {"role": "user", "content": [{"type": "text", "text": format_stop_and_summarize(task)}]}
     response = await completions.create(**agent.completion_request([nudge]))
-    data = response.model_dump() if hasattr(response, "model_dump") else dict(response)
-    message = ((data.get("choices") or [{}])[0]).get("message") or {}
+    _, message = response_message(response)
     text = message.get("content")
     return text if isinstance(text, str) and text.strip() else None
 


### PR DESCRIPTION
## What

`examples/navigator_n2/shared.py::stop_and_summarize()` (added in #290, the step-cap
wrap-up feature) hand-rolled this two-line idiom to normalize a chat-completions
response and pull out its first message:

```python
data = response.model_dump() if hasattr(response, "model_dump") else dict(response)
message = ((data.get("choices") or [{}])[0]).get("message") or {}
```

This is the exact same pattern `yutori/navigator/n2.py` and `n2_compaction.py` used to
duplicate before #271 (2026-08-30) extracted it into
`n2_compaction.py::response_message(response) -> tuple[dict, dict]`. #290 landed after
that dedup and reintroduced the pattern at a third call site, on the example side this
time.

## Why this is an improvement

Same duplicated logic, now a third instance of a pattern this repo has already
identified and centralized once. Consolidating keeps all three call sites
(`n2.py`, `n2_compaction.py`, and now `examples/navigator_n2/shared.py`) sharing one
implementation instead of drifting independently.

## Why this is safe

- **No behavior change.** `response_message()`'s body is the byte-for-byte same
  expression `shared.py` inlined (only cosmetic parenthesis differences). Both the
  `response.model_dump()` path and the plain-dict `dict(response)` fallback path are
  preserved exactly.
- **No public API change.** `stop_and_summarize()`'s signature and return value are
  untouched; `response_message` itself is untouched (not modified, just called from a
  new site).
- **Precedent for the import.** `response_message` isn't re-exported from
  `yutori.navigator.__all__`, but examples already import internal, non-`__all__`
  navigator submodules directly and even a `_`-prefixed helper today (e.g.
  `examples/_common.py` imports from `yutori.navigator.replay`, `yutori.navigator.loop`,
  and `yutori.navigator.replay._clip_image_url`). This follows that established
  pattern rather than introducing a new one.
- **Verified:**
  - The existing `test_shared_stop_and_summarize_returns_visible_text_only` test
    (which exercises both the visible-text and empty/tool-call response shapes)
    passes unchanged.
  - Full suite: `pytest -q -m "not slow"` → 755 passed / 3 skipped / 1 deselected
    (identical to baseline).
  - Targeted n2 tests (`test_navigator_n2.py`, `test_navigator_n2_compaction.py`,
    `test_navigator_n2_cookbooks.py`, `test_navigator_n2_entrypoints.py`) → 119 passed.
  - `ruff check .` and `ruff format --check examples/navigator_n2/shared.py` clean.

1 file changed, +2/-2.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GvkS4d7tcWddp6ofWK4rQZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change in example code with identical parsing logic and no API or behavior changes.
> 
> **Overview**
> **`stop_and_summarize`** in the navigator n2 examples no longer inlines chat-completions response parsing; it calls the shared **`response_message`** helper from **`n2_compaction`** (same logic already used in the main navigator n2 code).
> 
> Behavior, return value, and tests are unchanged—this only removes a third copy of the normalize-then-read-first-message pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f4174b8ef164e9c30db024fc5af2618e9f69514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->