### PR TITLE
refactor(navigator): dedupe scroll-to-notches conversion in the n2 sandbox adapters

### DIFF
--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -51,6 +51,9 @@ from yutori.navigator.sandbox_tools import (
 from yutori.navigator.sandbox_tools import (
     result_stdout as _result_stdout,
 )
+from yutori.navigator.sandbox_tools import (
+    scroll_notches_from_pixels as _scroll_notches_from_pixels,
+)
 
 
 class CuaSandboxComputer(ShellFileToolsMixin):
@@ -128,42 +131,11 @@ class CuaSandboxComputer(ShellFileToolsMixin):
         until its server dispatch is fixed.
         """
         self._pointer = (x, y)
-        notches_x, notches_y = await self._scroll_notches(scroll_x, scroll_y, model_action)
+        notches_x, notches_y = await _scroll_notches_from_pixels(scroll_x, scroll_y, model_action, self.get_dimensions)
         await self._with_modifiers(
             modifier,
             lambda: self.sandbox.mouse.scroll(x, y, scroll_x=notches_x, scroll_y=notches_y),
         )
-
-    async def _scroll_notches(
-        self,
-        scroll_x: int,
-        scroll_y: int,
-        model_action: dict[str, Any] | None,
-    ) -> tuple[int, int]:
-        """Convert the loop's pixel deltas into Cua wheel notches.
-
-        The loop's ``scroll_x``/``scroll_y`` are pixel deltas (10% of the native
-        dimension per model unit, positive = down/right), but Cua's identically
-        named parameters are wheel notches with pynput signs (positive = up/right
-        — its own default is ``scroll_y=3``, a notch count). Passing the pixels
-        through scrolls the wrong way by two orders of magnitude. The model's
-        call carries the exact notch count, so prefer it; otherwise recover it
-        by inverting the loop's translation.
-        """
-        action = model_action or {}
-        direction, amount = action.get("direction"), action.get("amount")
-        if direction in ("up", "down", "left", "right") and type(amount) is int and amount > 0:
-            if direction in ("up", "down"):
-                return 0, amount if direction == "up" else -amount
-            return (amount if direction == "right" else -amount), 0
-        width, height = await self.get_dimensions()
-        if scroll_y:
-            notches = max(1, round(abs(scroll_y) / (0.1 * height)))
-            return 0, (-notches if scroll_y > 0 else notches)
-        if scroll_x:
-            notches = max(1, round(abs(scroll_x) / (0.1 * width)))
-            return (notches if scroll_x > 0 else -notches), 0
-        return 0, 0
 
     async def drag(self, path: list[dict[str, int]]) -> None:
         if len(path) < 2:

--- a/examples/navigator_n2/direct_x11_adapter.py
+++ b/examples/navigator_n2/direct_x11_adapter.py
@@ -57,6 +57,9 @@ from yutori.navigator.sandbox_tools import (
 from yutori.navigator.sandbox_tools import (
     format_shell_result as _shell_result,
 )
+from yutori.navigator.sandbox_tools import (
+    scroll_notches_from_pixels as _scroll_notches_from_pixels,
+)
 
 # The SDK loop's key vocabulary is already canonical lowercase (punctuation
 # arrives as literal characters); only these names spell differently in
@@ -202,7 +205,7 @@ class LocalX11Computer(ShellFileToolsMixin):
         modifier: Sequence[str] | None = None,
         model_action: dict[str, Any] | None = None,
     ) -> None:
-        notches_x, notches_y = await self._scroll_notches(scroll_x, scroll_y, model_action)
+        notches_x, notches_y = await _scroll_notches_from_pixels(scroll_x, scroll_y, model_action, self.get_dimensions)
 
         def run() -> None:
             gui = self._gui()
@@ -213,34 +216,6 @@ class LocalX11Computer(ShellFileToolsMixin):
                 gui.hscroll(notches_x, x, y)
 
         await self._with_modifiers(modifier, lambda: self._run_gui(run))
-
-    async def _scroll_notches(
-        self,
-        scroll_x: int,
-        scroll_y: int,
-        model_action: dict[str, Any] | None,
-    ) -> tuple[int, int]:
-        """Convert the loop's pixel deltas into X11 wheel notches.
-
-        The loop's ``scroll_x``/``scroll_y`` are pixel deltas (10% of the native
-        dimension per model unit, positive = down/right); the wheel scrolls in
-        detents with positive = up/right. The model's call carries the exact
-        notch count, so prefer it; otherwise invert the loop's translation.
-        """
-        action = model_action or {}
-        direction, amount = action.get("direction"), action.get("amount")
-        if direction in ("up", "down", "left", "right") and type(amount) is int and amount > 0:
-            if direction in ("up", "down"):
-                return 0, amount if direction == "up" else -amount
-            return (amount if direction == "right" else -amount), 0
-        width, height = await self.get_dimensions()
-        if scroll_y:
-            notches = max(1, round(abs(scroll_y) / (0.1 * height)))
-            return 0, (-notches if scroll_y > 0 else notches)
-        if scroll_x:
-            notches = max(1, round(abs(scroll_x) / (0.1 * width)))
-            return (notches if scroll_x > 0 else -notches), 0
-        return 0, 0
 
     async def type(self, text: str) -> None:
         def run() -> None:

--- a/yutori/navigator/sandbox_tools.py
+++ b/yutori/navigator/sandbox_tools.py
@@ -27,6 +27,7 @@ import base64
 import io
 import json
 import shlex
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from PIL import Image
@@ -347,6 +348,38 @@ def clamp_bash_timeout(timeout: float | None) -> float:
     return max(0.0, min(float(BASH_TIMEOUT_DEFAULT_SECONDS if timeout is None else timeout), BASH_TIMEOUT_MAX_SECONDS))
 
 
+async def scroll_notches_from_pixels(
+    scroll_x: int,
+    scroll_y: int,
+    model_action: "dict[str, Any] | None",
+    get_dimensions: Callable[[], Awaitable[tuple[int, int]]],
+) -> tuple[int, int]:
+    """Convert the loop's pixel scroll deltas into wheel notches.
+
+    The loop hands adapters pixel deltas (``round(amount * 0.1 * dimension)``,
+    positive = down/right), but wheel APIs (Cua's mouse, pyautogui, ...) take
+    notches with the opposite sign convention (positive = up/right). The
+    model's own tool call carries the exact notch count via ``direction``/
+    ``amount`` in ``model_action``, so prefer that; otherwise recover the
+    notch count by inverting the loop's pixel translation, calling
+    ``get_dimensions`` only in that fallback path.
+    """
+    action = model_action or {}
+    direction, amount = action.get("direction"), action.get("amount")
+    if direction in ("up", "down", "left", "right") and type(amount) is int and amount > 0:
+        if direction in ("up", "down"):
+            return 0, amount if direction == "up" else -amount
+        return (amount if direction == "right" else -amount), 0
+    width, height = await get_dimensions()
+    if scroll_y:
+        notches = max(1, round(abs(scroll_y) / (0.1 * height)))
+        return 0, (-notches if scroll_y > 0 else notches)
+    if scroll_x:
+        notches = max(1, round(abs(scroll_x) / (0.1 * width)))
+        return (notches if scroll_x > 0 else -notches), 0
+    return 0, 0
+
+
 IMAGE_VIEW_MAX_EDGE = 1568
 
 
@@ -496,5 +529,6 @@ __all__ = [
     "result_returncode",
     "result_stderr",
     "result_stdout",
+    "scroll_notches_from_pixels",
     "truncate_tool_output",
 ]


### PR DESCRIPTION
## What

`examples/navigator_n2/cua_adapter.py::CuaSandboxComputer.scroll()` and `examples/navigator_n2/direct_x11_adapter.py::LocalX11Computer.scroll()` each carried a private `_scroll_notches()` method (both added in #339) that converts the n2 loop's pixel scroll deltas into wheel notches — the same `direction`/`amount` fast path, the same fallback arithmetic inverting the loop's pixel translation via `get_dimensions()`. The two method bodies were byte-for-byte identical; only the docstring wording differed ("Cua wheel notches" vs. "X11 wheel notches").

Extracted `scroll_notches_from_pixels()` into `yutori/navigator/sandbox_tools.py` — the module the two adapters' own docstrings already name as their shared home for exactly this kind of reference logic (it already hosts `clamp_bash_timeout()`, `result_stdout()`/`result_stderr()`/`result_returncode()`, `format_shell_output()`, etc., extracted the same way in #333/#336). Both `scroll()` methods now delegate to the shared helper instead of their own private method.

The helper takes a `get_dimensions` callback rather than resolved dimensions, so it preserves the original laziness exactly: dimensions are fetched only when the model-action fast path doesn't apply, same as before.

## Why it's safe

- **No public API change.** This is example/reference adapter code, not part of the published `yutori` package's public surface (not re-exported from `yutori/navigator/__init__.py`).
- **No behavior change.** The extracted function body is byte-for-byte identical to what each adapter's private method did before (verified with a diff before touching either file — the only difference was docstring wording). Each `scroll()` call site passes the exact same arguments in the exact same order.
- **Verified**: fresh `pip install -e ".[dev,examples]"` + `pytest -q -m "not slow"` → 797 passed / 3 skipped / 1 deselected (matches baseline once `pytest-asyncio` from the `dev` extra is installed). Targeted scroll/sandbox-tools/adapter tests (`tests/test_navigator_n2_cookbooks.py`, `tests/test_navigator_sandbox_tools.py`, `tests/test_navigator_n2_entrypoints.py`) all pass unchanged. `ruff check .` and `ruff format --check` clean on the touched files.

3 files changed, +42/-61.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXEm9QWKVGV5VYgdPoiCf3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of example adapter code with unchanged call semantics; no auth, data, or public API surface changes.
> 
> **Overview**
> **Moves duplicated scroll math** from the Cua and direct X11 n2 example adapters into a single shared helper in `sandbox_tools`.
> 
> Both `CuaSandboxComputer.scroll()` and `LocalX11Computer.scroll()` previously owned identical private `_scroll_notches()` logic (pixel deltas from the loop → wheel notches, with a `model_action` direction/amount fast path). That logic now lives in `scroll_notches_from_pixels()`, which takes a `get_dimensions` callback so screen size is still fetched only on the fallback path. Each adapter deletes its private method and calls the shared function with the same arguments as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 020c360b0df88971f5c79ea34d997c894dfabb1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->