### PR TITLE
refactor(examples): cookbook depends on cua-sandbox directly

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -67,7 +67,7 @@ The example implements a `MemoToolSuite` with three custom tools:
 
 ## navigator_n2/
 
-The [public Cua cookbook](navigator_n2/README.md) runs Navigator n2 in a local Docker container. It keeps its own Python 3.12 environment (Cua's requirement), so it works independently of the Setup above — only `yutori auth login` carries over:
+The [public Cua cookbook](navigator_n2/README.md) runs Navigator n2 in a local Docker container. It keeps its own environment (`cua-sandbox` needs Python 3.11–3.13), so it works independently of the Setup above — only `yutori auth login` carries over:
 
 ```bash
 cd examples/navigator_n2

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -1,8 +1,8 @@
 # Navigator n2 with public Cua
 
-These runnable cookbooks use the public Python SDK loop, stable model id n2, and public Cua packages. They do not import an agent package or source code from another repository. Cua provides the local Docker runtime; the adapter and n2 loop in this repository are maintained by Yutori.
+These runnable cookbooks use the public Python SDK loop, stable model id n2, and the public `cua-sandbox` package. They do not import an agent package or source code from another repository. Cua provides the local Docker runtime; the adapter and n2 loop in this repository are maintained by Yutori.
 
-The cookbook environment is separate because Cua 0.1.6 requires Python 3.12 or 3.13. The tested Cua dependencies are pinned in pyproject.toml, and the SDK source is used from this checkout.
+The cookbook environment is separate because `cua-sandbox` requires Python 3.11–3.13. The tested dependency is pinned in pyproject.toml, and the SDK source is used from this checkout.
 
 On minimal Debian or Ubuntu images (including `python:3.12-slim`), install the compiler and Linux input headers that Cua's `evdev` dependency builds against:
 

--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -33,7 +33,7 @@ from yutori.navigator.sandbox_tools import (
 
 
 class CuaSandboxComputer(ShellFileToolsMixin):
-    """N2 computer-handler adapter built only on the public cua==0.1.6 API."""
+    """N2 computer-handler adapter built only on the public cua-sandbox API."""
 
     def __init__(self, sandbox: Any) -> None:
         self.sandbox = sandbox

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -2,12 +2,11 @@
 name = "yutori-navigator-n2-cookbooks"
 version = "0.1.0"
 description = "Public Cua cookbooks for stable Yutori Navigator n2"
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
-    "cua==0.1.6",
-    # Newest cua-cli needs cua-sandbox>=0.1.28, whose API-key path can no longer
-    # create image-based cloud VMs. 0.1.17 keeps the local Docker runtime working;
-    # uv then resolves cua-cli back to 0.1.13, the newest release without that floor.
+    # cua-sandbox >=0.1.28 retires image-based VM creation (its API-key path
+    # drops the image); 0.1.17 keeps the local Docker runtime working. The
+    # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
     "yutori==0.9.6",
 ]

--- a/examples/navigator_n2/remote_sandbox.py
+++ b/examples/navigator_n2/remote_sandbox.py
@@ -32,7 +32,7 @@ def _watch_url(sandbox) -> "str | None":
 
 
 async def main(args: argparse.Namespace) -> None:
-    from cua import Image, Sandbox
+    from cua_sandbox import Image, Sandbox
 
     # Resolve every Yutori-owned input before third-party infrastructure can be allocated.
     api_key = require_api_key()

--- a/tests/test_navigator_n2_cookbooks.py
+++ b/tests/test_navigator_n2_cookbooks.py
@@ -198,7 +198,6 @@ def test_cookbook_uses_pinned_public_runtime_dependencies() -> None:
 
     assert version_match is not None
     sdk_version = version_match.group(1)
-    assert '"cua==0.1.6"' in project
     assert '"cua-sandbox==0.1.17"' in project
     assert f'"yutori=={sdk_version}"' in project
     assert f'"yutori[macos]=={sdk_version}"' in project

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -40,7 +40,7 @@ async def test_remote_sandbox_resolves_yutori_key_before_allocation(monkeypatch:
         def ephemeral(*_args: object, **_kwargs: object) -> object:
             pytest.fail("sandbox allocation started before Yutori authentication")
 
-    monkeypatch.setitem(sys.modules, "cua", SimpleNamespace(Image=FakeImage, Sandbox=FakeSandbox))
+    monkeypatch.setitem(sys.modules, "cua_sandbox", SimpleNamespace(Image=FakeImage, Sandbox=FakeSandbox))
 
     def missing_api_key() -> str:
         raise RuntimeError("missing Yutori key")
@@ -68,7 +68,7 @@ async def test_remote_sandbox_rejects_tool_set_before_allocation(monkeypatch: py
         def ephemeral(*_args: object, **_kwargs: object) -> object:
             pytest.fail("sandbox allocation started before tool-set validation")
 
-    monkeypatch.setitem(sys.modules, "cua", SimpleNamespace(Image=FakeImage, Sandbox=FakeSandbox))
+    monkeypatch.setitem(sys.modules, "cua_sandbox", SimpleNamespace(Image=FakeImage, Sandbox=FakeSandbox))
     monkeypatch.setattr(remote_sandbox, "require_api_key", lambda: "test-yutori-key")
     args = argparse.Namespace(
         max_steps=1,
@@ -121,7 +121,7 @@ async def test_remote_sandbox_wires_local_container_runtime(monkeypatch: pytest.
     async def fake_run_agent(_agent: object, task: str, *, completions: object) -> None:
         seen["task"] = task
 
-    monkeypatch.setitem(sys.modules, "cua", SimpleNamespace(Image=FakeImage, Sandbox=FakeSandbox))
+    monkeypatch.setitem(sys.modules, "cua_sandbox", SimpleNamespace(Image=FakeImage, Sandbox=FakeSandbox))
     monkeypatch.setattr(remote_sandbox, "require_api_key", lambda: "test-yutori-key")
     monkeypatch.setattr(remote_sandbox, "CuaSandboxComputer", FakeComputer)
     monkeypatch.setattr(remote_sandbox, "N2ComputerAgent", FakeAgent)


### PR DESCRIPTION
## Summary
The `cua` meta-package added nothing the cookbook uses — `cua-sandbox` exports `Image` and `Sandbox` directly. Depending on it alone:

- **Smaller env**: 277 packages / 348 MB → **222 packages / 192 MB** (fresh-resolution control vs after; `cua`, `cua-cli`, `cua-agent`, `litellm`, `google-genai`, `av` all gone).
- **No more version backtracking**: the old pin comment had to explain why `cua-sandbox==0.1.17` forced `cua-cli` down to 0.1.13; `cua-cli` is no longer in the tree at all.
- **Wider floor**: cookbook `requires-python` widens from 3.12–3.13 to **3.11–3.13** (`cua-sandbox`'s own floor).

Docs updated (cookbook README, examples/README); tests updated (fake module name, pin assertion).

## Verification
- Fresh `uv sync` + imports on macOS and on `python:3.11-slim` / `python:3.12-slim` (documented apt line unchanged, both floors work).
- Full suite green; ruff clean.
- **Live local-Docker run** on the swapped dependency: the model found no Calculator in the XFCE menu, located `xcalc` via `bash`, launched it on `DISPLAY=:1` as a background bash task, clicked the on-screen buttons, and read back 17 × 23 = 391 — watch URL printed, no leftover containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to example dependencies, imports, and docs; runtime pin unchanged at cua-sandbox 0.1.17 with updated tests.
> 
> **Overview**
> The Navigator n2 cookbook **drops the `cua` meta-package** and pins **`cua-sandbox==0.1.17` only**, since `Image` and `Sandbox` come from that package. **`remote_sandbox.py`** now imports from **`cua_sandbox`** instead of **`cua`**.
> 
> **`requires-python`** widens from 3.12–3.13 to **3.11–3.13** to match `cua-sandbox`. Dependency comments and README copy (examples README + `navigator_n2/README.md`) describe the sandbox package and Python floor instead of the old `cua` / `cua-cli` backtracking story. **`CuaSandboxComputer`**’s docstring references the public **`cua-sandbox`** API.
> 
> Tests drop the **`cua==0.1.6`** pin assertion and stub **`cua_sandbox`** in entrypoint tests instead of **`cua`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8f98857cc21b8d8327f1a39b02e9a7a0decd1a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->