### PR TITLE
fix(n2): avoid Cua bash hangs with background processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ uv run python remote_sandbox.py --auto-approve "Open Calculator and compute 17 *
 ```
 
 The script prints a `Watch the desktop live:` URL at startup — open it in a browser to follow along.
+The Linux image in this example has no Calculator desktop app, and the example shows n2 moving between bash and GUI interactions to discover, launch, and visually operate the available `xcalc` fallback.
 
 #### Run on a Daytona Linux VM
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -45,6 +45,8 @@ uv run python remote_sandbox.py "Open Calculator and compute 17 * 23"
 
 The script prints a `Watch the desktop live: http://localhost:<port>/vnc.html` link at startup — open it in a browser to follow the agent's actions on the sandbox's noVNC viewer. If a run hits `--max-steps`, the entrypoints take one summarize-only turn (no tool execution) and print the model's summary of progress before exiting.
 
+The current sandbox image has no Calculator desktop entry, although `xcalc` is available. In the suggested task, n2 moves between the GUI and bash to confirm the missing launcher, discover and launch `xcalc`, and then complete the calculation visually.
+
 This cookbook intentionally does not expose Cua cloud. Cua's current cloud path uses Fleet pools and provider-owned credentials rather than the retired image-based VM API in the pinned Python package; follow [Cua's current CLI documentation](https://cua.ai/docs/reference/cua-cli/cli-reference) if you need that infrastructure.
 
 The adapter supports the five current n2 tools: `computer_batch`, `edit`, `read`, `write`, and `bash`. It executes normalized coordinates against the sandbox's native screen, preserves a bash working directory, and uses Cua key-down/key-up primitives to keep modifiers attached to their click or scroll gesture.

--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -39,9 +39,6 @@ from yutori.navigator.sandbox_tools import (
     result_returncode as _result_returncode,
 )
 from yutori.navigator.sandbox_tools import (
-    result_stderr as _result_stderr,
-)
-from yutori.navigator.sandbox_tools import (
     result_stdout as _result_stdout,
 )
 
@@ -187,14 +184,12 @@ class CuaSandboxComputer(ShellFileToolsMixin):
         run_in_background: bool = False,
     ) -> str:
         cwd = await self._working_directory()
-        prefix = f"cd {shlex.quote(cwd)} && "
         if run_in_background:
             log_path = f"/tmp/yutori-n2-bash-{uuid.uuid4().hex[:8]}.log"
