### PR TITLE
feat(examples): Daytona 500-turn budget and the trained background-bash format

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -80,7 +80,7 @@ uv run python remote_sandbox.py --auto-approve \
 
 A computer-use agent using third-party [Daytona](https://www.daytona.io) infrastructure. `N2ComputerAgent` runs the loop, while this Yutori-maintained example provides a compact `DaytonaComputer` adapter plus sandbox lifecycle wiring. It serves the full current tool set: GUI and `bash` natively, and the file tools (`read`/`write`/`edit`/`grep`/`glob`) via the SDK's `ShellFileToolsMixin` — [cua_adapter.py](navigator_n2/cua_adapter.py) shows a second wiring of the same mixin, and [api.md](../api.md)'s "Navigator n2" section documents the contract. The ephemeral sandbox is deleted, with deletion confirmation requested, when the run ends.
 
-The script declares Python 3.10+, the Yutori SDK, and the tested Daytona version as inline metadata; `uv` installs them into an isolated environment automatically. If the run hits the step cap, the example takes one summarize-only turn (no tool execution) and prints the model's summary of progress before exiting:
+The script declares Python 3.10+, the Yutori SDK, and the tested Daytona version as inline metadata; `uv` installs them into an isolated environment automatically. The default turn budget (`--max-steps 500`) gives harder tasks room to finish; pass a smaller budget (e.g. `--max-steps 100`) for simpler tasks, or to truncate a trajectory for time or cost. If the run hits the cap, the example takes one summarize-only turn (no tool execution) and prints the model's summary of progress before exiting:
 
 ```bash
 export DAYTONA_API_KEY=...   # https://app.daytona.io

--- a/examples/navigator_n2/shared.py
+++ b/examples/navigator_n2/shared.py
@@ -117,7 +117,15 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Approve environment actions without prompting. Host shell commands may still require confirmation.",
     )
-    parser.add_argument("--max-steps", type=int, default=50, help="Maximum model turns (default: 50)")
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=500,
+        help=(
+            "Maximum model turns (default: 500, sized for harder tasks; "
+            "pass a smaller budget for simpler tasks or to cap time/cost)"
+        ),
+    )
 
 
 def _text_items(response: dict[str, Any]) -> list[str]:

--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -231,19 +231,26 @@ class DaytonaComputer(ShellFileToolsMixin):
     async def run_bash_command(self, command: str, timeout: float = 120.0, run_in_background: bool = False) -> str:
         if run_in_background:
             log_path = f"/tmp/yutori-n2-{uuid.uuid4().hex[:8]}.log"
-            launched = await self._sandbox.process.exec(
-                f"nohup sh -c {shlex.quote(command)} > {log_path} 2>&1 & echo $!",
-                cwd=self._cwd,
-                timeout=30,
-            )
-            pid = launched.result.strip()
-            return (
-                f"Started background task `bash_{log_path[-12:-4]}`.\n"
-                f"stdout+stderr is streaming to: {log_path}\n"
-                "Use the read tool on that file to retrieve output.\n"
-                f"Process id: {pid}\n"
-                f"To cancel: run bash with `kill {pid}`"
-            )
+            try:
+                launched = await self._sandbox.process.exec(
+                    f"nohup sh -c {shlex.quote(command)} > {log_path} 2>&1 & echo $!",
+                    cwd=self._cwd,
+                    timeout=30,
+                )
+            except Exception as exc:  # noqa: BLE001 - a failed start is a normal tool result
+                return f"ERROR: failed to start background command: {exc}"
+            # The pid lines are conditional, like the reference: better three good
+            # lines than a `kill ` with nothing to kill.
+            pid = (launched.result or "").strip()
+            lines = [
+                f"Started background task `bash_{log_path[-12:-4]}`.",
+                f"stdout+stderr is streaming to: {log_path}",
+                "Use the read tool on that file to retrieve output.",
+            ]
+            if pid and not launched.exit_code:
+                lines.append(f"Process id: {pid}")
+                lines.append(f"To cancel: run bash with `kill {pid}`")
+            return "\n".join(lines)
 
         # The n2 bash contract: the timeout is clamped to [0, 600] and an expiry is
         # a normal result the model can react to, never a raised failure envelope.

--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -38,7 +38,7 @@ Usage:
         "Find the OS version and free disk space of this machine, and save a summary to a file on the desktop"
 
 Add --record to save a screen recording of the run to n2-daytona-run.mp4.
-Add --max-steps N to raise the turn budget (default: 50); at the cap the run
+Add --max-steps N to change the turn budget (default: 500); at the cap the run
 prints the model's summary of progress and exits non-zero.
 Long runs compact automatically (the SDK default); each compaction prints a notice.
 
@@ -74,7 +74,7 @@ TYPE_CHUNK_MAX_CHARS = 500
 # Where --record saves the screen recording after the run.
 RECORDING_PATH = "n2-daytona-run.mp4"
 
-MAX_STEPS = 50
+MAX_STEPS = 500
 
 
 def _positive_int(value: str) -> int:
@@ -235,6 +235,7 @@ class DaytonaComputer(ShellFileToolsMixin):
             return (
                 f"Started background task `bash_{log_path[-12:-4]}`.\n"
                 f"stdout+stderr is streaming to: {log_path}\n"
+                "Use the read tool on that file to retrieve output.\n"
                 f"Process id: {pid}\n"
                 f"To cancel: run bash with `kill {pid}`"
             )

--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -38,8 +38,10 @@ Usage:
         "Find the OS version and free disk space of this machine, and save a summary to a file on the desktop"
 
 Add --record to save a screen recording of the run to n2-daytona-run.mp4.
-Add --max-steps N to change the turn budget (default: 500); at the cap the run
-prints the model's summary of progress and exits non-zero.
+Add --max-steps N to change the turn budget. The default (500) gives harder
+tasks room to finish; pass a smaller budget (e.g. 100) for simpler tasks, or
+to truncate a trajectory for time or cost. At the cap the run prints the
+model's summary of progress and exits non-zero.
 Long runs compact automatically (the SDK default); each compaction prints a notice.
 
 Walkthrough: https://docs.yutori.com/reference/n2-daytona
@@ -91,7 +93,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--max-steps",
         type=_positive_int,
         default=MAX_STEPS,
-        help=f"Maximum model turns (default: {MAX_STEPS})",
+        help=(
+            f"Maximum model turns (default: {MAX_STEPS}, sized for harder tasks; "
+            "pass a smaller budget for simpler tasks or to cap time/cost)"
+        ),
     )
     parser.add_argument(
         "--record",

--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -239,6 +239,13 @@ class DaytonaComputer(ShellFileToolsMixin):
                 )
             except Exception as exc:  # noqa: BLE001 - a failed start is a normal tool result
                 return f"ERROR: failed to start background command: {exc}"
+            if launched.exit_code:
+                # The launch line itself failed — nothing started; don't claim it did.
+                # (The reference reports the same ERROR shape via its exception path.)
+                detail = (launched.result or "").strip()
+                return f"ERROR: failed to start background command: exit code {launched.exit_code}" + (
+                    f"\n{detail}" if detail else ""
+                )
             # The pid lines are conditional, like the reference: better three good
             # lines than a `kill ` with nothing to kill.
             pid = (launched.result or "").strip()
@@ -247,7 +254,7 @@ class DaytonaComputer(ShellFileToolsMixin):
                 f"stdout+stderr is streaming to: {log_path}",
                 "Use the read tool on that file to retrieve output.",
             ]
-            if pid and not launched.exit_code:
+            if pid:
                 lines.append(f"Process id: {pid}")
                 lines.append(f"To cancel: run bash with `kill {pid}`")
             return "\n".join(lines)

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -644,3 +644,23 @@ async def test_daytona_scroll_rejects_horizontal_in_both_forms() -> None:
         await computer.scroll(10, 20, 0, 0, model_action={"action": "scroll", "direction": "left", "amount": 2})
     with pytest.raises(NotImplementedError):
         await computer.scroll(10, 20, 45, 0)
+
+
+async def test_daytona_bash_background_result_matches_the_trained_format() -> None:
+    async def exec_(*_args, **_kwargs):
+        return SimpleNamespace(result="4242\n", exit_code=0)
+
+    computer = _daytona_computer_with_exec(exec_)
+    result = await computer.run_bash_command("sleep 999", run_in_background=True)
+
+    lines = result.split("\n")
+    assert lines[0].startswith("Started background task `bash_")
+    assert lines[1].startswith("stdout+stderr is streaming to: /tmp/yutori-n2-")
+    assert lines[2] == "Use the read tool on that file to retrieve output."
+    assert lines[3] == "Process id: 4242"
+    assert lines[4] == "To cancel: run bash with `kill 4242`"
+
+
+def test_daytona_default_turn_budget_is_500() -> None:
+    assert navigator_n2_daytona.MAX_STEPS == 500
+    assert navigator_n2_daytona.parse_args(["task"]).max_steps == 500

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -686,3 +686,15 @@ async def test_daytona_bash_background_start_failure_is_a_normal_result() -> Non
     result = await computer.run_bash_command("sleep 999", run_in_background=True)
 
     assert result.startswith("ERROR: failed to start background command: ")
+
+
+async def test_daytona_bash_background_launch_failure_is_an_error_result() -> None:
+    async def exec_(*_args, **_kwargs):
+        return SimpleNamespace(result="sh: 1: cannot fork\n", exit_code=2)
+
+    computer = _daytona_computer_with_exec(exec_)
+    result = await computer.run_bash_command("sleep 999", run_in_background=True)
+
+    assert result.startswith("ERROR: failed to start background command: exit code 2")
+    assert "cannot fork" in result
+    assert "Started background task" not in result

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -664,3 +664,25 @@ async def test_daytona_bash_background_result_matches_the_trained_format() -> No
 def test_daytona_default_turn_budget_is_500() -> None:
     assert navigator_n2_daytona.MAX_STEPS == 500
     assert navigator_n2_daytona.parse_args(["task"]).max_steps == 500
+
+
+async def test_daytona_bash_background_pid_lines_are_conditional() -> None:
+    async def exec_(*_args, **_kwargs):
+        return SimpleNamespace(result="", exit_code=0)
+
+    computer = _daytona_computer_with_exec(exec_)
+    result = await computer.run_bash_command("sleep 999", run_in_background=True)
+
+    lines = result.split("\n")
+    assert len(lines) == 3  # no `Process id: ` / `kill ` lines with nothing to kill
+    assert lines[2] == "Use the read tool on that file to retrieve output."
+
+
+async def test_daytona_bash_background_start_failure_is_a_normal_result() -> None:
+    async def exec_(*_args, **_kwargs):
+        raise RuntimeError("sandbox gone")
+
+    computer = _daytona_computer_with_exec(exec_)
+    result = await computer.run_bash_command("sleep 999", run_in_background=True)
+
+    assert result.startswith("ERROR: failed to start background command: ")


### PR DESCRIPTION
## Summary
Two parity follow-ups to #297's full-tool-set repin, from a praxis-vs-example audit of the tool contract:

### Background bash points at the read tool
The background-task result regains the trained line **"Use the read tool on that file to retrieve output."** — it was deliberately dropped when the old batch-plus-bash pin served no `read` tool, and #297's repin to `TOOL_SET_COMPUTER_USE_LATEST` makes it correct (and expected by the model) again. The format now matches the reference implementation line for line — including its guards: the `Process id:` / `To cancel:` lines are conditional (omitted when the launch reports no pid), and a failed background start returns the trained `ERROR: failed to start background command: ...` result instead of a raised envelope. A nonzero exit from the launch line itself returns the same trained ERROR shape (with the exit code and captured output as detail) instead of a success message the launch didn't earn. Contract tests pin the five-line format, the conditional omission, and both failure results.

### Turn budget 500, documented
- `MAX_STEPS` 50 → 500 — the budget the benchmark harness runs n2 with, so the example's default no longer step-caps real tasks.
- The docstring, `--max-steps` help, and `examples/README.md`'s Daytona section now explain the policy: the 500 default gives harder tasks room to finish; pass a smaller budget (e.g. 100) for simpler tasks, or to truncate a trajectory for time or cost.
- `README.md` and `examples/navigator_n2/README.md` audited: no stale step numbers (the `default: 100` in examples/README.md is the n1.5 example's own flag).
- The Cua cookbook entrypoints (`navigator_n2/shared.py`) move to the same 500 default with the same guidance — the two n2 examples no longer disagree 10x on the turn budget. The loop's own default (`max_steps=None`) is untouched; the n1.5 examples keep their separate 100.

## Verification
- New tests: the background result's exact five-line format (including the read-tool line), and the 500 default via both `MAX_STEPS` and `parse_args`.
- `775 passed, 3 skipped` (suite re-run green after the cookbook change); ruff check and format clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to example scripts, CLI defaults, and Daytona adapter behavior with new contract tests; no production auth or core SDK loop defaults are altered.
> 
> **Overview**
> Raises the default **`--max-steps`** from **50 to 500** for the Daytona n2 example and the shared n2 cookbook CLI (`shared.py`), with matching help text and README notes that explain using a lower budget for simple runs or cost/time limits.
> 
> **Daytona background `bash`** now matches the trained/reference tool result: it adds the **“Use the read tool on that file to retrieve output.”** line, omits **Process id** / **kill** hints when no PID is returned, and returns **`ERROR: failed to start background command: ...`** (including launch non-zero exit with stderr detail) instead of claiming success or raising. New tests lock the five-line success shape, conditional PID lines, the 500 default, and both failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d4738454f16870aaa32c2ca01201aef38045f58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



