### PR TITLE
docs(api): drop the retired-n1 references

### DIFF
--- a/api.md
+++ b/api.md
@@ -85,8 +85,6 @@ usage = client.get_usage(period="7d")
 - `navigator_rate_limits` (`dict`): `requests_today`, `daily_limit`, `remaining_requests`, `reset_at`, `per_second_limit`
 - `activity` (`dict`): `period`, `scout_runs`, `browsing_tasks`, `research_tasks`, `navigator_calls`
 
-The response also includes `n1_rate_limits` and `activity.n1_calls` as deprecated aliases of `navigator_rate_limits` and `navigator_calls` respectively. They will be removed in a future release — prefer the `navigator_*` names.
-
 ## Model constants and tool sets
 
 Importable from `yutori.navigator`. Prefer these over hard-coded strings so upgrades land automatically.
@@ -103,15 +101,12 @@ from yutori.navigator import (
 
 | Constant | Value | Notes |
 |----------|-------|-------|
-| `NAVIGATOR_N1_MODEL` | `"n1-latest"` | Retired: the API rejects `n1-*` model ids with HTTP 400. Kept for import compatibility only. |
 | `NAVIGATOR_N1_5_MODEL` | `"n1.5-latest"` | Alias for the latest stable Navigator n1.5 model (current default). |
 | `TOOL_SET_CORE` | `"browser_tools_core-20260403"` | Default Navigator n1.5 tool set — 18 coordinate-based browser tools. |
 | `TOOL_SET_EXPANDED` | `"browser_tools_expanded-20260403"` | Core tools + `extract_elements`, `find`, `set_element_value`, `execute_js`. |
 | `NAVIGATOR_N2_MODEL` | `"n2"` | Stable Navigator n2 model identifier and `N2ComputerAgent` default. |
 | `TOOL_SET_COMPUTER_USE_LATEST` | `"computer_use_tools-20260830"` | Current n2 tool set: `computer_batch`, `edit`, `read`, `write`, and `bash`. A batch contains up to 20 actions drawn from 15 action types, including held mouse/key actions and screenshot. |
 | `NAVIGATOR_COORDINATE_SCALE` | `1000` | The normalized action space is `NAVIGATOR_COORDINATE_SCALE × NAVIGATOR_COORDINATE_SCALE`. |
-
-`N1_MODEL`, `N1_5_MODEL`, and `N1_COORDINATE_SCALE` are still importable from the same module as deprecated aliases of the `NAVIGATOR_*` constants and may be removed in a future release.
 
 **Replay note.** The SDK also accepts the immutable `computer_use_tools-20260818` browser set for replaying recorded trajectories. It is not a desktop set: its extra `goto_url` call requires a computer handler that implements `async goto_url(url: str)`. The bundled desktop and public Cua sandbox adapters deliberately return a recoverable unsupported-environment result for that browser-only call.
 
@@ -166,19 +161,6 @@ parsed = getattr(response, "parsed_json", None)
 - `**kwargs`: Any other OpenAI Chat Completions parameter (`temperature`, `tools`, `tool_choice`, `response_format`, etc.). If the caller already passes `extra_body`, the SDK merges Navigator n1.5 params into it.
 
 **Returns:** `openai.types.chat.ChatCompletion`. When `json_schema` is set on Navigator n1.5 and parsing succeeds, the API also sets `response.parsed_json`.
-
-**Migrating from the retired Navigator n1** (the API rejects `n1-*` model ids; reference: [docs.yutori.com](https://docs.yutori.com/reference/n1-5)):
-
-| Feature | Navigator n1 | Navigator n1.5 |
-|---------|----|----|
-| Tool sets | Fixed | `tool_set` (core / expanded) |
-| Disable tools | — | `disable_tools` supported |
-| Structured JSON output | — | `json_schema` → `response.parsed_json` |
-| Mouse move action | `hover` | `mouse_move` |
-| Key press param | `key_comb` (Playwright names) | `key` (lowercase names) |
-| Click modifiers | — | `ref`, `modifier` |
-| Extra actions | — | `hold_key`, `middle_click`, `mouse_down`, `mouse_up`, `go_forward` |
-| `type` extras | `press_enter_after`, `clear_before_typing` | — |
 
 #### Navigator n2
 


### PR DESCRIPTION
## Why

The API rejects `n1-*` model ids with HTTP 400, so nothing a reader can actually do with api.md involves n1 — but four places still documented it, and one of them was a full migration table for a move nobody arriving now makes. For a pre-stabilization SDK being cleaned up for incoming usage, that is pure noise.

## What

Removed from api.md:

- The `NAVIGATOR_N1_MODEL` row in the constants table ("Retired… kept for import compatibility only").
- The `N1_MODEL` / `N1_5_MODEL` / `N1_COORDINATE_SCALE` deprecated-alias note.
- The `n1_rate_limits` / `activity.n1_calls` response-alias paragraph under `get_usage`.
- The "Migrating from the retired Navigator n1" heading and its eight-row n1→n1.5 comparison table.

**Docs only.** The constants stay exported and importable (they are still used in the test fixtures), so nothing breaks for a caller who has one in code — they simply stop being advertised to new readers. Say the word if you want the exports themselves dropped; that is a code change with test updates, worth its own PR.

## Testing

785 passed, 3 skipped. No remaining retired-n1 references in api.md, llms.txt, or README (verified by grep excluding n1.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only reference edits with no SDK or API behavior changes.
> 
> **Overview**
> **Documentation-only cleanup** of `api.md` so new readers are not steered toward retired Navigator n1, which the API rejects with HTTP 400.
> 
> The **`get_usage`** section no longer documents deprecated response aliases (`n1_rate_limits`, `activity.n1_calls`). The **model constants** table drops the retired `NAVIGATOR_N1_MODEL` row and the note about deprecated `N1_*` import aliases. The full **“Migrating from the retired Navigator n1”** section and its n1→n1.5 comparison table are removed. **Runtime exports are unchanged** — deprecated constants remain importable for existing callers and tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e6067fafa8b0b89feb2941a62245d12b26bd24b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->