### PR TITLE
refactor(navigator): dedupe the atomic-status-file wait in the n2 sandbox adapters

### DIFF
--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -57,6 +57,9 @@ from yutori.navigator.sandbox_tools import (
 from yutori.navigator.sandbox_tools import (
     scroll_notches_from_pixels as _scroll_notches_from_pixels,
 )
+from yutori.navigator.sandbox_tools import (
+    wait_for_file as _wait_for_file,
+)
 
 
 class CuaSandboxComputer(ShellFileToolsMixin):
@@ -272,15 +275,7 @@ class CuaSandboxComputer(ShellFileToolsMixin):
         if not isinstance(process_id, int) or process_id <= 0:
             raise RuntimeError("Cua PTY did not return a valid process id.")
 
-        async def wait_for_status() -> None:
-            delay = 0.01
-            while not await self.sandbox.files.exists(status_path):
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, 0.25)
-
-        try:
-            await asyncio.wait_for(wait_for_status(), timeout=timeout_s)
-        except asyncio.TimeoutError:
+        if not await _wait_for_file(lambda: self.sandbox.files.exists(status_path), timeout_s):
             try:
                 await asyncio.wait_for(self.sandbox.terminal.close(process_id), timeout=5)
             except Exception:  # noqa: BLE001 - the disposable sandbox is the final cleanup boundary

--- a/examples/navigator_n2/direct_x11_adapter.py
+++ b/examples/navigator_n2/direct_x11_adapter.py
@@ -63,6 +63,9 @@ from yutori.navigator.sandbox_tools import (
 from yutori.navigator.sandbox_tools import (
     scroll_notches_from_pixels as _scroll_notches_from_pixels,
 )
+from yutori.navigator.sandbox_tools import (
+    wait_for_file as _wait_for_file,
+)
 
 # The SDK loop's key vocabulary is already canonical lowercase (punctuation
 # arrives as literal characters); only these names spell differently in
@@ -380,16 +383,11 @@ class LocalX11Computer(ShellFileToolsMixin):
                 start_new_session=True,
             )
 
-        async def wait_for_status() -> None:
-            delay = 0.01
-            while not os.path.exists(status_path):
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, 0.25)
+        async def _status_exists() -> bool:
+            return os.path.exists(status_path)
 
         try:
-            try:
-                await asyncio.wait_for(wait_for_status(), timeout=timeout_s)
-            except asyncio.TimeoutError:
+            if not await _wait_for_file(_status_exists, timeout_s):
                 with contextlib.suppress(ProcessLookupError):
                     os.killpg(process.pid, signal.SIGKILL)
                 return f"Command timed out after {timeout_s:g}s"

--- a/yutori/navigator/sandbox_tools.py
+++ b/yutori/navigator/sandbox_tools.py
@@ -23,6 +23,7 @@ through direct X11 access, respectively).
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import io
 import json
@@ -354,6 +355,32 @@ def format_background_task_started(log_path: str, process_id: Any) -> str:
     )
 
 
+async def wait_for_file(exists: Callable[[], Awaitable[bool]], timeout_seconds: float) -> bool:
+    """Poll ``exists`` with capped exponential backoff until it returns true or
+    ``timeout_seconds`` elapses.
+
+    This is the n2 ``bash`` contract's atomic-status-file wait: the adapter's
+    generated script writes a status file only once the command has fully
+    exited, so polling for that file's existence is the completion signal,
+    independent of any backgrounded descendant still running. Delay starts at
+    10ms and doubles up to a 250ms cap. Returns ``False`` on timeout rather
+    than raising, so the caller can turn it into a normal (non-exceptional)
+    "Command timed out" result.
+    """
+
+    async def poll() -> None:
+        delay = 0.01
+        while not await exists():
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 0.25)
+
+    try:
+        await asyncio.wait_for(poll(), timeout=timeout_seconds)
+    except asyncio.TimeoutError:
+        return False
+    return True
+
+
 BASH_TIMEOUT_DEFAULT_SECONDS = 120.0
 BASH_TIMEOUT_MAX_SECONDS = 600.0
 
@@ -547,4 +574,5 @@ __all__ = [
     "result_stdout",
     "scroll_notches_from_pixels",
     "truncate_tool_output",
+    "wait_for_file",
 ]


