### PR TITLE
refactor(examples): dedupe response-message parsing in n2 Daytona example

### DIFF
--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -50,6 +50,7 @@ import uuid
 
 from yutori import AsyncYutoriClient
 from yutori.navigator import TOOL_SET_COMPUTER_USE_BASH_BATCH, N2ComputerAgent, format_stop_and_summarize
+from yutori.navigator.n2_compaction import response_message
 
 # Any snapshot carrying Daytona's computer-use bundle. This one is a bare XFCE
 # desktop at 1024x768; build your own to give the model a browser or an editor.
@@ -297,8 +298,8 @@ async def main(task: str, max_steps: int = MAX_STEPS, record: bool = False) -> N
             # The sandbox is already deleted; only the Yutori client is needed.
             nudge = {"role": "user", "content": [{"type": "text", "text": format_stop_and_summarize(task)}]}
             response = await client.chat.completions.create(**agent.completion_request([nudge]))
-            data = response.model_dump() if hasattr(response, "model_dump") else dict(response)
-            summary = (((data.get("choices") or [{}])[0]).get("message") or {}).get("content")
+            _, message = response_message(response)
+            summary = message.get("content")
             if isinstance(summary, str) and summary.strip():
                 print(f"Step cap reached; the model's summary of progress so far:\n{summary}")
             raise RuntimeError(f"Stopped after {max_steps} steps (summary above)")


### PR DESCRIPTION
## What

`examples/navigator_n2_daytona.py::main()` hand-rolled the same "normalize a chat-completions response and pull its first message" idiom that `yutori/navigator/n2.py` and `n2_compaction.py` already deduped into `n2_compaction.py::response_message()` in #271:

```python
data = response.model_dump() if hasattr(response, "model_dump") else dict(response)
summary = (((data.get("choices") or [{}])[0]).get("message") or {}).get("content")
```

#292 just fixed the exact same duplication in `examples/navigator_n2/shared.py::stop_and_summarize()`, but that PR only touched `shared.py` — it didn't catch this fourth live instance in the standalone Daytona example's own step-cap wrap-up block (added in #281, present through #293).

This PR delegates to the existing `response_message()` helper here too:

```python
_, message = response_message(response)
summary = message.get("content")
```

## Why this is safe

- **Zero public-API change.** `navigator_n2_daytona.py` is an example script, not part of the installed `yutori` package's public surface.
- `response_message()`'s body is byte-for-byte the same expression this file inlined — no behavior change.
- `navigator_n2_daytona.py` is deliberately a self-contained single-file `uv run` script (PEP 723 inline deps: `daytona`, `yutori`) and does **not** depend on the `examples/navigator_n2/` package, by design (that package has its own separate `pyproject.toml`/Python 3.12 env for Cua). This change respects that boundary — it only reaches into `yutori.navigator.n2_compaction`, a submodule of the `yutori` package that's already a declared dependency of this script (and that `examples/navigator_n2/shared.py` itself already imports from directly, per precedent noted in #292).

## Verification

- `pytest -q -m "not slow"`: 713 passed, 9 skipped, 1 deselected — identical counts to `main` before this change.
- The existing `test_daytona_step_cap_takes_one_summarize_only_turn` end-to-end test (in `tests/test_navigator_n2_entrypoints.py`) exercises this exact code path with a plain-dict fake response and passes unchanged.
- `ruff check .` — all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01HZoSGEDvAFuFERD13ZzkWW


---
_Generated by [Claude Code](https://claude.ai/code/session_01HZoSGEDvAFuFERD13ZzkWW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only refactor with no API or logic change beyond calling an existing helper with equivalent parsing.
> 
> **Overview**
> The standalone Daytona example’s **max-steps wrap-up** no longer hand-rolls chat-completion parsing when printing a summarize-only summary after the sandbox is torn down.
> 
> It now imports **`response_message`** from `yutori.navigator.n2_compaction` and uses that helper to extract the first choice’s message content—the same normalization logic that was previously inlined (Pydantic `model_dump()` vs plain dict). Behavior on the step-cap path is unchanged; this aligns the example with deduping done elsewhere (#271, #292).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6e6e12d9df54965943bd6beec26c70ae125f1ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->