### PR TITLE
refactor(n2): dedupe N2InlineCompactor's init/reset state fields

### DIFF
--- a/yutori/navigator/n2_compaction.py
+++ b/yutori/navigator/n2_compaction.py
@@ -392,15 +392,13 @@ class N2InlineCompactor:
         self.target_max_chars = target_max_chars
         self.max_attempts = max_attempts
         self.retry_delay_seconds = retry_delay_seconds
-        self.compaction_count = 0
-        self.last_result: Optional[N2CompactionResult] = None
-        self._awaiting_post_compaction_baseline = False
+        self.reset()
 
     def reset(self) -> None:
         """Reset state for a new ``N2ComputerAgent.run()`` conversation."""
 
         self.compaction_count = 0
-        self.last_result = None
+        self.last_result: Optional[N2CompactionResult] = None
         self._awaiting_post_compaction_baseline = False
 
     async def compact(


### PR DESCRIPTION
## The structural issue

`N2InlineCompactor.__init__` and its public `reset()` method (`yutori/navigator/n2_compaction.py`) each independently listed the same three per-conversation state fields:

```python
self.compaction_count = 0
self.last_result: Optional[N2CompactionResult] = None
self._awaiting_post_compaction_baseline = False
```

`__init__` carried the type annotation on `last_result`; `reset()` had a bare re-assignment of the same three fields. Two independent listings of the same state invite drift — a future state field added to one could easily be missed in the other (the exact "same mechanism, different consequence" bug class this repo's own guidelines call out).

## The fix

`__init__` now calls `self.reset()` after setting its config attributes, so there's a single place that defines the compactor's initial/reset state. The type annotation moved with the assignment into `reset()` (mypy attaches attribute types to whichever method carries the annotated assignment, so this is not just cosmetic).

## Why it's an improvement

Single source of truth for the compactor's per-conversation state — any future field only needs to be added once.

## Why it's safe — no public API change

- `N2InlineCompactor` is exported and documented in `api.md`, but this touches neither its public constructor signature nor `reset()`'s signature/behavior — only removes the duplicated inline listing.
- The object's resulting state after `__init__` is byte-identical to before (same three fields, same values, same order of execution relative to the validated config attributes).
- `reset()`'s public contract ("reset state for a new `N2ComputerAgent.run()` conversation") is unchanged; `__init__` now uses it internally instead of repeating it.

## Verification

- `ruff check` / `ruff format --check` on the touched file: clean.
- `mypy --ignore-missing-imports yutori/navigator/n2_compaction.py`: identical error set before/after (only line-number shifts from the 2-line diff; no new errors, confirming the annotation move didn't lose type information for `self.last_result`).
- Targeted tests (`test_navigator_n2_compaction.py`, `test_navigator_n2.py`, `test_navigator_n2_harness.py`, `test_navigator_n2_cookbooks.py`): 129 passed.
- Full suite `pytest -m "not slow"`: 713 passed / 9 skipped / 1 deselected — identical to the baseline on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UgHoPESJ53SekfEuvVSPs7)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with identical runtime state; no API or compaction logic changes.
> 
> **Overview**
> **`N2InlineCompactor`** no longer sets per-conversation state twice: **`__init__`** drops the inline assignments for `compaction_count`, `last_result`, and `_awaiting_post_compaction_baseline` and instead calls **`reset()`** after config fields are validated and stored.
> 
> The **`Optional[N2CompactionResult]`** annotation on **`last_result`** moves to **`reset()`** so mypy still types the attribute on the single assignment site. Post-construction and post-**`reset()`** values are unchanged; public constructor and **`reset()`** behavior are the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a1ce00988ce8b9c5f95eef03ac51713d8e920e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->