### PR TITLE
docs(README): references dropdown last among the n2 alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ uv run https://raw.githubusercontent.com/yutori-ai/yutori-sdk-python/main/exampl
     "Find the OS version and free disk space of this machine, and save a summary to a file on the desktop"
 ```
 
-<details>
+<details open>
 <summary>Run in local Docker instead (Cua cookbook)</summary>
 
 The [Cua cookbook](examples/navigator_n2/README.md) runs the same agent in a local Docker container instead of a cloud VM — no cloud credential needed:

--- a/README.md
+++ b/README.md
@@ -202,13 +202,6 @@ uv run https://raw.githubusercontent.com/yutori-ai/yutori-sdk-python/main/exampl
 ```
 
 <details>
-<summary>References, trained conventions, and long-run behavior</summary>
-
-See the [Navigator n2 reference](https://docs.yutori.com/reference/n2) for the tools, actions, and coordinate system, and the [API reference](api.md#navigator-n2) for direct `client.chat.completions.create(...)` calls. A few conventions the model is trained around — the `bash` tool rather than a GUI terminal, image-returning reads, all-or-nothing tool sets — are covered in the [API reference](api.md#navigator-n2-loop), and the SDK ships the reference file-tool implementation (`ShellFileToolsMixin`) for any sandbox with a shell. Long runs are compacted automatically once the context grows; pass `compactor=None` to disable, and the run instead stops cleanly at the model's 128k context limit.
-
-</details>
-
-<details>
 <summary>Run in local Docker instead (Cua cookbook)</summary>
 
 The [Cua cookbook](examples/navigator_n2/README.md) runs the same agent in a local Docker container instead of a cloud VM — no cloud credential needed:
@@ -232,6 +225,13 @@ The script prints a `Watch the desktop live:` URL at startup — open it in a br
 uvx yutori-mcp computer-use setup
 uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the result." --app Calculator
 ```
+
+</details>
+
+<details>
+<summary>References, trained conventions, and long-run behavior</summary>
+
+See the [Navigator n2 reference](https://docs.yutori.com/reference/n2) for the tools, actions, and coordinate system, and the [API reference](api.md#navigator-n2) for direct `client.chat.completions.create(...)` calls. A few conventions the model is trained around — the `bash` tool rather than a GUI terminal, image-returning reads, all-or-nothing tool sets — are covered in the [API reference](api.md#navigator-n2-loop), and the SDK ships the reference file-tool implementation (`ShellFileToolsMixin`) for any sandbox with a shell. Long runs are compacted automatically once the context grows; pass `compactor=None` to disable, and the run instead stops cleanly at the model's 128k context limit.
 
 </details>
 


### PR DESCRIPTION
Moves the "References, trained conventions, and long-run behavior" details block after "Drive your own local Mac", so the n2 section's dropdowns read: run alternatives first (Docker, Mac), reference material last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only reordering and default expand state; no code or API behavior changes.
> 
> **Overview**
> **Navigator n2 README layout** is reordered so practical run paths appear before reference text.
> 
> The **“References, trained conventions, and long-run behavior”** `<details>` block is moved from immediately after the Daytona quick start to **after** “Drive your own local Mac” (Yutori MCP), so the collapsibles read: local Docker → local Mac → references. The references copy is unchanged.
> 
> The **“Run in local Docker instead (Cua cookbook)”** section is now **`<details open>`**, so that alternative is expanded by default instead of collapsed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d136d20d610ee933e0d64421ce984658fc33bc7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->