### PR TITLE
docs(README): row 3 cites both file-tool paths, mixin first

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Your `MyComputer` environment is responsible for tool implementations (they are 
 |---|---|---|
 | `computer_batch` | the single-action GUI primitives (`click`, `type`, etc)<br>[reference implementation: [cua_adapter.py](examples/navigator_n2/cua_adapter.py)] | the batching: validation, coordinate mapping, sequencing, the screenshot result |
 | `bash` | `run_bash_command`<br>[reference implementation: [cua_adapter.py](examples/navigator_n2/cua_adapter.py)] | [`format_shell_output`](yutori/navigator/sandbox_tools.py) for the result format |
-| `read`/`write`/`edit` | `read_file`/`write_file`/`edit_file`<br>[reference implementation: [MacOSComputer](yutori/navigator/macos/computer.py)] | [`ShellFileToolsMixin`](yutori/navigator/sandbox_tools.py): a complete implementation over your sandbox's shell |
+| `read`/`write`/`edit` | `read_file`/`write_file`/`edit_file`<br>[reference implementations: [cua_adapter.py](examples/navigator_n2/cua_adapter.py) (via the mixin), [MacOSComputer](yutori/navigator/macos/computer.py) (native)] | [`ShellFileToolsMixin`](yutori/navigator/sandbox_tools.py): a complete implementation over your sandbox's shell — inherit it and supply its two small hooks |
 
 The full contract is documented in [Navigator n2 loop](api.md#navigator-n2-loop).
 


### PR DESCRIPTION
The file-tool row's citation pointed only at MacOSComputer — the native, minority path — while the majority path (inherit `ShellFileToolsMixin`, wired in cua_adapter.py) went uncited. Now: `[reference implementations: cua_adapter.py (via the mixin), MacOSComputer (native)]`, and the SDK column says how the complete implementation is consumed — "inherit it and supply its two small hooks" — which resolves the "SDK provides it, yet I implement it?" tension.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En9KXQXXppoNWfEs4nxWBW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only wording; no runtime, API, or security behavior changes.
> 
> **Overview**
> Updates the Navigator n2 **read/write/edit** table row so integrators see **both** integration paths, not only the native macOS one.
> 
> The **You implement** column now links **`cua_adapter.py` (via `ShellFileToolsMixin`)** ahead of **`MacOSComputer` (native)**. The **SDK provides** blurb for `ShellFileToolsMixin` now states that the mixin is the full shell-backed implementation and that you **inherit it and wire its two small hooks**, clarifying why the SDK column still lists a complete implementation while the implementer column names `read_file` / `write_file` / `edit_file`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8427c05ef47a50ae3e3aee54b4c479628ef97748. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->