### PR TITLE
chore: ignore screen recordings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Screen recordings — `examples/navigator_n2_daytona.py --record` writes
+# n2-daytona-run.mp4 to the working directory.
+*.mp4


### PR DESCRIPTION
## Why

`examples/navigator_n2_daytona.py --record` writes its video to `RECORDING_PATH = "n2-daytona-run.mp4"` in the working directory. Running the documented command from a checkout therefore leaves an untracked ~2.5 MB binary next to the source, one `git add -A` away from being committed — which is exactly how it nearly landed in a docs PR earlier today.

## What

`*.mp4` added to `.gitignore`, with a comment naming where the file comes from. No video files are tracked today, so nothing is affected retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates `.gitignore`; no runtime or application behavior changes.
> 
> **Overview**
> Adds **`*.mp4`** to `.gitignore` so screen recordings from the documented **`examples/navigator_n2_daytona.py --record`** flow (which writes **`n2-daytona-run.mp4`** in the repo root) stay untracked and are less likely to be committed by mistake.
> 
> A short comment in `.gitignore` documents where those files come from.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a170283241ba23223d7eb2cb223adff8db4aeb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->