### PR TITLE
feat(macos): withhold keystrokes when the frontmost app changed since the last frame

### DIFF
--- a/api.md
+++ b/api.md
@@ -553,6 +553,8 @@ Constructor parameters (the `**loop_policies` keywords have [their own table](#l
 
 `MacOSComputer` is the native macOS adapter — CuaDriver session, capture/input, shell lifecycle, cancellation, recovery, and the optional presentation overlay. It is what Yutori MCP runs; local shell execution stays off unless the caller enables it.
 
+Keyboard actions carry a focus guard (`verify_focus=True`): the adapter records the frontmost application at every screenshot and re-checks it right before `type_text`, `press_key`, and `hotkey`. If focus moved since the frame the model reasoned over — a dialog, a notification, a slow launch — the keys are not sent and the model receives `MacOSFocusChangedError` with a fresh frame as the tool result. The probe uses LaunchServices (`lsappinfo`) and needs no permission grant; when it cannot answer, the guard fails open. Pass `verify_focus=False` to disable it, or `frontmost_probe=` to substitute the probe in tests.
+
 #### Running and resuming
 
 `run(task)` (a task string or a message list) is an async generator yielding `{"output": [items], "usage": {...}, "message": {...}}` per model turn (`message` is the raw assistant message) and `{"output": [result items], "usage": {}}` per executed tool call. The items are responses-style dicts, the same shapes kept in `agent.trajectory`:

--- a/tests/test_navigator_macos_computer.py
+++ b/tests/test_navigator_macos_computer.py
@@ -20,10 +20,12 @@ import yutori.navigator.macos.computer as computer_module
 from yutori.navigator.macos.computer import (
     MacOSActionRefusedError,
     MacOSComputer,
+    MacOSFocusChangedError,
     MacOSRecoverableActionError,
     MacOSTargetCrashedError,
     MacOSUncertainActionError,
 )
+from yutori.navigator.macos.frontmost import FrontmostApp
 from yutori.navigator.macos.polling import FramePollResult
 from yutori.navigator.macos.transport import CuaDriverToolError, CuaDriverUncertainActionError
 from yutori.navigator.macos.types import MacOSPresentationStatus, N2Observation
@@ -820,3 +822,93 @@ async def test_wait_for_change_raises_on_an_aborted_poll(monkeypatch):
 
     with pytest.raises(asyncio.CancelledError, match="operator_stop"):
         await computer.wait_for_change(500, _frame(1))
+
+
+def _frontmost_probe(sequence: list[FrontmostApp | None]):
+    calls = {"count": 0}
+
+    async def probe() -> FrontmostApp | None:
+        calls["count"] += 1
+        return sequence.pop(0) if len(sequence) > 1 else sequence[0]
+
+    probe.calls = calls  # type: ignore[attr-defined]
+    return probe
+
+
+async def test_keyboard_delivery_proceeds_while_the_frontmost_app_is_unchanged():
+    transport = FakeTransport()
+    probe = _frontmost_probe([FrontmostApp(10, "Calculator")])
+    async with MacOSComputer(transport, owns_transport=False, presentation=False, frontmost_probe=probe) as computer:
+        await computer.screenshot()
+        await computer.type("9*9=")
+        await computer.keypress("Return")
+        await computer.keypress(["cmd", "c"])
+    sent = [call[0] for call in transport.calls]
+    assert sent.count("type_text") == 1 and sent.count("press_key") == 1 and sent.count("hotkey") == 1
+    assert computer.focus_guard_trips == 0
+    # One probe per screenshot plus one per keyboard action.
+    assert probe.calls["count"] == 4
+
+
+async def test_keystrokes_are_withheld_when_focus_moved_since_the_last_frame():
+    transport = FakeTransport([_png(100, 50), _png(200, 80)])
+    probe = _frontmost_probe([FrontmostApp(10, "Calculator"), FrontmostApp(20, "Slack")])
+    async with MacOSComputer(transport, owns_transport=False, presentation=False, frontmost_probe=probe) as computer:
+        await computer.screenshot()
+        captures_before = [call[0] for call in transport.calls].count("get_desktop_state")
+        with pytest.raises(MacOSFocusChangedError) as raised:
+            await computer.type("hello")
+        error = raised.value
+        assert error.recoverable
+        assert "Calculator (pid 10)" in str(error) and "Slack (pid 20)" in str(error)
+        assert isinstance(error.observation, N2Observation)
+        assert (error.observation.native_width, error.observation.native_height) == (200, 80)
+        assert computer.focus_guard_trips == 1
+        # The refusal captured exactly one fresh frame for the model.
+        assert [call[0] for call in transport.calls].count("get_desktop_state") == captures_before + 1
+        # That frame re-anchored the guard on Slack, so a retry against it goes through.
+        await computer.type("hello")
+    assert [call[0] for call in transport.calls].count("type_text") == 1
+
+
+async def test_focus_guard_fails_open_when_the_probe_cannot_answer():
+    transport = FakeTransport()
+    probe = _frontmost_probe([None])
+    async with MacOSComputer(transport, owns_transport=False, presentation=False, frontmost_probe=probe) as computer:
+        await computer.screenshot()
+        await computer.keypress("Return")
+    assert [call[0] for call in transport.calls].count("press_key") == 1
+
+
+async def test_focus_guard_fails_open_when_the_probe_raises():
+    transport = FakeTransport()
+
+    async def probe() -> FrontmostApp | None:
+        raise OSError("lsappinfo missing")
+
+    async with MacOSComputer(transport, owns_transport=False, presentation=False, frontmost_probe=probe) as computer:
+        await computer.screenshot()
+        await computer.type("x")
+    assert [call[0] for call in transport.calls].count("type_text") == 1
+
+
+async def test_focus_guard_can_be_disabled():
+    transport = FakeTransport()
+    probe = _frontmost_probe([FrontmostApp(10, "Calculator"), FrontmostApp(20, "Slack")])
+    async with MacOSComputer(
+        transport, owns_transport=False, presentation=False, verify_focus=False, frontmost_probe=probe
+    ) as computer:
+        await computer.screenshot()
+        await computer.type("x")
+    assert probe.calls["count"] == 0
+    assert [call[0] for call in transport.calls].count("type_text") == 1
+
+
+async def test_pointer_actions_do_not_consult_the_focus_guard():
+    transport = FakeTransport()
+    probe = _frontmost_probe([FrontmostApp(10, "Calculator"), FrontmostApp(20, "Slack")])
+    async with MacOSComputer(transport, owns_transport=False, presentation=False, frontmost_probe=probe) as computer:
+        await computer.screenshot()
+        await computer.click(5, 5)
+    assert probe.calls["count"] == 1
+    assert [call[0] for call in transport.calls].count("click") == 1

--- a/tests/test_navigator_macos_frontmost.py
+++ b/tests/test_navigator_macos_frontmost.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
 import yutori.navigator.macos.frontmost as frontmost_module
 from yutori.navigator.macos.frontmost import FrontmostApp, frontmost_app, parse_lsappinfo_info
 
@@ -65,19 +67,46 @@ async def test_frontmost_app_rejects_an_unexpected_front_payload(monkeypatch):
     assert await frontmost_app() is None
 
 
-async def test_run_times_out_without_hanging(monkeypatch):
-    class HungProcess:
-        returncode = None
+class HungProcess:
+    def __init__(self):
+        self.returncode = None
+        self.killed = False
+        self.waited = False
 
-        async def communicate(self):
-            await asyncio.sleep(60)
+    async def communicate(self):
+        await asyncio.sleep(60)
 
-        def kill(self):
-            self.returncode = -9
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self):
+        self.waited = True
+        return self.returncode
+
+
+async def test_timed_out_probe_kills_and_reaps_the_child_then_fails_open(monkeypatch):
+    process = HungProcess()
 
     async def fake_exec(*_command, **_kwargs):
-        return HungProcess()
+        return process
 
     monkeypatch.setattr(frontmost_module, "_LSAPPINFO_TIMEOUT_SECONDS", 0.01)
     monkeypatch.setattr(frontmost_module.asyncio, "create_subprocess_exec", fake_exec)
-    assert await frontmost_module._run("lsappinfo", "front") is None
+    assert await frontmost_app() is None
+    assert process.killed and process.waited
+
+
+async def test_cancelled_probe_kills_and_reaps_the_child(monkeypatch):
+    process = HungProcess()
+
+    async def fake_exec(*_command, **_kwargs):
+        return process
+
+    monkeypatch.setattr(frontmost_module.asyncio, "create_subprocess_exec", fake_exec)
+    task = asyncio.create_task(frontmost_module._run("lsappinfo", "front"))
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert process.killed and process.waited

--- a/tests/test_navigator_macos_frontmost.py
+++ b/tests/test_navigator_macos_frontmost.py
@@ -1,0 +1,83 @@
+"""Tests for the LaunchServices frontmost-application probe."""
+
+from __future__ import annotations
+
+import asyncio
+
+import yutori.navigator.macos.frontmost as frontmost_module
+from yutori.navigator.macos.frontmost import FrontmostApp, frontmost_app, parse_lsappinfo_info
+
+_INFO_OUTPUT = """"Google Chrome" ASN:0x0-0x2ec2ec: (in front)
+    bundleID=[ NULL ]
+    bundle path=[ NULL ]
+    executable path=[ NULL ]
+    pid = 88740 !cgsConnection !signalled type=[ NULL ]  flavor=[ NULL ]  Version=[ NULL ]  Arch=!!none
+"""
+
+
+def test_parse_lsappinfo_info_reads_pid_and_name():
+    assert parse_lsappinfo_info(_INFO_OUTPUT) == FrontmostApp(pid=88740, name="Google Chrome")
+
+
+def test_parse_lsappinfo_info_tolerates_a_missing_name():
+    assert parse_lsappinfo_info("    pid = 42 !cgsConnection\n") == FrontmostApp(pid=42, name=None)
+
+
+def test_parse_lsappinfo_info_returns_none_without_a_pid():
+    assert parse_lsappinfo_info('"Finder" ASN:0x0-0x1: (in front)\n') is None
+
+
+def test_describe_falls_back_to_the_pid():
+    assert FrontmostApp(7, "Notes").describe() == "Notes (pid 7)"
+    assert FrontmostApp(7).describe() == "pid 7"
+
+
+async def test_frontmost_app_chains_the_two_lsappinfo_calls(monkeypatch):
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*command: str) -> str | None:
+        calls.append(command)
+        if command[1] == "front":
+            return "ASN:0x0-0x2ec2ec:\n"
+        return _INFO_OUTPUT
+
+    monkeypatch.setattr(frontmost_module, "_run", fake_run)
+    assert await frontmost_app() == FrontmostApp(pid=88740, name="Google Chrome")
+    assert calls == [
+        ("lsappinfo", "front"),
+        ("lsappinfo", "info", "-only", "pid", "-only", "name", "ASN:0x0-0x2ec2ec:"),
+    ]
+
+
+async def test_frontmost_app_fails_open_when_launchservices_is_unavailable(monkeypatch):
+    async def fake_run(*command: str) -> str | None:
+        return None
+
+    monkeypatch.setattr(frontmost_module, "_run", fake_run)
+    assert await frontmost_app() is None
+
+
+async def test_frontmost_app_rejects_an_unexpected_front_payload(monkeypatch):
+    async def fake_run(*command: str) -> str | None:
+        return "No front application\n"
+
+    monkeypatch.setattr(frontmost_module, "_run", fake_run)
+    assert await frontmost_app() is None
+
+
+async def test_run_times_out_without_hanging(monkeypatch):
+    class HungProcess:
+        returncode = None
+
+        async def communicate(self):
+            await asyncio.sleep(60)
+
+        def kill(self):
+            self.returncode = -9
+
+    async def fake_exec(*_command, **_kwargs):
+        return HungProcess()
+
+    monkeypatch.setattr(frontmost_module, "_LSAPPINFO_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(frontmost_module.asyncio, "create_subprocess_exec", fake_exec)
+    assert await frontmost_module._run("lsappinfo", "front") is None

--- a/yutori/navigator/macos/__init__.py
+++ b/yutori/navigator/macos/__init__.py
@@ -6,10 +6,12 @@ from .computer import (
     MacOSActionRefusedError,
     MacOSComputer,
     MacOSComputerError,
+    MacOSFocusChangedError,
     MacOSRecoverableActionError,
     MacOSTargetCrashedError,
     MacOSUncertainActionError,
 )
+from .frontmost import FrontmostApp, frontmost_app
 from .overlay_build import (
     MacOSOverlayCheck,
     MacOSOverlayPreparationError,
@@ -31,9 +33,11 @@ from .types import (
 __all__ = [
     "COMMAND_PREVIEW_MAX_CHARACTERS",
     "CancellationLatch",
+    "FrontmostApp",
     "MacOSActionRefusedError",
     "MacOSComputer",
     "MacOSComputerError",
+    "MacOSFocusChangedError",
     "MacOSOverlayCheck",
     "MacOSOverlayPreparationError",
     "MacOSPresentationCapabilities",
@@ -48,6 +52,7 @@ __all__ = [
     "PreparedMacOSOverlay",
     "ShellPresentationEvent",
     "check_macos_overlay",
+    "frontmost_app",
     "prepare_macos_overlay",
     "sanitize_command_preview",
 ]

--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -22,6 +22,7 @@ from typing import Any, Literal
 
 from PIL import Image
 
+from .frontmost import FrontmostApp, frontmost_app
 from .no_progress import NoProgressWatchdog
 from .polling import FRAME_POLL_ACTION_MAX_MS, FramePollResult, frame_poll_wait_budget_ms, poll_until_frame_changes
 from .presentation import MacOSPresentationController
@@ -63,6 +64,15 @@ class MacOSUncertainActionError(MacOSRecoverableActionError):
     def __init__(self, message: str, observation: "N2Observation | None" = None) -> None:
         super().__init__(message)
         self.observation = observation
+
+
+class MacOSFocusChangedError(MacOSUncertainActionError):
+    """Keystrokes were withheld because the frontmost app changed since the last screenshot.
+
+    Desktop-scope keyboard delivery goes to whatever application is frontmost. When that is
+    no longer the application the model was looking at, the safe outcome is to send nothing
+    and hand the model a fresh frame; the attached observation is that frame.
+    """
 
 
 class MacOSTargetCrashedError(MacOSComputerError):
@@ -210,6 +220,8 @@ class MacOSComputer:
         recover_target: "Callable[[], Awaitable[int | None]] | None" = None,
         overlay_cache_directory: "str | Path | None" = None,
         known_secrets: "Sequence[str]" = (),
+        verify_focus: bool = True,
+        frontmost_probe: "Callable[[], Awaitable[FrontmostApp | None]] | None" = None,
     ) -> None:
         if transport is not None and owns_transport is None:
             raise ValueError("owns_transport must be explicit when transport is injected")
@@ -224,6 +236,10 @@ class MacOSComputer:
         self.target_pid = target_pid
         self.recover_target = recover_target
         self.overlay_cache_directory = overlay_cache_directory
+        self.verify_focus = verify_focus
+        self._frontmost_probe = frontmost_probe or frontmost_app
+        self._observed_frontmost: "FrontmostApp | None" = None
+        self._focus_guard_trips = 0
         values = (known_secrets,) if isinstance(known_secrets, str) else known_secrets
         self._known_secrets = tuple(secret for secret in values if secret)
         self.presentation: "MacOSPresentationController | None" = None
@@ -380,6 +396,8 @@ class MacOSComputer:
         observation = await self._encode_observation(capture_id, png_bytes, width, height)
         self._current_observation = observation
         self._no_progress.record_frame(observation)
+        if self.verify_focus:
+            self._observed_frontmost = await self._probe_frontmost()
         await self._ensure_target_alive()
         return observation
 
@@ -506,12 +524,14 @@ class MacOSComputer:
             raise MacOSRecoverableActionError(
                 "The pinned Cua Driver cannot hold a modifier while typing text."
             )
+        await self._guard_frontmost("type_text")
         await self._mutate("type_text", self._desktop_args(text=text, delay_ms=0))
 
     async def keypress(self, keys: "Sequence[str] | str") -> None:
         sequence = [keys] if isinstance(keys, str) else list(keys)
         if self._emulated_held_keys:
             sequence = self._merged_modifiers(sequence)
+        await self._guard_frontmost("press_key" if len(sequence) == 1 else "hotkey")
         if len(sequence) == 1:
             await self._mutate("press_key", self._desktop_args(key=sequence[0]))
         else:
@@ -1038,6 +1058,44 @@ class MacOSComputer:
         finally:
             self._timings["action_ms"] += (time.monotonic() - started_at) * 1000
         await self._ensure_target_alive()
+
+    @property
+    def focus_guard_trips(self) -> int:
+        return self._focus_guard_trips
+
+    async def _probe_frontmost(self) -> "FrontmostApp | None":
+        try:
+            return await self._await_with_cancellation(self._frontmost_probe())
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 - the probe is advisory; failing open keeps input flowing
+            return None
+
+    async def _guard_frontmost(self, tool: str) -> None:
+        """Refuse desktop-scope keystrokes when focus moved since the model's last frame.
+
+        The driver delivers ``type_text``/``press_key``/``hotkey`` in desktop scope to the
+        frontmost application without a target check. Comparing the frontmost app now with
+        the one recorded at the last screenshot catches a dialog, notification, slow launch,
+        or app switch that landed after the model decided what to type. On a mismatch the
+        keys are not sent and the model receives the current frame instead.
+        """
+        if not self.verify_focus or self._observed_frontmost is None:
+            return
+        current = await self._probe_frontmost()
+        if current is None or current.pid == self._observed_frontmost.pid:
+            return
+        expected = self._observed_frontmost
+        self._focus_guard_trips += 1
+        observation = None
+        with suppress(Exception):
+            observation = await self.screenshot()
+        raise MacOSFocusChangedError(
+            f"{tool} was not sent: the frontmost application changed from {expected.describe()} to "
+            f"{current.describe()} after the last screenshot. Check the attached frame and retry the keys "
+            "if that application is the intended target.",
+            observation,
+        )
 
     def _desktop_args(self, **arguments: Any) -> dict[str, Any]:
         return {

--- a/yutori/navigator/macos/frontmost.py
+++ b/yutori/navigator/macos/frontmost.py
@@ -1,0 +1,74 @@
+"""Frontmost-application probe used to guard keyboard delivery.
+
+The n2 macOS loop types through the driver's desktop scope: keystrokes go to whatever
+application is frontmost, with no target pid. That is what the model expects, but it
+also means a focus change between the screenshot the model reasoned over and the
+keystroke it chose lands the text in the wrong application. The probe here reads the
+frontmost application through LaunchServices (``lsappinfo``), which needs no TCC grant
+and costs a few milliseconds, so the handler can record it per observation and compare
+right before delivering keys.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass
+
+_LSAPPINFO_TIMEOUT_SECONDS = 2.0
+_PID_PATTERN = re.compile(r"^\s*pid\s*=\s*(\d+)", re.MULTILINE)
+_NAME_PATTERN = re.compile(r'^"(.*?)"\s+ASN:', re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class FrontmostApp:
+    pid: int
+    name: str | None = None
+
+    def describe(self) -> str:
+        return f"{self.name} (pid {self.pid})" if self.name else f"pid {self.pid}"
+
+
+def parse_lsappinfo_info(output: str) -> FrontmostApp | None:
+    """Extract pid and display name from ``lsappinfo info -only pid -only name <ASN>`` output."""
+    pid_match = _PID_PATTERN.search(output)
+    if pid_match is None:
+        return None
+    name_match = _NAME_PATTERN.search(output)
+    return FrontmostApp(pid=int(pid_match.group(1)), name=name_match.group(1) if name_match else None)
+
+
+async def _run(*command: str) -> str | None:
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except (OSError, ValueError):
+        return None
+    try:
+        stdout, _ = await asyncio.wait_for(process.communicate(), timeout=_LSAPPINFO_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError:
+        process.kill()
+        return None
+    if process.returncode != 0:
+        return None
+    return stdout.decode("utf-8", "replace")
+
+
+async def frontmost_app() -> FrontmostApp | None:
+    """Return the frontmost regular application, or None when it cannot be determined.
+
+    A None result disables the focus guard for that step rather than blocking input:
+    the probe is a safety net, and LaunchServices being unavailable (headless session,
+    login window) is not evidence that focus moved.
+    """
+    asn = await _run("lsappinfo", "front")
+    if not asn or not asn.strip().startswith("ASN:"):
+        return None
+    info = await _run("lsappinfo", "info", "-only", "pid", "-only", "name", asn.strip())
+    if info is None:
+        return None
+    return parse_lsappinfo_info(info)

--- a/yutori/navigator/macos/frontmost.py
+++ b/yutori/navigator/macos/frontmost.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+from contextlib import suppress
 from dataclasses import dataclass
 
 _LSAPPINFO_TIMEOUT_SECONDS = 2.0
@@ -50,12 +51,22 @@ async def _run(*command: str) -> str | None:
         return None
     try:
         stdout, _ = await asyncio.wait_for(process.communicate(), timeout=_LSAPPINFO_TIMEOUT_SECONDS)
-    except asyncio.TimeoutError:
-        process.kill()
-        return None
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        # Reap the child on both exits: a hung LaunchServices binary must not survive the
+        # probe, and every screenshot or keystroke would otherwise spawn another one.
+        await _reap(process)
+        raise
     if process.returncode != 0:
         return None
     return stdout.decode("utf-8", "replace")
+
+
+async def _reap(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is None:
+        with suppress(ProcessLookupError):
+            process.kill()
+    with suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(process.wait()), timeout=_LSAPPINFO_TIMEOUT_SECONDS)
 
 
 async def frontmost_app() -> FrontmostApp | None:
@@ -65,10 +76,13 @@ async def frontmost_app() -> FrontmostApp | None:
     the probe is a safety net, and LaunchServices being unavailable (headless session,
     login window) is not evidence that focus moved.
     """
-    asn = await _run("lsappinfo", "front")
-    if not asn or not asn.strip().startswith("ASN:"):
+    try:
+        asn = await _run("lsappinfo", "front")
+        if not asn or not asn.strip().startswith("ASN:"):
+            return None
+        info = await _run("lsappinfo", "info", "-only", "pid", "-only", "name", asn.strip())
+    except asyncio.TimeoutError:
         return None
-    info = await _run("lsappinfo", "info", "-only", "pid", "-only", "name", asn.strip())
     if info is None:
         return None
     return parse_lsappinfo_info(info)


### PR DESCRIPTION
## Problem
`MacOSComputer` delivers `type_text` / `press_key` / `hotkey` in the driver's desktop scope: keys go to whatever application is frontmost, with no target pid. cua-driver 0.20+ added verified foreground focus before input (trycua/cua#3068), but that guard only runs for pid+window_id-targeted keyboard delivery, so this loop never benefits. Any focus change between the screenshot the model reasoned over and the keystroke it chose lands the text in the wrong app. In a live run today the model's Spotlight query was typed into the chat box of the app that happened to be frontmost.

## Change
- New `yutori.navigator.macos.frontmost`: TCC-free frontmost-app probe through LaunchServices (`lsappinfo`), ~10 ms, bounded timeout, fails open.
- `MacOSComputer` records the frontmost app at every screenshot and re-checks it right before each keyboard action. On a mismatch nothing is sent and `MacOSFocusChangedError` (recoverable, subclass of `MacOSUncertainActionError`) carries a fresh frame back to the model as the tool result; that frame re-anchors the guard so a retry against the new app goes through.
- Pointer actions are not guarded: clicks are addressed by coordinates read off the frame.
- `verify_focus=False` disables; `frontmost_probe=` substitutes the probe in tests; `focus_guard_trips` exposes the count.
- `api.md` documents the behavior.

## Why not pid-target the keyboard actions instead
That would route through the driver's pid dispatcher (AX insertion, terminal short-circuits, per-app policies) instead of the global HID path the loop uses today, which changes typing semantics across apps and needs a broad live matrix. This guard keeps delivery identical and adds only the check.

## Verification
- `ruff check` clean; `pytest -m "not slow"`: 492 passed (13 new tests: probe parsing/chaining/timeout, guard pass/trip/fail-open/disabled/pointer-untouched)
- Live against cua-driver 0.23.2: focus moved Safari → Calculator after the frame; `type()` refused in 973 ms with the new 4096×2304 frame attached; `keypress("Escape")` retry delivered in 229 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live agent input semantics on macOS (keys may be refused where they previously always went to the frontmost app), but failures are recoverable and the guard fails open when the probe cannot run.
> 
> **Overview**
> Adds a **focus guard** on macOS desktop-scope keyboard delivery so `type`, `keypress`, and hotkeys are not sent when the frontmost app’s PID differs from the one recorded at the last screenshot.
> 
> A new LaunchServices probe (`lsappinfo` via `frontmost.py`) records frontmost app on each screenshot and re-checks before keyboard actions. On mismatch, input is withheld and the model gets **`MacOSFocusChangedError`** (recoverable, with a fresh frame) instead of typing into the wrong app. The probe **fails open** when LaunchServices is unavailable, on timeout, or on errors; **`verify_focus=False`** and injectable **`frontmost_probe`** support tests and opt-out. Pointer actions are unchanged. **`api.md`** documents the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d27cae1f878ba158a7b0269b2da79cbc9569405d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->