### PR TITLE
Rename Navigator n2 local Docker entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ yutori auth login            # or export YUTORI_API_KEY=...
 
 cd examples/navigator_n2
 uv sync --python 3.12
-uv run python remote_sandbox.py --auto-approve "Open Calculator and compute 17 * 23"
+uv run python local_docker.py --auto-approve "Open Calculator and compute 17 * 23"
 ```
 
 The script prints a `Watch the desktop live:` URL at startup — open it in a browser to follow along.

--- a/examples/README.md
+++ b/examples/README.md
@@ -72,7 +72,7 @@ The [public Cua cookbook](navigator_n2/README.md) runs Navigator n2 in a local D
 ```bash
 cd examples/navigator_n2
 uv sync --python 3.12
-uv run python remote_sandbox.py --auto-approve \
+uv run python local_docker.py --auto-approve \
     "Open Calculator and compute 17 * 23"
 ```
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -40,7 +40,7 @@ The sandbox entrypoint adapts public Cua mouse, keyboard, screenshot, shell, and
 
 ~~~bash
 docker info
-uv run python remote_sandbox.py "Open Calculator and compute 17 * 23"
+uv run python local_docker.py "Open Calculator and compute 17 * 23"
 ~~~
 
 The script prints a `Watch the desktop live: http://localhost:<port>/vnc.html` link at startup — open it in a browser to follow the agent's actions on the sandbox's noVNC viewer. If a run hits `--max-steps`, the entrypoints take one summarize-only turn (no tool execution) and print the model's summary of progress before exiting.
@@ -71,7 +71,7 @@ Both examples always send an explicit immutable tool-set id. The default alias i
 | gui | computer_use_tools-20260708 |
 
 ~~~bash
-uv run python remote_sandbox.py --tool-set gui "Open Calculator and compute 17 * 23"
+uv run python local_docker.py --tool-set gui "Open Calculator and compute 17 * 23"
 ~~~
 
 The public n2 reference documents the current five tools, all 15 batch action types, the 20-action batch limit, screenshot compression, and the single-result-per-tool-call rule: https://docs.yutori.com/reference/n2

--- a/examples/navigator_n2/local_docker.py
+++ b/examples/navigator_n2/local_docker.py
@@ -1,4 +1,4 @@
-"""Run stable Navigator n2 in a disposable local Docker Linux sandbox."""
+"""Run stable Navigator n2 in a disposable local Docker container."""
 
 from __future__ import annotations
 

--- a/tests/test_navigator_n2_cookbooks.py
+++ b/tests/test_navigator_n2_cookbooks.py
@@ -114,7 +114,7 @@ def test_every_ported_example_is_importable_without_its_optional_runtime() -> No
         "examples.navigator_n2",
         "examples.navigator_n2.local_driver",
         "examples.navigator_n2.local_macos",
-        "examples.navigator_n2.remote_sandbox",
+        "examples.navigator_n2.local_docker",
         "examples.navigator_n2.shared",
         "examples.navigator_n2_daytona",
     ):

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 import pytest
 
 from examples import navigator_n2_daytona
-from examples.navigator_n2 import remote_sandbox
+from examples.navigator_n2 import local_docker
 
 
 def test_daytona_script_declares_its_uv_environment_inline() -> None:
@@ -21,15 +21,15 @@ def test_daytona_script_declares_its_uv_environment_inline() -> None:
     assert '#   "yutori>=0.9.6",' in script
 
 
-def test_remote_sandbox_cli_accepts_documented_docker_command(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(sys, "argv", ["remote_sandbox.py", "Open Calculator"])
+def test_local_docker_cli_accepts_documented_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["local_docker.py", "Open Calculator"])
 
-    args = remote_sandbox.parse_args()
+    args = local_docker.parse_args()
 
     assert args.task == "Open Calculator"
 
 
