### PR TITLE
docs(README): local Docker run first, Daytona second

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,23 @@ async with AsyncYutoriClient() as client:
 
 `computer` is your adapter for interfacing with the computer: the loop calls it to execute the model's actions and capture the results — screenshots, command output, file contents.
 
+#### Run in local Docker (Cua cookbook)
+
+The [Cua cookbook](examples/navigator_n2/README.md) instantiates this agent loop in a local Docker container — no cloud account needed beyond your Yutori login:
+
+```bash
+yutori auth login            # or export YUTORI_API_KEY=...
+
+cd examples/navigator_n2
+uv sync --python 3.12
+uv run python remote_sandbox.py --auto-approve "Open Calculator and compute 17 * 23"
+```
+
+The script prints a `Watch the desktop live:` URL at startup — open it in a browser to follow along.
+
 #### Run on a Daytona Linux VM
 
-[examples/navigator_n2_daytona.py](examples/navigator_n2_daytona.py) instantiates this agent loop on a [Daytona](https://www.daytona.io) Linux `computer`; [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona) walks through it. To run it:
+[examples/navigator_n2_daytona.py](examples/navigator_n2_daytona.py) runs the same agent on a [Daytona](https://www.daytona.io) Linux VM — a `DAYTONA_API_KEY` is the one extra credential; [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona) walks through it. To run it:
 
 ```bash
 yutori auth login            # or export YUTORI_API_KEY=...
@@ -202,18 +216,6 @@ export DAYTONA_API_KEY=...   # https://app.daytona.io
 uv run https://raw.githubusercontent.com/yutori-ai/yutori-sdk-python/main/examples/navigator_n2_daytona.py \
     "Find the OS version and free disk space of this machine, and save a summary to a file on the desktop"
 ```
-
-#### Run in local Docker instead (Cua cookbook)
-
-The [Cua cookbook](examples/navigator_n2/README.md) runs the same agent in a local Docker container instead of a cloud VM — no cloud credential needed:
-
-```bash
-cd examples/navigator_n2
-uv sync --python 3.12
-uv run python remote_sandbox.py --auto-approve "Open Calculator and compute 17 * 23"
-```
-
-The script prints a `Watch the desktop live:` URL at startup — open it in a browser to follow along.
 
 <details>
 <summary>Drive your own local Mac</summary>


### PR DESCRIPTION
Swaps the two n2 run subsections: the Cua cookbook (local Docker, only a Yutori login) now precedes the Daytona example (which adds a second account/credential). Flow-dependent text updated with the swap: the first section "instantiates this agent loop", the second "runs the same agent" with `DAYTONA_API_KEY` framed as the one extra credential, the Docker heading drops "instead", and the Docker snippet now carries the `yutori auth login` line since it is the reader's first runnable block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only reordering and wording; no runtime, API, or security behavior changes.
> 
> **Overview**
> Reorders the Navigator n2 quick-start so **local Docker (Cua cookbook)** is the first path and **Daytona** is second, reflecting lower friction (Yutori login only vs. an extra `DAYTONA_API_KEY`).
> 
> Copy is adjusted for the new flow: Docker is described as where the loop is **instantiated**; Daytona as where it **runs the same agent**, with Daytona framed as the one extra credential. The Docker heading drops “instead,” and the Docker bash block now includes `yutori auth login` as the reader’s first runnable snippet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71abf83d67e3cc6064bf42218e0e459428d18e0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->