### PR TITLE
docs: bump macos extra pip pin to 0.9.9 in navigator_n2 cookbook

### DIFF
--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.8'
+pip install 'yutori[macos]==0.9.9'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 


### PR DESCRIPTION
## What

`examples/navigator_n2/README.md`'s macOS install instructions still pinned `yutori[macos]==0.9.8`, one version behind the current `0.9.9` release.

## Why

Release PR #347 (chore(release): 0.9.9) bumped the SDK version in `examples/navigator_n2/pyproject.toml`, `install.sh`, and the top-level `pyproject.toml`, but did not touch the pip install line in `examples/navigator_n2/README.md`. Every prior release (0.9.3 → 0.9.4 → 0.9.5 → ... → 0.9.8) bumped this exact line alongside the release — #347 broke that pattern, leaving the cookbook doc one version stale.

Code (`pyproject.toml`, `install.sh`) is the source of truth here; this PR brings the doc back in line with it.

## Verification

Checked adjacent doc surfaces for the same drift and found none:
- cua-driver pin (`0.23.2`, from #345) is consistent across `pyproject.toml` and `api.md`.
- Scroll direction docs (`api.md`) already describe all 4 directions (up/down/left/right) per #339's widened validation.
- `examples/navigator_n2/` filenames (`local_docker.py`, `local_macos.py`, `local_x11.py`, `direct_x11_adapter.py`, `cua_adapter.py`, `shared.py`) all match their references in `README.md`, `api.md`, and `llms.txt`.
- No `CHANGELOG.md` exists in this repo.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VNSpDKYxeW9eH9EcTjwkvL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only version pin change with no runtime or security impact.
> 
> **Overview**
> Updates the **Local macOS** cookbook install line in `examples/navigator_n2/README.md` from `yutori[macos]==0.9.8` to **`0.9.9`**, matching `examples/navigator_n2/pyproject.toml` and the rest of the 0.9.9 release bump that omitted this README line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1bf6450f5866ee5b7a4e58d6be1c4f24ed32717. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->