### PR TITLE
docs(n2): state the tool-ownership principle in README and api.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,13 +189,13 @@ async with AsyncYutoriClient() as client:
         ...  # each step yields the model's messages, tool calls, and tool results
 ```
 
-The tool implementations live either in the `N2ComputerAgent` harness or in your `MyComputer` environment:
+The tool implementations live either in the `N2ComputerAgent` harness or in your `MyComputer` environment — the harness implements tools that only transform the protocol, your environment implements every tool whose effect happens inside it:
 
 | Tool | Implemented by | What you write / reuse |
 |---|---|---|
-| `computer_batch` | SDK's `N2ComputerAgent` | implementation of GUI actions (`click`, `type`, etc) — reference: [cua_adapter.py](examples/navigator_n2/cua_adapter.py) |
+| `computer_batch` | SDK's `N2ComputerAgent` | the single-action GUI primitives the batch executes through (`click`, `type`, etc) — reference: [cua_adapter.py](examples/navigator_n2/cua_adapter.py) |
 | `bash` | your `MyComputer` | `run_bash_command` — reference: [cua_adapter.py](examples/navigator_n2/cua_adapter.py) |
-| `read`/`write`/`edit` | your `MyComputer` | inherit the SDK's [`ShellFileToolsMixin`](yutori/navigator/sandbox_tools.py), which implements all three over your sandbox's shell |
+| `read`/`write`/`edit` | your `MyComputer` | inherit the SDK's [`ShellFileToolsMixin`](yutori/navigator/sandbox_tools.py), which implements all three over your sandbox's shell — or implement them natively, as [MacOSComputer](yutori/navigator/macos/computer.py) does |
 
 The full contract is documented in [Navigator n2 loop](api.md#navigator-n2-loop).
 

--- a/api.md
+++ b/api.md
@@ -565,6 +565,8 @@ Failure conventions: a GUI handler reports failure by returning `{"success": Fal
 
 #### Tool ownership
 
+The split follows one principle: the loop implements what only transforms the protocol; the adapter implements every tool whose effect happens inside the environment.
+
 | Tool | Implemented by | Notes |
 |---|---|---|
 | `computer_batch` (and the older sets' standalone GUI actions and `screenshot`) | The loop | Validates the batch, maps coordinates, normalizes key names, runs members in order, stops at the first error, captures the one post-batch frame, and formats the `[i:name]` result. The adapter only executes the GUI primitives above. |
@@ -583,7 +585,7 @@ For any sandbox whose shell has `python3` (stdlib only) on PATH, mix `yutori.nav
 | `run_sandbox_shell(command, *, timeout_seconds)` | Run one shell command in the sandbox; return any object with `stdout`, `stderr`, and `returncode` attributes. |
 | `file_tool_cwd() -> str` | The directory relative paths resolve against (usually the bash tool's tracked cwd). |
 
-To implement the file tools without a shell, reproduce the contracts of the sandbox-side `FILE_TOOL_SCRIPT` (`yutori/navigator/sandbox_tools.py`).
+The shell is one transport, not the contract: to implement the file tools without one — as `MacOSComputer` does natively — reproduce the contracts of the sandbox-side `FILE_TOOL_SCRIPT` (`yutori/navigator/sandbox_tools.py`).
 
 #### Callbacks and confirmation
 


### PR DESCRIPTION
Small additions on top of the #321/#322 restructure, adding the *why* behind the ownership split:

- **Principle stated once in each doc**: the loop implements what only transforms the protocol; the adapter implements every tool whose effect happens inside the environment. (README table lead-in; opening line of api.md's "Tool ownership".)
- **README row clarifications**: `computer_batch` "executes through" your single-action primitives (it's harness-owned but can't touch the environment itself); the file-tool row notes the mixin's shell is one transport — implement natively as [MacOSComputer](yutori/navigator/macos/computer.py) does.
- **api.md's no-shell sentence** gains the same nuance: "The shell is one transport, not the contract … as `MacOSComputer` does natively."

Docs-only; suite 783 passed / 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only clarifications; no runtime, API, or behavioral changes.
> 
> **Overview**
> **Documentation-only** update that spells out *why* Navigator n2 splits tools between `N2ComputerAgent` and the computer adapter.
> 
> **README** now states the rule up front (loop = protocol transforms; adapter = effects inside the environment), tightens the `computer_batch` row to say the harness runs batches *through* your GUI primitives, and notes file tools can use `ShellFileToolsMixin` or a native path like **`MacOSComputer`**.
> 
> **api.md** adds the same principle at the start of **Tool ownership**, and reframes the no-shell file-tools guidance: the shell is one transport, not the contract, with **`MacOSComputer`** as the native example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ae93ba35b75f3b327965423b1af7977508cb0b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->