### PR TITLE
docs(examples): a text-only answer indicates stop

### DIFF
--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -14,7 +14,7 @@ Navigator n2 looks at a full-screen screenshot and answers with tool calls — a
 (`read`/`write`/`edit`/`grep`/`glob`). `N2ComputerAgent`, the SDK's n2 agent
 loop, executes each call through a small adapter, sends the result back (a
 fresh screenshot for the batch, the tool's output otherwise), and asks again
-until the model answers with text.
+until the model answers with just text, which indicates stop.
 
 Daytona is third-party infrastructure; this Yutori-maintained example contains
 the whole integration — the `DaytonaComputer` adapter plus the sandbox


### PR DESCRIPTION
One-line docstring clarification from review: the loop "asks again until the model answers with just text, which indicates stop."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only clarification in an example file; no executable code or SDK contracts changed.
> 
> **Overview**
> Updates the module docstring in `navigator_n2_daytona.py` so the **N2ComputerAgent** loop description is explicit: it keeps turning until the model returns **only text**, and that plain-text reply means **stop** (not merely “answers with text,” which could be read as mixed with tool calls).
> 
> No runtime or API behavior changes—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54dca3197bb2d4af7337a9705a29ca1fdaf8a7e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->