-            result = await self.sandbox.shell.run(
-                f"{prefix}nohup sh -c {shlex.quote(command)} > {log_path} 2>&1 < /dev/null & echo $!",
-                timeout=30,
+            session = await self.sandbox.terminal.create(
+                f"cd {shlex.quote(cwd)} && exec sh -c {shlex.quote(command)} > {shlex.quote(log_path)} 2>&1 < /dev/null"
             )
-            process_id = _result_stdout(result).strip() or "unknown"
+            process_id = str(session.get("pid") or "unknown")
             return (
                 f"Started background task `bash_{log_path[-12:-4]}`.\n"
                 f"stdout+stderr is streaming to: {log_path}\n"
@@ -203,27 +198,107 @@ class CuaSandboxComputer(ShellFileToolsMixin):
                 f"To cancel: run bash with `kill {process_id}`"
             )
 
-        sentinel = f"__YUTORI_N2_BASH_CWD_{uuid.uuid4().hex}__"
-        wrapped = f"{prefix}{command}\n__yutori_rc=$?\nprintf '\\n{sentinel}%s' \"$PWD\"\nexit $__yutori_rc"
         # The n2 bash contract: the timeout is clamped to [0, 600] and an expiry is a
-        # NORMAL result the model can react to, never a raised failure envelope. (The
-        # sandbox API discards partial output on expiry, so the result is the bare line.)
+        # NORMAL result the model can react to, never a raised failure envelope.
         timeout_s = _clamp_bash_timeout(timeout)
         if timeout_s == 0:
             return "Command timed out after 0s"
+
+        # cua-computer-server runs /cmd subprocesses on uvloop. If a shell command
+        # leaves any descendant alive (for example ``xcalc &``), uvloop reports that
+        # the shell exited but never finishes communicate(), so /cmd waits until its
+        # client timeout. Run bash in Cua's public PTY API instead. Redirecting all
+        # three standard streams prevents descendants from retaining the PTY, while
+        # the atomic status file distinguishes shell completion from output that a
+        # deliberately backgrounded descendant may continue to produce.
+        token = uuid.uuid4().hex
+        result_prefix = f"/tmp/yutori-n2-bash-{token}"
+        stdout_path = f"{result_prefix}.stdout"
+        stderr_path = f"{result_prefix}.stderr"
+        status_path = f"{result_prefix}.status"
+        cwd_path = f"{result_prefix}.cwd"
+        inner_cwd_tmp = f"{cwd_path}.tmp"
+        status_tmp = f"{status_path}.tmp"
+        finish = f"__yutori_finish_{token}"
+        inner = (
+            f"{finish}() {{\n"
+            f"  printf '%s\\n' \"$PWD\" > {shlex.quote(inner_cwd_tmp)}\n"
+            f"  mv {shlex.quote(inner_cwd_tmp)} {shlex.quote(cwd_path)}\n"
+            "}\n"
+            f"trap {finish} 0\n"
+            f"{command}"
+        )
+        wrapped = (
+            "(\n"
+            f"cd {shlex.quote(cwd)}\n"
+            "__yutori_cd_rc=$?\n"
+            'if [ "$__yutori_cd_rc" -eq 0 ]; then\n'
+            f"  sh -c {shlex.quote(inner)}\n"
+            "  __yutori_rc=$?\n"
+            "else\n"
+            "  __yutori_rc=$__yutori_cd_rc\n"
+            "fi\n"
+            f"if [ ! -f {shlex.quote(cwd_path)} ]; then\n"
+            f"  printf '%s\\n' \"$PWD\" > {shlex.quote(cwd_path)}\n"
+            "fi\n"
+            f"printf '%s' \"$__yutori_rc\" > {shlex.quote(status_tmp)}\n"
+            f"mv {shlex.quote(status_tmp)} {shlex.quote(status_path)}\n"
+            'exit "$__yutori_rc"\n'
+            f") < /dev/null > {shlex.quote(stdout_path)} 2> {shlex.quote(stderr_path)}"
+        )
+        session = await self.sandbox.terminal.create(wrapped)
+        process_id = session.get("pid")
+        if not isinstance(process_id, int) or process_id <= 0:
+            raise RuntimeError("Cua PTY did not return a valid process id.")
+
+        async def wait_for_status() -> None:
+            delay = 0.01
+            while not await self.sandbox.files.exists(status_path):
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, 0.25)
+
         try:
-            result = await self.sandbox.shell.run(wrapped, timeout=timeout_s)
-        except Exception as error:  # noqa: BLE001 - classify sandbox timeouts below
-            if "timeout" in type(error).__name__.lower() or "timed out" in str(error).lower():
-                return f"Command timed out after {timeout_s:g}s"
-            raise
-        stdout = _result_stdout(result)
-        body, marker, new_cwd = stdout.rpartition(f"\n{sentinel}")
-        if marker:
+            await asyncio.wait_for(wait_for_status(), timeout=timeout_s)
+        except asyncio.TimeoutError:
+            try:
+                await asyncio.wait_for(self.sandbox.terminal.close(process_id), timeout=5)
+            except Exception:  # noqa: BLE001 - the disposable sandbox is the final cleanup boundary
+                pass
+            await self._remove_bash_result_files(
+                stdout_path,
+                stderr_path,
+                status_path,
+                status_tmp,
+                cwd_path,
+                inner_cwd_tmp,
+            )
+            return f"Command timed out after {timeout_s:g}s"
+
+        try:
+            stdout, stderr, status, new_cwd = await asyncio.gather(
+                self.sandbox.files.read_text(stdout_path),
+                self.sandbox.files.read_text(stderr_path),
+                self.sandbox.files.read_text(status_path),
+                self.sandbox.files.read_text(cwd_path),
+            )
             self._bash_cwd = new_cwd.strip() or cwd
