### PR TITLE
refactor(cli): stop double-reading YUTORI_INSTALL_CLIENT in maybe_install_mcp_server

### DIFF
--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -846,11 +846,10 @@ def maybe_install_mcp_server(
     success_detail = "Configured Yutori MCP server. Restart your AI tool to load it."
 
     if not interactive:
-        client = os.environ.get("YUTORI_INSTALL_CLIENT", "").strip()
         clients = _resolve_noninteractive_clients()
         base = ("npx", "add-mcp", "-y", "-g", "-n", "yutori")
         noninteractive_command = (*base, *_client_agent_flags(clients), "uvx yutori-mcp")
-        if not client:
+        if clients == DEFAULT_NONINTERACTIVE_MCP_CLIENTS:
             default_list = ", ".join(DEFAULT_NONINTERACTIVE_MCP_CLIENTS)
             success_detail = (
                 f"Registered Yutori MCP for the default client set ({default_list}). "


### PR DESCRIPTION
## What

`maybe_install_mcp_server`'s non-interactive branch read the `YUTORI_INSTALL_CLIENT` env var directly (into a local `client`) just to decide whether to show the default-client-set success message, then separately called `_resolve_noninteractive_clients()` — which reads the *same* env var again — to build the actual `-a` flags passed to `add-mcp`.

Two independent reads of the same input to drive one decision is exactly the drift risk `_resolve_noninteractive_clients()` was extracted for in #284 (its own docstring: "shared ... so a change to one client list can't drift from the other"). This closes the other half of that gap, inside `maybe_install_mcp_server` itself, where the duplicate read had crept back in.

## Change

Replaced the direct `os.environ.get("YUTORI_INSTALL_CLIENT", ...)` read with a comparison against the already-computed `clients` result. `_resolve_noninteractive_clients()` returns a 1-tuple when the env var is set, and the 4-element `DEFAULT_NONINTERACTIVE_MCP_CLIENTS` otherwise — so `clients == DEFAULT_NONINTERACTIVE_MCP_CLIENTS` is exactly equivalent to the old `not client` check, with no behavior change: same command built, same success/skip messages.

```diff
-        client = os.environ.get("YUTORI_INSTALL_CLIENT", "").strip()
         clients = _resolve_noninteractive_clients()
         base = ("npx", "add-mcp", "-y", "-g", "-n", "yutori")
         noninteractive_command = (*base, *_client_agent_flags(clients), "uvx yutori-mcp")
-        if not client:
+        if clients == DEFAULT_NONINTERACTIVE_MCP_CLIENTS:
```

## Why it's safe

- Internal CLI helper, not part of the published package's public API surface.
- Purely a "read the value once instead of twice" refactor — the resulting condition is provably equivalent (env-var-set path always yields a 1-tuple, which can never equal the 4-element default tuple).
- 1 file, 1 line removed / 1 line changed.

## Verification

- `pytest tests/test_install_flow.py -k mcp_server` → 11/11 passed (covers both the default-client-set and `YUTORI_INSTALL_CLIENT`-scoped success-message branches this touches).
- Full suite: `pytest -q -m "not slow"` → 823 passed, 3 skipped, 1 deselected — identical to baseline.
- `ruff check .` → clean.
- `ruff format --check` reports pre-existing drift on this file unrelated to this change (confirmed present on `main` before this commit too, via `git stash`; CI here only runs `ruff check`, not `ruff format --check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhPTg2538XDHBcYPEqHWph


---
_Generated by [Claude Code](https://claude.ai/code/session_01GhPTg2538XDHBcYPEqHWph)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal installer refactor with provably equivalent branching; no change to commands or public API.
> 
> **Overview**
> In non-interactive MCP server install, the success-message branch no longer reads `YUTORI_INSTALL_CLIENT` on its own. It uses the `clients` tuple from `_resolve_noninteractive_clients()` and treats the default four-agent set via `clients == DEFAULT_NONINTERACTIVE_MCP_CLIENTS` instead of `if not client`.
> 
> **Behavior is unchanged:** scoped installs still get the generic success line; unset env still gets the default-client-set hint. This aligns with #284’s goal—one resolver drives both the `add-mcp -a` flags and the messaging so those paths can’t drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c1685a94b7ac24d3f9b9cdee80ee5354bc443f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->