### PR TITLE
Add direct X11 Docker cookbook

### DIFF
--- a/examples/navigator_n2/.dockerignore
+++ b/examples/navigator_n2/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile.direct_x11
+!x11_docker_session.py

--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -1,0 +1,40 @@
+FROM python:3.12-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_ROOT_USER_ACTION=ignore \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        less \
+        libxcb-render0 \
+        libxcb-shm0 \
+        libxcb1 \
+        novnc \
+        openbox \
+        procps \
+        python3-tk \
+        x11-apps \
+        x11-utils \
+        xauth \
+        xclip \
+        xdotool \
+        xfonts-base \
+        x11vnc \
+        xterm \
+        xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+# The checkout is mounted at /sdk when the container runs. Installing the
+# released package here supplies its third-party dependencies; PYTHONPATH then
+# makes the mounted checkout itself win at import time.
+RUN python -m pip install --no-cache-dir \
+    "yutori==0.9.9" \
+    "pyautogui>=0.9.54" \
+    "mss>=9.0.1"
+
+COPY x11_docker_session.py /usr/local/bin/x11_docker_session.py
+
+WORKDIR /work
+ENTRYPOINT ["python", "/usr/local/bin/x11_docker_session.py"]

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -53,6 +53,14 @@ uv run --extra linux python local_x11.py "Open the calculator and compute 17 * 2
 
 Non-ASCII text falls back to clipboard paste, which needs `xclip` installed in the session.
 
+The same entrypoint can run inside a disposable Docker/Xvfb desktop on macOS or Linux. The Python wrapper builds the desktop image, mounts this checkout read-only, starts Xvfb with Openbox, and invokes `local_x11.py` inside it:
+
+~~~bash
+uv run python local_x11_docker.py "Launch xcalc and compute 17 * 23."
+~~~
+
+The wrapper prints a `Watch the desktop live: http://localhost:<port>/vnc.html` link for a view-only noVNC session. The port is selected automatically and published only on the host's loopback interface. No application is pre-opened: n2 can launch GUI programs with its bash tool, or open the installed xterm itself when a visible terminal is useful. Container actions, including shell commands, are auto-approved by default; pass `--confirm-actions` to restore per-action prompts. The wrapper passes `YUTORI_API_KEY` by name when set; otherwise it mounts `~/.yutori/config.json` read-only. The agent's shell and file tools operate in the container's writable `/work` directory, not in the mounted checkout.
+
 ## Disposable Linux sandbox
 
 The sandbox entrypoint adapts public Cua mouse, keyboard, screenshot, shell, and file interfaces to `N2ComputerAgent`. It creates a disposable Linux desktop in local Docker and destroys it when the process exits. Confirm Docker Desktop or Docker Engine is running, then run:

--- a/examples/navigator_n2/local_docker.py
+++ b/examples/navigator_n2/local_docker.py
@@ -6,14 +6,13 @@ import argparse
 
 from yutori import AsyncYutoriClient
 from yutori.auth import require_api_key
-from yutori.navigator import NAVIGATOR_N2_MODEL, N2ComputerAgent
 
 try:
     from .cua_adapter import CuaSandboxComputer
-    from .shared import build_confirmation_callback, parse_common_args, run_agent, run_cli_main, selected_tool_set
+    from .shared import parse_common_args, run_cli_main, run_computer_agent, selected_tool_set
 except ImportError:
     from cua_adapter import CuaSandboxComputer
-    from shared import build_confirmation_callback, parse_common_args, run_agent, run_cli_main, selected_tool_set
+    from shared import parse_common_args, run_cli_main, run_computer_agent, selected_tool_set
 
 
 def _watch_url(sandbox) -> "str | None":
@@ -42,16 +41,14 @@ async def main(args: argparse.Namespace) -> None:
             if watch:
                 print(f"Watch the desktop live: {watch}")
             computer = CuaSandboxComputer(sandbox)
-            async with N2ComputerAgent(
+            await run_computer_agent(
+                client=client,
                 computer=computer,
-                completions=client.chat.completions,
-                model=NAVIGATOR_N2_MODEL,
+                args=args,
                 tool_set=tool_set,
-                max_steps=args.max_steps,
-                action_confirmation_callback=build_confirmation_callback(args.auto_approve, always_confirm_shell=False),
+                always_confirm_shell=False,
                 supports_click_modifiers=True,
-            ) as agent:
-                await run_agent(agent, args.task, completions=client.chat.completions)
+            )
 
 
 def parse_args() -> argparse.Namespace:

