### PR TITLE
docs(n2): rephrase the ownership principle

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ async with AsyncYutoriClient() as client:
         ...  # each step yields the model's messages, tool calls, and tool results
 ```
 
-The tool implementations live either in the `N2ComputerAgent` harness or in your `MyComputer` environment — the harness implements tools that only transform the protocol, your environment implements every tool whose effect happens inside it:
+Your `MyComputer` environment is responsible for tool implementations (they are system-dependent); the `N2ComputerAgent` harness is responsible for tool transformation and batching:
 
 | Tool | Implemented by | What you write / reuse |
 |---|---|---|

--- a/api.md
+++ b/api.md
@@ -565,7 +565,7 @@ Failure conventions: a GUI handler reports failure by returning `{"success": Fal
 
 #### Tool ownership
 
-The split follows one principle: the loop implements what only transforms the protocol; the adapter implements every tool whose effect happens inside the environment.
+The split follows one principle: the adapter is responsible for tool implementations (they are system-dependent); the loop is responsible for tool transformation and batching.
 
 | Tool | Implemented by | Notes |
 |---|---|---|


### PR DESCRIPTION
Rephrase the ownership principle in both docs: the environment/adapter is responsible for tool implementations (they are system-dependent); the harness/loop is responsible for tool transformation and batching. README table lead-in and api.md's "Tool ownership" opening line now use the same phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no code or API behavior impact.
> 
> **Overview**
> **Aligns Navigator n2 tool-ownership wording** in `README.md` and `api.md` so both documents state the same split.
> 
> The lead-in before the README tool table and the opening line under **Tool ownership** in `api.md` now say the **environment/adapter** owns **tool implementations** (because they are system-dependent) and the **harness/loop** (`N2ComputerAgent`) owns **tool transformation and batching**. The ownership tables and behavioral docs are unchanged; only the principle sentence was rephrased for clarity and consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3249597812237e4930f47c1109e41ce59cde1724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->