### PR TITLE
docs(README): "SDK's N2ComputerAgent" in the ownership table

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The tool implementations live either in the `N2ComputerAgent` harness or in your
 
 | Tool | Implemented by | What you write / reuse |
 |---|---|---|
-| `computer_batch` | `N2ComputerAgent` | implementation of GUI actions (`click`, `type`, etc) — reference: [cua_adapter.py](examples/navigator_n2/cua_adapter.py) |
+| `computer_batch` | SDK's `N2ComputerAgent` | implementation of GUI actions (`click`, `type`, etc) — reference: [cua_adapter.py](examples/navigator_n2/cua_adapter.py) |
 | `bash` | your `MyComputer` | `run_bash_command` — reference: [cua_adapter.py](examples/navigator_n2/cua_adapter.py) |
 | `read`/`write`/`edit` | your `MyComputer` | inherit the SDK's [`ShellFileToolsMixin`](yutori/navigator/sandbox_tools.py), which implements all three over your sandbox's shell |
 


### PR DESCRIPTION
One-cell polish on the #319 table: the `computer_batch` row now says "SDK's `N2ComputerAgent`", parallel to "your `MyComputer`" in the other rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only wording change with no runtime or API impact.
> 
> **Overview**
> Updates the Navigator n2 tool-ownership table so the **`computer_batch`** row’s “Implemented by” column reads **SDK's `N2ComputerAgent`**, matching the “your `MyComputer`” phrasing used for **`bash`** and file tools. No behavior or API changes—documentation wording only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeabace46b58ea1cf2a7ee87ce1d307fb1f6bb76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->