### PR TITLE
docs(README): Docker cookbook as a plain sub-heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,7 @@ uv run https://raw.githubusercontent.com/yutori-ai/yutori-sdk-python/main/exampl
     "Find the OS version and free disk space of this machine, and save a summary to a file on the desktop"
 ```
 
-<details open>
-<summary>Run in local Docker instead (Cua cookbook)</summary>
+#### Run in local Docker instead (Cua cookbook)
 
 The [Cua cookbook](examples/navigator_n2/README.md) runs the same agent in a local Docker container instead of a cloud VM — no cloud credential needed:
 
@@ -213,8 +212,6 @@ uv run python remote_sandbox.py --auto-approve "Open Calculator and compute 17 *
 ```
 
 The script prints a `Watch the desktop live:` URL at startup — open it in a browser to follow along.
-
-</details>
 
 <details>
 <summary>Drive your own local Mac</summary>

--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ See the [Navigator n2 reference](https://docs.yutori.com/reference/n2) for the t
 
 </details>
 
-### Agent-loop helpers
+<details>
+<summary>Agent-loop helpers</summary>
 
 The `yutori.navigator` subpackage exposes optional helpers for typical agent loops:
 
@@ -251,6 +252,8 @@ The `yutori.navigator` subpackage exposes optional helpers for typical agent loo
 
 
 Full helper reference: [api.md](api.md).
+
+</details>
 
 ## Browsing API
 


### PR DESCRIPTION
Follow-up to #304: the Docker cookbook section was pinned open (`<details open>`), so a real `####` sub-heading reads better than a details block that never collapses meaningfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README restructuring with no runtime, API, or security impact.
> 
> **Overview**
> **README Navigator n2 section layout only** — no code or API changes.
> 
> The local Docker / Cua cookbook instructions are no longer inside an always-open `<details>` block; they use a visible `####` sub-heading so that path reads like a normal subsection next to Daytona.
> 
> The **Agent-loop helpers** table and link to `api.md` are moved into a collapsible `<details>` block (same pattern as the Mac MCP and references sections above), so the long helper table is optional to expand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43ca4f77cc712ee051a86d35bba784a9e7eacae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->