-            body = _append_stream(body, _result_stderr(result))
-            return _format_shell_output(body, _result_returncode(result))
-        return _shell_result(result)
+            body = _append_stream(stdout, stderr)
+            return _format_shell_output(body, int(status.strip()))
+        finally:
+            await self._remove_bash_result_files(
+                stdout_path,
+                stderr_path,
+                status_path,
+                status_tmp,
+                cwd_path,
+                inner_cwd_tmp,
+            )
+
+    async def _remove_bash_result_files(self, *paths: str) -> None:
+        await asyncio.gather(
+            *(self.sandbox.files.remove(path) for path in paths),
+            return_exceptions=True,
+        )
 
     async def _working_directory(self) -> str:
         if self._bash_cwd is None:

--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -187,7 +187,8 @@ class CuaSandboxComputer(ShellFileToolsMixin):
         if run_in_background:
             log_path = f"/tmp/yutori-n2-bash-{uuid.uuid4().hex[:8]}.log"
             session = await self.sandbox.terminal.create(
-                f"cd {shlex.quote(cwd)} && exec sh -c {shlex.quote(command)} > {shlex.quote(log_path)} 2>&1 < /dev/null"
+                f"cd {shlex.quote(cwd)} && exec /bin/bash -c {shlex.quote(command)} "
+                f"> {shlex.quote(log_path)} 2>&1 < /dev/null"
             )
             process_id = str(session.get("pid") or "unknown")
             return (
@@ -233,7 +234,7 @@ class CuaSandboxComputer(ShellFileToolsMixin):
             f"cd {shlex.quote(cwd)}\n"
             "__yutori_cd_rc=$?\n"
             'if [ "$__yutori_cd_rc" -eq 0 ]; then\n'
-            f"  sh -c {shlex.quote(inner)}\n"
+            f"  /bin/bash -c {shlex.quote(inner)}\n"
             "  __yutori_rc=$?\n"
             "else\n"
             "  __yutori_rc=$__yutori_cd_rc\n"

--- a/tests/test_navigator_n2_cookbooks.py
+++ b/tests/test_navigator_n2_cookbooks.py
@@ -423,6 +423,7 @@ async def test_public_cua_adapter_uses_pty_for_a_command_that_leaves_xcalc_runni
     assert shell_commands == ["pwd"]  # The command itself never uses Cua's hanging /cmd path.
     assert len(terminal_commands) == 1
     assert "nohup xcalc" in terminal_commands[0]
+    assert "/bin/bash -c" in terminal_commands[0]
     assert "< /dev/null" in terminal_commands[0]
     assert f"> {result_prefix}.stdout 2> {result_prefix}.stderr" in terminal_commands[0]
     assert computer._bash_cwd == "/next-workspace"
@@ -481,7 +482,9 @@ async def test_public_cua_adapter_uses_pty_for_explicit_background_bash(
 
     output = await computer.run_bash_command("sleep 999", run_in_background=True)
 
-    assert commands == ["cd /workspace && exec sh -c 'sleep 999' > /tmp/yutori-n2-bash-cccccccc.log 2>&1 < /dev/null"]
+    assert commands == [
+        "cd /workspace && exec /bin/bash -c 'sleep 999' > /tmp/yutori-n2-bash-cccccccc.log 2>&1 < /dev/null"
+    ]
     assert output == (
         "Started background task `bash_cccccccc`.\n"
         "stdout+stderr is streaming to: /tmp/yutori-n2-bash-cccccccc.log\n"

--- a/tests/test_navigator_n2_cookbooks.py
+++ b/tests/test_navigator_n2_cookbooks.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock
 import pytest
 from PIL import Image
 
+from examples.navigator_n2 import cua_adapter as cua_adapter_module
 from examples.navigator_n2.cua_adapter import CuaSandboxComputer
 from examples.navigator_n2.shared import TOOL_SET_ALIASES, RunGuard, selected_tool_set
 from examples.navigator_n2_daytona import CWD_SENTINEL, DaytonaComputer
@@ -374,28 +375,150 @@ async def test_public_cua_adapter_executes_all_current_batch_actions() -> None:
     assert held_shift_down < mouse_move < held_shift_up
 
 
-async def test_public_cua_adapter_preserves_bash_cwd_when_the_command_fails() -> None:
-    class FailingBashShell:
-        async def run(self, command: str, timeout: int = 30) -> SimpleNamespace:
-            del timeout
-            if command == "pwd":
-                return SimpleNamespace(stdout="/workspace\n", stderr="", returncode=0)
-            sentinel = re.search(r"__YUTORI_N2_BASH_CWD_[a-f0-9]+__", command)
-            assert sentinel is not None
-            return SimpleNamespace(
-                stdout=f"command output\n{sentinel.group()}/next-workspace\n",
-                stderr="command error",
-                returncode=7,
-            )
+async def test_public_cua_adapter_uses_pty_for_a_command_that_leaves_xcalc_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = "a" * 32
+    result_prefix = f"/tmp/yutori-n2-bash-{token}"
+    contents = {
+        f"{result_prefix}.stdout": "calculator launched\n",
+        f"{result_prefix}.stderr": "font warning",
+        f"{result_prefix}.status": "0",
+        f"{result_prefix}.cwd": "/next-workspace\n",
+    }
+    removed: list[str] = []
+    terminal_commands: list[str] = []
+    shell_commands: list[str] = []
 
-    sandbox = FakeSandbox()
-    sandbox.shell = FailingBashShell()
-    computer = CuaSandboxComputer(sandbox)
+    class Shell:
+        async def run(self, command: str, timeout: int = 30) -> SimpleNamespace:
+            shell_commands.append(command)
+            assert timeout == 30
+            return SimpleNamespace(stdout="/workspace\n", stderr="", returncode=0)
+
+    class Terminal:
+        async def create(self, command: str) -> dict[str, int]:
+            terminal_commands.append(command)
+            return {"pid": 4242}
+
+    class Files:
+        async def exists(self, path: str) -> bool:
+            return path in contents
+
+        async def read_text(self, path: str) -> str:
+            return contents[path]
+
+        async def remove(self, path: str) -> None:
+            removed.append(path)
+
+    monkeypatch.setattr(cua_adapter_module.uuid, "uuid4", lambda: SimpleNamespace(hex=token))
+    computer = CuaSandboxComputer(SimpleNamespace(shell=Shell(), terminal=Terminal(), files=Files()))
+    command = (
+        "export DISPLAY=:1; nohup xcalc >/tmp/xcalc.log 2>&1 & sleep 3; "
+        'cat /tmp/xcalc.log; echo "---"; DISPLAY=:1 wmctrl -l'
+    )
+
+    output = await computer.run_bash_command(command)
+
+    assert shell_commands == ["pwd"]  # The command itself never uses Cua's hanging /cmd path.
+    assert len(terminal_commands) == 1
+    assert "nohup xcalc" in terminal_commands[0]
+    assert "< /dev/null" in terminal_commands[0]
+    assert f"> {result_prefix}.stdout 2> {result_prefix}.stderr" in terminal_commands[0]
+    assert computer._bash_cwd == "/next-workspace"
+    assert output == "calculator launched\nfont warning"
+    assert set(removed).issuperset(contents)
+
+
+async def test_public_cua_adapter_preserves_bash_cwd_and_failure_output_over_pty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = "b" * 32
+    result_prefix = f"/tmp/yutori-n2-bash-{token}"
+    contents = {
+        f"{result_prefix}.stdout": "command output\n",
+        f"{result_prefix}.stderr": "command error",
+        f"{result_prefix}.status": "7",
+        f"{result_prefix}.cwd": "/next-workspace\n",
+    }
+
+    class Terminal:
+        async def create(self, _command: str) -> dict[str, int]:
+            return {"pid": 4242}
+
+    class Files:
+        async def exists(self, path: str) -> bool:
+            return path in contents
+
+        async def read_text(self, path: str) -> str:
+            return contents[path]
+
+        async def remove(self, _path: str) -> None:
+            pass
+
+    monkeypatch.setattr(cua_adapter_module.uuid, "uuid4", lambda: SimpleNamespace(hex=token))
+    computer = CuaSandboxComputer(SimpleNamespace(shell=FakeShell(), terminal=Terminal(), files=Files()))
 
     output = await computer.run_bash_command("false")
 
     assert computer._bash_cwd == "/next-workspace"
     assert output == "Exit code 7\ncommand output\ncommand error"
+
+
+async def test_public_cua_adapter_uses_pty_for_explicit_background_bash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = "c" * 32
+    commands: list[str] = []
+
+    class Terminal:
+        async def create(self, command: str) -> dict[str, int]:
+            commands.append(command)
+            return {"pid": 4242}
+
+    monkeypatch.setattr(cua_adapter_module.uuid, "uuid4", lambda: SimpleNamespace(hex=token))
+    computer = CuaSandboxComputer(SimpleNamespace(shell=FakeShell(), terminal=Terminal()))
+
+    output = await computer.run_bash_command("sleep 999", run_in_background=True)
+
+    assert commands == ["cd /workspace && exec sh -c 'sleep 999' > /tmp/yutori-n2-bash-cccccccc.log 2>&1 < /dev/null"]
+    assert output == (
+        "Started background task `bash_cccccccc`.\n"
+        "stdout+stderr is streaming to: /tmp/yutori-n2-bash-cccccccc.log\n"
+        "Use the read tool on that file to retrieve output.\n"
+        "Process id: 4242\n"
+        "To cancel: run bash with `kill 4242`"
+    )
+
+
+async def test_public_cua_adapter_pty_timeout_is_a_normal_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = "d" * 32
+    closed: list[int] = []
+
+    class Terminal:
+        async def create(self, _command: str) -> dict[str, int]:
+            return {"pid": 4242}
+
+        async def close(self, pid: int) -> bool:
+            closed.append(pid)
+            return True
+
+    class Files:
+        async def exists(self, _path: str) -> bool:
+            return False
+
+        async def remove(self, _path: str) -> None:
+            pass
+
+    monkeypatch.setattr(cua_adapter_module.uuid, "uuid4", lambda: SimpleNamespace(hex=token))
+    computer = CuaSandboxComputer(SimpleNamespace(shell=FakeShell(), terminal=Terminal(), files=Files()))
+
+    output = await computer.run_bash_command("sleep 10", timeout=0.01)
+
+    assert output == "Command timed out after 0.01s"
+    assert closed == [4242]
 
 
 def test_cua_file_tools_match_the_n2_tool_contract(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- route the Cua adapter's n2 bash commands through its public PTY and file APIs, avoiding the `/cmd` hang when a completed shell leaves a background descendant alive
- preserve timeout, output, exit-code, persistent-directory, and explicit-background behavior across supported Python versions
- document how the Calculator prompt demonstrates n2 switching between bash and GUI interactions

## Testing

- `uv run pytest -q` (789 passed, 3 skipped)
- focused cookbook and entrypoint tests on Python 3.9, 3.10, and 3.12 (46 passed on each)
- Ruff check and format check on the changed Python files
- exact reported `xcalc` Docker command returned in 3.17s and listed the Calculator window

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core bash execution in the reference Cua adapter with a more complex PTY/file orchestration path; behavior is heavily tested but affects all n2 bash in Docker sandboxes.
> 
> **Overview**
> Fixes **Cua sandbox bash hangs** when commands leave background processes alive (e.g. launching `xcalc &`). `CuaSandboxComputer.run_bash_command` no longer uses `sandbox.shell.run` for n2 bash; it runs wrapped commands via **`sandbox.terminal.create`**, collects stdout/stderr/exit code and working directory through temp files, and cleans up (including closing the PTY on timeout).
> 
> **Explicit background** bash (`run_in_background=True`) also goes through the terminal API with redirected streams instead of `nohup` over `/cmd`. The n2 contract is unchanged: timeouts return normal `"Command timed out after …"` strings, exit codes and cwd persistence still apply.
> 
> Docs for the Calculator demo now note the image has **no Calculator launcher** and that n2 is expected to mix **bash and GUI** to find and run `xcalc`. Tests were updated to pin PTY behavior for the xcalc case, failures, background runs, and timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66bcc5427c298df3ea935192a43cbb7105276c7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->