### PR TITLE
refactor(examples): dedupe the poll-until-ready loops in the X11 Docker session script

### DIFF
--- a/examples/navigator_n2/x11_docker_session.py
+++ b/examples/navigator_n2/x11_docker_session.py
@@ -10,10 +10,13 @@ import socket
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 VNC_PORT = 5900
 NOVNC_PORT = 6080
+_READY_ATTEMPTS = 40
+_READY_INTERVAL_SECONDS = 0.25
 
 
 def _stop(process: subprocess.Popen[bytes]) -> None:
@@ -39,46 +42,61 @@ def _start(command: list[str], environment: dict[str, str]) -> subprocess.Popen[
     )
 
 
+def _wait_until_ready(
+    is_ready: Callable[[], bool],
+    *,
+    name: str,
+    process: subprocess.Popen[bytes] | None = None,
+) -> None:
+    """Poll ``is_ready`` for up to ``_READY_ATTEMPTS`` tries, ``_READY_INTERVAL_SECONDS`` apart.
+
+    When ``process`` is given, an early exit is reported immediately instead of being
+    retried until the attempt budget runs out.
+    """
+    for _ in range(_READY_ATTEMPTS):
+        if process is not None and process.poll() is not None:
+            raise RuntimeError(f"{name} exited with status {process.returncode}")
+        if is_ready():
+            return
+        time.sleep(_READY_INTERVAL_SECONDS)
+    raise RuntimeError(f"{name} did not become ready")
+
+
 def _wait_for_display(environment: dict[str, str]) -> None:
