### PR TITLE
refactor(navigator): dedupe the cwd-tracking bash wrapper script in the n2 sandbox adapters

### DIFF
--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -37,6 +37,9 @@ from yutori.navigator.sandbox_tools import (
     append_stream as _append_stream,
 )
 from yutori.navigator.sandbox_tools import (
+    build_cwd_tracking_bash_script as _build_cwd_tracking_bash_script,
+)
+from yutori.navigator.sandbox_tools import (
     clamp_bash_timeout as _clamp_bash_timeout,
 )
 from yutori.navigator.sandbox_tools import (
@@ -243,33 +246,8 @@ class CuaSandboxComputer(ShellFileToolsMixin):
         cwd_path = f"{result_prefix}.cwd"
         inner_cwd_tmp = f"{cwd_path}.tmp"
         status_tmp = f"{status_path}.tmp"
-        finish = f"__yutori_finish_{token}"
-        inner = (
-            f"{finish}() {{\n"
-            f"  printf '%s\\n' \"$PWD\" > {shlex.quote(inner_cwd_tmp)}\n"
-            f"  mv {shlex.quote(inner_cwd_tmp)} {shlex.quote(cwd_path)}\n"
-            "}\n"
-            f"trap {finish} 0\n"
-            f"{command}"
-        )
-        wrapped = (
-            "(\n"
-            f"cd {shlex.quote(cwd)}\n"
-            "__yutori_cd_rc=$?\n"
-            'if [ "$__yutori_cd_rc" -eq 0 ]; then\n'
-            f"  /bin/bash -c {shlex.quote(inner)}\n"
-            "  __yutori_rc=$?\n"
-            "else\n"
-            "  __yutori_rc=$__yutori_cd_rc\n"
-            "fi\n"
-            f"if [ ! -f {shlex.quote(cwd_path)} ]; then\n"
-            f"  printf '%s\\n' \"$PWD\" > {shlex.quote(cwd_path)}\n"
-            "fi\n"
-            f"printf '%s' \"$__yutori_rc\" > {shlex.quote(status_tmp)}\n"
-            f"mv {shlex.quote(status_tmp)} {shlex.quote(status_path)}\n"
-            'exit "$__yutori_rc"\n'
-            f") < /dev/null > {shlex.quote(stdout_path)} 2> {shlex.quote(stderr_path)}"
-        )
+        script = _build_cwd_tracking_bash_script(command, cwd=cwd, cwd_path=cwd_path, status_path=status_path)
+        wrapped = f"(\n{script}) < /dev/null > {shlex.quote(stdout_path)} 2> {shlex.quote(stderr_path)}"
         session = await self.sandbox.terminal.create(wrapped)
         process_id = session.get("pid")
         if not isinstance(process_id, int) or process_id <= 0:

--- a/examples/navigator_n2/direct_x11_adapter.py
+++ b/examples/navigator_n2/direct_x11_adapter.py
@@ -49,6 +49,9 @@ from yutori.navigator.sandbox_tools import (
     append_stream as _append_stream,
 )
 from yutori.navigator.sandbox_tools import (
+    build_cwd_tracking_bash_script as _build_cwd_tracking_bash_script,
+)
+from yutori.navigator.sandbox_tools import (
     clamp_bash_timeout as _clamp_bash_timeout,
 )
 from yutori.navigator.sandbox_tools import (
@@ -347,31 +350,7 @@ class LocalX11Computer(ShellFileToolsMixin):
         status_path = f"{result_prefix}.status"
         cwd_path = f"{result_prefix}.cwd"
         status_tmp = f"{status_path}.tmp"
-        finish = f"__yutori_finish_{token}"
-        inner = (
-            f"{finish}() {{\n"
-            f"  printf '%s\\n' \"$PWD\" > {shlex.quote(cwd_path)}.tmp\n"
-            f"  mv {shlex.quote(cwd_path)}.tmp {shlex.quote(cwd_path)}\n"
-            "}\n"
-            f"trap {finish} 0\n"
-            f"{command}"
-        )
-        wrapped = (
-            f"cd {shlex.quote(cwd)}\n"
-            "__yutori_cd_rc=$?\n"
-            'if [ "$__yutori_cd_rc" -eq 0 ]; then\n'
-            f"  /bin/bash -c {shlex.quote(inner)}\n"
-            "  __yutori_rc=$?\n"
-            "else\n"
-            "  __yutori_rc=$__yutori_cd_rc\n"
-            "fi\n"
-            f"if [ ! -f {shlex.quote(cwd_path)} ]; then\n"
-            f"  printf '%s\\n' \"$PWD\" > {shlex.quote(cwd_path)}\n"
-            "fi\n"
-            f"printf '%s' \"$__yutori_rc\" > {shlex.quote(status_tmp)}\n"
-            f"mv {shlex.quote(status_tmp)} {shlex.quote(status_path)}\n"
-            'exit "$__yutori_rc"\n'
-        )
+        wrapped = _build_cwd_tracking_bash_script(command, cwd=cwd, cwd_path=cwd_path, status_path=status_path)
         with open(stdout_path, "wb") as stdout_file, open(stderr_path, "wb") as stderr_file:
             process = await asyncio.create_subprocess_exec(
                 "/bin/bash",

--- a/yutori/navigator/sandbox_tools.py
+++ b/yutori/navigator/sandbox_tools.py
@@ -28,6 +28,7 @@ import base64
 import io
 import json
 import shlex
+import uuid
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -390,6 +391,50 @@ def clamp_bash_timeout(timeout: float | None) -> float:
     return max(0.0, min(float(BASH_TIMEOUT_DEFAULT_SECONDS if timeout is None else timeout), BASH_TIMEOUT_MAX_SECONDS))
 
 
+def build_cwd_tracking_bash_script(command: str, *, cwd: str, cwd_path: str, status_path: str) -> str:
+    """Build the n2 `bash` wrapper script: `cd` into ``cwd``, run ``command``, and record its
+    resulting working directory and exit status for the caller to read back afterward.
+
+    The exit status is only meaningful once ``status_path`` exists, so both it and the recorded
+    cwd are written to a ``.tmp`` sibling and moved into place, never written in place: a status
+    poller must never observe a partially written file. The cwd capture runs in an inner shell
+    with its own ``trap ... 0`` so it fires even if ``command`` exits early, backgrounds a
+    descendant, or is killed by a signal — the outer ``if`` only backstops the case where the cd
+    itself failed and the inner shell never ran.
+
+    Returns the script body only; the caller supplies its own output redirection, either embedded
+    in the string (wrapping it in ``(...)`` with a trailing `` < /dev/null > out 2> err`` to hand
+    one string to a remote shell) or via subprocess stdout/stderr handles.
+    """
+    status_tmp = f"{status_path}.tmp"
+    cwd_tmp = f"{cwd_path}.tmp"
+    finish = f"__yutori_finish_{uuid.uuid4().hex}"
+    inner = (
+        f"{finish}() {{\n"
+        f"  printf '%s\\n' \"$PWD\" > {shlex.quote(cwd_tmp)}\n"
+        f"  mv {shlex.quote(cwd_tmp)} {shlex.quote(cwd_path)}\n"
+        "}\n"
+        f"trap {finish} 0\n"
+        f"{command}"
+    )
+    return (
+        f"cd {shlex.quote(cwd)}\n"
+        "__yutori_cd_rc=$?\n"
+        'if [ "$__yutori_cd_rc" -eq 0 ]; then\n'
+        f"  /bin/bash -c {shlex.quote(inner)}\n"
+        "  __yutori_rc=$?\n"
+        "else\n"
+        "  __yutori_rc=$__yutori_cd_rc\n"
+        "fi\n"
+        f"if [ ! -f {shlex.quote(cwd_path)} ]; then\n"
+        f"  printf '%s\\n' \"$PWD\" > {shlex.quote(cwd_path)}\n"
+        "fi\n"
+        f"printf '%s' \"$__yutori_rc\" > {shlex.quote(status_tmp)}\n"
+        f"mv {shlex.quote(status_tmp)} {shlex.quote(status_path)}\n"
+        'exit "$__yutori_rc"\n'
+    )
+
+
 async def scroll_notches_from_pixels(
     scroll_x: int,
     scroll_y: int,
@@ -562,6 +607,7 @@ __all__ = [
     "IMAGE_VIEW_MAX_EDGE",
     "ShellFileToolsMixin",
     "append_stream",
+    "build_cwd_tracking_bash_script",
     "clamp_bash_timeout",
     "format_background_task_started",
     "format_shell_output",


### PR DESCRIPTION
## What

`CuaSandboxComputer.run_bash_command` (`examples/navigator_n2/cua_adapter.py`) and `LocalX11Computer.run_bash_command` (`examples/navigator_n2/direct_x11_adapter.py`) each hand-rolled the same ~20-line trap-based bash wrapper script: `cd` into the tracked cwd, run the command inside an inner shell whose own `trap ... 0` records the resulting `$PWD` even if the command exits early or backgrounds a descendant, then atomically write the exit status (via a `.tmp` file + `mv`) that the caller polls for. The two copies were byte-for-byte identical apart from what wraps around them — Cua needs the whole thing as one string (with its own `(...) < /dev/null > out 2> err` redirection appended) so it can hand it to a remote PTY, while the X11 adapter pipes stdout/stderr through subprocess file handles directly.

Extracted `build_cwd_tracking_bash_script(command, *, cwd, cwd_path, status_path)` into `yutori/navigator/sandbox_tools.py`, next to its sibling shell-result/bash-contract helpers (`clamp_bash_timeout`, `wait_for_file`, `format_background_task_started`, `scroll_notches_from_pixels` — all added by earlier PRs consolidating this exact same pair of adapters). Both adapters now call it and build their own wrapping around the returned script body exactly as before.

## Why

This is the same duplication-drift risk the sibling helpers above were extracted to avoid: two hand-maintained copies of a subtle, escaping-sensitive shell script (trap semantics, atomic status-file writes) that could silently diverge if one call site were "fixed" without the other.

## Why it's safe

- **No public API change.** `sandbox_tools.py` is not re-exported from `yutori/navigator/__init__.py` (only `ShellFileToolsMixin` is) and this new helper is not added to `api.md`'s curated import list — matching exactly how the other sibling helpers in this module were added.
- **No behavior change.** The returned script string is byte-for-byte identical to what each call site built inline before; only the temp function name inside the script (an implementation detail never observed by any caller or test) is now generated by the helper instead of by the call site.
- **Example-only + one new pure function** — 3 files touched, +55/-52.

## Verified

- Targeted tests exercising `run_bash_command` end-to-end (real bash: timeouts, background runs, cwd persistence, `xcalc`-style surviving descendants): `pytest tests/test_navigator_n2_cookbooks.py tests/test_navigator_n2_entrypoints.py` → 54 passed.
- Full suite: `pytest -q -m "not slow"` → 797 passed / 3 skipped / 1 deselected — identical to the pre-change baseline.
- `ruff check .` and `ruff format --check` on all three touched files clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAbTwEkM2EzZRyE1XQV7Bp

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAbTwEkM2EzZRyE1XQV7Bp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of example adapters plus a new internal helper; shell contract and polling semantics stay the same, with existing navigator n2 tests covering `run_bash_command`.
> 
> **Overview**
> Pulls the duplicated **trap-based bash wrapper** (cd into tracked cwd, run the command, atomically write exit status and final `$PWD` via `.tmp` + `mv`) out of the Cua and direct X11 n2 example adapters into shared **`build_cwd_tracking_bash_script`** in `sandbox_tools.py`.
> 
> Each adapter still wires the returned script body the same way as before: Cua wraps it in a subshell with stdin/stdout/stderr redirection for the remote PTY; the X11 path passes it to `create_subprocess_exec` with stdout/stderr files. **Behavior is intended to be unchanged** aside from the inner `__yutori_finish_*` trap name now coming from a UUID inside the helper rather than the per-run token at the call site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e627d37f55fc4f4fbfc364a95f476010927c0ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->