### PR TITLE
refactor(examples): dedupe hold_key/wait/release_held_mouse_button in n2 adapters

### DIFF
--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -32,6 +32,7 @@ from collections.abc import Awaitable, Callable, Sequence
 from typing import Any
 
 from yutori.navigator import ShellFileToolsMixin
+from yutori.navigator.sandbox_tools import PointerKeyLifecycleMixin
 from yutori.navigator.sandbox_tools import (
     append_stream as _append_stream,
 )
@@ -70,7 +71,7 @@ from yutori.navigator.sandbox_tools import (
 )
 
 
-class CuaSandboxComputer(ShellFileToolsMixin):
+class CuaSandboxComputer(ShellFileToolsMixin, PointerKeyLifecycleMixin):
     """N2 computer-handler adapter built only on the public cua-sandbox API."""
 
     def __init__(self, sandbox: Any) -> None:
@@ -170,16 +171,6 @@ class CuaSandboxComputer(ShellFileToolsMixin):
     async def key_up(self, key: str) -> None:
         await self.sandbox.keyboard.key_up(key)
 
-    async def hold_key(self, key: str, ms: int = 1_000) -> None:
-        await self.key_down(key)
-        try:
-            await asyncio.sleep(ms / 1_000)
-        finally:
-            await self.key_up(key)
-
-    async def wait(self, ms: int = 1_000) -> None:
-        await asyncio.sleep(ms / 1_000)
-
     def _resolve_and_set_pointer(self, x: int | None, y: int | None, *, action: str) -> tuple[int, int]:
         if (x is None) != (y is None):
             raise ValueError(f"{action} coordinates must include both x and y")
@@ -200,10 +191,6 @@ class CuaSandboxComputer(ShellFileToolsMixin):
             await self.sandbox.mouse.mouse_up(*point)
         finally:
             self._left_mouse_down = False
-
-    async def release_held_mouse_button(self) -> None:
-        if self._left_mouse_down:
-            await self.left_mouse_up()
 
     async def run_shell_command(
         self,

--- a/examples/navigator_n2/direct_x11_adapter.py
+++ b/examples/navigator_n2/direct_x11_adapter.py
@@ -44,6 +44,7 @@ from types import SimpleNamespace
 from typing import Any
 
 from yutori.navigator import ShellFileToolsMixin
+from yutori.navigator.sandbox_tools import PointerKeyLifecycleMixin
 from yutori.navigator.sandbox_tools import (
     append_stream as _append_stream,
 )
@@ -107,7 +108,7 @@ def _is_directly_typeable(gui: Any, character: str) -> bool:
     )
 
 
-class LocalX11Computer(ShellFileToolsMixin):
+class LocalX11Computer(ShellFileToolsMixin, PointerKeyLifecycleMixin):
     """N2 computer handler with direct access to an X11 display and local shell.
 
     ``gui`` exists for tests: any object with pyautogui's surface (``click``,
@@ -269,16 +270,6 @@ class LocalX11Computer(ShellFileToolsMixin):
     async def key_up(self, key: str) -> None:
         await self._run_gui(lambda: self._gui().keyUp(_map_key(key)))
 
-    async def hold_key(self, key: str, ms: int = 1_000) -> None:
-        await self.key_down(key)
-        try:
-            await asyncio.sleep(ms / 1_000)
-        finally:
-            await self.key_up(key)
-
-    async def wait(self, ms: int = 1_000) -> None:
-        await asyncio.sleep(ms / 1_000)
-
     async def left_mouse_down(self, x: int | None = None, y: int | None = None) -> None:
         def run() -> None:
             gui = self._gui()
@@ -302,10 +293,6 @@ class LocalX11Computer(ShellFileToolsMixin):
             await self._run_gui(run)
         finally:
             self._left_mouse_down = False
-
-    async def release_held_mouse_button(self) -> None:
-        if self._left_mouse_down:
-            await self.left_mouse_up()
 
     # -- shell / file tools --------------------------------------------------
 

--- a/yutori/navigator/sandbox_tools.py
+++ b/yutori/navigator/sandbox_tools.py
@@ -537,6 +537,40 @@ def python_file_tool_command(script: str, *arguments: str) -> str:
     return "python3 -c " + shlex.quote(script) + "".join(f" {shlex.quote(argument)}" for argument in arguments)
 
 
+class PointerKeyLifecycleMixin:
+    """Shared ``hold_key``/``wait``/``release_held_mouse_button`` n2 tool handlers.
+
+    Mix into a computer adapter that already implements ``key_down``, ``key_up``,
+    and ``left_mouse_up``, and tracks a ``_left_mouse_down`` bool set by its own
+    ``left_mouse_down``/``left_mouse_up``.
+    """
+
+    async def key_down(self, key: str) -> None:
+        raise NotImplementedError
+
+    async def key_up(self, key: str) -> None:
+        raise NotImplementedError
+
+    async def left_mouse_up(self, x: int | None = None, y: int | None = None) -> None:
+        raise NotImplementedError
+
+    _left_mouse_down: bool = False
+
+    async def hold_key(self, key: str, ms: int = 1_000) -> None:
+        await self.key_down(key)
+        try:
+            await asyncio.sleep(ms / 1_000)
+        finally:
+            await self.key_up(key)
+
+    async def wait(self, ms: int = 1_000) -> None:
+        await asyncio.sleep(ms / 1_000)
+
+    async def release_held_mouse_button(self) -> None:
+        if self._left_mouse_down:
+            await self.left_mouse_up()
+
+
 class ShellFileToolsMixin:
     """The five n2 file-tool handlers over any sandbox shell.
 