-async def test_remote_sandbox_resolves_yutori_key_before_allocation(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_local_docker_resolves_yutori_key_before_allocation(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeImage:
         @staticmethod
         def linux(**_kwargs: object) -> object:
@@ -45,7 +45,7 @@ async def test_remote_sandbox_resolves_yutori_key_before_allocation(monkeypatch:
     def missing_api_key() -> str:
         raise RuntimeError("missing Yutori key")
 
-    monkeypatch.setattr(remote_sandbox, "require_api_key", missing_api_key)
+    monkeypatch.setattr(local_docker, "require_api_key", missing_api_key)
     args = argparse.Namespace(
         max_steps=1,
         task="test",
@@ -54,10 +54,10 @@ async def test_remote_sandbox_resolves_yutori_key_before_allocation(monkeypatch:
     )
 
     with pytest.raises(RuntimeError, match="missing Yutori key"):
-        await remote_sandbox.main(args)
+        await local_docker.main(args)
 
 
-async def test_remote_sandbox_rejects_tool_set_before_allocation(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_local_docker_rejects_tool_set_before_allocation(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeImage:
         @staticmethod
         def linux(**_kwargs: object) -> object:
@@ -69,7 +69,7 @@ async def test_remote_sandbox_rejects_tool_set_before_allocation(monkeypatch: py
             pytest.fail("sandbox allocation started before tool-set validation")
 
     monkeypatch.setitem(sys.modules, "cua_sandbox", SimpleNamespace(Image=FakeImage, Sandbox=FakeSandbox))
-    monkeypatch.setattr(remote_sandbox, "require_api_key", lambda: "test-yutori-key")
+    monkeypatch.setattr(local_docker, "require_api_key", lambda: "test-yutori-key")
     args = argparse.Namespace(
         max_steps=1,
         task="test",
@@ -78,10 +78,10 @@ async def test_remote_sandbox_rejects_tool_set_before_allocation(monkeypatch: py
     )
 
     with pytest.raises(ValueError, match="unknown tool set"):
-        await remote_sandbox.main(args)
+        await local_docker.main(args)
 
 
-async def test_remote_sandbox_wires_local_container_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_local_docker_wires_local_container_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, object] = {}
     fake_sandbox = object()
 
@@ -122,10 +122,10 @@ async def test_remote_sandbox_wires_local_container_runtime(monkeypatch: pytest.
         seen["task"] = task
 
     monkeypatch.setitem(sys.modules, "cua_sandbox", SimpleNamespace(Image=FakeImage, Sandbox=FakeSandbox))
-    monkeypatch.setattr(remote_sandbox, "require_api_key", lambda: "test-yutori-key")
-    monkeypatch.setattr(remote_sandbox, "CuaSandboxComputer", FakeComputer)
-    monkeypatch.setattr(remote_sandbox, "N2ComputerAgent", FakeAgent)
-    monkeypatch.setattr(remote_sandbox, "run_agent", fake_run_agent)
+    monkeypatch.setattr(local_docker, "require_api_key", lambda: "test-yutori-key")
+    monkeypatch.setattr(local_docker, "CuaSandboxComputer", FakeComputer)
+    monkeypatch.setattr(local_docker, "N2ComputerAgent", FakeAgent)
+    monkeypatch.setattr(local_docker, "run_agent", fake_run_agent)
     args = argparse.Namespace(
         max_steps=2,
         task="test",
@@ -133,7 +133,7 @@ async def test_remote_sandbox_wires_local_container_runtime(monkeypatch: pytest.
         auto_approve=True,
     )
 
-    await remote_sandbox.main(args)
+    await local_docker.main(args)
 
     assert seen["image"] == {"kind": "container"}
     assert seen["ephemeral"] == ("linux-image", {"local": True})
@@ -142,11 +142,11 @@ async def test_remote_sandbox_wires_local_container_runtime(monkeypatch: pytest.
     assert seen["sandbox-closed"] is True
 
 
-def test_remote_sandbox_watch_url_comes_from_the_runtime_info() -> None:
+def test_local_docker_watch_url_comes_from_the_runtime_info() -> None:
     info = SimpleNamespace(host="localhost", vnc_port=54423)
-    assert remote_sandbox._watch_url(SimpleNamespace(_runtime_info=info)) == "http://localhost:54423/vnc.html"
-    assert remote_sandbox._watch_url(SimpleNamespace(_runtime_info=None)) is None
-    assert remote_sandbox._watch_url(SimpleNamespace()) is None
+    assert local_docker._watch_url(SimpleNamespace(_runtime_info=info)) == "http://localhost:54423/vnc.html"
+    assert local_docker._watch_url(SimpleNamespace(_runtime_info=None)) is None
+    assert local_docker._watch_url(SimpleNamespace()) is None
 
 
 def test_daytona_cli_record_flag_is_optional_and_order_safe() -> None:


### PR DESCRIPTION
## Summary

- Rename examples/navigator_n2/remote_sandbox.py to local_docker.py because it now exclusively launches a local Docker container.
- Update every documented command and the cookbook entrypoint tests.
- Leave api.md and llms.txt unchanged because they reference the cookbook directory rather than the filename.

## Validation

- uv run pytest -q (789 passed, 3 skipped)
- uv run ruff check .
- uv run python examples/navigator_n2/local_docker.py --help

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and naming-only change with test renames; no runtime or API behavior changes.
> 
> **Overview**
> Renames the Navigator n2 Cua cookbook entrypoint from **`remote_sandbox.py`** to **`local_docker.py`** so the filename matches behavior: it only spins up a **local Docker** desktop, not a remote sandbox.
> 
> **Docs** (`README.md`, `examples/README.md`, `examples/navigator_n2/README.md`) now show `uv run python local_docker.py` everywhere the old script was referenced. The module docstring in **`local_docker.py`** is tightened to say “local Docker container” instead of “Linux sandbox.”
> 
> **Tests** import `examples.navigator_n2.local_docker` and rename the entrypoint tests from `test_remote_sandbox_*` to `test_local_docker_*`; behavior under test is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf37436f586b896f18bdd95a78480f0a4ddf7df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->