--- a/examples/navigator_n2/local_x11.py
+++ b/examples/navigator_n2/local_x11.py
@@ -8,15 +8,14 @@ import sys
 
 from yutori import AsyncYutoriClient
 from yutori.auth import require_api_key
-from yutori.navigator import NAVIGATOR_N2_MODEL, N2ComputerAgent
 from yutori.navigator.n2_actions import TOOL_SETS_WITH_CLICK_MODIFIERS
 
 try:
     from .direct_x11_adapter import LocalX11Computer
-    from .shared import build_confirmation_callback, parse_common_args, run_agent, run_cli_main, selected_tool_set
+    from .shared import parse_common_args, run_cli_main, run_computer_agent, selected_tool_set
 except ImportError:
     from direct_x11_adapter import LocalX11Computer
-    from shared import build_confirmation_callback, parse_common_args, run_agent, run_cli_main, selected_tool_set
+    from shared import parse_common_args, run_cli_main, run_computer_agent, selected_tool_set
 
 
 def _require_x11() -> None:
@@ -40,20 +39,24 @@ async def main(args: argparse.Namespace) -> None:
     tool_set = selected_tool_set(args.tool_set)
     computer = LocalX11Computer()
     async with AsyncYutoriClient(api_key=require_api_key()) as client:
-        async with N2ComputerAgent(
+        await run_computer_agent(
+            client=client,
             computer=computer,
-            completions=client.chat.completions,
-            model=NAVIGATOR_N2_MODEL,
+            args=args,
             tool_set=tool_set,
-            max_steps=args.max_steps,
-            action_confirmation_callback=build_confirmation_callback(args.auto_approve, always_confirm_shell=True),
+            always_confirm_shell=not getattr(args, "auto_approve_shell", False),
             supports_click_modifiers=tool_set in TOOL_SETS_WITH_CLICK_MODIFIERS,
-        ) as agent:
-            await run_agent(agent, args.task, completions=client.chat.completions)
+        )
 
 
-def parse_args() -> argparse.Namespace:
-    return parse_common_args(__doc__)
+def _add_internal_arguments(parser: argparse.ArgumentParser) -> None:
+    # Internal bridge for local_x11_docker.py. Native X11 keeps shell
+    # confirmation armed even with --auto-approve.
+    parser.add_argument("--auto-approve-shell", action="store_true", help=argparse.SUPPRESS)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    return parse_common_args(__doc__, argv, configure_parser=_add_internal_arguments)
 
 
 if __name__ == "__main__":

--- a/examples/navigator_n2/local_x11.py
+++ b/examples/navigator_n2/local_x11.py
@@ -37,7 +37,7 @@ def _require_x11() -> None:
 async def main(args: argparse.Namespace) -> None:
     _require_x11()
     tool_set = selected_tool_set(args.tool_set)
-    computer = LocalX11Computer()
+    computer = LocalX11Computer(cwd=args.workspace)
     async with AsyncYutoriClient(api_key=require_api_key()) as client:
         await run_computer_agent(
             client=client,
@@ -50,8 +50,9 @@ async def main(args: argparse.Namespace) -> None:
 
 
 def _add_internal_arguments(parser: argparse.ArgumentParser) -> None:
-    # Internal bridge for local_x11_docker.py. Native X11 keeps shell
-    # confirmation armed even with --auto-approve.
+    # Internal bridges for local_x11_docker.py. Native X11 keeps its home
+    # workspace and shell confirmation armed even with --auto-approve.
+    parser.add_argument("--workspace", help=argparse.SUPPRESS)
     parser.add_argument("--auto-approve-shell", action="store_true", help=argparse.SUPPRESS)
 
 

--- a/examples/navigator_n2/local_x11_docker.py
+++ b/examples/navigator_n2/local_x11_docker.py
@@ -19,6 +19,7 @@ except ImportError:
 
 IMAGE = "yutori-n2-direct-x11:local"
 CONTAINER_CONFIG_PATH = "/root/.yutori/config.json"
+CONTAINER_WORKDIR = "/work"
 CONTAINER_NOVNC_PORT = 6080
 
 
@@ -91,6 +92,8 @@ def main(args: argparse.Namespace) -> None:
         args.tool_set,
         "--max-steps",
         str(args.max_steps),
+        "--workspace",
+        CONTAINER_WORKDIR,
     ]
     if args.auto_approve:
         local_x11_command.extend(["--auto-approve", "--auto-approve-shell"])
