### PR TITLE
refactor(macos): extract the sleep-vs-cancellation race shared by 3 call sites

### DIFF
--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -26,7 +26,7 @@ from .frontmost import FrontmostApp, frontmost_app
 from .no_progress import NoProgressWatchdog
 from .polling import FRAME_POLL_ACTION_MAX_MS, FramePollResult, frame_poll_wait_budget_ms, poll_until_frame_changes
 from .presentation import MacOSPresentationController
-from .process_lifecycle import cancel_and_drain
+from .process_lifecycle import cancel_and_drain, race_sleep_against_cancellation
 from .sanitize import sanitize_command_preview
 from .transport import (
     CuaDriverConnectionError,
@@ -1370,18 +1370,15 @@ class MacOSComputer:
         if seconds <= 0:
             self.cancellation.raise_if_cancelled()
             return
-        sleeper = asyncio.create_task(asyncio.sleep(seconds))
-        cancellation = asyncio.create_task(self.cancellation.wait())
         timeout: float | None = None
         if self.execution_deadline is not None:
             remaining = max(0.0, self.execution_deadline - time.monotonic())
             # The sleeper owns ordinary waits; an equal timeout races it and can falsely latch the deadline.
             if remaining <= seconds:
                 timeout = remaining
-        done, pending = await asyncio.wait(
-            {sleeper, cancellation}, timeout=timeout, return_when=asyncio.FIRST_COMPLETED
+        sleeper, cancellation, done = await race_sleep_against_cancellation(
+            seconds, self.cancellation, timeout=timeout
         )
-        await cancel_and_drain(*pending)
         if sleeper not in done:
             if cancellation not in done:
                 self.cancellation.request("deadline")

--- a/yutori/navigator/macos/polling.py
+++ b/yutori/navigator/macos/polling.py
@@ -12,7 +12,7 @@ from typing import Literal
 
 from PIL import Image
 
-from .process_lifecycle import cancel_and_drain
+from .process_lifecycle import race_sleep_against_cancellation
 from .types import CancellationLatch, N2Observation
 
 FRAME_SIGNATURE_WIDTH = 160
@@ -87,10 +87,7 @@ async def _sleep_or_cancel(delay: float, cancellation: "CancellationLatch | None
     if cancellation is None:
         await asyncio.sleep(delay)
         return False
-    sleeper = asyncio.create_task(asyncio.sleep(delay))
-    cancelled = asyncio.create_task(cancellation.wait())
-    done, pending = await asyncio.wait({sleeper, cancelled}, return_when=asyncio.FIRST_COMPLETED)
-    await cancel_and_drain(*pending)
+    _sleeper, cancelled, done = await race_sleep_against_cancellation(delay, cancellation)
     return cancelled in done
 
 

--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -13,7 +13,13 @@ from pathlib import Path
 from typing import Any
 
 from .overlay_build import OVERLAY_PROTOCOL_VERSION, PreparedMacOSOverlay, load_prepared_macos_overlay
-from .process_lifecycle import cancel_and_drain, drain_stream, spawn_rpc_subprocess, terminate_process_gracefully
+from .process_lifecycle import (
+    cancel_and_drain,
+    drain_stream,
+    race_sleep_against_cancellation,
+    spawn_rpc_subprocess,
+    terminate_process_gracefully,
+)
 from .types import (
     CancellationLatch,
     MacOSPresentationCapabilities,
@@ -706,10 +712,7 @@ class MacOSPresentationController:
     async def _sleep(self, seconds: float) -> bool:
         if self.cancellation.cancelled:
             return False
-        sleeper = asyncio.create_task(asyncio.sleep(seconds))
-        cancelled = asyncio.create_task(self.cancellation.wait())
-        done, pending = await asyncio.wait({sleeper, cancelled}, return_when=asyncio.FIRST_COMPLETED)
-        await cancel_and_drain(*pending)
+        sleeper, _cancelled, done = await race_sleep_against_cancellation(seconds, self.cancellation)
         return sleeper in done
 
     def _validate_ready(self, reply: dict[str, Any]) -> MacOSPresentationCapabilities:

--- a/yutori/navigator/macos/process_lifecycle.py
+++ b/yutori/navigator/macos/process_lifecycle.py
@@ -14,7 +14,10 @@ cancellation before continuing.
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .types import CancellationLatch
 
 # Screenshot-bearing JSON-RPC frames routinely exceed asyncio's 64 KiB default,
 # so both stdio peers raise the stream limit to the same ceiling.
@@ -66,6 +69,25 @@ async def cancel_and_drain(*tasks: "asyncio.Task[Any]") -> None:
         if not task.done():
             task.cancel()
     await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def race_sleep_against_cancellation(
+    seconds: float,
+    cancellation: "CancellationLatch",
+    *,
+    timeout: "float | None" = None,
+) -> "tuple[asyncio.Task[Any], asyncio.Task[Any], set[asyncio.Task[Any]]]":
+    """Race ``asyncio.sleep(seconds)`` against ``cancellation.wait()``, draining the loser.
+
+    Returns ``(sleeper, cancelled, done)`` so a caller can tell which task(s) finished --
+    ``sleeper in done`` if the sleep (or an optional *timeout*) elapsed first, ``cancelled in
+    done`` if cancellation won, or neither if *timeout* elapsed before either task did.
+    """
+    sleeper = asyncio.create_task(asyncio.sleep(seconds))
+    cancelled = asyncio.create_task(cancellation.wait())
+    done, pending = await asyncio.wait({sleeper, cancelled}, timeout=timeout, return_when=asyncio.FIRST_COMPLETED)
+    await cancel_and_drain(*pending)
+    return sleeper, cancelled, done
 
 
 async def terminate_process_gracefully(


### PR DESCRIPTION
## What

Three call sites in `yutori/navigator/macos/` hand-duplicated the same "race a sleep against a `CancellationLatch`" idiom:

- `polling.py::_sleep_or_cancel`
- `presentation.py::MacOSPresentationController._sleep`
- `computer.py::_ComputerHandler._sleep` (adds an optional deadline-derived `timeout`)

Each independently did: create a sleep task and a `cancellation.wait()` task, `asyncio.wait(..., return_when=FIRST_COMPLETED)`, `cancel_and_drain()` the loser. `process_lifecycle.py`'s own docstring already flagged that "the frame-polling and no-progress helpers... repeatedly need to cancel a set of in-flight tasks... and await their cancellation" — the team had extracted the shared tail (`cancel_and_drain`) but not the race itself.

Extracted `race_sleep_against_cancellation()` into `process_lifecycle.py` (alongside `cancel_and_drain`, which it now calls internally). It returns `(sleeper, cancelled, done)` so each of the three wrappers keeps translating the result into its own existing contract:

- `polling.py`: unchanged bool-inverted return, unchanged early-exit special cases (`delay <= 0`, `cancellation is None`)
- `presentation.py`: unchanged bool-inverted return, unchanged early-exit check
- `computer.py`: unchanged `timeout` computation and unchanged raise/`request("deadline")` branch on timeout

## Why it's safe

- Same task creation, same `asyncio.wait` call (including `computer.py`'s optional deadline `timeout`), same `cancel_and_drain` on the loser, same per-caller post-processing — a purely mechanical extraction of the common middle, with each wrapper's differing early-exit/return logic left untouched in the wrapper.
- All three are internal/private methods (`_sleep`, `_sleep_or_cancel` are not part of the public API); no external call-site changes.
- Full test suite passes: `818 passed, 3 skipped` (targeted macOS test files also verified in isolation: `55 passed`).
- `ruff check` passes on all 4 touched files.

No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGqnWXAYncR2yE1r9PNALn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGqnWXAYncR2yE1r9PNALn)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of cancellation-aware sleeps with preserved per-call-site semantics; no public API or security-sensitive logic changes.
> 
> **Overview**
> Adds **`race_sleep_against_cancellation()`** in `process_lifecycle.py` next to `cancel_and_drain`, encapsulating the repeated pattern of racing `asyncio.sleep` against `CancellationLatch.wait()`, draining the loser, and returning `(sleeper, cancelled, done)` for callers to interpret.
> 
> **`computer.py`**, **`polling.py`**, and **`presentation.py`** now call this helper from their private `_sleep` / `_sleep_or_cancel` paths instead of duplicating task creation and `asyncio.wait`. Each wrapper keeps its existing contract (bool vs raise, optional deadline `timeout`, early exits for zero delay or missing cancellation).
> 
> No intended behavior change—mechanical deduplication across internal macOS navigator asyncio lifecycle code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdcaaec5a06a2a8527f5d71e1eaca65af54ef68f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->