### PR TITLE
docs(README): unmangle the Daytona section intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The script prints a `Watch the desktop live:` URL at startup — open it in a br
 
 #### Run on a Daytona Linux VM
 
-[examples/navigator_n2_daytona.py](examples/navigator_n2_daytona.py) runs the same agent on a [Daytona](https://www.daytona.io) Linux VM — create a `DAYTONA_API_KEY` at [app.daytona.io](https://app.daytona.io); [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona) walks through it. To run it:
+[examples/navigator_n2_daytona.py](examples/navigator_n2_daytona.py) runs the same agent on a [Daytona](https://www.daytona.io) Linux VM. Create an API key at [app.daytona.io](https://app.daytona.io), then:
 
 ```bash
 yutori auth login            # or export YUTORI_API_KEY=...
@@ -216,6 +216,8 @@ export DAYTONA_API_KEY=...   # https://app.daytona.io
 uv run https://raw.githubusercontent.com/yutori-ai/yutori-sdk-python/main/examples/navigator_n2_daytona.py \
     "Find the OS version and free disk space of this machine, and save a summary to a file on the desktop"
 ```
+
+See [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona) for a full walkthrough.
 
 <details>
 <summary>Drive your own local Mac</summary>


### PR DESCRIPTION
Follow-up to #309: the Daytona intro had become a dash-and-semicolon chain of three fragments. Now:

- Intro is two plain sentences: what the example does, then "Create an API key at [app.daytona.io](https://app.daytona.io), then:" leading into the snippet.
- The [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona) walkthrough reference moves to a short sentence after the snippet (parallel to the Docker section's post-snippet "Watch the desktop live" line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation wording and link placement only; no code or runtime behavior changes.
> 
> **Overview**
> **README only:** the **Run on a Daytona Linux VM** subsection is rewritten for readability, not new behavior.
> 
> The opening blurb is split into two sentences—what `navigator_n2_daytona.py` does, then “Create an API key at app.daytona.io, then:” before the bash block—instead of one long dash/semicolon chain that mixed setup, docs link, and run instructions.
> 
> The **[Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona)** link moves to a short line **after** the snippet, mirroring how the Docker section puts “Watch the desktop live” below its commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0603c7f67aa17d33be1d0f9d982041303b1d1023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->