### PR TITLE
Consolidate duplicated atomic-file-write logic into a shared helper

### DIFF
--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -1,0 +1,59 @@
+"""Tests for the shared atomic-write helper used by credentials and overlay_build."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from yutori._fileutils import atomic_write_text
+
+
+def test_writes_contents(tmp_path):
+    target = tmp_path / "config.json"
+    atomic_write_text(target, "hello")
+    assert target.read_text(encoding="utf-8") == "hello"
+
+
+def test_sets_requested_mode(tmp_path):
+    target = tmp_path / "secret.txt"
+    atomic_write_text(target, "s3cr3t", mode=0o600)
+    assert (target.stat().st_mode & 0o777) == 0o600
+
+
+def test_default_mode_is_owner_only(tmp_path):
+    target = tmp_path / "secret.txt"
+    atomic_write_text(target, "s3cr3t")
+    assert (target.stat().st_mode & 0o777) == 0o600
+
+
+def test_no_temp_files_left_behind(tmp_path):
+    target = tmp_path / "config.json"
+    atomic_write_text(target, "hello")
+    assert [p.name for p in tmp_path.iterdir()] == ["config.json"]
+
+
+def test_overwrites_existing_file(tmp_path):
+    target = tmp_path / "config.json"
+    atomic_write_text(target, "old")
+    atomic_write_text(target, "new")
+    assert target.read_text(encoding="utf-8") == "new"
+    assert [p.name for p in tmp_path.iterdir()] == ["config.json"]
+
+
+def test_temp_file_cleaned_up_when_write_fails(tmp_path, monkeypatch):
+    target = tmp_path / "config.json"
+
+    real_fdopen = os.fdopen
+
+    def failing_fdopen(fd, *args, **kwargs):
+        os.close(fd)
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "fdopen", failing_fdopen)
+    with pytest.raises(OSError, match="disk full"):
+        atomic_write_text(target, "hello")
+    monkeypatch.setattr(os, "fdopen", real_fdopen)
+
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []

--- a/yutori/_fileutils.py
+++ b/yutori/_fileutils.py
@@ -1,0 +1,34 @@
+"""Shared atomic local-file-write helper.
+
+Used for small state/secret files (the CLI's saved API key, the macOS overlay
+build cache's pointer files) where a reader must never observe a partial
+write, even if the process is interrupted mid-write.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_text(path: Path, contents: str, *, mode: int = 0o600) -> None:
+    """Atomically write ``contents`` to ``path``.
+
+    Writes to a temp file in ``path``'s own directory (so the final
+    ``os.replace`` is a same-filesystem rename), chmods it to ``mode``, then
+    renames it into place. A concurrent reader of ``path`` therefore always
+    sees either the previous complete contents or the new complete contents,
+    never a partial write. The temp file is removed if anything raises before
+    the rename lands; ``os.replace`` itself leaves nothing behind to clean up
+    on the success path.
+    """
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}-", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(contents)
+        tmp_path.chmod(mode)
+        os.replace(tmp_path, path)
+    finally:
+        tmp_path.unlink(missing_ok=True)

--- a/yutori/auth/credentials.py
+++ b/yutori/auth/credentials.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 import json
 import os
-import tempfile
 from pathlib import Path
 from typing import Any
 
+from .._fileutils import atomic_write_text
 from ..exceptions import AuthenticationError
 from .constants import CONFIG_DIR, CONFIG_FILE
 
@@ -50,26 +50,7 @@ def save_config(api_key: str) -> None:
     os.chmod(config_dir, 0o700)
 
     content = json.dumps({"api_key": api_key}, indent=2)
-
-    # Atomic write: temp file in same directory, then rename.
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w",
-        dir=config_dir,
-        prefix=".config_",
-        suffix=".tmp",
-        delete=False,
-    )
-    tmp_path = Path(tmp.name)
-    try:
-        with tmp as f:
-            f.write(content)
-        os.chmod(tmp_path, 0o600)
-        os.replace(tmp_path, config_path)
-    finally:
-        # On success os.replace moved the temp file, so missing_ok handles
-        # both the success path and any mid-write failure (including
-        # KeyboardInterrupt).
-        tmp_path.unlink(missing_ok=True)
+    atomic_write_text(config_path, content)
 
 
 def clear_config() -> None:
