### PR TITLE
refactor(navigator): read shell results through three shared accessors

### DIFF
--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -35,6 +35,15 @@ from yutori.navigator.sandbox_tools import (
 from yutori.navigator.sandbox_tools import (
     format_shell_result as _shell_result,
 )
+from yutori.navigator.sandbox_tools import (
+    result_returncode as _result_returncode,
+)
+from yutori.navigator.sandbox_tools import (
+    result_stderr as _result_stderr,
+)
+from yutori.navigator.sandbox_tools import (
+    result_stdout as _result_stdout,
+)
 
 
 class CuaSandboxComputer(ShellFileToolsMixin):
@@ -185,7 +194,7 @@ class CuaSandboxComputer(ShellFileToolsMixin):
                 f"{prefix}nohup sh -c {shlex.quote(command)} > {log_path} 2>&1 < /dev/null & echo $!",
                 timeout=30,
             )
-            process_id = str(getattr(result, "stdout", "") or "").strip() or "unknown"
+            process_id = _result_stdout(result).strip() or "unknown"
             return (
                 f"Started background task `bash_{log_path[-12:-4]}`.\n"
                 f"stdout+stderr is streaming to: {log_path}\n"
@@ -208,20 +217,20 @@ class CuaSandboxComputer(ShellFileToolsMixin):
             if "timeout" in type(error).__name__.lower() or "timed out" in str(error).lower():
                 return f"Command timed out after {timeout_s:g}s"
             raise
-        stdout = str(getattr(result, "stdout", "") or "")
+        stdout = _result_stdout(result)
         body, marker, new_cwd = stdout.rpartition(f"\n{sentinel}")
         if marker:
             self._bash_cwd = new_cwd.strip() or cwd
-            body = _append_stream(body, str(getattr(result, "stderr", "") or ""))
-            return _format_shell_output(body, int(getattr(result, "returncode", 0) or 0))
+            body = _append_stream(body, _result_stderr(result))
+            return _format_shell_output(body, _result_returncode(result))
         return _shell_result(result)
 
     async def _working_directory(self) -> str:
         if self._bash_cwd is None:
             result = await self.sandbox.shell.run("pwd", timeout=30)
-            if int(getattr(result, "returncode", 0) or 0) != 0:
+            if _result_returncode(result) != 0:
                 raise RuntimeError(_shell_result(result))
-            self._bash_cwd = str(getattr(result, "stdout", "") or "").strip()
+            self._bash_cwd = _result_stdout(result).strip()
         if not self._bash_cwd:
             raise RuntimeError("Sandbox shell did not report a working directory.")
         return self._bash_cwd

--- a/tests/test_navigator_sandbox_tools.py
+++ b/tests/test_navigator_sandbox_tools.py
@@ -7,6 +7,12 @@ import json
 from types import SimpleNamespace
 
 from yutori.navigator import FILE_TOOL_SCRIPT, ShellFileToolsMixin, format_shell_output
+from yutori.navigator.sandbox_tools import (
+    format_shell_result,
+    result_returncode,
+    result_stderr,
+    result_stdout,
+)
 
 
 class RecordingAdapter(ShellFileToolsMixin):
@@ -58,3 +64,15 @@ def test_shared_helpers_render_the_bash_contract() -> None:
     assert format_shell_output("", 0) == "(Bash completed with no output)"
     assert format_shell_output("boom", 7) == "Exit code 7\nboom"
     assert "def done(text):" in FILE_TOOL_SCRIPT  # in-VM script is exported intact
+
+
+def test_result_accessors_tolerate_missing_and_none_fields() -> None:
+    full = SimpleNamespace(stdout="out", stderr="err", returncode=2)
+    assert (result_stdout(full), result_stderr(full), result_returncode(full)) == ("out", "err", 2)
+
+    # A sandbox result may omit a field entirely, or set it to None; both read as "unset".
+    for sparse in (SimpleNamespace(), SimpleNamespace(stdout=None, stderr=None, returncode=None)):
+        assert result_stdout(sparse) == ""
+        assert result_stderr(sparse) == ""
+        assert result_returncode(sparse) == 0
+        assert format_shell_result(sparse) == "(Bash completed with no output)"

--- a/yutori/navigator/sandbox_tools.py
+++ b/yutori/navigator/sandbox_tools.py
@@ -286,6 +286,26 @@ else:
 """
 
 
+# The shell-result contract ``run_sandbox_shell`` returns: an object exposing
+# ``stdout``, ``stderr``, and ``returncode``. It is duck-typed because every sandbox
+# SDK spells its own result type differently, so read it only through these three
+# accessors -- they are the one place the tolerated shapes (attribute absent, or
+# present but ``None``) are decided.
+def result_stdout(result: Any) -> str:
+    """Read a shell result's ``stdout``, treating a missing or ``None`` field as empty."""
+    return str(getattr(result, "stdout", "") or "")
+
+
+def result_stderr(result: Any) -> str:
+    """Read a shell result's ``stderr``, treating a missing or ``None`` field as empty."""
+    return str(getattr(result, "stderr", "") or "")
+
+
+def result_returncode(result: Any) -> int:
+    """Read a shell result's ``returncode``, treating a missing or ``None`` field as 0 (success)."""
+    return int(getattr(result, "returncode", 0) or 0)
+
+
 def append_stream(base: str, addition: str) -> str:
     """Append a second output stream to the first, inserting a newline only where one is missing."""
     if not addition:
@@ -295,7 +315,7 @@ def append_stream(base: str, addition: str) -> str:
 
 def join_output_streams(result: Any) -> str:
     """Join Cua's separate stdout and stderr streams without losing either."""
-    return append_stream(str(getattr(result, "stdout", "") or ""), str(getattr(result, "stderr", "") or ""))
+    return append_stream(result_stdout(result), result_stderr(result))
 
 
 def truncate_tool_output(text: str, max_chars: int = BASH_RESULT_MAX_CHARS) -> str:
@@ -313,10 +333,7 @@ def format_shell_output(output: str, exit_code: int) -> str:
 
 
 def format_shell_result(result: Any) -> str:
-    return format_shell_output(
-        join_output_streams(result),
-        int(getattr(result, "returncode", 0) or 0),
-    )
+    return format_shell_output(join_output_streams(result), result_returncode(result))
 
 
 BASH_TIMEOUT_DEFAULT_SECONDS = 120.0
@@ -451,13 +468,14 @@ class ShellFileToolsMixin:
         result = await self.run_sandbox_shell(
             python_file_tool_command(FILE_TOOL_SCRIPT, encoded), timeout_seconds=timeout
         )
-        if int(getattr(result, "returncode", 0) or 0) != 0:
+        returncode = result_returncode(result)
+        if returncode != 0:
             # n2 expects unexpected failures as a plain ``ERROR: ...``
             # tool result the model can react to, never a raised failure envelope.
-            detail = str(getattr(result, "stderr", "") or "").strip().splitlines()
-            reason = detail[-1] if detail else f"{operation} failed with exit code {getattr(result, 'returncode', '?')}"
+            detail = result_stderr(result).strip().splitlines()
+            reason = detail[-1] if detail else f"{operation} failed with exit code {returncode}"
             return f"ERROR: {reason}"
-        return str(getattr(result, "stdout", "") or "")
+        return result_stdout(result)
 
 
 __all__ = [
@@ -474,5 +492,8 @@ __all__ = [
     "join_output_streams",
     "python_file_tool_command",
     "render_image_result",
+    "result_returncode",
+    "result_stderr",
+    "result_stdout",
     "truncate_tool_output",
 ]


### PR DESCRIPTION
## Issue

`sandbox_tools.py` defines the duck-typed shell-result contract that an adapter's `run_sandbox_shell` returns — its own docstring spells it out as *"an object with `stdout`, `stderr`, and `returncode` attributes"* — but that contract lives only in prose. Every read site re-derives it by hand, so the same three expressions are written out **11 times** across the module and the Cua reference adapter:

| expression | occurrences |
| --- | --- |
| `str(getattr(result, "stdout", "") or "")` | 5 |
| `str(getattr(result, "stderr", "") or "")` | 3 |
| `int(getattr(result, "returncode", 0) or 0)` | 4 |

The `or ""` / `or 0` inside each is load-bearing (a sandbox SDK may set a field to `None` rather than omit it), which is exactly the kind of detail that drifts when a twelfth site gets added — and there is real pressure to add sites: `examples/navigator_n2_daytona.py` already hand-builds a `SimpleNamespace(stdout=…, stderr=…, returncode=…)` just to satisfy this contract.

## Improvement

Extract the three expressions into `result_stdout` / `result_stderr` / `result_returncode` in `sandbox_tools.py`, and route all 11 call sites through them. The tolerated shapes are now decided in one place, next to the contract they implement, and a new adapter author has something to call instead of an incantation to copy.

Follows the existing convention in this module: added to `sandbox_tools.__all__` alongside `append_stream` / `join_output_streams` / `truncate_tool_output`, and **not** re-exported from `yutori/navigator/__init__.py` (same as those three).

## Safety

**No public API or behavior change.** Each accessor is the replaced expression verbatim — this is a pure extraction.

- Equivalence proven with a standalone script over **257 result shapes** (`stdout` ∈ empty/`None`/text/trailing-newline/`0`/bytes, `stderr` ∈ empty/`None`/single/multi-line, `returncode` ∈ `0`/`None`/positive/negative/numeric-string/`bool`, plus objects missing one, two, or all three attributes): **0 mismatches**.
- End-to-end smoke of the refactored `CuaSandboxComputer` against a fake sandbox — cwd-sentinel path, background-task path, and the `pwd`-failure `RuntimeError` — all render byte-identical results.
- Full suite green: **736 passed, 9 skipped** (735 before; +1 new test), `ruff check .` clean.
- Adds `test_result_accessors_tolerate_missing_and_none_fields`, pinning the missing-vs-`None` tolerance that was previously only implicit in the inlined `or` defaults.

### The one non-mechanical line

`_run_file_tool`'s error reason previously read the raw attribute with a distinct default:

```python
reason = detail[-1] if detail else f"{operation} failed with exit code {getattr(result, 'returncode', '?')}"
```

That `'?'` fallback was **unreachable**. The guard directly above it maps a missing or `None` returncode to `0` and returns early, so the branch only executes when `returncode` is present and nonzero. The value is now hoisted into a local and reused, which renders identically for every int returncode (verified in the equivalence script) and removes the last hand-rolled `getattr` from the file.

Deliberately left alone: `n2_actions.py`'s repeated `TOOL_SET_COMPUTER_USE_20260825`/`20260830` pairs across ~8 frozensets. The in-code comment on `TOOL_SETS_BATCH_ONLY_GUI` explains that membership is enumerated *on purpose*, because a derived definition previously readmitted a set silently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5i16kvsHTAB61hk5Ehqy1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with equivalent expressions; behavior is covered by new unit tests and existing navigator tests.
> 
> **Overview**
> Centralizes how navigator adapters read duck-typed sandbox shell results by adding **`result_stdout`**, **`result_stderr`**, and **`result_returncode`** in `sandbox_tools.py`, with documented handling for missing attributes and `None` values.
> 
> **`join_output_streams`**, **`format_shell_result`**, **`ShellFileToolsMixin._run_file_tool`**, and the Cua reference adapter’s bash/cwd paths now call these helpers instead of repeating inline `getattr`/`or` expressions. The accessors are listed in **`__all__`** (not re-exported from the top-level navigator package).
> 
> Adds **`test_result_accessors_tolerate_missing_and_none_fields`** to lock in the sparse-result behavior that was previously implicit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd2e0eddcb392a5de1d8b1aaee17ca257639a4e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->