### PR TITLE
refactor(examples): dedupe n2 local-desktop CLI entrypoint boilerplate

### DIFF
--- a/examples/navigator_n2/local_docker.py
+++ b/examples/navigator_n2/local_docker.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import asyncio
 
 from yutori import AsyncYutoriClient
 from yutori.auth import require_api_key
@@ -11,10 +10,10 @@ from yutori.navigator import NAVIGATOR_N2_MODEL, N2ComputerAgent
 
 try:
     from .cua_adapter import CuaSandboxComputer
-    from .shared import add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
+    from .shared import build_confirmation_callback, parse_common_args, run_agent, run_cli_main, selected_tool_set
 except ImportError:
     from cua_adapter import CuaSandboxComputer
-    from shared import add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
+    from shared import build_confirmation_callback, parse_common_args, run_agent, run_cli_main, selected_tool_set
 
 
 def _watch_url(sandbox) -> "str | None":
@@ -56,13 +55,8 @@ async def main(args: argparse.Namespace) -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
-    add_common_arguments(parser)
-    return parser.parse_args()
+    return parse_common_args(__doc__)
 
 
 if __name__ == "__main__":
-    try:
-        asyncio.run(main(parse_args()))
-    except KeyboardInterrupt:
-        print("Interrupted.")
+    run_cli_main(main, parse_args)

--- a/examples/navigator_n2/local_macos.py
+++ b/examples/navigator_n2/local_macos.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import asyncio
 
 from yutori import AsyncYutoriClient
 from yutori.auth import require_api_key
@@ -12,9 +11,9 @@ from yutori.navigator.macos import MacOSComputer
 from yutori.navigator.n2_actions import TOOL_SETS_WITH_CLICK_MODIFIERS
 
 try:
-    from .shared import add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
+    from .shared import build_confirmation_callback, parse_common_args, run_agent, run_cli_main, selected_tool_set
 except ImportError:
-    from shared import add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
+    from shared import build_confirmation_callback, parse_common_args, run_agent, run_cli_main, selected_tool_set
 
 
 async def main(args: argparse.Namespace) -> None:
@@ -35,13 +34,8 @@ async def main(args: argparse.Namespace) -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
-    add_common_arguments(parser)
-    return parser.parse_args()
+    return parse_common_args(__doc__)
 
 
 if __name__ == "__main__":
-    try:
-        asyncio.run(main(parse_args()))
-    except KeyboardInterrupt:
-        print("Interrupted.")
+    run_cli_main(main, parse_args)

--- a/examples/navigator_n2/shared.py
+++ b/examples/navigator_n2/shared.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from yutori.navigator import (
@@ -130,6 +132,28 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
             "pass a smaller budget for simpler tasks or to cap time/cost)"
         ),
     )
+
+
+def parse_common_args(description: str | None, argv: list[str] | None = None) -> argparse.Namespace:
+    """Build the shared cookbook parser and parse it -- the ``parse_args()`` body every
+    local-desktop entrypoint (``local_docker.py``, ``local_macos.py``) repeated verbatim
+    apart from its module ``description``."""
+    parser = argparse.ArgumentParser(description=description)
+    add_common_arguments(parser)
+    return parser.parse_args(argv)
+
+
+def run_cli_main(
+    main: Callable[[argparse.Namespace], Awaitable[None]],
+    parse_args: Callable[[], argparse.Namespace],
+) -> None:
+    """Run an entrypoint's ``main(parse_args())`` under ``asyncio.run``, printing a plain
+    message instead of a traceback on Ctrl-C -- the ``if __name__ == "__main__":`` body every
+    local-desktop entrypoint repeated verbatim."""
+    try:
+        asyncio.run(main(parse_args()))
+    except KeyboardInterrupt:
+        print("Interrupted.")
 
 
 def _text_items(response: dict[str, Any]) -> list[str]:


### PR DESCRIPTION
## What

`examples/navigator_n2/local_docker.py` and `local_macos.py` each hand-rolled the identical
`parse_args()` body:

```python
def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser(description=__doc__)
    add_common_arguments(parser)
    return parser.parse_args()
```

and the identical `if __name__ == "__main__":` guard:

```python
if __name__ == "__main__":
    try:
        asyncio.run(main(parse_args()))
    except KeyboardInterrupt:
        print("Interrupted.")
```

Extracted `parse_common_args(description)` and `run_cli_main(main, parse_args)` into
`shared.py` (already the shared home for this package's CLI/confirmation helpers — see
`add_common_arguments`, `build_confirmation_callback`, `run_agent`); both entrypoints now
delegate.

## Why it's safe

- Pure extraction, no logic change: `parse_common_args` builds the exact same
  `ArgumentParser` (still routed through `add_common_arguments`) and `run_cli_main` calls
  `asyncio.run(main(parse_args()))` inside the same `try/except KeyboardInterrupt` with the
  same `"Interrupted."` message.
- `parse_args()` and `main()` keep their existing module-level names and signatures in both
  files, so `tests/test_navigator_n2_entrypoints.py::test_local_docker_cli_accepts_documented_command`
  (which calls `local_docker.parse_args()` directly) is unaffected, and both modules remain
  independently `python -m`-runnable and directly importable, matching
  `test_every_ported_example_is_importable_without_its_optional_runtime`.
- `examples/` is not part of the published SDK's public API surface (not in `yutori/`, not in
  `api.md`), so this touches zero public behavior.
- Dropped the now-unused `import asyncio` from both entrypoint files.

## Verification

- `pytest -q -m "not slow"` — 788 passed / 3 skipped / 1 deselected (unchanged from baseline)
- `pytest -q tests/test_navigator_n2_entrypoints.py tests/test_navigator_n2_cookbooks.py` — 46 passed
- `ruff check .` and `ruff format --check examples/navigator_n2/` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01KrFubpGVA7KmdRx4ZKunCU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only refactor with no logic change to parsing or runtime behavior; no SDK or production paths affected.
> 
> **Overview**
> **Deduplicates** the repeated Navigator n2 cookbook CLI setup in `local_docker.py` and `local_macos.py` by moving it into `shared.py`.
> 
> Both entrypoints now call **`parse_common_args(__doc__)`** instead of hand-building an `ArgumentParser` with `add_common_arguments`, and **`run_cli_main(main, parse_args)`** instead of inline `asyncio.run` plus `KeyboardInterrupt` handling. `shared.py` gains those helpers (with optional `argv` on `parse_common_args` for programmatic parsing); **`asyncio` is removed** from the two entrypoint modules.
> 
> Agent setup, confirmation policy, and `main`/`parse_args` names are unchanged so existing tests that call `local_docker.parse_args()` and direct module execution keep working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b30483859efecba64f13e2e640f56355dc61535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->