### PR TITLE
chore(release): 0.9.8

### DIFF
--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.7",
+    "yutori==0.9.8",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.7"]
+macos = ["yutori[macos]==0.9.8"]
 
 [tool.uv.sources]
 yutori = { path = "../..", editable = true }

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.7"
+YUTORI_INSTALLER_VERSION="0.9.8"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.7"
+version = "0.9.8"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Patch release carrying:

- n2 support for `computer_use_tools-20260830` as the default, with explicit 20260825/20260830 constants and corrected capability grouping (#328).
- n2 `tools` / `disable_tools` documentation and the expanded adapter ownership and trained-contract guidance (#317–#327).
- The focused n2 cookbook pointer-resolution refactor (#316).

Bumps the package version, Navigator n2 cookbook pins, and regenerated installer to `0.9.8`.

Validation: 784 passed, 3 skipped, 1 deselected; Ruff clean; shell/freshness checks; wheel + sdist build; Twine checks; exact-distribution packaging test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and dependency pin updates only; no runtime or API logic changes in this diff.
> 
> **Overview**
> **Patch release 0.9.8** — this PR only updates version identifiers so installs and examples align with the release (the functional n2, docs, and cookbook work landed in earlier PRs).
> 
> The **`yutori`** package version in root **`pyproject.toml`** moves from **0.9.7** to **0.9.8**. The curl bootstrap **`install.sh`** **`YUTORI_INSTALLER_VERSION`** is bumped the same way so users see the correct release in the installer header. **Navigator n2** example cookbooks pin **`yutori==0.9.8`** (and **`yutori[macos]==0.9.8`**) instead of 0.9.7.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68b54e7acd03ad14c21194df5586cf6f2edcbd9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->