### PR TITLE
docs(README): sub-heading for the Daytona run

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ async with AsyncYutoriClient() as client:
 
 `computer` is your adapter for interfacing with the computer: the loop calls it to execute the model's actions and capture the results — screenshots, command output, file contents.
 
+#### Run on a Daytona Linux VM
+
 [examples/navigator_n2_daytona.py](examples/navigator_n2_daytona.py) instantiates this agent loop on a [Daytona](https://www.daytona.io) Linux `computer`; [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona) walks through it. To run it:
 
 ```bash


### PR DESCRIPTION
Adds `#### Run on a Daytona Linux VM` above the Daytona example paragraph, parallel to the "Run in local Docker instead (Cua cookbook)" sub-heading — the two n2 run paths now have matching structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README formatting with no code or runtime impact.
> 
> **Overview**
> Adds a **`#### Run on a Daytona Linux VM`** sub-heading immediately before the existing Daytona example and `uv run` snippet in the Navigator n2 section.
> 
> This mirrors the **`#### Run in local Docker instead (Cua cookbook)`** block so the two documented n2 run paths share the same heading + body layout; no commands, links, or example content change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29c071e3cfa92a5065e830c42d7318027284668a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->