### PR TITLE
docs(README): ownership table as the task view — you implement vs SDK provides

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,11 @@ async with AsyncYutoriClient() as client:
 
 Your `MyComputer` environment is responsible for tool implementations (they are system-dependent); the `N2ComputerAgent` harness is responsible for tool transformation and batching:
 
-| Tool | Implemented by | What you write / reuse |
+| Tool | You implement | The SDK provides |
 |---|---|---|
-| `computer_batch` | SDK's `N2ComputerAgent` | the single-action GUI primitives the batch executes through (`click`, `type`, etc) — reference: [cua_adapter.py](examples/navigator_n2/cua_adapter.py) |
-| `bash` | your `MyComputer` | `run_bash_command` — reference: [cua_adapter.py](examples/navigator_n2/cua_adapter.py) |
-| `read`/`write`/`edit` | your `MyComputer` | inherit the SDK's [`ShellFileToolsMixin`](yutori/navigator/sandbox_tools.py), which implements all three over your sandbox's shell — or implement them natively, as [MacOSComputer](yutori/navigator/macos/computer.py) does |
+| `computer_batch` | the single-action GUI primitives (`click`, `type`, etc)<br>[reference implementation: [cua_adapter.py](examples/navigator_n2/cua_adapter.py)] | the batching: validation, coordinate mapping, sequencing, the screenshot result |
+| `bash` | `run_bash_command`<br>[reference implementation: [cua_adapter.py](examples/navigator_n2/cua_adapter.py)] | [`format_shell_output`](yutori/navigator/sandbox_tools.py) for the result format |
+| `read`/`write`/`edit` | `read_file`/`write_file`/`edit_file`<br>[reference implementation: [MacOSComputer](yutori/navigator/macos/computer.py)] | [`ShellFileToolsMixin`](yutori/navigator/sandbox_tools.py): a complete implementation over your sandbox's shell |
 
 The full contract is documented in [Navigator n2 loop](api.md#navigator-n2-loop).
 


### PR DESCRIPTION
The previous columns mixed the ownership question ("Implemented by") with the task question ("What you write / reuse"), which made the two interesting rows read as contradictions — `computer_batch` was "implemented by the SDK" yet assigned the reader work, and `read`/`write`/`edit` were "yours" yet inherited. The lead-in sentence already carries the ownership principle, so the table becomes purely the task view:

- Columns: **You implement** / **The SDK provides** — uniform semantics in every row.
- Reference implementations cited on their own line per cell (`[reference implementation: …]`); rows 1–2 cite cua_adapter.py, row 3 cites MacOSComputer (the native file-tool implementation), with `ShellFileToolsMixin` in the SDK column as the ready-made alternative.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to README table wording and links; no runtime or API behavior affected.
> 
> **Overview**
> The Navigator n2 tool matrix in **README** is reframed so both columns answer the same question on every row: what **you implement** versus what **the SDK provides**, replacing the mixed “Implemented by” / “What you write / reuse” headers that made `computer_batch` and file tools read contradictory.
> 
> Each row now lists concrete methods or primitives on the left (e.g. `run_bash_command`, `read_file`/`write_file`/`edit_file`) and SDK responsibilities on the right (batching for `computer_batch`, `format_shell_output`, `ShellFileToolsMixin`). Reference implementations are split onto their own line per cell, pointing to `cua_adapter.py` for GUI/bash and `MacOSComputer` for native file tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1f445f253692c64c1b9486ac99cfbb4f6f6621f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->