### PR TITLE
chore(release): 0.9.7

### DIFF
--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.6",
+    "yutori==0.9.7",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.6"]
+macos = ["yutori[macos]==0.9.7"]
 
 [tool.uv.sources]
 yutori = { path = "../..", editable = true }

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.6"
+YUTORI_INSTALLER_VERSION="0.9.7"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.6"
+version = "0.9.7"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Patch release carrying:

- **`yutori.navigator.N2Computer`** (#314) — the typed adapter protocol for `N2ComputerAgent` computer implementations.
- n2 docs fixes (#311, #307–#310): adapter-contract pointer from the README snippet, Docker-first run sections, stale-sentence cleanups.

Bumps `pyproject.toml`, the Cua cookbook's `yutori` pins, and the regenerated `install.sh` (freshness gate). Tag + PyPI dispatch follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and dependency pin updates with no logic changes in this diff.
> 
> **Overview**
> **Release packaging bump** from `0.9.6` to **`0.9.7`** so the published SDK, examples, and installer stay in sync.
> 
> Updates the root `pyproject.toml` version, the Navigator n2 cookbook’s `yutori` / `yutori[macos]` pins in `examples/navigator_n2/pyproject.toml`, and `YUTORI_INSTALLER_VERSION` in the regenerated `install.sh` (used in the bootstrap header and freshness checks).
> 
> No runtime or API code changes in this diff—only version constants for the patch release described in the PR notes (`N2Computer`, n2 docs fixes) that already merged elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcd83c418658c2b66932dd300d39de3ecf97392d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->