### PR TITLE
docs(README): polish the n2 tool-ownership table

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,15 +189,15 @@ async with AsyncYutoriClient() as client:
         ...  # each step yields the model's messages, tool calls, and tool results
 ```
 
-`computer` is your adapter for interfacing with the computer. Who implements each tool:
+The tool implementations live either in the `N2ComputerAgent` harness or in your `MyComputer` environment:
 
 | Tool | Implemented by | What you write / reuse |
 |---|---|---|
-| `computer_batch` | `N2ComputerAgent` — coordinates, sequencing, screenshots | the GUI primitives it calls (`click`, `type`, …), typed by the `N2Computer` protocol |
-| `bash` | your `MyComputer` | `run_bash_command`; `format_shell_output` renders the trained result shape |
-| `read`/`write`/`edit` | your `MyComputer` | reuse `ShellFileToolsMixin` — needs only a shell + `python3` in the sandbox |
+| `computer_batch` | `N2ComputerAgent` | implementation of GUI actions (`click`, `type`, etc) — reference: [cua_adapter.py](examples/navigator_n2/cua_adapter.py) |
+| `bash` | your `MyComputer` | `run_bash_command` — reference: [cua_adapter.py](examples/navigator_n2/cua_adapter.py) |
+| `read`/`write`/`edit` | your `MyComputer` | inherit the SDK's [`ShellFileToolsMixin`](yutori/navigator/sandbox_tools.py), which implements all three over your sandbox's shell |
 
-The full contract is documented in [Navigator n2 loop](api.md#navigator-n2-loop); [cua_adapter.py](examples/navigator_n2/cua_adapter.py) is the reference implementation.
+The full contract is documented in [Navigator n2 loop](api.md#navigator-n2-loop).
 
 #### Run in local Docker (Cua cookbook)
 


### PR DESCRIPTION
Follow-up polish on the #318 table:

- Drop the post-snippet "`computer` is your adapter…" sentence (the pre-snippet lead-in already says you implement the environment); the table now opens with "The tool implementations live either in the `N2ComputerAgent` harness or in your `MyComputer` environment:".
- Trim cell noise (loop-mechanics aside, protocol mention, trained-shape phrasing, shell+python3 clause) and de-cryptify the mixin row ("inherit the SDK's `ShellFileToolsMixin`, which implements all three over your sandbox's shell").
- Each row links its reference implementation ([cua_adapter.py](examples/navigator_n2/cua_adapter.py), [sandbox_tools.py](yutori/navigator/sandbox_tools.py)); the closing line keeps only the api.md contract pointer.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to README; no runtime or API behavior changes.
> 
> **Overview**
> **Polishes the Navigator n2 “who implements which tool” section** in the README so it’s easier to scan and points readers at concrete references.
> 
> The intro before the table now states that implementations live in **`N2ComputerAgent`** or **`MyComputer`**, replacing the redundant “`computer` is your adapter…” line. Table cells are shortened (less loop/protocol/trained-shape wording), and each row links to **`cua_adapter.py`** or **`ShellFileToolsMixin`** in **`sandbox_tools.py`**. The closing note keeps only the **`api.md`** contract link and drops the duplicate **`cua_adapter.py`** mention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c63ee697c6318499daffbdb662510be6e5b1f42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->