### PR DESCRIPTION
## What

`CuaSandboxComputer.run_bash_command` (`examples/navigator_n2/cua_adapter.py`) and `LocalX11Computer.run_bash_command` (`examples/navigator_n2/direct_x11_adapter.py`) each hand-roll the byte-identical exponential-backoff polling loop that waits for the generated bash wrapper's atomic status file to appear before reading results:

```python
async def wait_for_status() -> None:
    delay = 0.01
    while not <exists-check>:
        await asyncio.sleep(delay)
        delay = min(delay * 2, 0.25)

try:
    await asyncio.wait_for(wait_for_status(), timeout=timeout_s)
except asyncio.TimeoutError:
    ...
```

Only the existence check differs: Cua's is an async sandbox-files RPC (`await self.sandbox.files.exists(status_path)`); the direct-X11 adapter's is a synchronous `os.path.exists(status_path)`.

This is fresh ground left over from the same functions that five recent PRs (#333, #336, #339, #341, #342) already deduped the neighboring pieces of — the bash-timeout clamp, the background-task-started message, scroll-to-notches conversion, and the shell-result accessors all moved to `yutori/navigator/sandbox_tools.py` in that series, but this polling loop was untouched.

## Change

Extract `wait_for_file(exists, timeout_seconds) -> bool` into `sandbox_tools.py`, alongside its sibling helpers (`clamp_bash_timeout`, `format_background_task_started`, `scroll_notches_from_pixels`, the `result_*` accessors). It takes the existence check as an async predicate, runs the same 10ms→250ms-capped backoff, and returns `False` on timeout instead of raising — matching what both call sites already did by hand.

Both adapters now delegate:
- `cua_adapter.py`: `await _wait_for_file(lambda: self.sandbox.files.exists(status_path), timeout_s)`
- `direct_x11_adapter.py`: a small `_status_exists()` async wrapper around the same `os.path.exists` call, passed to the same helper.

No behavior change — same polling schedule, same timeout semantics, same downstream cleanup/return paths in both call sites (just re-expressed as `if not await wait_for_file(...):` instead of `try/except asyncio.TimeoutError`).

## Why it's safe

- Example/reference code only — not re-exported from any public `yutori` package surface beyond the already-public `sandbox_tools` module these adapters already import from.
- Pure extraction: the loop body, delay schedule, and `asyncio.wait_for` wrapping are byte-for-byte identical to what each adapter did before.
- Existing tests exercise both timeout paths end-to-end: `test_public_cua_adapter_pty_timeout_is_a_normal_result` (fake Cua sandbox) and a real-subprocess timeout assertion for `LocalX11Computer` in `tests/test_navigator_n2_cookbooks.py`.

## Verification

- `pytest -q tests/test_navigator_sandbox_tools.py tests/test_navigator_n2_cookbooks.py tests/test_navigator_n2.py tests/test_navigator_n2_harness.py tests/test_navigator_n2_compaction.py` → 149 passed
- Full suite `pytest -q -m "not slow"` (with the `examples` extra installed) → 797 passed / 3 skipped / 1 deselected — unchanged from baseline
- `ruff check .` and `ruff format --check` on the touched files → clean

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_016YDRkCQHKMrVQoMWT7ECFP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure extraction in example adapters and shared sandbox helpers; polling schedule and timeout semantics are unchanged and covered by existing n2 cookbook tests.
> 
> **Overview**
> Adds shared **`wait_for_file`** in `yutori/navigator/sandbox_tools.py` so both n2 example adapters stop duplicating the same exponential-backoff poll (10ms → 250ms cap) that waits for the bash wrapper’s atomic status file before reading results.
> 
> **`CuaSandboxComputer`** and **`LocalX11Computer`** now call the helper with their respective existence checks (sandbox `files.exists` vs local `os.path.exists` via a thin async wrapper). Timeouts still return **`False`** instead of raising, so callers keep the same “Command timed out after Xs” cleanup paths—only expressed as `if not await _wait_for_file(...)` instead of hand-rolled `try/except asyncio.TimeoutError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8d9a557074103b721876447eab1158b585adc3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->