### PR TITLE
docs(README): tighten the two n2 run-section credential mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ async with AsyncYutoriClient() as client:
 
 #### Run in local Docker (Cua cookbook)
 
-The [Cua cookbook](examples/navigator_n2/README.md) instantiates this agent loop in a local Docker container — no cloud account needed beyond your Yutori login:
+The [Cua cookbook](examples/navigator_n2/README.md) instantiates this agent loop in a local Docker container:
 
 ```bash
 yutori auth login            # or export YUTORI_API_KEY=...
@@ -207,7 +207,7 @@ The script prints a `Watch the desktop live:` URL at startup — open it in a br
 
 #### Run on a Daytona Linux VM
 
-[examples/navigator_n2_daytona.py](examples/navigator_n2_daytona.py) runs the same agent on a [Daytona](https://www.daytona.io) Linux VM — a `DAYTONA_API_KEY` is the one extra credential; [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona) walks through it. To run it:
+[examples/navigator_n2_daytona.py](examples/navigator_n2_daytona.py) runs the same agent on a [Daytona](https://www.daytona.io) Linux VM — create a `DAYTONA_API_KEY` at [app.daytona.io](https://app.daytona.io); [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona) walks through it. To run it:
 
 ```bash
 yutori auth login            # or export YUTORI_API_KEY=...


### PR DESCRIPTION
Two wording fixes in the n2 run subsections (follow-up to #307):

- **Docker/Cua intro**: drop "— no cloud account needed beyond your Yutori login". It flagged what's *not* needed rather than telling the reader anything actionable; the snippet's `yutori auth login` line already shows the actual requirement.
- **Daytona intro**: replace the "a `DAYTONA_API_KEY` is the one extra credential" fragment with a direct instruction — "create a `DAYTONA_API_KEY` at [app.daytona.io](https://app.daytona.io)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no code, auth, or runtime behavior impact.
> 
> **Overview**
> **README** Navigator n2 run instructions are tightened in two places.
> 
> The **local Docker (Cua)** blurb no longer says a cloud account isn’t required beyond Yutori login; the intro now just points at the cookbook, since the snippet already shows `yutori auth login`.
> 
> The **Daytona** blurb replaces vague “one extra credential” wording with an explicit step to **create a `DAYTONA_API_KEY` at app.daytona.io**, aligned with the export line in the code block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c1a4060de3f579a00db856e73d984a338f0aab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->