### PR TITLE
refactor(examples): dedupe shell-result formatting in n2 Daytona example

### DIFF
--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -59,6 +59,7 @@ from yutori.navigator import (
     TOOL_SET_COMPUTER_USE_LATEST,
     N2ComputerAgent,
     ShellFileToolsMixin,
+    format_shell_output,
     format_stop_and_summarize,
 )
 from yutori.navigator.n2_compaction import response_message
@@ -73,8 +74,6 @@ TYPE_CHUNK_MAX_CHARS = 500
 # Where --record saves the screen recording after the run.
 RECORDING_PATH = "n2-daytona-run.mp4"
 
-# The n2 `bash` tool caps one result at this many characters.
-BASH_RESULT_MAX_CHARS = 30_000
 MAX_STEPS = 50
 
 
@@ -100,12 +99,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=f"Record the sandbox screen and save the video to {RECORDING_PATH} when the run ends.",
     )
     return parser.parse_args(argv)
-
-
-def _truncate(text: str, max_chars: int = BASH_RESULT_MAX_CHARS) -> str:
-    if len(text) <= max_chars:
-        return text
-    return f"{text[:max_chars]}\n\n[... output truncated, {len(text) - max_chars} more chars ...]"
 
 
 # `bash` promises a working directory that persists across calls, but every
@@ -267,11 +260,9 @@ class DaytonaComputer(ShellFileToolsMixin):
             self._cwd = cwd or self._cwd
         else:
             output = result.result  # killed before the sentinel could print (e.g. by a signal)
-        # The tool owns its result text; this is the format n2 expects.
-        output = _truncate(output)
-        if result.exit_code:
-            return f"Exit code {result.exit_code}\n{output}" if output else f"Exit code {result.exit_code}"
-        return output or "(Bash completed with no output)"
+        # The SDK's shared shell-result formatter owns the n2-expected shape
+        # (truncation cap, exit-code header, empty-output text).
+        return format_shell_output(output, result.exit_code)
 
 
 async def main(task: str, max_steps: int = MAX_STEPS, record: bool = False) -> None:


### PR DESCRIPTION
## What

`DaytonaComputer.run_bash_command` (`examples/navigator_n2_daytona.py`) hand-rolled its own `_truncate()` helper plus an inline exit-code/empty-output branch to render `bash` results — the exact same "truncation cap, `Exit code N` header on failure, `(Bash completed with no output)` on empty success" logic that `yutori.navigator.sandbox_tools.format_shell_output()` already implements byte-for-byte identically (that helper landed in #296, is already re-exported publicly from `yutori.navigator`, and is already used by the Cua adapter's own bash formatting in this same commit range).

This is the same pattern-class as #292/#294 (deduping `response_message()` parsing into this same file) — a freshly-added helper that a sibling/self-contained example missed wiring up to.

## Why it's an improvement

- One fewer hand-maintained copy of a formatting contract that n2 was trained on (truncation cap, exit-code header, empty-output text) — future changes to that contract only need to happen in `sandbox_tools.py`.
- Removes a dead local constant (`BASH_RESULT_MAX_CHARS = 30_000`) that duplicated the SDK's own default.
- Net -9 lines in the example.

## Why it's safe

- Example-only code; zero public SDK API change (`format_shell_output` was already public via `yutori.navigator`, and this file already imports from that same module).
- The replaced logic is byte-for-byte identical to what `format_shell_output` does — verified by direct comparison, not just behaviorally.
- No test pins the removed `_truncate` name or inlines its logic directly; existing Daytona bash tests (timeout/cwd-sentinel/error paths) are unaffected and still pass.
- Verified: full suite `pytest -q -m "not slow"` → 769 passed / 3 skipped / 1 deselected (matches baseline), targeted `test_navigator_n2_entrypoints.py` + `test_navigator_n2_cookbooks.py` + `test_navigator_sandbox_tools.py` → 42 passed, `ruff check .` and `ruff format --check` on the touched file both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gz5x2enet3iF7HV3dW3ETM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz5x2enet3iF7HV3dW3ETM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only refactor with behavior intended to match the removed inline formatting; no public API changes.
> 
> **Overview**
> The n2 Daytona example stops duplicating bash result formatting and routes `DaytonaComputer.run_bash_command` through the shared **`format_shell_output`** helper from `yutori.navigator`.
> 
> Local **`_truncate`** and **`BASH_RESULT_MAX_CHARS`** are removed; truncation, non-zero exit-code headers, and empty-success text now follow the same n2 contract as the rest of the SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433347bd5b7334e38a939160c1f34e5cadcd2799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->