### PR TITLE
refactor(navigator): dedupe the n2 background-task-started message in the sandbox adapters

### DIFF
--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -40,6 +40,9 @@ from yutori.navigator.sandbox_tools import (
     clamp_bash_timeout as _clamp_bash_timeout,
 )
 from yutori.navigator.sandbox_tools import (
+    format_background_task_started as _format_background_task_started,
+)
+from yutori.navigator.sandbox_tools import (
     format_shell_output as _format_shell_output,
 )
 from yutori.navigator.sandbox_tools import (
@@ -214,13 +217,7 @@ class CuaSandboxComputer(ShellFileToolsMixin):
                 f"> {shlex.quote(log_path)} 2>&1 < /dev/null"
             )
             process_id = str(session.get("pid") or "unknown")
-            return (
-                f"Started background task `bash_{log_path[-12:-4]}`.\n"
-                f"stdout+stderr is streaming to: {log_path}\n"
-                "Use the read tool on that file to retrieve output.\n"
-                f"Process id: {process_id}\n"
-                f"To cancel: run bash with `kill {process_id}`"
-            )
+            return _format_background_task_started(log_path, process_id)
 
         # The n2 bash contract: the timeout is clamped to [0, 600] and an expiry is a
         # NORMAL result the model can react to, never a raised failure envelope.

--- a/examples/navigator_n2/direct_x11_adapter.py
+++ b/examples/navigator_n2/direct_x11_adapter.py
@@ -52,6 +52,9 @@ from yutori.navigator.sandbox_tools import (
     clamp_bash_timeout as _clamp_bash_timeout,
 )
 from yutori.navigator.sandbox_tools import (
+    format_background_task_started as _format_background_task_started,
+)
+from yutori.navigator.sandbox_tools import (
     format_shell_output as _format_shell_output,
 )
 from yutori.navigator.sandbox_tools import (
@@ -322,13 +325,7 @@ class LocalX11Computer(ShellFileToolsMixin):
                     stderr=subprocess.STDOUT,
                     start_new_session=True,
                 )
-            return (
-                f"Started background task `bash_{log_path[-12:-4]}`.\n"
-                f"stdout+stderr is streaming to: {log_path}\n"
-                "Use the read tool on that file to retrieve output.\n"
-                f"Process id: {process.pid}\n"
-                f"To cancel: run bash with `kill {process.pid}`"
-            )
+            return _format_background_task_started(log_path, process.pid)
 
         # The n2 bash contract: the timeout is clamped to [0, 600] and an expiry is a
         # NORMAL result the model can react to, never a raised failure envelope.

--- a/yutori/navigator/sandbox_tools.py
+++ b/yutori/navigator/sandbox_tools.py
@@ -339,6 +339,21 @@ def format_shell_result(result: Any) -> str:
     return format_shell_output(join_output_streams(result), result_returncode(result))
 
 
+def format_background_task_started(log_path: str, process_id: Any) -> str:
+    """Render the n2 ``run_bash_command(run_in_background=True)`` acknowledgment.
+
+    ``log_path`` is expected to end in ``.log``; the task id shown to the model is
+    the 8 characters before that suffix (the random hex the caller generated it from).
+    """
+    return (
+        f"Started background task `bash_{log_path[-12:-4]}`.\n"
+        f"stdout+stderr is streaming to: {log_path}\n"
+        "Use the read tool on that file to retrieve output.\n"
+        f"Process id: {process_id}\n"
+        f"To cancel: run bash with `kill {process_id}`"
+    )
+
+
 BASH_TIMEOUT_DEFAULT_SECONDS = 120.0
 BASH_TIMEOUT_MAX_SECONDS = 600.0
 
@@ -521,6 +536,7 @@ __all__ = [
     "ShellFileToolsMixin",
     "append_stream",
     "clamp_bash_timeout",
+    "format_background_task_started",
     "format_shell_output",
     "format_shell_result",
     "join_output_streams",


### PR DESCRIPTION
## What

`CuaSandboxComputer.run_bash_command` (`examples/navigator_n2/cua_adapter.py`) and
`LocalX11Computer.run_bash_command` (`examples/navigator_n2/direct_x11_adapter.py`) each
hand-rolled the byte-identical 5-line "background task started" acknowledgment string
returned when `run_bash_command(..., run_in_background=True)`:

```python
return (
    f"Started background task `bash_{log_path[-12:-4]}`.\n"
    f"stdout+stderr is streaming to: {log_path}\n"
    "Use the read tool on that file to retrieve output.\n"
    f"Process id: {process_id}\n"
    f"To cancel: run bash with `kill {process_id}`"
)
```

only the `process_id` source differed (a Cua terminal session's `pid` field vs. a local
`subprocess.Popen`'s `.pid`).

Extracted `format_background_task_started(log_path, process_id)` into
`yutori/navigator/sandbox_tools.py`, the existing shared home for the n2 sandbox-adapter
formatting helpers (`format_shell_output`, `format_shell_result`, `clamp_bash_timeout`,
`scroll_notches_from_pixels`, ...) that both example adapters already import from. Both
call sites now delegate to it.

`examples/navigator_n2_daytona.py` has a superficially similar message but was deliberately
left alone — it uses a different log-path prefix and builds the lines conditionally (pid
may be empty when the launch line fails), so it isn't the same idiom and forcing it through
this helper would be a behavior change, not a mechanical dedupe.

## Why it's safe

- Purely internal reorganization inside two example scripts and one non-re-exported helper
  module (`sandbox_tools.py` is not re-exported wholesale from `yutori/navigator/__init__.py`
  — only a curated subset is, and this new function isn't in that subset). The new function
  is appended to `sandbox_tools.py`'s own `__all__` alongside its siblings, but that's purely
  additive.
- No existing exported symbol's signature or behavior changes — the produced string is
  byte-for-byte identical to before at both call sites (verified by inspection: the extracted
  body is a straight copy-paste).
- Full test suite: `797 passed, 3 skipped, 1 deselected` (identical to `main`, including with
  the `examples` extra installed so the adapter/example test modules collect).
- `ruff check .` and `ruff format --check` clean on the touched files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FFHv4PSRpL1NXW4KJbDbFf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical string deduplication in example adapters with no intended change to model-visible output or public navigator exports.
> 
> **Overview**
> Extracts **`format_background_task_started(log_path, process_id)`** into `yutori/navigator/sandbox_tools.py` next to the other n2 shell formatting helpers.
> 
> **`CuaSandboxComputer`** and **`LocalX11Computer`** no longer inline the same five-line acknowledgment for `run_bash_command(..., run_in_background=True)`; both call the shared helper (Cua still passes the terminal session `pid`, local X11 still passes `subprocess.Popen.pid`). The helper is exported via `sandbox_tools.__all__` only; behavior of the returned string is unchanged at those call sites.
> 
> The Daytona example’s similar but conditional background message is intentionally **not** switched to this helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37339e600f01c137f0f4d6ee463bbb8c609d89e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->