### PR TITLE
refactor(navigator): dedupe bash-timeout clamping in the n2 sandbox adapters

### DIFF
--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -27,6 +27,9 @@ from yutori.navigator.sandbox_tools import (
     append_stream as _append_stream,
 )
 from yutori.navigator.sandbox_tools import (
+    clamp_bash_timeout as _clamp_bash_timeout,
+)
+from yutori.navigator.sandbox_tools import (
     format_shell_output as _format_shell_output,
 )
 from yutori.navigator.sandbox_tools import (
@@ -196,7 +199,7 @@ class CuaSandboxComputer(ShellFileToolsMixin):
         # The n2 bash contract: the timeout is clamped to [0, 600] and an expiry is a
         # NORMAL result the model can react to, never a raised failure envelope. (The
         # sandbox API discards partial output on expiry, so the result is the bare line.)
-        timeout_s = max(0.0, min(float(120.0 if timeout is None else timeout), 600.0))
+        timeout_s = _clamp_bash_timeout(timeout)
         if timeout_s == 0:
             return "Command timed out after 0s"
         try:

--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -67,6 +67,7 @@ from yutori.navigator import (
     format_stop_and_summarize,
 )
 from yutori.navigator.n2_compaction import response_message
+from yutori.navigator.sandbox_tools import clamp_bash_timeout
 
 # Any snapshot carrying Daytona's computer-use bundle. This one is a bare XFCE
 # desktop at 1024x768; build your own to give the model a browser or an editor.
@@ -264,7 +265,7 @@ class DaytonaComputer(ShellFileToolsMixin):
         # The n2 bash contract: the timeout is clamped to [0, 600] and an expiry is
         # a normal result the model can react to, never a raised failure envelope.
         # (Daytona raises on expiry and discards the partial output.)
-        timeout_s = max(0.0, min(float(120.0 if timeout is None else timeout), 600.0))
+        timeout_s = clamp_bash_timeout(timeout)
         if timeout_s == 0:
             return "Command timed out after 0s"
         # Run the command, then report the directory it finished in, keeping

--- a/yutori/navigator/sandbox_tools.py
+++ b/yutori/navigator/sandbox_tools.py
@@ -319,6 +319,15 @@ def format_shell_result(result: Any) -> str:
     )
 
 
+BASH_TIMEOUT_DEFAULT_SECONDS = 120.0
+BASH_TIMEOUT_MAX_SECONDS = 600.0
+
+
+def clamp_bash_timeout(timeout: float | None) -> float:
+    """Clamp a `bash` timeout into the n2 contract's [0, 600] range, defaulting a missing value to 120s."""
+    return max(0.0, min(float(BASH_TIMEOUT_DEFAULT_SECONDS if timeout is None else timeout), BASH_TIMEOUT_MAX_SECONDS))
+
+
 IMAGE_VIEW_MAX_EDGE = 1568
 
 
@@ -453,10 +462,13 @@ class ShellFileToolsMixin:
 
 __all__ = [
     "BASH_RESULT_MAX_CHARS",
+    "BASH_TIMEOUT_DEFAULT_SECONDS",
+    "BASH_TIMEOUT_MAX_SECONDS",
     "FILE_TOOL_SCRIPT",
     "IMAGE_VIEW_MAX_EDGE",
     "ShellFileToolsMixin",
     "append_stream",
+    "clamp_bash_timeout",
     "format_shell_output",
     "format_shell_result",
     "join_output_streams",


### PR DESCRIPTION
## What

Both n2 computer-use example adapters — `examples/navigator_n2/cua_adapter.py::CuaSandboxComputer.run_bash_command` and the standalone `examples/navigator_n2_daytona.py::DaytonaComputer.run_bash_command` — independently hand-rolled the identical n2 bash-timeout clamp formula, byte-for-byte:

```python
timeout_s = max(0.0, min(float(120.0 if timeout is None else timeout), 600.0))
```

Extracted `clamp_bash_timeout()` (with the `BASH_TIMEOUT_DEFAULT_SECONDS`/`BASH_TIMEOUT_MAX_SECONDS` constants it names) into `yutori/navigator/sandbox_tools.py`, which already houses the other shared shell-result helpers (`format_shell_output`, `append_stream`, `format_shell_result`) both of these same adapters already import. Both call sites now delegate to it instead of reimplementing the formula.

## Why it's safe

- The extracted function reproduces the inline formula exactly — same inputs produce the same clamped float, verified by reading through both call sites line-for-line before touching either.
- `sandbox_tools.py` is already the established shared home for this exact class of helper (see `format_shell_output`/`append_stream`/`format_shell_result`, all imported the same way by both adapters), so this follows existing precedent rather than introducing a new pattern.
- This only touches example code (`examples/`) plus an additive export in `yutori/navigator/sandbox_tools.py` — no existing public signature, return type, or behavior changes anywhere in the SDK's core surface.
- Full test suite passes unchanged: `784 passed, 3 skipped, 1 deselected` (identical to `main`).
- `ruff check .` is clean. (`ruff format --check` on the touched file surfaces one pre-existing, unrelated formatting nit at `_run_file_tool`, present on `main` before this change too — left untouched per this repo's convention of not smuggling unrelated reformatting into a refactor diff.)
- Targeted tests covering both adapters' bash-timeout behavior (`tests/test_navigator_n2_entrypoints.py`, `tests/test_navigator_n2_cookbooks.py`) pass unchanged, including the existing test that pins the exact clamped-timeout and `"Command timed out after Ns"` behavior.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hj9ES1bK3RPAkka1t44mQg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in example adapters and an additive helper export; no changes to core agent loop contracts.
> 
> **Overview**
> Centralizes the n2 **bash** timeout rules (default **120s**, clamp to **[0, 600]**) in `clamp_bash_timeout()` on `yutori/navigator/sandbox_tools.py`, alongside the existing shell-result helpers.
> 
> **`CuaSandboxComputer.run_bash_command`** and **`DaytonaComputer.run_bash_command`** now call that helper instead of duplicating the same `max/min` expression. Named constants **`BASH_TIMEOUT_DEFAULT_SECONDS`** and **`BASH_TIMEOUT_MAX_SECONDS`** are exported from the module; runtime timeout and `"Command timed out after Ns"` behavior stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043d11f89bce11955b3085086026092fd723e543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->