### PR TITLE
refactor(examples): dedupe local_x11.py CLI entrypoint boilerplate

### DIFF
--- a/examples/navigator_n2/local_x11.py
+++ b/examples/navigator_n2/local_x11.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import asyncio
 import os
 import sys
 
@@ -14,10 +13,10 @@ from yutori.navigator.n2_actions import TOOL_SETS_WITH_CLICK_MODIFIERS
 
 try:
     from .direct_x11_adapter import LocalX11Computer
-    from .shared import add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
+    from .shared import build_confirmation_callback, parse_common_args, run_agent, run_cli_main, selected_tool_set
 except ImportError:
     from direct_x11_adapter import LocalX11Computer
-    from shared import add_common_arguments, build_confirmation_callback, run_agent, selected_tool_set
+    from shared import build_confirmation_callback, parse_common_args, run_agent, run_cli_main, selected_tool_set
 
 
 def _require_x11() -> None:
@@ -54,13 +53,8 @@ async def main(args: argparse.Namespace) -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
-    add_common_arguments(parser)
-    return parser.parse_args()
+    return parse_common_args(__doc__)
 
 
 if __name__ == "__main__":
-    try:
-        asyncio.run(main(parse_args()))
-    except KeyboardInterrupt:
-        print("Interrupted.")
+    run_cli_main(main, parse_args)

--- a/examples/navigator_n2/shared.py
+++ b/examples/navigator_n2/shared.py
@@ -136,8 +136,8 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
 
 def parse_common_args(description: str | None, argv: list[str] | None = None) -> argparse.Namespace:
     """Build the shared cookbook parser and parse it -- the ``parse_args()`` body every
-    local-desktop entrypoint (``local_docker.py``, ``local_macos.py``) repeated verbatim
-    apart from its module ``description``."""
+    local-desktop entrypoint (``local_docker.py``, ``local_macos.py``, ``local_x11.py``)
+    repeated verbatim apart from its module ``description``."""
     parser = argparse.ArgumentParser(description=description)
     add_common_arguments(parser)
     return parser.parse_args(argv)


### PR DESCRIPTION
## Why

PR #340 extracted `shared.py`'s `parse_common_args()`/`run_cli_main()` to remove the byte-identical `parse_args()`/`if __name__ == "__main__":` boilerplate duplicated across the n2 local-desktop cookbook entrypoints — but only updated `local_docker.py` and `local_macos.py`. `local_x11.py`, the third sibling in the same directory, still hand-rolled the exact same two blocks:

```python
def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser(description=__doc__)
    add_common_arguments(parser)
    return parser.parse_args()


if __name__ == "__main__":
    try:
        asyncio.run(main(parse_args()))
    except KeyboardInterrupt:
        print("Interrupted.")
```

## What

- `local_x11.py` now calls `parse_common_args(__doc__)` and `run_cli_main(main, parse_args)`, matching its two siblings exactly.
- `local_x11.py`'s `_require_x11()` precondition already lives as the first line inside `main()`, so `run_cli_main`'s `asyncio.run(main(parse_args()))` wrapper reaches it unchanged — no behavior difference.
- Dropped the now-unused `asyncio` import and the direct `add_common_arguments` import (still used internally by `parse_common_args`).
- Updated `parse_common_args()`'s docstring to name all three entrypoints it now covers.

## Safety

- No public-API change — this only touches example scripts, not the `yutori` package surface.
- Same CLI flags, same `--help` description, same `KeyboardInterrupt` handling as before (`parse_common_args`/`run_cli_main` are pinned to identical bodies as the code they replace, verified by diff against `local_docker.py`/`local_macos.py`).
- `_require_x11()`'s platform/`$DISPLAY` checks are untouched and still run before anything else in `main()`.

## Test

- Full suite: `812 passed, 3 skipped, 1 deselected` (baseline-identical) with the `examples`/`dev` extras installed.
- `ruff check .` and `ruff format --check` on both touched files: clean.
- Manually verified `examples.navigator_n2.local_x11.parse_args()` still parses `task`/`--tool-set`/`--auto-approve`/`--max-steps` identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EstrUP5XQtTE98yeVMJ1Uo


---
_Generated by [Claude Code](https://claude.ai/code/session_01EstrUP5XQtTE98yeVMJ1Uo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-script-only refactor with behavior-preserving shared helpers; no package API or runtime path changes beyond matching existing sibling entrypoints.
> 
> **Overview**
> Aligns **`local_x11.py`** with the other n2 local-desktop cookbooks by routing CLI parsing and the `__main__` block through **`parse_common_args(__doc__)`** and **`run_cli_main(main, parse_args)`** in `shared.py`, replacing duplicated `ArgumentParser` setup and `asyncio.run` / `KeyboardInterrupt` handling.
> 
> Removes the now-unused **`asyncio`** and **`add_common_arguments`** imports from `local_x11.py`. **`shared.parse_common_args`**’s docstring now lists **`local_x11.py`** alongside `local_docker.py` and `local_macos.py`. Agent logic and **`_require_x11()`** at the start of **`main()`** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9acf0df1e4f7de6a8e07460773a1af252884d326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->