### PR TITLE
refactor(examples): dedupe pointer resolution in left_mouse_down/up

### DIFF
--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -132,23 +132,22 @@ class CuaSandboxComputer(ShellFileToolsMixin):
     async def wait(self, ms: int = 1_000) -> None:
         await asyncio.sleep(ms / 1_000)
 
-    async def left_mouse_down(self, x: int | None = None, y: int | None = None) -> None:
+    def _resolve_and_set_pointer(self, x: int | None, y: int | None, *, action: str) -> tuple[int, int]:
         if (x is None) != (y is None):
-            raise ValueError("mouse_down coordinates must include both x and y")
+            raise ValueError(f"{action} coordinates must include both x and y")
         point = (x, y) if x is not None and y is not None else self._pointer
         if point is None:
-            raise ValueError("mouse_down requires coordinates before the pointer has moved")
+            raise ValueError(f"{action} requires coordinates before the pointer has moved")
         self._pointer = point
+        return point
+
+    async def left_mouse_down(self, x: int | None = None, y: int | None = None) -> None:
+        point = self._resolve_and_set_pointer(x, y, action="mouse_down")
         await self.sandbox.mouse.mouse_down(*point)
         self._left_mouse_down = True
 
     async def left_mouse_up(self, x: int | None = None, y: int | None = None) -> None:
-        if (x is None) != (y is None):
-            raise ValueError("mouse_up coordinates must include both x and y")
-        point = (x, y) if x is not None and y is not None else self._pointer
-        if point is None:
-            raise ValueError("mouse_up requires coordinates before the pointer has moved")
-        self._pointer = point
+        point = self._resolve_and_set_pointer(x, y, action="mouse_up")
         try:
             await self.sandbox.mouse.mouse_up(*point)
         finally:


### PR DESCRIPTION
## What

`CuaSandboxComputer.left_mouse_down` and `left_mouse_up` (in `examples/navigator_n2/cua_adapter.py`) independently implemented the same pointer-resolution logic:

- validate that `x`/`y` are either both given or both omitted
- fall back to the last-known pointer (`self._pointer`) when omitted
- raise if there's still no pointer to use
- update `self._pointer`

The two copies differed only in the action name embedded in the `ValueError` messages (`"mouse_down ..."` vs `"mouse_up ..."`).

## Why

This is a straightforward duplicated-validation pattern in the same file — a small helper removes the drift risk (a future edit to one copy silently missing the other) without touching any call sites outside the class.

## Change

Extracted `_resolve_and_set_pointer(self, x, y, *, action)`, parameterized by the action name used in the two error messages, and had both `left_mouse_down`/`left_mouse_up` call it.

## Why it's safe

- The helper is a literal factoring-out of the identical logic; `f"{action} coordinates must include both x and y"` with `action="mouse_down"`/`"mouse_up"` produces byte-identical strings to the original hardcoded messages.
- No signature, return type, or control-flow change for either public method.
- `tests/test_navigator_n2_cookbooks.py::test_public_cua_adapter_executes_all_current_batch_actions` exercises both `mouse_down`/`mouse_up` (via the pointer fallback path) end to end and passes unchanged.
- Full test suite: 782 passed, 3 skipped, 1 pre-existing unrelated failure (`test_packaging.py::test_built_distributions_include_packaged_assets`, fails identically on `main` in this sandbox due to a missing `build` module — not related to this change).
- `ruff check` and `ruff format --check` pass on the changed file.


---
_Generated by [Claude Code](https://claude.ai/code/session_014f3sVv9Vi1VQivfqRBEBFJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor in an example adapter only; logic and error strings are preserved byte-for-byte for the two mouse methods.
> 
> **Overview**
> In `examples/navigator_n2/cua_adapter.py`, **`CuaSandboxComputer`** no longer duplicates the same x/y validation, `_pointer` fallback, and pointer update in **`left_mouse_down`** and **`left_mouse_up`**.
> 
> A new private helper **`_resolve_and_set_pointer`** centralizes that logic and takes an **`action`** string so **`ValueError`** messages still say `mouse_down` vs `mouse_up` like before. Public method behavior and signatures are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c952207c470f0bc7f4aaa366f8dec6a28a350dda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->