### PR TITLE
refactor(navigator): dedupe bash result-file path construction in the n2 sandbox adapters

### DIFF
--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -28,13 +28,18 @@ from __future__ import annotations
 
 import asyncio
 import shlex
-import uuid
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any
 
 from yutori.navigator import ShellFileToolsMixin
 from yutori.navigator.sandbox_tools import (
     append_stream as _append_stream,
+)
+from yutori.navigator.sandbox_tools import (
+    background_bash_log_path as _background_bash_log_path,
+)
+from yutori.navigator.sandbox_tools import (
+    build_bash_result_paths as _build_bash_result_paths,
 )
 from yutori.navigator.sandbox_tools import (
     build_cwd_tracking_bash_script as _build_cwd_tracking_bash_script,
@@ -217,7 +222,7 @@ class CuaSandboxComputer(ShellFileToolsMixin):
     ) -> str:
         cwd = await self._working_directory()
         if run_in_background:
-            log_path = f"/tmp/yutori-n2-bash-{uuid.uuid4().hex[:8]}.log"
+            log_path = _background_bash_log_path("/tmp")
             session = await self.sandbox.terminal.create(
                 f"cd {shlex.quote(cwd)} && exec /bin/bash -c {shlex.quote(command)} "
                 f"> {shlex.quote(log_path)} 2>&1 < /dev/null"
@@ -238,55 +243,34 @@ class CuaSandboxComputer(ShellFileToolsMixin):
         # three standard streams prevents descendants from retaining the PTY, while
         # the atomic status file distinguishes shell completion from output that a
         # deliberately backgrounded descendant may continue to produce.
-        token = uuid.uuid4().hex
-        result_prefix = f"/tmp/yutori-n2-bash-{token}"
-        stdout_path = f"{result_prefix}.stdout"
-        stderr_path = f"{result_prefix}.stderr"
-        status_path = f"{result_prefix}.status"
-        cwd_path = f"{result_prefix}.cwd"
-        inner_cwd_tmp = f"{cwd_path}.tmp"
-        status_tmp = f"{status_path}.tmp"
-        script = _build_cwd_tracking_bash_script(command, cwd=cwd, cwd_path=cwd_path, status_path=status_path)
-        wrapped = f"(\n{script}) < /dev/null > {shlex.quote(stdout_path)} 2> {shlex.quote(stderr_path)}"
+        paths = _build_bash_result_paths("/tmp")
+        script = _build_cwd_tracking_bash_script(command, cwd=cwd, cwd_path=paths.cwd, status_path=paths.status)
+        wrapped = f"(\n{script}) < /dev/null > {shlex.quote(paths.stdout)} 2> {shlex.quote(paths.stderr)}"
         session = await self.sandbox.terminal.create(wrapped)
         process_id = session.get("pid")
         if not isinstance(process_id, int) or process_id <= 0:
             raise RuntimeError("Cua PTY did not return a valid process id.")
 
-        if not await _wait_for_file(lambda: self.sandbox.files.exists(status_path), timeout_s):
+        if not await _wait_for_file(lambda: self.sandbox.files.exists(paths.status), timeout_s):
             try:
                 await asyncio.wait_for(self.sandbox.terminal.close(process_id), timeout=5)
             except Exception:  # noqa: BLE001 - the disposable sandbox is the final cleanup boundary
                 pass
-            await self._remove_bash_result_files(
-                stdout_path,
-                stderr_path,
-                status_path,
-                status_tmp,
-                cwd_path,
-                inner_cwd_tmp,
-            )
+            await self._remove_bash_result_files(*paths.cleanup_paths())
             return f"Command timed out after {timeout_s:g}s"
 
         try:
             stdout, stderr, status, new_cwd = await asyncio.gather(
-                self.sandbox.files.read_text(stdout_path),
-                self.sandbox.files.read_text(stderr_path),
-                self.sandbox.files.read_text(status_path),
-                self.sandbox.files.read_text(cwd_path),
+                self.sandbox.files.read_text(paths.stdout),
+                self.sandbox.files.read_text(paths.stderr),
+                self.sandbox.files.read_text(paths.status),
+                self.sandbox.files.read_text(paths.cwd),
             )
             self._bash_cwd = new_cwd.strip() or cwd
             body = _append_stream(stdout, stderr)
             return _format_shell_output(body, int(status.strip()))
         finally:
-            await self._remove_bash_result_files(
-                stdout_path,
-                stderr_path,
-                status_path,
-                status_tmp,
-                cwd_path,
-                inner_cwd_tmp,
-            )
+            await self._remove_bash_result_files(*paths.cleanup_paths())
 
     async def _remove_bash_result_files(self, *paths: str) -> None:
         await asyncio.gather(

--- a/examples/navigator_n2/direct_x11_adapter.py
+++ b/examples/navigator_n2/direct_x11_adapter.py
@@ -37,7 +37,6 @@ import shutil
 import signal
 import subprocess
 import tempfile
-import uuid
 from collections.abc import Awaitable, Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -47,6 +46,12 @@ from typing import Any
 from yutori.navigator import ShellFileToolsMixin
 from yutori.navigator.sandbox_tools import (
     append_stream as _append_stream,
+)
+from yutori.navigator.sandbox_tools import (
+    background_bash_log_path as _background_bash_log_path,
+)
+from yutori.navigator.sandbox_tools import (
+    build_bash_result_paths as _build_bash_result_paths,
 )
 from yutori.navigator.sandbox_tools import (
     build_cwd_tracking_bash_script as _build_cwd_tracking_bash_script,
@@ -321,7 +326,7 @@ class LocalX11Computer(ShellFileToolsMixin):
     ) -> str:
         cwd = self._bash_cwd
         if run_in_background:
-            log_path = os.path.join(tempfile.gettempdir(), f"yutori-n2-bash-{uuid.uuid4().hex[:8]}.log")
+            log_path = _background_bash_log_path(tempfile.gettempdir())
             with open(log_path, "wb") as log_file:
                 process = subprocess.Popen(
                     ["/bin/bash", "-c", command],
@@ -343,15 +348,9 @@ class LocalX11Computer(ShellFileToolsMixin):
         # descendant alive (``xcalc &``) holds a pipe open past bash's own exit,
         # so a pipe read would hang the full timeout. The status file appearing
         # is the completion signal, independent of surviving descendants.
-        token = uuid.uuid4().hex
-        result_prefix = os.path.join(tempfile.gettempdir(), f"yutori-n2-bash-{token}")
-        stdout_path = f"{result_prefix}.stdout"
-        stderr_path = f"{result_prefix}.stderr"
-        status_path = f"{result_prefix}.status"
-        cwd_path = f"{result_prefix}.cwd"
-        status_tmp = f"{status_path}.tmp"
-        wrapped = _build_cwd_tracking_bash_script(command, cwd=cwd, cwd_path=cwd_path, status_path=status_path)
-        with open(stdout_path, "wb") as stdout_file, open(stderr_path, "wb") as stderr_file:
+        paths = _build_bash_result_paths(tempfile.gettempdir())
+        wrapped = _build_cwd_tracking_bash_script(command, cwd=cwd, cwd_path=paths.cwd, status_path=paths.status)
+        with open(paths.stdout, "wb") as stdout_file, open(paths.stderr, "wb") as stderr_file:
             process = await asyncio.create_subprocess_exec(
                 "/bin/bash",
                 "-c",
@@ -363,17 +362,17 @@ class LocalX11Computer(ShellFileToolsMixin):
             )
 
         async def _status_exists() -> bool:
-            return os.path.exists(status_path)
+            return os.path.exists(paths.status)
 
         try:
             if not await _wait_for_file(_status_exists, timeout_s):
                 with contextlib.suppress(ProcessLookupError):
                     os.killpg(process.pid, signal.SIGKILL)
                 return f"Command timed out after {timeout_s:g}s"
-            stdout = Path(stdout_path).read_text(encoding="utf-8", errors="replace")
-            stderr = Path(stderr_path).read_text(encoding="utf-8", errors="replace")
-            status = Path(status_path).read_text(encoding="utf-8")
-            new_cwd = Path(cwd_path).read_text(encoding="utf-8", errors="replace").strip()
+            stdout = Path(paths.stdout).read_text(encoding="utf-8", errors="replace")
+            stderr = Path(paths.stderr).read_text(encoding="utf-8", errors="replace")
+            status = Path(paths.status).read_text(encoding="utf-8")
+            new_cwd = Path(paths.cwd).read_text(encoding="utf-8", errors="replace").strip()
             self._bash_cwd = new_cwd or cwd
             return _format_shell_output(_append_stream(stdout, stderr), int(status.strip()))
         finally:
@@ -381,7 +380,7 @@ class LocalX11Computer(ShellFileToolsMixin):
             if process.returncode is None:
                 with contextlib.suppress(asyncio.TimeoutError):
                     await asyncio.wait_for(process.wait(), timeout=5)
-            for path in (stdout_path, stderr_path, status_path, status_tmp, cwd_path, f"{cwd_path}.tmp"):
+            for path in paths.cleanup_paths():
                 with contextlib.suppress(OSError):
                     os.unlink(path)
 

--- a/tests/test_navigator_n2_cookbooks.py
+++ b/tests/test_navigator_n2_cookbooks.py
@@ -17,7 +17,6 @@ from unittest.mock import AsyncMock
 import pytest
 from PIL import Image
 
-from examples.navigator_n2 import cua_adapter as cua_adapter_module
 from examples.navigator_n2.cua_adapter import CuaSandboxComputer
 from examples.navigator_n2.shared import TOOL_SET_ALIASES, RunGuard, selected_tool_set
 from examples.navigator_n2_daytona import CWD_SENTINEL, DaytonaComputer
@@ -29,6 +28,7 @@ from yutori.navigator import (
     N2ComputerAgent,
 )
 from yutori.navigator import format_shell_output as _format_shell_output
+from yutori.navigator import sandbox_tools as sandbox_tools_module
 from yutori.navigator.n2_actions import TOOL_SETS_WITH_CLICK_MODIFIERS
 
 from .conftest import FakeCompletions
@@ -492,7 +492,7 @@ async def test_public_cua_adapter_uses_pty_for_a_command_that_leaves_xcalc_runni
         async def remove(self, path: str) -> None:
             removed.append(path)
 
-    monkeypatch.setattr(cua_adapter_module.uuid, "uuid4", lambda: SimpleNamespace(hex=token))
+    monkeypatch.setattr(sandbox_tools_module.uuid, "uuid4", lambda: SimpleNamespace(hex=token))
     computer = CuaSandboxComputer(SimpleNamespace(shell=Shell(), terminal=Terminal(), files=Files()))
     command = (
         "export DISPLAY=:1; nohup xcalc >/tmp/xcalc.log 2>&1 & sleep 3; "
@@ -538,7 +538,7 @@ async def test_public_cua_adapter_preserves_bash_cwd_and_failure_output_over_pty
         async def remove(self, _path: str) -> None:
             pass
 
-    monkeypatch.setattr(cua_adapter_module.uuid, "uuid4", lambda: SimpleNamespace(hex=token))
+    monkeypatch.setattr(sandbox_tools_module.uuid, "uuid4", lambda: SimpleNamespace(hex=token))
     computer = CuaSandboxComputer(SimpleNamespace(shell=FakeShell(), terminal=Terminal(), files=Files()))
 
     output = await computer.run_bash_command("false")
@@ -558,7 +558,7 @@ async def test_public_cua_adapter_uses_pty_for_explicit_background_bash(
             commands.append(command)
             return {"pid": 4242}
 
-    monkeypatch.setattr(cua_adapter_module.uuid, "uuid4", lambda: SimpleNamespace(hex=token))
+    monkeypatch.setattr(sandbox_tools_module.uuid, "uuid4", lambda: SimpleNamespace(hex=token))
     computer = CuaSandboxComputer(SimpleNamespace(shell=FakeShell(), terminal=Terminal()))
 
     output = await computer.run_bash_command("sleep 999", run_in_background=True)
@@ -596,7 +596,7 @@ async def test_public_cua_adapter_pty_timeout_is_a_normal_result(
         async def remove(self, _path: str) -> None:
             pass
 
-    monkeypatch.setattr(cua_adapter_module.uuid, "uuid4", lambda: SimpleNamespace(hex=token))
+    monkeypatch.setattr(sandbox_tools_module.uuid, "uuid4", lambda: SimpleNamespace(hex=token))
     computer = CuaSandboxComputer(SimpleNamespace(shell=FakeShell(), terminal=Terminal(), files=Files()))
 
     output = await computer.run_bash_command("sleep 10", timeout=0.01)

--- a/yutori/navigator/sandbox_tools.py
+++ b/yutori/navigator/sandbox_tools.py
@@ -27,10 +27,11 @@ import asyncio
 import base64
 import io
 import json
+import os
 import shlex
 import uuid
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, NamedTuple
 
 from PIL import Image
 
@@ -435,6 +436,46 @@ def build_cwd_tracking_bash_script(command: str, *, cwd: str, cwd_path: str, sta
     )
 
 
+class BashResultPaths(NamedTuple):
+    """File paths for one `run_bash_command` invocation's result-file handoff.
+
+    Built from a random token under ``base_dir`` so concurrent bash calls never
+    collide; ``status_tmp``/``cwd_tmp`` are the write-then-`mv` staging paths
+    `build_cwd_tracking_bash_script` targets before its atomic rename.
+    """
+
+    stdout: str
+    stderr: str
+    status: str
+    cwd: str
+    status_tmp: str
+    cwd_tmp: str
+
+    def cleanup_paths(self) -> tuple[str, str, str, str, str, str]:
+        """All six paths, in the order callers remove them once a result is read."""
+        return (self.stdout, self.stderr, self.status, self.status_tmp, self.cwd, self.cwd_tmp)
+
+
+def build_bash_result_paths(base_dir: str) -> BashResultPaths:
+    """Allocate a fresh, collision-free set of `run_bash_command` result-file paths under ``base_dir``."""
+    prefix = os.path.join(base_dir, f"yutori-n2-bash-{uuid.uuid4().hex}")
+    status_path = f"{prefix}.status"
+    cwd_path = f"{prefix}.cwd"
+    return BashResultPaths(
+        stdout=f"{prefix}.stdout",
+        stderr=f"{prefix}.stderr",
+        status=status_path,
+        cwd=cwd_path,
+        status_tmp=f"{status_path}.tmp",
+        cwd_tmp=f"{cwd_path}.tmp",
+    )
+
+
+def background_bash_log_path(base_dir: str) -> str:
+    """Allocate a fresh `run_bash_command(run_in_background=True)` log path under ``base_dir``."""
+    return os.path.join(base_dir, f"yutori-n2-bash-{uuid.uuid4().hex[:8]}.log")
+
+
 async def scroll_notches_from_pixels(
     scroll_x: int,
     scroll_y: int,
@@ -603,10 +644,13 @@ __all__ = [
     "BASH_RESULT_MAX_CHARS",
     "BASH_TIMEOUT_DEFAULT_SECONDS",
     "BASH_TIMEOUT_MAX_SECONDS",
+    "BashResultPaths",
     "FILE_TOOL_SCRIPT",
     "IMAGE_VIEW_MAX_EDGE",
     "ShellFileToolsMixin",
     "append_stream",
+    "background_bash_log_path",
+    "build_bash_result_paths",
     "build_cwd_tracking_bash_script",
     "clamp_bash_timeout",
     "format_background_task_started",


### PR DESCRIPTION
## Structural issue

`CuaSandboxComputer.run_bash_command` (`examples/navigator_n2/cua_adapter.py`) and `LocalX11Computer.run_bash_command` (`examples/navigator_n2/direct_x11_adapter.py`) each hand-rolled the identical construction of a bash-result token and its derived file paths — a `stdout`/`stderr`/`status`/`cwd` path plus their `.tmp` staging siblings, all built from `f"{base_dir}/yutori-n2-bash-{uuid.uuid4().hex}"` — and, separately, the identical construction of a background-task log path from a shortened token. The only real difference between the two copies was the base directory: the Cua sandbox always has `/tmp`, while the local X11 adapter uses the host's `tempfile.gettempdir()`.

This continues the exact extraction pattern already applied to this same pair of files by #341 (`scroll_notches_from_pixels`), #342 (`format_background_task_started`), #343 (`wait_for_file`), and #344 (`build_cwd_tracking_bash_script`) — each pulling one more piece of duplicated bash-result plumbing into `yutori/navigator/sandbox_tools.py`.

## What changed

- Added `BashResultPaths` (a `NamedTuple`) and `build_bash_result_paths(base_dir) -> BashResultPaths` to `sandbox_tools.py`, parametrized by base directory so both adapters can share it.
- Added `background_bash_log_path(base_dir)` for the parallel background-task log-path construction.
- Both adapters now call these helpers with their own base directory (`"/tmp"` for Cua, `tempfile.gettempdir()` for X11) instead of re-deriving the paths inline.
- Removed the now-unused `uuid` import from both adapter files.

## Why this is safe

- **No behavior change.** `os.path.join(base_dir, name)` produces the exact same path string as the prior f-string interpolation, and the resulting path set, construction order, and cleanup order are unchanged.
- **No public API change.** `sandbox_tools.py` is documented as reference/internal implementation for adapter authors; these two new helpers are additive exports in that same module, following the existing convention (`build_cwd_tracking_bash_script`, `wait_for_file`, `clamp_bash_timeout`, etc.).
- **Verified**: full test suite green before and after (`pytest -q -m "not slow"` → 812 passed / 3 skipped / 1 deselected, unchanged), `ruff check .` and `ruff format --check` clean on all touched files. Four tests in `tests/test_navigator_n2_cookbooks.py` that monkeypatch `uuid.uuid4` to pin deterministic tokens now patch it at its new call site (`sandbox_tools`'s `uuid` module object, which is the same singleton `uuid` module either way) instead of the adapter module — same effect, updated because the call moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFnFf7TX1xFt5KCPzuREzw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFnFf7TX1xFt5KCPzuREzw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only path construction with equivalent strings and cleanup order; bash behavior and n2 contracts are unchanged.
> 
> **Overview**
> Moves duplicated **bash result-file** and **background log** path logic from the Cua and direct X11 n2 adapters into shared helpers in `sandbox_tools.py`, continuing the same extraction pattern as earlier bash plumbing refactors.
> 
> **`BashResultPaths`**, **`build_bash_result_paths(base_dir)`**, and **`background_bash_log_path(base_dir)`** now own the UUID-prefixed `/tmp/yutori-n2-bash-*` paths (stdout/stderr/status/cwd plus `.tmp` staging) and the shortened background `.log` path. Each adapter passes its own base directory (`/tmp` vs `tempfile.gettempdir()`) and uses **`paths.cleanup_paths()`** instead of hand-listed deletes. Local **`uuid`** imports are removed from the adapters.
> 
> Tests that pin deterministic tokens now monkeypatch **`sandbox_tools_module.uuid`** where UUIDs are generated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc462d283f5e97a1d2fc70d285dc42cffccaacdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->