### PR TITLE
chore(macos): pin the cua-driver extra at 0.23.2

### DIFF
--- a/api.md
+++ b/api.md
@@ -880,7 +880,7 @@ Optional extras:
 |-------|----------|---------|
 | `dev` | `pytest`, `pytest-asyncio`, `ruff`, `build` | Development tooling. |
 | `examples` | `loguru`, `playwright`, `pydantic`, `tenacity` | Running the `examples/` scripts. Pydantic is also the library to install if you want to pass Pydantic models to `output_schema=`. |
-| `macos` | `cua-driver==0.19.3` | Native macOS CUA driver for Navigator n2 loops. |
+| `macos` | `cua-driver==0.23.2` | Native macOS CUA driver for Navigator n2 loops. |
 
 ## Error handling example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ yutori = "yutori.cli.main:app"
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "ruff>=0.1", "build>=1.2.0"]
 examples = ["loguru>=0.7.0", "playwright>=1.40.0", "pydantic>=2.0.0", "tenacity>=9.0.0"]
-macos = ["cua-driver==0.19.3; python_version >= '3.10' and platform_system == 'Darwin'"]
+macos = ["cua-driver==0.23.2; python_version >= '3.10' and platform_system == 'Darwin'"]
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- `yutori[macos]` extra and `api.md` still named `cua-driver==0.19.3`; move both to 0.23.2

## Why
yutori-mcp is moving its hard-gated CuaDriver pin to 0.23.2 (yutori-ai/yutori-mcp PR opened alongside this one). The SDK's driver-facing transport is schema-compatible: verified with `cua-driver describe` on both releases for every tool `MacOSComputer` and `CuaDriverTransport` send; nothing removed, nothing newly required. Live smoke on 0.23.2 (setup → doctor → Calculator run) passed with SDK 0.9.2 unchanged.

No code change; this only keeps the extra aligned with the driver users are told to install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and optional-dependency pin only; no SDK logic or default install path changes.
> 
> **Overview**
> Bumps the **`macos`** optional extra from **`cua-driver==0.19.3`** to **`cua-driver==0.23.2`** in `pyproject.toml` and the Dependencies table in `api.md`. There is no runtime or Navigator code change—only the install pin and docs stay aligned with the driver version Yutori MCP and macOS Navigator n2 setups are expected to use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45c18bf5fa977d670b9b33ec7f15ba11c205b737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->