@@ -113,7 +116,7 @@ def main(args: argparse.Namespace) -> None:
             "--mount",
             f"type=bind,source={repo_root},target=/sdk,readonly",
             "--workdir",
-            "/work",
+            CONTAINER_WORKDIR,
             "--env",
             "PYTHONPATH=/sdk",
             IMAGE,

--- a/examples/navigator_n2/local_x11_docker.py
+++ b/examples/navigator_n2/local_x11_docker.py
@@ -1,0 +1,141 @@
+"""Run stable Navigator n2 against a disposable X11 desktop in local Docker."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+from yutori.auth import get_auth_status, require_api_key
+
+try:
+    from .shared import parse_common_args, selected_tool_set
+except ImportError:
+    from shared import parse_common_args, selected_tool_set
+
+
+IMAGE = "yutori-n2-direct-x11:local"
+CONTAINER_CONFIG_PATH = "/root/.yutori/config.json"
+CONTAINER_NOVNC_PORT = 6080
+
+
+def _authentication_args() -> list[str]:
+    """Forward the normal Yutori credential source without putting a key in argv."""
+    status = get_auth_status()
+    if status.source == "env_var":
+        return ["--env", "YUTORI_API_KEY"]
+    if status.source == "config_file" and status.config_path:
+        return [
+            "--mount",
+            f"type=bind,source={status.config_path},target={CONTAINER_CONFIG_PATH},readonly",
+        ]
+    if not status.authenticated:
+        require_api_key()  # Raise the SDK's standard missing-credential error.
+    raise RuntimeError(f"unsupported Yutori authentication source: {status.source!r}")
+
+
+def _run_checked(command: list[str], description: str, **kwargs: object) -> None:
+    try:
+        result = subprocess.run(command, **kwargs)
+    except FileNotFoundError as error:
+        raise SystemExit("docker is not installed") from error
+    if result.returncode != 0:
+        raise SystemExit(f"{description} failed with exit code {result.returncode}")
+
+
+def _available_local_port() -> int:
+    """Ask the OS for an unused loopback port for Docker's noVNC mapping."""
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def main(args: argparse.Namespace) -> None:
+    # Reject missing credentials and invalid model inputs before Docker does work.
+    authentication_args = _authentication_args()
+    selected_tool_set(args.tool_set)
+
+    if shutil.which("docker") is None:
+        raise SystemExit("docker is not installed")
+    _run_checked(
+        ["docker", "info"],
+        "Docker availability check",
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    example_dir = Path(__file__).resolve().parent
+    repo_root = example_dir.parents[1]
+    dockerfile = example_dir / "Dockerfile.direct_x11"
+    _run_checked(
+        [
+            "docker",
+            "build",
+            "--file",
+            str(dockerfile),
+            "--tag",
+            IMAGE,
+            str(example_dir),
+        ],
+        "Direct X11 image build",
+    )
+
+    local_x11_command = [
+        "python",
+        "/sdk/examples/navigator_n2/local_x11.py",
+        args.task,
+        "--tool-set",
+        args.tool_set,
+        "--max-steps",
+        str(args.max_steps),
+    ]
+    if args.auto_approve:
+        local_x11_command.extend(["--auto-approve", "--auto-approve-shell"])
+
+    novnc_port = _available_local_port()
+    docker_command = [
+        "docker",
+        "run",
+        "--rm",
+        "--init",
+        "--interactive",
+        "--publish",
+        f"127.0.0.1:{novnc_port}:{CONTAINER_NOVNC_PORT}",
+    ]
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        docker_command.append("--tty")
+    docker_command.extend(
+        [
+            *authentication_args,
+            "--mount",
+            f"type=bind,source={repo_root},target=/sdk,readonly",
+            "--workdir",
+            "/work",
+            "--env",
+            "PYTHONPATH=/sdk",
+            IMAGE,
+            *local_x11_command,
+        ]
+    )
+
+    print(f"Watch the desktop live: http://localhost:{novnc_port}/vnc.html", flush=True)
+    try:
+        result = subprocess.run(docker_command)
+    except FileNotFoundError as error:
+        raise SystemExit("docker is not installed") from error
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    return parse_common_args(__doc__, argv, auto_approve_default=True)
+
+
+if __name__ == "__main__":
+    try:
+        main(parse_args())
+    except KeyboardInterrupt:
+        print("Interrupted.")

--- a/examples/navigator_n2/shared.py
+++ b/examples/navigator_n2/shared.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from yutori.navigator import (
+    NAVIGATOR_N2_MODEL,
     TOOL_SET_COMPUTER_USE,
     TOOL_SET_COMPUTER_USE_20260825,
     TOOL_SET_COMPUTER_USE_BASH_BATCH,
@@ -22,6 +23,7 @@ from yutori.navigator import (
     TOOL_SET_COMPUTER_USE_HYBRID,
     TOOL_SET_COMPUTER_USE_HYBRID_BATCH,
     TOOL_SET_COMPUTER_USE_LATEST,
+    N2ComputerAgent,
     format_stop_and_summarize,
 )
 from yutori.navigator.n2_compaction import response_message
@@ -107,7 +109,32 @@ def build_confirmation_callback(auto_approve: bool, *, always_confirm_shell: boo
     return confirm
 
 
-def add_common_arguments(parser: argparse.ArgumentParser) -> None:
+async def run_computer_agent(
+    *,
+    client: Any,
+    computer: Any,
+    args: argparse.Namespace,
+    tool_set: str,
+    always_confirm_shell: bool,
+    supports_click_modifiers: bool,
+) -> None:
+    """Configure and run the common n2 computer-agent loop for local cookbooks."""
+    async with N2ComputerAgent(
+        computer=computer,
+        completions=client.chat.completions,
+        model=NAVIGATOR_N2_MODEL,
+        tool_set=tool_set,
+        max_steps=args.max_steps,
+        action_confirmation_callback=build_confirmation_callback(
+            args.auto_approve,
+            always_confirm_shell=always_confirm_shell,
+        ),
+        supports_click_modifiers=supports_click_modifiers,
+    ) as agent:
+        await run_agent(agent, args.task, completions=client.chat.completions)
+
+
+def add_common_arguments(parser: argparse.ArgumentParser, *, auto_approve_default: bool = False) -> None:
     parser.add_argument("task", help="Task for stable Navigator n2")
     parser.add_argument(
         "--tool-set",
@@ -118,11 +145,20 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
             + ") or dated id. Default: latest (computer_use_tools-20260830)."
         ),
     )
-    parser.add_argument(
-        "--auto-approve",
-        action="store_true",
-        help="Approve environment actions without prompting. Host shell commands may still require confirmation.",
-    )
+    if auto_approve_default:
+        parser.add_argument(
+            "--confirm-actions",
+            dest="auto_approve",
+            action="store_false",
+            default=True,
+            help="Prompt before each action instead of approving actions in the disposable environment.",
+        )
+    else:
+        parser.add_argument(
+            "--auto-approve",
+            action="store_true",
+            help="Approve environment actions without prompting. Host shell commands may still require confirmation.",
+        )
     parser.add_argument(
         "--max-steps",
         type=int,
@@ -134,12 +170,20 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def parse_common_args(description: str | None, argv: list[str] | None = None) -> argparse.Namespace:
+def parse_common_args(
+    description: str | None,
+    argv: list[str] | None = None,
+    *,
+    auto_approve_default: bool = False,
+    configure_parser: Callable[[argparse.ArgumentParser], None] | None = None,
+) -> argparse.Namespace:
     """Build the shared cookbook parser and parse it -- the ``parse_args()`` body every
     local-desktop entrypoint (``local_docker.py``, ``local_macos.py``, ``local_x11.py``)
     repeated verbatim apart from its module ``description``."""
     parser = argparse.ArgumentParser(description=description)
-    add_common_arguments(parser)
+    add_common_arguments(parser, auto_approve_default=auto_approve_default)
+    if configure_parser is not None:
+        configure_parser(parser)
     return parser.parse_args(argv)
 
 

--- a/examples/navigator_n2/x11_docker_session.py
+++ b/examples/navigator_n2/x11_docker_session.py
@@ -1,0 +1,167 @@
+"""Boot the image's virtual X11 desktop, then run the requested command."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import secrets
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+VNC_PORT = 5900
+NOVNC_PORT = 6080
+
+
+def _stop(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+
+
+def _start(command: list[str], environment: dict[str, str]) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(
+        command,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def _wait_for_display(environment: dict[str, str]) -> None:
+    for _ in range(40):
+        ready = subprocess.run(
+            ["xdpyinfo", "-display", environment["DISPLAY"]],
+            env=environment,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if ready.returncode == 0:
+            return
+        time.sleep(0.25)
+    raise RuntimeError("Xvfb did not become ready")
+
+
+def _wait_for_port(port: int, process: subprocess.Popen[bytes], name: str) -> None:
+    for _ in range(40):
+        if process.poll() is not None:
+            raise RuntimeError(f"{name} exited with status {process.returncode}")
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.25):
+                return
+        except OSError:
+            time.sleep(0.25)
+    raise RuntimeError(f"{name} did not become ready")
+
+
+def _wait_for_window_manager(environment: dict[str, str], process: subprocess.Popen[bytes]) -> None:
+    for _ in range(40):
+        if process.poll() is not None:
+            raise RuntimeError(f"Openbox exited with status {process.returncode}")
+        ready = subprocess.run(
+            ["xprop", "-root", "_NET_SUPPORTING_WM_CHECK"],
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        if ready.returncode == 0 and b"_NET_SUPPORTING_WM_CHECK(WINDOW)" in ready.stdout:
+            return
+        time.sleep(0.25)
+    raise RuntimeError("Openbox did not become ready")
+
+
+def main(command: list[str]) -> int:
+    if not command:
+        raise SystemExit("the X11 container needs a command to run")
+
+    environment = os.environ.copy()
+    environment.update(DISPLAY=":99", XDG_SESSION_TYPE="x11", XAUTHORITY="/tmp/direct-x11.Xauthority")
+    authority_path = Path(environment["XAUTHORITY"])
+    authority_path.touch(mode=0o600)
+    subprocess.run(
+        [
+            "xauth",
+            "-f",
+            str(authority_path),
+            "add",
+            environment["DISPLAY"],
+            "MIT-MAGIC-COOKIE-1",
+            secrets.token_hex(16),
+        ],
+        env=environment,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+
+    processes: list[subprocess.Popen[bytes]] = []
+    try:
+        processes.append(
+            _start(
+                [
+                    "Xvfb",
+                    environment["DISPLAY"],
+                    "-screen",
+                    "0",
+                    "1280x720x24",
+                    "-auth",
+                    str(authority_path),
+                    "-nolisten",
+                    "tcp",
+                ],
+                environment,
+            )
+        )
+        _wait_for_display(environment)
+        vnc = _start(
+            [
+                "x11vnc",
+                "-display",
+                environment["DISPLAY"],
+                "-auth",
+                str(authority_path),
+                "-rfbport",
+                str(VNC_PORT),
+                "-localhost",
+                "-forever",
+                "-shared",
+                "-viewonly",
+                "-nopw",
+            ],
+            environment,
+        )
+        processes.append(vnc)
+        _wait_for_port(VNC_PORT, vnc, "x11vnc")
+        novnc = _start(
+            [
+                "websockify",
+                "--web=/usr/share/novnc",
+                str(NOVNC_PORT),
+                f"localhost:{VNC_PORT}",
+            ],
+            environment,
+        )
+        processes.append(novnc)
+        _wait_for_port(NOVNC_PORT, novnc, "noVNC")
+        openbox = _start(["openbox"], environment)
+        processes.append(openbox)
+        _wait_for_window_manager(environment, openbox)
+        return subprocess.run(command, env=environment).returncode
+    finally:
+        for process in reversed(processes):
+            _stop(process)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -162,10 +162,15 @@ def test_local_x11_docker_cli_accepts_documented_command() -> None:
 
 
 def test_local_x11_native_keeps_shell_auto_approval_internal() -> None:
-    assert local_x11.parse_args(["Open Calculator", "--auto-approve"]).auto_approve_shell is False
-    assert (
-        local_x11.parse_args(["Open Calculator", "--auto-approve", "--auto-approve-shell"]).auto_approve_shell is True
+    native_args = local_x11.parse_args(["Open Calculator", "--auto-approve"])
+    assert native_args.auto_approve_shell is False
+    assert native_args.workspace is None
+
+    docker_args = local_x11.parse_args(
+        ["Open Calculator", "--auto-approve", "--auto-approve-shell", "--workspace", "/work"]
     )
+    assert docker_args.auto_approve_shell is True
+    assert docker_args.workspace == "/work"
 
 
 async def test_local_x11_delegates_to_shared_agent_setup(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -186,18 +191,23 @@ async def test_local_x11_delegates_to_shared_agent_setup(monkeypatch: pytest.Mon
     async def fake_run_computer_agent(**kwargs: object) -> None:
         seen["agent-args"] = kwargs
 
+    def fake_local_x11_computer(*, cwd: str | None) -> object:
+        seen["computer-cwd"] = cwd
+        return computer
+
     monkeypatch.setattr(local_x11, "_require_x11", lambda: None)
     monkeypatch.setattr(local_x11, "require_api_key", lambda: "test-yutori-key")
     monkeypatch.setattr(local_x11, "AsyncYutoriClient", FakeClient)
-    monkeypatch.setattr(local_x11, "LocalX11Computer", lambda: computer)
+    monkeypatch.setattr(local_x11, "LocalX11Computer", fake_local_x11_computer)
     monkeypatch.setattr(local_x11, "run_computer_agent", fake_run_computer_agent)
 
-    args = local_x11.parse_args(["Open Calculator", "--auto-approve"])
+    args = local_x11.parse_args(["Open Calculator", "--auto-approve", "--workspace", "/work"])
     await local_x11.main(args)
 
     agent_args = seen["agent-args"]
     assert isinstance(agent_args, dict)
     assert seen["api-key"] == "test-yutori-key"
+    assert seen["computer-cwd"] == "/work"
     assert agent_args["computer"] is computer
     assert agent_args["args"] is args
     assert agent_args["always_confirm_shell"] is True
@@ -249,6 +259,7 @@ def test_local_x11_docker_builds_image_and_delegates_to_local_x11(
     ]
     assert "/sdk/examples/navigator_n2/local_x11.py" in docker_run
     assert "Open Calculator" in docker_run
+    assert ["--workspace", "/work"] == docker_run[docker_run.index("--workspace") : docker_run.index("--workspace") + 2]
     assert docker_run[-2:] == ["--auto-approve", "--auto-approve-shell"]
     assert "Watch the desktop live: http://localhost:54321/vnc.html" in capsys.readouterr().out
 

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 import pytest
 
 from examples import navigator_n2_daytona
-from examples.navigator_n2 import local_docker
+from examples.navigator_n2 import local_docker, local_x11, local_x11_docker, shared
 
 
 def test_daytona_script_declares_its_uv_environment_inline() -> None:
@@ -27,6 +27,7 @@ def test_local_docker_cli_accepts_documented_command(monkeypatch: pytest.MonkeyP
     args = local_docker.parse_args()
 
     assert args.task == "Open Calculator"
+    assert args.auto_approve is False
 
 
 async def test_local_docker_resolves_yutori_key_before_allocation(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -124,8 +125,8 @@ async def test_local_docker_wires_local_container_runtime(monkeypatch: pytest.Mo
     monkeypatch.setitem(sys.modules, "cua_sandbox", SimpleNamespace(Image=FakeImage, Sandbox=FakeSandbox))
     monkeypatch.setattr(local_docker, "require_api_key", lambda: "test-yutori-key")
     monkeypatch.setattr(local_docker, "CuaSandboxComputer", FakeComputer)
-    monkeypatch.setattr(local_docker, "N2ComputerAgent", FakeAgent)
-    monkeypatch.setattr(local_docker, "run_agent", fake_run_agent)
+    monkeypatch.setattr(shared, "N2ComputerAgent", FakeAgent)
+    monkeypatch.setattr(shared, "run_agent", fake_run_agent)
     args = argparse.Namespace(
         max_steps=2,
         task="test",
@@ -138,6 +139,9 @@ async def test_local_docker_wires_local_container_runtime(monkeypatch: pytest.Mo
     assert seen["image"] == {"kind": "container"}
     assert seen["ephemeral"] == ("linux-image", {"local": True})
     assert seen["computer-sandbox"] is fake_sandbox
+    agent_kwargs = seen["agent"]
+    assert isinstance(agent_kwargs, dict)
+    assert agent_kwargs["supports_click_modifiers"] is True
     assert seen["task"] == "test"
     assert seen["sandbox-closed"] is True
 
@@ -147,6 +151,133 @@ def test_local_docker_watch_url_comes_from_the_runtime_info() -> None:
     assert local_docker._watch_url(SimpleNamespace(_runtime_info=info)) == "http://localhost:54423/vnc.html"
     assert local_docker._watch_url(SimpleNamespace(_runtime_info=None)) is None
     assert local_docker._watch_url(SimpleNamespace()) is None
+
+
+def test_local_x11_docker_cli_accepts_documented_command() -> None:
+    args = local_x11_docker.parse_args(["Open Calculator"])
+
+    assert args.task == "Open Calculator"
+    assert args.auto_approve is True
+    assert local_x11_docker.parse_args(["--confirm-actions", "Open Calculator"]).auto_approve is False
+
+
+def test_local_x11_native_keeps_shell_auto_approval_internal() -> None:
+    assert local_x11.parse_args(["Open Calculator", "--auto-approve"]).auto_approve_shell is False
+    assert (
+        local_x11.parse_args(["Open Calculator", "--auto-approve", "--auto-approve-shell"]).auto_approve_shell is True
+    )
+
+
+async def test_local_x11_delegates_to_shared_agent_setup(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+    computer = object()
+
+    class FakeClient:
+        def __init__(self, *, api_key: str) -> None:
+            seen["api-key"] = api_key
+            self.chat = SimpleNamespace(completions=object())
+
+        async def __aenter__(self) -> "FakeClient":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            pass
+
+    async def fake_run_computer_agent(**kwargs: object) -> None:
+        seen["agent-args"] = kwargs
+
+    monkeypatch.setattr(local_x11, "_require_x11", lambda: None)
+    monkeypatch.setattr(local_x11, "require_api_key", lambda: "test-yutori-key")
+    monkeypatch.setattr(local_x11, "AsyncYutoriClient", FakeClient)
+    monkeypatch.setattr(local_x11, "LocalX11Computer", lambda: computer)
+    monkeypatch.setattr(local_x11, "run_computer_agent", fake_run_computer_agent)
+
+    args = local_x11.parse_args(["Open Calculator", "--auto-approve"])
+    await local_x11.main(args)
+
+    agent_args = seen["agent-args"]
+    assert isinstance(agent_args, dict)
+    assert seen["api-key"] == "test-yutori-key"
+    assert agent_args["computer"] is computer
+    assert agent_args["args"] is args
+    assert agent_args["always_confirm_shell"] is True
+    assert agent_args["supports_click_modifiers"] is True
+
+
+def test_local_x11_docker_builds_image_and_delegates_to_local_x11(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs: object) -> SimpleNamespace:
+        commands.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setenv("YUTORI_API_KEY", "test-yutori-key")
+    monkeypatch.setattr(
+        local_x11_docker,
+        "require_api_key",
+        lambda: pytest.fail("get_auth_status already resolved an authenticated source"),
+    )
+    monkeypatch.setattr(
+        local_x11_docker,
+        "get_auth_status",
+        lambda: SimpleNamespace(authenticated=True, source="env_var", config_path=None),
+    )
+    monkeypatch.setattr(local_x11_docker.shutil, "which", lambda _command: "/usr/local/bin/docker")
+    monkeypatch.setattr(local_x11_docker, "_available_local_port", lambda: 54321)
+    monkeypatch.setattr(local_x11_docker.subprocess, "run", fake_run)
+    args = argparse.Namespace(
+        max_steps=7,
+        task="Open Calculator",
+        tool_set="latest",
+        auto_approve=True,
+    )
+
+    local_x11_docker.main(args)
+
+    assert commands[0] == ["docker", "info"]
+    assert commands[1][0:2] == ["docker", "build"]
+    docker_run = commands[2]
+    assert docker_run[0:2] == ["docker", "run"]
+    assert ["--publish", "127.0.0.1:54321:6080"] == docker_run[
+        docker_run.index("--publish") : docker_run.index("--publish") + 2
+    ]
+    assert ["--env", "YUTORI_API_KEY"] == docker_run[
+        docker_run.index("YUTORI_API_KEY") - 1 : docker_run.index("YUTORI_API_KEY") + 1
+    ]
+    assert "/sdk/examples/navigator_n2/local_x11.py" in docker_run
+    assert "Open Calculator" in docker_run
+    assert docker_run[-2:] == ["--auto-approve", "--auto-approve-shell"]
+    assert "Watch the desktop live: http://localhost:54321/vnc.html" in capsys.readouterr().out
+
+    documentation = Path(local_x11_docker.__file__).with_name("README.md").read_text(encoding="utf-8")
+    assert 'uv run python local_x11_docker.py "Launch xcalc and compute 17 * 23."' in documentation
+    assert "A terminal is open" not in documentation
+    assert "view-only noVNC session" in documentation
+
+
+def test_local_x11_docker_uses_sdk_config_path_for_authentication(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        local_x11_docker,
+        "require_api_key",
+        lambda: pytest.fail("get_auth_status already resolved an authenticated source"),
+    )
+    monkeypatch.setattr(
+        local_x11_docker,
+        "get_auth_status",
+        lambda: SimpleNamespace(
+            authenticated=True,
+            source="config_file",
+            config_path="/custom/yutori/config.json",
+        ),
+    )
+
+    assert local_x11_docker._authentication_args() == [
+        "--mount",
+        "type=bind,source=/custom/yutori/config.json,target=/root/.yutori/config.json,readonly",
+    ]
 
 
 def test_daytona_cli_record_flag_is_optional_and_order_safe() -> None:


### PR DESCRIPTION
## Summary

- add a Python wrapper and minimal Docker image for running the direct-X11 n2 example on macOS or Linux
- expose a localhost-only, view-only noVNC URL and start with an empty Openbox desktop so n2 launches apps itself
- auto-approve actions inside the disposable container by default, with --confirm-actions to restore prompts
- share common n2 agent setup between the existing local Docker and direct-X11 entrypoints

## Testing

- uv run pytest -q (818 passed, 3 skipped)
- uv run ruff check examples/navigator_n2 tests/test_navigator_n2_entrypoints.py
- uv run ruff format --check examples/navigator_n2 tests/test_navigator_n2_entrypoints.py
- uv run python -m compileall -q examples/navigator_n2
- built Dockerfile.direct_x11 against published yutori 0.9.9
- live Docker smoke: noVNC, Openbox readiness, xcalc launch, and no pre-opened xterm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to example entrypoints and a local disposable container; credentials are forwarded without embedding keys in argv, and VNC is localhost view-only.
> 
> **Overview**
> Adds a **disposable Docker + Xvfb** path for the direct-X11 Navigator n2 example so macOS/Linux hosts can run `local_x11` without a native X11 session. **`local_x11_docker.py`** builds a minimal image, mounts the repo at `/sdk`, forwards Yutori auth via env or read-only config bind, publishes **loopback-only noVNC**, and runs **`local_x11.py`** inside the container with workspace **`/work`** and **auto-approved actions** by default (`--confirm-actions` to prompt).
> 
> The image entrypoint **`x11_docker_session.py`** boots Xvfb, view-only x11vnc/noVNC, and Openbox on an empty desktop before executing the requested command.
> 
> **Refactor:** **`shared.run_computer_agent`** and extended **`parse_common_args`** (`auto_approve_default`, optional parser hooks) replace duplicated `N2ComputerAgent` wiring in **`local_docker.py`** and **`local_x11.py`**. Native X11 keeps shell confirmation even with `--auto-approve`; the Docker bridge uses hidden **`--workspace`** / **`--auto-approve-shell`** flags on **`local_x11.py`**.
> 
> README and entrypoint tests document and lock in the Docker CLI, auth forwarding, and delegation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 740a4b69f88b46cad6f6142c1fea5f68b0322bd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->