@@ -151,7 +132,5 @@ def require_api_key(api_key: str | None = None) -> str:
     """
     resolved = resolve_api_key(api_key)
     if not resolved:
-        raise AuthenticationError(
-            "No API key provided. Run 'yutori auth login', set YUTORI_API_KEY, or pass api_key."
-        )
+        raise AuthenticationError("No API key provided. Run 'yutori auth login', set YUTORI_API_KEY, or pass api_key.")
     return resolved

--- a/yutori/navigator/macos/overlay_build.py
+++ b/yutori/navigator/macos/overlay_build.py
@@ -11,10 +11,11 @@ import stat
 import subprocess
 import tempfile
 import time
-import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from ..._fileutils import atomic_write_text
 
 OVERLAY_PROTOCOL_VERSION = 2
 RENDERER_PROTOCOL_VERSION = 3
@@ -214,13 +215,6 @@ def _acquire_lock(path: Path) -> None:
             time.sleep(0.25)
 
 
-def _write_atomic(path: Path, contents: str) -> None:
-    temporary = path.parent / f".{path.name}-{uuid.uuid4().hex}.tmp"
-    temporary.write_text(contents, encoding="utf-8")
-    temporary.chmod(0o600)
-    os.replace(temporary, path)
-
-
 def _remove_owned_entry(path: Path) -> None:
     if not path.exists():
         return
@@ -288,7 +282,7 @@ def prepare_macos_overlay(
             except MacOSOverlayPreparationError:
                 _remove_owned_entry(entry)
             else:
-                _write_atomic(pointer, f"{json.dumps({'key': key})}\n")
+                atomic_write_text(pointer, f"{json.dumps({'key': key})}\n")
                 return prepared
 
         temporary = Path(tempfile.mkdtemp(prefix=f".build-{key}-", dir=cache))
@@ -327,7 +321,7 @@ def prepare_macos_overlay(
         finally:
             if temporary.exists():
                 shutil.rmtree(temporary)
-        _write_atomic(pointer, f"{json.dumps({'key': key})}\n")
+        atomic_write_text(pointer, f"{json.dumps({'key': key})}\n")
         return _load_entry(cache, key, verify_packaged_assets=True)
     finally:
         if lock.exists():


### PR DESCRIPTION
## What

`yutori/auth/credentials.py::save_config` and `yutori/navigator/macos/overlay_build.py::_write_atomic` each hand-rolled the same "write to a temp file in the target's directory, chmod it, then `os.replace` it into place" atomic-write pattern independently, with slightly different temp-file naming (`tempfile.NamedTemporaryFile` with a `.config_`/`.tmp` prefix/suffix vs. a manual `uuid4().hex`-based name) and different cleanup robustness (credentials.py cleaned up the temp file in a `finally`; overlay_build.py did not).

This PR extracts the shared logic into `yutori/_fileutils.py::atomic_write_text(path, contents, *, mode=0o600)` and has both call sites delegate to it. `overlay_build._write_atomic` is removed entirely since it was a one-line wrapper after the extraction; its two call sites now call `atomic_write_text` directly.

## Why this is an improvement

- One tested implementation of a security-relevant pattern (this code path handles a stored API key and a build-cache pointer file) instead of two independently-maintained copies that had already drifted in cleanup behavior.
- Future fixes/hardening to the atomic-write pattern only need to happen once.

## Why it's safe (no behavioral change)

- Same directory-local temp file, same chmod-before-replace ordering, same end state (final file only, no temp files left behind) for both call sites.
- The one behavioral *tightening* is that `overlay_build`'s writes now also clean up their temp file if the write fails partway through (matching `credentials.py`'s existing behavior) — this only affects an already-failing path and cannot change success-path behavior.
- Existing tests exercise both call sites unmodified and pass:
  - `tests/test_auth.py` (`TestCredentials`), including `test_save_atomic_no_temp_files_left`, `test_save_sets_file_permissions_0600`, `test_save_sets_directory_permissions_0700`.
  - `tests/test_navigator_macos_overlay_build.py::test_prepare_is_atomic_cached_and_read_only_check_does_not_mutate` and the concurrent-preparation test.
- Added `tests/test_fileutils.py` with direct unit tests for the new helper (writes contents, sets requested/default mode, leaves no temp files, overwrites cleanly, cleans up on a mid-write failure).
- Full suite: `770` (pre-existing) `+ 6` (new) `= 776 passed, 3 skipped` locally; `ruff check` and `ruff format --check` clean on all touched files.

## Scope

4 files changed: new `yutori/_fileutils.py` + `tests/test_fileutils.py`, plus edits to the two call sites (`yutori/auth/credentials.py`, `yutori/navigator/macos/overlay_build.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdvb9w2ZoqenpexNxL7sX2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with equivalent success-path behavior; overlay pointer writes gain temp cleanup only on failure paths, with existing auth and overlay tests still exercising call sites.
> 
> **Overview**
> Introduces **`atomic_write_text`** in `yutori/_fileutils.py` as the single implementation of same-directory temp write → chmod → `os.replace`, aimed at secrets and small state files (API key config, overlay cache pointers).
> 
> **`save_config`** in `credentials.py` drops its inline `NamedTemporaryFile` logic and calls the helper instead. **`overlay_build.py`** removes **`_write_atomic`** and the `uuid` import; both pointer writes now use **`atomic_write_text`**, so failed writes also clean up temp files (previously only credentials did).
> 
> Adds **`tests/test_fileutils.py`** with direct coverage of content, permissions, overwrite, no leftover temps, and cleanup on write failure. One unrelated line-wrap change on the `require_api_key` error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7760c6e8a169eede54868d3cc9024b505cd91228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->