### PR TITLE
fix(examples): latency-robust triple click on Daytona

### DIFF
--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -146,10 +146,13 @@ class DaytonaComputer(ShellFileToolsMixin):
         await self._cu.mouse.click(x, y, "left", double=True)
 
     async def triple_click(self, x: int, y: int) -> None:
-        # Daytona's REST API has no native triple click; three rapid clicks match
-        # the toolkit convention (select paragraph/line).
-        for _ in range(3):
-            await self._cu.mouse.click(x, y, "left")
+        # Daytona's REST API has no native triple click. A native double first
+        # preserves the OS multi-click pairing regardless of network latency;
+        # the follow-up click completes the triple when round-trips fit the
+        # multi-click window (measured ~230ms vs the ~400ms GTK default), and
+        # still leaves a double-click selection behind when they don't.
+        await self._cu.mouse.click(x, y, "left", double=True)
+        await self._cu.mouse.click(x, y, "left")
 
     async def move(self, x: int, y: int) -> None:
         await self._cu.mouse.move(x, y)

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -522,12 +522,12 @@ def _daytona_computer_with_exec(exec_) -> "navigator_n2_daytona.DaytonaComputer"
     return navigator_n2_daytona.DaytonaComputer(sandbox)
 
 
-async def test_daytona_triple_click_is_three_rapid_clicks() -> None:
-    clicks: list[tuple[int, int, str]] = []
+async def test_daytona_triple_click_pairs_a_native_double_with_one_single() -> None:
+    clicks: list[tuple[int, int, str, bool]] = []
 
     class FakeMouse:
         async def click(self, x: int, y: int, button: str = "left", double: bool = False) -> None:
-            clicks.append((x, y, button))
+            clicks.append((x, y, button, double))
 
     computer = navigator_n2_daytona.DaytonaComputer(
         SimpleNamespace(process=SimpleNamespace(), computer_use=SimpleNamespace(mouse=FakeMouse()))
@@ -535,7 +535,9 @@ async def test_daytona_triple_click_is_three_rapid_clicks() -> None:
 
     await computer.triple_click(5, 9)
 
-    assert clicks == [(5, 9, "left")] * 3
+    # The native double survives any network latency; the single completes the
+    # triple when round-trips fit the OS multi-click window.
+    assert clicks == [(5, 9, "left", True), (5, 9, "left", False)]
 
 
 async def test_daytona_file_tools_ride_the_shared_mixin() -> None:


### PR DESCRIPTION
## Summary
Follow-up to Bugbot's timing finding on #297. `DaytonaComputer.triple_click` now sends a **native `double=True` click plus one follow-up click** (2 round-trips) instead of three sequential singles (3 round-trips): the native double preserves OS multi-click pairing regardless of network latency, and the worst case degrades to a double-click selection instead of three stray singles.

## Measurements (live sandbox)
- Sequential REST click round-trip: **214–237 ms (median 227 ms)** → OS-visible spacing of the old three-singles form was ~230 ms per gap, *inside* GTK's ~400 ms multi-click window — so the finding's "rarely land inside the window" didn't hold on this link, but the robustness argument does: on slower links three singles fail completely while double+single always keeps the pair.
- Fallback-shape timing (native double then single): double call 434–457 ms, follow-up gap 211–238 ms.

Test updated to pin the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the Daytona example adapter and its unit test; no changes to core SDK auth, data, or payment paths.
> 
> **Overview**
> **Daytona `triple_click`** no longer fires three separate REST single-clicks. It now sends one **native double-click** (`double=True`) and then one single click, so the OS keeps a valid double-click pair even when network latency stretches spacing between requests.
> 
> When the follow-up single lands inside the desktop multi-click window, behavior completes as a triple; if not, the run still gets a **double-click selection** instead of three unrelated singles. Comments in the example document the timing rationale (~230 ms round-trips vs ~400 ms GTK window).
> 
> The entrypoint test was renamed and updated to assert exactly **two** mouse API calls with the expected `double` flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7da37202bcf1b364c53cf7537cbb8e737f2fe622. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->