-    for _ in range(40):
-        ready = subprocess.run(
+    def is_ready() -> bool:
+        result = subprocess.run(
             ["xdpyinfo", "-display", environment["DISPLAY"]],
             env=environment,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-        if ready.returncode == 0:
-            return
-        time.sleep(0.25)
-    raise RuntimeError("Xvfb did not become ready")
+        return result.returncode == 0
+
+    _wait_until_ready(is_ready, name="Xvfb")
 
 
 def _wait_for_port(port: int, process: subprocess.Popen[bytes], name: str) -> None:
-    for _ in range(40):
-        if process.poll() is not None:
-            raise RuntimeError(f"{name} exited with status {process.returncode}")
+    def is_ready() -> bool:
         try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.25):
-                return
+            with socket.create_connection(("127.0.0.1", port), timeout=_READY_INTERVAL_SECONDS):
+                return True
         except OSError:
-            time.sleep(0.25)
-    raise RuntimeError(f"{name} did not become ready")
+            return False
+
+    _wait_until_ready(is_ready, name=name, process=process)
 
 
 def _wait_for_window_manager(environment: dict[str, str], process: subprocess.Popen[bytes]) -> None:
-    for _ in range(40):
-        if process.poll() is not None:
-            raise RuntimeError(f"Openbox exited with status {process.returncode}")
-        ready = subprocess.run(
+    def is_ready() -> bool:
+        result = subprocess.run(
             ["xprop", "-root", "_NET_SUPPORTING_WM_CHECK"],
             env=environment,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
         )
-        if ready.returncode == 0 and b"_NET_SUPPORTING_WM_CHECK(WINDOW)" in ready.stdout:
-            return
-        time.sleep(0.25)
-    raise RuntimeError("Openbox did not become ready")
+        return result.returncode == 0 and b"_NET_SUPPORTING_WM_CHECK(WINDOW)" in result.stdout
+
+    _wait_until_ready(is_ready, name="Openbox", process=process)
 
 
 def main(command: list[str]) -> int:

--- a/tests/test_x11_docker_session.py
+++ b/tests/test_x11_docker_session.py
@@ -1,0 +1,77 @@
+"""Characterization tests for the direct-X11 Docker cookbook's container entrypoint.
+
+``x11_docker_session.py`` runs only inside the ``Dockerfile.direct_x11`` image (see its
+``ENTRYPOINT``), so these tests exercise the polling helper directly rather than booting a
+real X server.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from examples.navigator_n2 import x11_docker_session
+
+
+def _fake_process(*, alive: bool, returncode: int | None = None) -> Any:
+    return SimpleNamespace(poll=lambda: None if alive else returncode, returncode=returncode)
+
+
+def test_wait_until_ready_returns_as_soon_as_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+    monkeypatch.setattr(x11_docker_session.time, "sleep", lambda seconds: calls.append(seconds))
+    attempts = iter([False, False, True])
+
+    x11_docker_session._wait_until_ready(lambda: next(attempts), name="thing")
+
+    assert calls == [x11_docker_session._READY_INTERVAL_SECONDS] * 2
+
+
+def test_wait_until_ready_raises_after_exhausting_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleep_calls = 0
+
+    def fake_sleep(_seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+
+    monkeypatch.setattr(x11_docker_session.time, "sleep", fake_sleep)
+
+    with pytest.raises(RuntimeError, match="thing did not become ready"):
+        x11_docker_session._wait_until_ready(lambda: False, name="thing")
+
+    assert sleep_calls == x11_docker_session._READY_ATTEMPTS
+
+
+def test_wait_until_ready_reports_an_early_process_exit_without_waiting_out_the_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(x11_docker_session.time, "sleep", lambda _seconds: pytest.fail("should not sleep"))
+    process = _fake_process(alive=False, returncode=17)
+
+    with pytest.raises(RuntimeError, match="thing exited with status 17"):
+        x11_docker_session._wait_until_ready(lambda: False, name="thing", process=process)
+
+
+def test_wait_until_ready_ignores_process_liveness_when_not_given(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(x11_docker_session.time, "sleep", lambda _seconds: None)
+
+    # No `process=` passed: readiness alone decides, matching `_wait_for_display`'s contract.
+    x11_docker_session._wait_until_ready(lambda: True, name="thing")
+
+
+def test_wait_for_port_checks_process_liveness_before_connecting(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(x11_docker_session.time, "sleep", lambda _seconds: pytest.fail("should not sleep"))
+    process = _fake_process(alive=False, returncode=9)
+
+    with pytest.raises(RuntimeError, match="x11vnc exited with status 9"):
+        x11_docker_session._wait_for_port(5900, process, "x11vnc")
+
+
+def test_wait_for_window_manager_checks_process_liveness_before_xprop(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(x11_docker_session.time, "sleep", lambda _seconds: pytest.fail("should not sleep"))
+    process = _fake_process(alive=False, returncode=3)
+
+    with pytest.raises(RuntimeError, match="Openbox exited with status 3"):
+        x11_docker_session._wait_for_window_manager({}, process)


### PR DESCRIPTION
## Issue

`examples/navigator_n2/x11_docker_session.py` — the `Dockerfile.direct_x11` container's `ENTRYPOINT` script that boots the virtual X11 desktop (Xvfb, x11vnc, websockify, Openbox) before running the requested command — hand-rolled the same "poll up to 40 times, 0.25s apart, then raise" loop three separate times:

- `_wait_for_display` (checks `xdpyinfo` return code)
- `_wait_for_port` (checks a TCP connect, plus an identical "raise immediately if the watched process already exited" guard)
- `_wait_for_window_manager` (checks `xprop` output, plus the same process-exited guard)

Two of the three duplicated the process-liveness check byte-for-byte, and all three duplicated the retry/sleep/timeout scaffolding around a different one-shot readiness check.

## Improvement

Extracted a single `_wait_until_ready(is_ready, *, name, process=None)` helper. Each of the three call sites now supplies only its own readiness predicate (and, where applicable, the process to watch for an early exit); the retry count, sleep interval, and both error-message formats (`"{name} did not become ready"` / `"{name} exited with status {code}"`) are unchanged.

Also added `tests/test_x11_docker_session.py` — this script previously had zero test coverage — to pin the extracted helper's behavior: readiness short-circuits the loop, exhausting the attempt budget raises, and an early process exit is reported immediately without waiting out the remaining attempts, plus one characterization test per original call site confirming the process-liveness-first ordering survived the extraction.

## Why it's safe

- **No public API change.** This script isn't part of the published `yutori` package (it lives under `examples/`) and is invoked only as the Docker image's entrypoint — nothing imports it.
- **No behavior change.** Same attempt count (40), same interval (0.25s), same error message text, same "check process liveness before the readiness probe" ordering for the two sites that had it, same absence of that check for `_wait_for_display` (which never had it).
- **Verified**: new tests pass (6/6); full suite unchanged (774 passed, 9 skipped, 1 deselected — identical to baseline); `ruff check .` and `ruff format --check` clean on touched files.

2 files changed (+116/-21): `examples/navigator_n2/x11_docker_session.py`, `tests/test_x11_docker_session.py` (new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01258eCipS2otgSp4Cfze8dq

---
_Generated by [Claude Code](https://claude.ai/code/session_01258eCipS2otgSp4Cfze8dq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only Docker entrypoint refactor with preserved retry semantics; new unit tests lock behavior without touching the published package API.
> 
> **Overview**
> The direct-X11 Docker **entrypoint** (`x11_docker_session.py`) no longer repeats the same “poll up to 40 times, 0.25s apart, then raise” logic in three places. A shared **`_wait_until_ready`** helper now owns retry timing, sleep, and error messages; **`_wait_for_display`**, **`_wait_for_port`**, and **`_wait_for_window_manager`** only supply readiness checks (and optional process exit handling).
> 
> Retry limits are named via **`_READY_ATTEMPTS`** and **`_READY_INTERVAL_SECONDS`**. Port waits use the same interval for socket connect timeout.
> 
> **`tests/test_x11_docker_session.py`** is new: six characterization tests on the helper and wrappers (early success, timeout, immediate failure when a watched process exits, and process-liveness-before-probe ordering for port/WM waits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c911fce3402482390e0dafb10c9bfa87e52bd03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->