### PR TITLE
chore(release): 0.9.9

### DIFF
--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.8",
+    "yutori==0.9.9",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.8"]
+macos = ["yutori[macos]==0.9.9"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.8"
+YUTORI_INSTALLER_VERSION="0.9.9"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.8"
+version = "0.9.9"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Release commit for 0.9.9, same shape as #329 (0.9.8): `pyproject.toml` version, the two pins in `examples/navigator_n2/pyproject.toml`, and `YUTORI_INSTALLER_VERSION` in the regenerated `install.sh` (`scripts/check_install_sh_fresh.sh` passes).

Since 0.9.8: cua-driver 0.23.2 pin for the `macos` extra (#345) and the frontmost focus guard in `MacOSComputer` (#346).

After merge, the publish workflow needs an **annotated** tag on the merge commit before it is dispatched:

```bash
git fetch origin main
git tag -a v0.9.9 -m "yutori 0.9.9" origin/main
git push origin v0.9.9
gh workflow run publish_to_pypi.yml --repo yutori-ai/yutori-sdk-python -f tag=v0.9.9
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version bumps across packaging and example pins with no logic changes in the diff.
> 
> **Overview**
> **Release 0.9.9** — version strings only, same layout as the prior 0.9.8 release commit.
> 
> Bumps `yutori` from **0.9.8** to **0.9.9** in the root `pyproject.toml`, aligns the Navigator n2 cookbook pins (`yutori` and `yutori[macos]`) in `examples/navigator_n2/pyproject.toml`, and updates `YUTORI_INSTALLER_VERSION` in `install.sh` so the curl installer banner matches the SDK release.
> 
> No runtime or API changes in this diff; it packages fixes already on main (e.g. macOS `cua-driver` pin and `MacOSComputer` frontmost-focus guard noted in the PR description). After merge, publishing still needs an annotated `v0.9.9` tag and the PyPI workflow dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a60a42301ae3ae250020f5c4ef3296eec197525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->