### PR DESCRIPTION
## What

`CuaSandboxComputer` (`examples/navigator_n2/cua_adapter.py`) and `LocalX11Computer` (`examples/navigator_n2/direct_x11_adapter.py`) each hand-rolled three byte-identical async methods:

```python
async def hold_key(self, key: str, ms: int = 1_000) -> None:
    await self.key_down(key)
    try:
        await asyncio.sleep(ms / 1_000)
    finally:
        await self.key_up(key)

async def wait(self, ms: int = 1_000) -> None:
    await asyncio.sleep(ms / 1_000)

async def release_held_mouse_button(self) -> None:
    if self._left_mouse_down:
        await self.left_mouse_up()
```

Both classes already share `ShellFileToolsMixin` for file/shell tooling; these three GUI-lifecycle methods rely only on each class's own `key_down`/`key_up`/`left_mouse_up` and `_left_mouse_down` flag, so they mix cleanly into a new `PointerKeyLifecycleMixin` on `yutori/navigator/sandbox_tools.py`, matching `ShellFileToolsMixin`'s existing convention (hook methods declared as `NotImplementedError` stubs, mixed into the adapter class which supplies the real implementations).

## Why this is an improvement

Removes a third occurrence of hand-copied adapter boilerplate this codebase has repeatedly deduped elsewhere (atomic-status-file wait loops, bash-timeout clamping), giving these three lifecycle methods one shared, documented home.

## Why it's safe

- Pure extraction — method bodies moved verbatim, same statements/order/arguments.
- `PointerKeyLifecycleMixin` is not re-exported from `yutori/navigator/__init__.py` and not documented in `api.md` (unlike `ShellFileToolsMixin`), so this is zero public-API change on this published PyPI package.
- `ruff check` / `ruff format --check` clean on all 3 touched files.
- Full test suite: `812 passed, 3 skipped, 1 deselected` — identical to baseline (confirmed via `pytest -m "not slow"` after `pip install -e ".[dev,examples]"`), including the targeted `test_navigator_n2_cookbooks.py`/`test_navigator_n2_entrypoints.py` (54 passed) that exercise these adapters.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiNYZq24Jzm5r8UetMRGQM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiNYZq24Jzm5r8UetMRGQM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure extraction refactor in example adapters; no public API change (`PointerKeyLifecycleMixin` is not in `__all__`).
> 
> **Overview**
> Introduces **`PointerKeyLifecycleMixin`** in `sandbox_tools.py` (alongside **`ShellFileToolsMixin`**) with shared n2 handlers for **`hold_key`**, **`wait`**, and **`release_held_mouse_button`**. The mixin documents the required hooks (`key_down` / `key_up` / `left_mouse_up` and `_left_mouse_down`).
> 
> **`CuaSandboxComputer`** and **`LocalX11Computer`** now inherit the mixin and drop their identical local copies of those three methods. Behavior is unchanged—logic moved verbatim into one place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8049b85999021779f6529d0eb1c8394a46f859e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->