### PR TITLE
macOS overlay: shell command rail and menu bar Stop item

### DIFF
--- a/tests/test_navigator_macos_presentation.py
+++ b/tests/test_navigator_macos_presentation.py
@@ -12,6 +12,7 @@ from yutori.navigator.macos.presentation import MacOSPresentationController, Mac
 from yutori.navigator.macos.types import (
     MacOSPresentationCapabilities,
     MacOSPresentationStatus,
+    ShellPresentationEvent,
 )
 
 
@@ -59,6 +60,23 @@ def test_ready_handshake_validates_protocol_geometry_scale_hotkey_and_stop_regio
                 "hotkey": True,
             }
         )
+
+
+def test_menu_bar_stop_item_on_another_display_is_accepted_without_a_region():
+    controller = MacOSPresentationController(native_width=2000, native_height=1200)
+    capabilities = controller._validate_ready(
+        {
+            "protocol_version": 2,
+            "width": 1000,
+            "height": 600,
+            "backing_scale": 2,
+            "hotkey": True,
+            "stop_control": "menu_bar",
+        }
+    )
+    assert capabilities.stop_region is None
+    controller._status = MacOSPresentationStatus(True, True, "active", "yutori", capabilities)
+    assert not controller.blocks_point((990, 5))
 
 
 async def test_reasoning_action_and_batch_map_to_renderer_operations(monkeypatch):
@@ -245,3 +263,92 @@ async def test_cancelled_request_does_not_poison_the_next_overlay_reply(monkeypa
     host = asyncio.create_task(controller._read_host())
     assert await second == {"id": 2, "ok": True}
     await host
+
+
+def _shell(task_id: str, command: str, state: str, *, background: bool = False, exit_code: "int | None" = None):
+    return {"type": "shell", "event": ShellPresentationEvent(task_id, command, background, state, exit_code)}
+
+
+def _rail_controller(monkeypatch):
+    """An active controller whose renderer traffic and sleeps are recorded instead of sent."""
+    controller = _active_controller()
+    operations: list[dict] = []
+    commands: list[dict] = []
+    sleeps: list[float] = []
+
+    async def send_operation(operation, **_kwargs):
+        operations.append(operation)
+        return {"ok": True}
+
+    async def send_command(command, **_kwargs):
+        commands.append(command)
+        return {"ok": True}
+
+    async def sleep(seconds):
+        sleeps.append(seconds)
+        return True
+
+    monkeypatch.setattr(controller, "_send_operation", send_operation)
+    monkeypatch.setattr(controller, "_send_command", send_command)
+    monkeypatch.setattr(controller, "_sleep", sleep)
+    return controller, operations, commands, sleeps
+
+
+def _rail_renders(commands: list[dict]) -> list[dict]:
+    return [command for command in commands if command.get("op") == "shellCommands"]
+
+
+async def test_foreground_shell_command_is_shown_in_the_rail_and_the_capsule(monkeypatch):
+    controller, operations, commands, sleeps = _rail_controller(monkeypatch)
+
+    await controller.present(_shell("shell-1", "ls -la ~/Documents", "starting"))
+    await controller.present(_shell("shell-1", "ls -la ~/Documents", "running"))
+
+    rail = _rail_renders(commands)
+    assert [entry["state"] for render in rail for entry in render["commands"]] == ["starting", "running"]
+    assert rail[-1]["commands"][0]["command"] == "ls -la ~/Documents"
+    assert rail[-1]["commands"][0]["run_in_background"] is False
+    assert rail[-1]["overflow"] == 0
+    assert any(
+        operation.get("op") == "showThought" and "Run command · $ ls -la ~/Documents" in operation["markdown"]
+        for operation in operations
+    )
+
+    await controller.present(_shell("shell-1", "ls -la ~/Documents", "completed", exit_code=0))
+    finished = _rail_renders(commands)[-1]["commands"][0]
+    assert (finished["state"], finished["exit_code"]) == ("completed", 0)
+    assert controller._shell_rail_removals
+    await asyncio.gather(*controller._shell_rail_removals)
+    assert _rail_renders(commands)[-1] == {"op": "shellCommands", "commands": [], "overflow": 0}
+    assert 4.0 in sleeps
+
+
+async def test_shell_rail_lists_newest_first_with_overflow_and_keeps_background_commands(monkeypatch):
+    controller, _operations, commands, _sleeps = _rail_controller(monkeypatch)
+
+    await controller.present(_shell("bash-1", "sleep 30", "running", background=True))
+    await controller.present(_shell("shell-2", "pwd", "running"))
+    await controller.present(_shell("shell-3", "whoami", "running"))
+    await controller.present(_shell("shell-4", "date", "running"))
+
+    render = _rail_renders(commands)[-1]
+    assert [entry["task_id"] for entry in render["commands"]] == ["shell-4", "shell-3", "shell-2"]
+    assert render["overflow"] == 1
+    assert not controller._shell_rail_removals
+
+    await controller.present(_shell("shell-4", "date", "failed", exit_code=1))
+    await asyncio.gather(*controller._shell_rail_removals)
+    render = _rail_renders(commands)[-1]
+    assert [entry["task_id"] for entry in render["commands"]] == ["shell-3", "shell-2", "bash-1"]
+    assert render["commands"][-1]["run_in_background"] is True
+    assert render["overflow"] == 0
+    assert controller.background_counts == {"started": 1, "completed": 0, "failed": 0, "cancelled": 0}
+
+
+async def test_shell_rail_does_not_resend_an_unchanged_render(monkeypatch):
+    controller, _operations, commands, _sleeps = _rail_controller(monkeypatch)
+
+    await controller.present(_shell("shell-1", "pwd", "running"))
+    await controller.present(_shell("shell-1", "pwd", "running"))
+
+    assert len(_rail_renders(commands)) == 1

--- a/yutori/navigator/macos/assets/macos-overlay-host.swift
+++ b/yutori/navigator/macos/assets/macos-overlay-host.swift
@@ -6,43 +6,52 @@ import WebKit
 
 private let overlayProtocolVersion = 2
 
-private let mousePointerIconViewBox: CGFloat = 24
+// The Yutori mark, from the platform dashboard's yutori-mark.svg (viewBox -2 -2 117 114),
+// with its two filled subpaths emitted as CGPath calls because AppKit has no SVG parser.
+private let yutoriMarkViewBox = CGRect(x: -2, y: -2, width: 117, height: 114)
 private let menuBarIconPoints: CGFloat = 18
 
-/// Lucide `mouse-pointer-2` (https://lucide.dev, ISC license) on its 24-unit box, the cursor
-/// glyph the rest of the Yutori UI uses. Generated from lucide-react 0.546.0 with the SVG
-/// arcs pre-converted to cubic curves, because AppKit has no SVG path parser.
-private func mousePointerGlyph() -> CGPath {
+private func yutoriMarkGlyph() -> CGPath {
     let path = CGMutablePath()
-    path.move(to: CGPoint(x: 4.037, y: 4.688))
-    path.addCurve(to: CGPoint(x: 4.141, y: 4.141), control1: CGPoint(x: 3.956, y: 4.502), control2: CGPoint(x: 3.998, y: 4.285))
-    path.addCurve(to: CGPoint(x: 4.688, y: 4.037), control1: CGPoint(x: 4.285, y: 3.998), control2: CGPoint(x: 4.502, y: 3.956))
-    path.addLine(to: CGPoint(x: 20.688, y: 10.537))
-    path.addCurve(to: CGPoint(x: 20.998, y: 11.033), control1: CGPoint(x: 20.888, y: 10.618), control2: CGPoint(x: 21.013, y: 10.818))
-    path.addCurve(to: CGPoint(x: 20.625, y: 11.484), control1: CGPoint(x: 20.984, y: 11.248), control2: CGPoint(x: 20.834, y: 11.43))
-    path.addLine(to: CGPoint(x: 14.501, y: 13.064))
-    path.addCurve(to: CGPoint(x: 13.063, y: 14.499), control1: CGPoint(x: 13.796, y: 13.245), control2: CGPoint(x: 13.246, y: 13.795))
-    path.addLine(to: CGPoint(x: 11.484, y: 20.625))
-    path.addCurve(to: CGPoint(x: 11.033, y: 20.998), control1: CGPoint(x: 11.43, y: 20.834), control2: CGPoint(x: 11.248, y: 20.984))
-    path.addCurve(to: CGPoint(x: 10.537, y: 20.688), control1: CGPoint(x: 10.818, y: 21.013), control2: CGPoint(x: 10.618, y: 20.888))
+    path.move(to: CGPoint(x: 101.976, y: 0.821))
+    path.addCurve(to: CGPoint(x: 112.792, y: 4.268), control1: CGPoint(x: 106.955, y: -1.13), control2: CGPoint(x: 111.542, y: 0.545))
+    path.addCurve(to: CGPoint(x: 107.458, y: 13.782), control1: CGPoint(x: 114.212, y: 8.495), control2: CGPoint(x: 111.387, y: 11.998))
+    path.addCurve(to: CGPoint(x: 41.788, y: 75.917), control1: CGPoint(x: 74.847, y: 28.593), control2: CGPoint(x: 41.789, y: 54.809))
+    path.addCurve(to: CGPoint(x: 56.307, y: 94.026), control1: CGPoint(x: 41.788, y: 89.734), control2: CGPoint(x: 49.874, y: 94.026))
+    path.addCurve(to: CGPoint(x: 70.874, y: 75.917), control1: CGPoint(x: 62.74, y: 94.026), control2: CGPoint(x: 70.874, y: 89.735))
+    path.addCurve(to: CGPoint(x: 61.224, y: 53.963), control1: CGPoint(x: 70.874, y: 67.866), control2: CGPoint(x: 65.997, y: 59.825))
+    path.addCurve(to: CGPoint(x: 72.341, y: 43.538), control1: CGPoint(x: 61.248, y: 53.934), control2: CGPoint(x: 66.374, y: 47.82))
+    path.addCurve(to: CGPoint(x: 86.633, y: 75.917), control1: CGPoint(x: 81.107, y: 53.662), control2: CGPoint(x: 86.633, y: 63.68))
+    path.addCurve(to: CGPoint(x: 56.307, y: 110), control1: CGPoint(x: 86.633, y: 95.549), control2: CGPoint(x: 73.925, y: 110))
+    path.addCurve(to: CGPoint(x: 25.982, y: 75.917), control1: CGPoint(x: 38.688, y: 110), control2: CGPoint(x: 25.982, y: 95.549))
+    path.addCurve(to: CGPoint(x: 101.976, y: 0.821), control1: CGPoint(x: 25.982, y: 44.34), control2: CGPoint(x: 73.673, y: 11.912))
+    path.closeSubpath()
+    path.move(to: CGPoint(x: 0.372, y: 4.272))
+    path.addCurve(to: CGPoint(x: 11.19, y: 0.826), control1: CGPoint(x: 1.623, y: 0.549), control2: CGPoint(x: 6.21, y: -1.125))
+    path.addCurve(to: CGPoint(x: 51.019, y: 23.596), control1: CGPoint(x: 22.754, y: 5.358), control2: CGPoint(x: 37.556, y: 13.453))
+    path.addCurve(to: CGPoint(x: 39.908, y: 33.718), control1: CGPoint(x: 44.765, y: 28.489), control2: CGPoint(x: 39.924, y: 33.701))
+    path.addCurve(to: CGPoint(x: 5.706, y: 13.786), control1: CGPoint(x: 29.529, y: 26.092), control2: CGPoint(x: 17.588, y: 19.182))
+    path.addCurve(to: CGPoint(x: 0.372, y: 4.272), control1: CGPoint(x: 1.777, y: 12.001), control2: CGPoint(x: -1.047, y: 8.499))
     path.closeSubpath()
     return path
 }
 
-/// A template image of the Lucide cursor, stroked the way Lucide draws it (2 units on a
-/// 24-unit box, round caps and joins), so it takes the menu bar's light or dark tint.
+/// A template image of the Yutori mark, filled, so it takes the menu bar's light or dark tint
+/// like the system status items around it.
 private func stopMenuBarIcon() -> NSImage {
-    let glyph = mousePointerGlyph()
+    let glyph = yutoriMarkGlyph()
     let image = NSImage(size: NSSize(width: menuBarIconPoints, height: menuBarIconPoints), flipped: true) { rect in
         guard let context = NSGraphicsContext.current?.cgContext else { return false }
-        let scale = rect.width / mousePointerIconViewBox
+        let scale = min(rect.width / yutoriMarkViewBox.width, rect.height / yutoriMarkViewBox.height)
+        context.translateBy(
+            x: (rect.width - yutoriMarkViewBox.width * scale) / 2,
+            y: (rect.height - yutoriMarkViewBox.height * scale) / 2
+        )
         context.scaleBy(x: scale, y: scale)
+        context.translateBy(x: -yutoriMarkViewBox.minX, y: -yutoriMarkViewBox.minY)
         context.addPath(glyph)
-        context.setStrokeColor(NSColor.black.cgColor)
-        context.setLineWidth(2)
-        context.setLineCap(.round)
-        context.setLineJoin(.round)
-        context.strokePath()
+        context.setFillColor(NSColor.black.cgColor)
+        context.fillPath()
         return true
     }
     image.isTemplate = true

--- a/yutori/navigator/macos/assets/macos-overlay-host.swift
+++ b/yutori/navigator/macos/assets/macos-overlay-host.swift
@@ -6,6 +6,50 @@ import WebKit
 
 private let overlayProtocolVersion = 2
 
+private let mousePointerIconViewBox: CGFloat = 24
+private let menuBarIconPoints: CGFloat = 18
+
+/// Lucide `mouse-pointer-2` (https://lucide.dev, ISC license) on its 24-unit box, the cursor
+/// glyph the rest of the Yutori UI uses. Generated from lucide-react 0.546.0 with the SVG
+/// arcs pre-converted to cubic curves, because AppKit has no SVG path parser.
+private func mousePointerGlyph() -> CGPath {
+    let path = CGMutablePath()
+    path.move(to: CGPoint(x: 4.037, y: 4.688))
+    path.addCurve(to: CGPoint(x: 4.141, y: 4.141), control1: CGPoint(x: 3.956, y: 4.502), control2: CGPoint(x: 3.998, y: 4.285))
+    path.addCurve(to: CGPoint(x: 4.688, y: 4.037), control1: CGPoint(x: 4.285, y: 3.998), control2: CGPoint(x: 4.502, y: 3.956))
+    path.addLine(to: CGPoint(x: 20.688, y: 10.537))
+    path.addCurve(to: CGPoint(x: 20.998, y: 11.033), control1: CGPoint(x: 20.888, y: 10.618), control2: CGPoint(x: 21.013, y: 10.818))
+    path.addCurve(to: CGPoint(x: 20.625, y: 11.484), control1: CGPoint(x: 20.984, y: 11.248), control2: CGPoint(x: 20.834, y: 11.43))
+    path.addLine(to: CGPoint(x: 14.501, y: 13.064))
+    path.addCurve(to: CGPoint(x: 13.063, y: 14.499), control1: CGPoint(x: 13.796, y: 13.245), control2: CGPoint(x: 13.246, y: 13.795))
+    path.addLine(to: CGPoint(x: 11.484, y: 20.625))
+    path.addCurve(to: CGPoint(x: 11.033, y: 20.998), control1: CGPoint(x: 11.43, y: 20.834), control2: CGPoint(x: 11.248, y: 20.984))
+    path.addCurve(to: CGPoint(x: 10.537, y: 20.688), control1: CGPoint(x: 10.818, y: 21.013), control2: CGPoint(x: 10.618, y: 20.888))
+    path.closeSubpath()
+    return path
+}
+
+/// A template image of the Lucide cursor, stroked the way Lucide draws it (2 units on a
+/// 24-unit box, round caps and joins), so it takes the menu bar's light or dark tint.
+private func stopMenuBarIcon() -> NSImage {
+    let glyph = mousePointerGlyph()
+    let image = NSImage(size: NSSize(width: menuBarIconPoints, height: menuBarIconPoints), flipped: true) { rect in
+        guard let context = NSGraphicsContext.current?.cgContext else { return false }
+        let scale = rect.width / mousePointerIconViewBox
+        context.scaleBy(x: scale, y: scale)
+        context.addPath(glyph)
+        context.setStrokeColor(NSColor.black.cgColor)
+        context.setLineWidth(2)
+        context.setLineCap(.round)
+        context.setLineJoin(.round)
+        context.strokePath()
+        return true
+    }
+    image.isTemplate = true
+    image.accessibilityDescription = "Yutori n2 is controlling this Mac"
+    return image
+}
+
 private func writeJSON(_ value: [String: Any]) {
     guard let data = try? JSONSerialization.data(withJSONObject: value) else { return }
     FileHandle.standardOutput.write(data)
@@ -17,12 +61,18 @@ private struct OverlayConfig: Decodable {
     let enableHotkey: Bool
 }
 
-private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKScriptMessageHandler {
+private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDelegate {
     private let htmlURL: URL
     private let config: OverlayConfig
     private var panel: NSPanel?
-    private var stopPanel: NSPanel?
-    private var stopRegion: [String: Double]?
+    // The Stop control is a menu bar status item with a cursor icon whose menu carries
+    // the Stop action. Its on-screen frame is reported as `stop_region` so the Python
+    // side keeps refusing model clicks on it.
+    private var stopItem: NSStatusItem?
+    // Where the shell rail starts, in overlay page points: a 16pt inset below the menu
+    // bar, right-aligned with the Stop item above it. The page cannot see the menu bar.
+    private var railTop: CGFloat = 0
+    private var railRight: CGFloat = 16
     private var webView: WKWebView?
     private var screen: NSScreen?
     private var hotKey: EventHotKeyRef?
@@ -76,60 +126,52 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
 
         self.panel = panel
         self.webView = webView
-        if config.showStopButton { createStopPanel(on: screen) }
+        railTop = screen.frame.maxY - screen.visibleFrame.maxY + 16
+        railRight = screen.frame.maxX - screen.visibleFrame.maxX + 16
+        if config.showStopButton { createStopMenuBarItem() }
         let hotkeyAvailable = config.enableHotkey && registerStopHotKey()
         panel.identifier = NSUserInterfaceItemIdentifier(hotkeyAvailable ? "n2-overlay-hotkey" : "n2-overlay-no-hotkey")
         webView.loadFileURL(htmlURL, allowingReadAccessTo: htmlURL.deletingLastPathComponent())
     }
 
-    private func createStopPanel(on screen: NSScreen) {
-        let size = NSSize(width: 146, height: 34)
-        let origin = NSPoint(
-            x: screen.visibleFrame.maxX - size.width - 16,
-            y: screen.visibleFrame.maxY - size.height - 16
-        )
-        let panel = NSPanel(
-            contentRect: NSRect(origin: origin, size: size),
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: false
-        )
-        panel.backgroundColor = .clear
-        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
-        panel.hasShadow = false
-        panel.hidesOnDeactivate = false
-        panel.ignoresMouseEvents = false
-        panel.isOpaque = false
-        panel.isReleasedWhenClosed = false
-        panel.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.overlayWindow)) + 1)
-        panel.alphaValue = 0
+    private func createStopMenuBarItem() {
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        if let button = item.button {
+            button.image = stopMenuBarIcon()
+            button.toolTip = "Yutori n2 is controlling this Mac. Stop with ⇧⌘Esc."
+        }
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        let status = NSMenuItem(title: "Yutori n2 is controlling this Mac", action: nil, keyEquivalent: "")
+        status.isEnabled = false
+        menu.addItem(status)
+        menu.addItem(.separator())
+        let stop = NSMenuItem(title: "Stop", action: #selector(stopFromMenu), keyEquivalent: "\u{1B}")
+        stop.keyEquivalentModifierMask = [.command, .shift]
+        stop.target = self
+        menu.addItem(stop)
+        item.menu = menu
+        stopItem = item
+    }
 
-        let configuration = WKWebViewConfiguration()
-        configuration.userContentController.add(self, name: "stop")
-        let webView = WKWebView(frame: NSRect(origin: .zero, size: size), configuration: configuration)
-        webView.setValue(false, forKey: "drawsBackground")
-        webView.loadHTMLString(
-            """
-            <!doctype html><meta name="color-scheme" content="dark"><style>
-            *{box-sizing:border-box}html,body{margin:0;width:100%;height:100%;background:transparent;font-family:-apple-system,BlinkMacSystemFont,sans-serif}
-            button{width:100%;height:100%;border:1px solid rgba(208,252,235,.5);border-radius:11px;color:rgba(240,255,250,.96);font-size:12px;font-weight:600;letter-spacing:.1px;background:radial-gradient(circle at 24% 12%,rgba(236,255,248,.22),transparent 48%),linear-gradient(145deg,rgba(24,170,126,.78),rgba(8,70,53,.72));-webkit-backdrop-filter:blur(16px) saturate(150%);box-shadow:inset 3px 4px 9px rgba(255,255,255,.08),inset -5px -6px 11px rgba(3,22,17,.16),inset -2px -3px 4px rgba(210,255,238,.3);cursor:default}
-            button:active{transform:scale(.98)}button:focus-visible{outline:2px solid white;outline-offset:-3px}
-            @media(prefers-reduced-transparency:reduce){button{background:rgba(8,70,53,.96);-webkit-backdrop-filter:none}}
-            @media(prefers-contrast:more){button{border-color:white;color:white}}
-            @media(prefers-reduced-motion:reduce){button{transition:none}}
-            </style><button onclick="webkit.messageHandlers.stop.postMessage('button')">Stop · ⇧⌘Esc</button>
-            """,
-            baseURL: nil
-        )
-        panel.contentView = webView
-        panel.orderFrontRegardless()
-        stopRegion = [
-            "x": (origin.x - screen.frame.minX) / screen.frame.width * 1000,
-            "y": (screen.frame.maxY - origin.y - size.height) / screen.frame.height * 1000,
-            "width": size.width / screen.frame.width * 1000,
-            "height": size.height / screen.frame.height * 1000,
+    @objc private func stopFromMenu() {
+        requestStop(source: "menu")
+    }
+
+    /// The Stop item's frame in the overlay's normalized 0-1000 space, or nil when the
+    /// item is not on this screen (the menu bar can live on another display). Status item
+    /// windows can overhang the screen frame by a point on notch displays, so the frame is
+    /// clipped to the screen rather than required to sit inside it.
+    private func stopItemRegion(on screen: NSScreen) -> [String: Double]? {
+        guard let itemFrame = stopItem?.button?.window?.frame else { return nil }
+        let frame = itemFrame.intersection(screen.frame)
+        guard !frame.isEmpty else { return nil }
+        return [
+            "x": (frame.minX - screen.frame.minX) / screen.frame.width * 1000,
+            "y": (screen.frame.maxY - frame.maxY) / screen.frame.height * 1000,
+            "width": frame.width / screen.frame.width * 1000,
+            "height": frame.height / screen.frame.height * 1000,
         ]
-        stopPanel = panel
     }
 
     private func registerStopHotKey() -> Bool {
@@ -159,10 +201,6 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
         ) == noErr
     }
 
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        requestStop(source: "button")
-    }
-
     private func requestStop(source: String) {
         guard !stopped else { return }
         stopped = true
@@ -179,11 +217,19 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
             "height": Int(webView.bounds.height.rounded()),
             "backing_scale": screen.backingScaleFactor,
             "hotkey": hotkeyAvailable,
-            "capabilities": ["capture", "encode", "background_tasks", "stop"],
+            "capabilities": ["capture", "encode", "shell_commands", "stop"],
         ]
-        if let stopRegion { ready["stop_region"] = stopRegion }
-        writeJSON(ready)
-        readCommands()
+        if stopItem != nil {
+            ready["stop_control"] = "menu_bar"
+            if let region = stopItemRegion(on: screen) { ready["stop_region"] = region }
+        }
+        let railStyle =
+            "document.documentElement.style.setProperty('--n2-rail-top', '\(railTop)px');"
+            + "document.documentElement.style.setProperty('--n2-rail-right', '\(railRight)px');"
+        webView.evaluateJavaScript(railStyle) { _, _ in
+            writeJSON(ready)
+            self.readCommands()
+        }
     }
 
     private func readCommands() {
@@ -250,15 +296,15 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
                 let quality = command["quality"] as? Double
             else { return fail(id, "Invalid encode request.") }
             encodeObservation(id: id, data: data, maxLongSide: maxLongSide, quality: quality)
-        case "backgroundTasks":
+        case "shellCommands":
             guard
-                let tasks = command["tasks"] as? [[String: Any]],
+                let commands = command["commands"] as? [[String: Any]],
                 let overflow = command["overflow"] as? Int
-            else { return fail(id, "Invalid background task request.") }
+            else { return fail(id, "Invalid shell command request.") }
             callJavaScript(
                 id: id,
-                body: "return window.__n2BackgroundTasks(payload)",
-                arguments: ["payload": ["tasks": tasks, "overflow": overflow]],
+                body: "return window.__n2ShellCommands(payload)",
+                arguments: ["payload": ["commands": commands, "overflow": overflow]],
                 validateReply: true
             )
         case "retire":
@@ -343,7 +389,7 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
         transitionToken += 1
         let token = transitionToken
         state = "hiding"
-        animate(visible: false, duration: 0.06, framesAfter: 2, includeStopPanel: false) {
+        animate(visible: false, duration: 0.06, framesAfter: 2) {
             guard token == self.transitionToken else { return self.reply(id, state: "stale", captureID: requestedID) }
             self.state = "hidden"
             self.reply(id, state: self.state, captureID: requestedID)
@@ -357,7 +403,7 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
         state = "revealing"
         waitForDisplayFrames(1) {
             guard token == self.transitionToken else { return self.reply(id, state: "stale", captureID: requestedID) }
-            self.animate(visible: true, duration: 0.12, framesAfter: 0, includeStopPanel: false) {
+            self.animate(visible: true, duration: 0.12, framesAfter: 0) {
                 guard token == self.transitionToken else { return self.reply(id, state: "stale", captureID: requestedID) }
                 self.state = "visible"
                 self.reply(id, state: self.state, captureID: requestedID)
@@ -369,10 +415,9 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
         visible: Bool,
         duration: TimeInterval,
         framesAfter: Int,
-        includeStopPanel: Bool = true,
         completion: @escaping () -> Void
     ) {
-        let windows = includeStopPanel ? [panel, stopPanel].compactMap { $0 } : [panel].compactMap { $0 }
+        let windows = [panel].compactMap { $0 }
         if visible { windows.forEach { $0.orderFrontRegardless() } }
         let effectiveDuration = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion ? 0 : duration
         NSAnimationContext.runAnimationGroup { context in
@@ -430,7 +475,9 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
         transitionToken += 1
         displayLinks.values.forEach { CVDisplayLinkStop($0) }
         displayLinks.removeAll()
-        [panel, stopPanel].compactMap { $0 }.forEach {
+        if let stopItem { NSStatusBar.system.removeStatusItem(stopItem) }
+        stopItem = nil
+        [panel].compactMap { $0 }.forEach {
             $0.alphaValue = 0
             $0.orderOut(nil)
             $0.close()

--- a/yutori/navigator/macos/assets/macos-overlay.js
+++ b/yutori/navigator/macos/assets/macos-overlay.js
@@ -67,31 +67,62 @@ window.__n2EncodeObservation = async ({ data, maxLongSide, quality }) => {
   return { data: encoded.slice(encoded.indexOf(",") + 1), format };
 };
 
-window.__n2BackgroundTasks = ({ tasks, overflow }) => {
-  const rail = document.getElementById("n2-background-rail");
+const SHELL_STATE_LABELS = {
+  starting: "starting",
+  running: "running",
+  completed: "done",
+  failed: "failed",
+  timed_out: "timed out",
+  cancelled: "cancelled",
+};
+
+// A finished command is labelled by its exit code alone; the failed/timed-out
+// states are coloured amber, so the label does not need to spell out "failed".
+const shellStateLabel = ({ state, exit_code: exitCode }) =>
+  exitCode != null && (state === "completed" || state === "failed")
+    ? `exit ${exitCode}`
+    : (SHELL_STATE_LABELS[state] ?? state);
+
+const shellSpan = (className, text) => {
+  const span = document.createElement("span");
+  span.className = className;
+  span.textContent = text;
+  return span;
+};
+
+// One phosphor "run command" panel per shell the model is running, newest on
+// top, stacked under the menu bar so the operator can read what is being
+// sent to this Mac without following the cursor capsule.
+window.__n2ShellCommands = ({ commands, overflow }) => {
+  const rail = document.getElementById("n2-shell-rail");
   rail.replaceChildren();
-  for (const task of tasks.slice(0, 3)) {
-    const row = document.createElement("div");
-    row.className = "n2-background-row";
-    const title = document.createElement("div");
-    title.className = "n2-background-title";
-    const id = document.createElement("span");
-    id.className = "n2-background-id";
-    id.textContent = task.task_id;
-    const state = document.createElement("span");
-    state.className = "n2-background-state";
-    state.textContent = task.state;
-    const command = document.createElement("div");
-    command.className = "n2-background-command";
-    command.textContent = `$ ${task.command}`;
-    title.append(id, state);
-    row.append(title, command);
-    rail.appendChild(row);
+  for (const entry of commands) {
+    const panel = document.createElement("div");
+    panel.className = "n2-shell-panel";
+    panel.dataset.state = entry.state;
+    const header = document.createElement("div");
+    header.className = "n2-shell-header";
+    header.append(
+      shellSpan("n2-shell-caret", "▌"),
+      shellSpan("n2-shell-label", entry.run_in_background ? "run in background" : "run command"),
+      shellSpan("n2-shell-state", shellStateLabel(entry)),
+    );
+    const body = document.createElement("div");
+    body.className = "n2-shell-body";
+    const command = document.createElement("pre");
+    command.className = "n2-shell-command";
+    command.textContent = entry.command;
+    if (entry.state === "starting" || entry.state === "running") {
+      command.appendChild(shellSpan("n2-shell-cursor", ""));
+    }
+    body.append(shellSpan("n2-shell-prompt", "$"), command);
+    panel.append(header, body);
+    rail.appendChild(panel);
   }
   if (overflow > 0) {
     const more = document.createElement("div");
-    more.className = "n2-background-overflow";
-    more.textContent = `+${overflow} more background commands`;
+    more.className = "n2-shell-overflow";
+    more.textContent = `+${overflow} more command${overflow === 1 ? "" : "s"}`;
     rail.appendChild(more);
   }
   return { ok: true };

--- a/yutori/navigator/macos/assets/navigator-overlay.css
+++ b/yutori/navigator/macos/assets/navigator-overlay.css
@@ -27,69 +27,128 @@ body {
   animation: n2ClickPulse 250ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
-#n2-background-rail {
+/*
+ * The shell rail sits at the top-right, just under the menu bar's Stop item, and
+ * lists the commands the model is running on this Mac. The host sets
+ * --n2-rail-top/--n2-rail-right once the page loads, because only it knows the
+ * menu bar height and which side the Dock is on. It borrows the phosphor
+ * "run command" panel the playground pins to its live view: translucent black,
+ * green CRT text with a soft bloom, a tracked-out header, and a `$` prompt.
+ */
+#n2-shell-rail {
   position: fixed;
-  top: 58px;
-  right: 16px;
+  top: var(--n2-rail-top, 58px);
+  right: var(--n2-rail-right, 16px);
   width: 310px;
   display: grid;
   gap: 6px;
   pointer-events: none;
+  color: #33ff33;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  text-shadow: 0 0 6px rgba(51, 255, 51, 0.55);
 }
 
-.n2-background-row,
-.n2-background-overflow {
-  min-height: 38px;
-  padding: 8px 10px;
-  border: 1px solid rgba(208, 252, 235, 0.42);
-  border-radius: 12px;
-  color: rgba(240, 255, 250, 0.96);
-  background:
-    radial-gradient(circle at 24% 12%, rgba(236, 255, 248, 0.2), transparent 48%),
-    linear-gradient(145deg, rgba(24, 170, 126, 0.76), rgba(8, 70, 53, 0.7));
-  -webkit-backdrop-filter: blur(16px) saturate(150%);
-  backdrop-filter: blur(16px) saturate(150%);
+.n2-shell-panel,
+.n2-shell-overflow {
+  overflow: hidden;
+  border: 1px solid rgba(51, 255, 51, 0.25);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.55);
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
   box-shadow:
-    inset 3px 4px 9px rgba(255, 255, 255, 0.07),
-    inset -5px -6px 11px rgba(3, 22, 17, 0.16),
-    0 8px 24px rgba(3, 22, 17, 0.18);
-  animation: n2RailIn 150ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    0 0 24px rgba(51, 255, 51, 0.1),
+    inset 0 0 48px rgba(0, 0, 0, 0.55);
+  animation: n2ShellRise 180ms ease-out both;
 }
 
-.n2-background-title {
+.n2-shell-header {
   display: flex;
   gap: 8px;
   align-items: center;
-  font-size: 11px;
-  font-weight: 650;
+  padding: 5px 10px;
+  border-bottom: 1px solid rgba(51, 255, 51, 0.2);
+  font-size: 9px;
+  line-height: 14px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  opacity: 0.7;
 }
 
-.n2-background-id {
+.n2-shell-caret,
+.n2-shell-state {
   flex: none;
-  opacity: 0.72;
-  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
-.n2-background-state {
-  margin-left: auto;
-  text-transform: capitalize;
-}
-
-.n2-background-command {
-  margin-top: 3px;
+/* The state is what the operator scans for, so the label gives way first. */
+.n2-shell-label {
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
-  color: rgba(240, 255, 250, 0.8);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.n2-background-overflow {
-  min-height: auto;
-  padding: 7px 10px;
-  font-size: 11px;
-  font-weight: 600;
+.n2-shell-state {
+  margin-left: auto;
+  text-align: right;
+}
+
+.n2-shell-panel[data-state="failed"] .n2-shell-state,
+.n2-shell-panel[data-state="timed_out"] .n2-shell-state {
+  color: #ffb454;
+  text-shadow: 0 0 6px rgba(255, 180, 84, 0.55);
+}
+
+.n2-shell-panel[data-state="cancelled"] {
+  color: rgba(51, 255, 51, 0.55);
+  text-shadow: none;
+}
+
+.n2-shell-body {
+  display: flex;
+  gap: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.n2-shell-prompt {
+  flex: none;
+  opacity: 0.7;
+}
+
+.n2-shell-command {
+  display: -webkit-box;
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  font: inherit;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+  word-break: break-all;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+}
+
+.n2-shell-cursor {
+  display: inline-block;
+  width: 1px;
+  height: 1.05em;
+  margin-left: 1px;
+  vertical-align: -0.12em;
+  background: currentColor;
+  animation: n2ShellBlink 1.06s step-end infinite;
+}
+
+.n2-shell-overflow {
+  padding: 5px 10px;
+  font-size: 9px;
+  line-height: 14px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  opacity: 0.7;
 }
 
 .yutori-overlay-cursor {
@@ -168,20 +227,35 @@ body {
   }
 }
 
-@keyframes n2RailIn {
+@keyframes n2ShellRise {
   from {
     opacity: 0;
-    transform: translateY(-4px);
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes n2ShellBlink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
   }
 }
 
 @media (prefers-reduced-transparency: reduce) {
-  .yutori-overlay-badge,
-  .n2-background-row,
-  .n2-background-overflow {
+  .yutori-overlay-badge {
     background: rgba(8, 70, 53, 0.96) !important;
     -webkit-backdrop-filter: none !important;
     backdrop-filter: none !important;
+  }
+  .n2-shell-panel,
+  .n2-shell-overflow {
+    background: rgba(0, 0, 0, 0.92);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
   }
 }
 
@@ -189,11 +263,19 @@ body {
   .yutori-overlay-rim {
     background: rgba(240, 255, 250, 0.94) !important;
   }
-  .yutori-overlay-thought-inner,
-  .n2-background-row,
-  .n2-background-overflow {
+  .yutori-overlay-thought-inner {
     color: white !important;
     border-color: white;
+  }
+  .n2-shell-panel,
+  .n2-shell-overflow {
+    border-color: rgba(51, 255, 51, 0.8);
+    background: rgba(0, 0, 0, 0.92);
+  }
+  .n2-shell-header,
+  .n2-shell-prompt,
+  .n2-shell-overflow {
+    opacity: 1;
   }
 }
 
@@ -204,9 +286,13 @@ body {
   .yutori-overlay-thought,
   .yutori-overlay-logo,
   .n2-overlay-click-pulse,
-  .n2-background-row,
-  .n2-background-overflow {
+  .n2-shell-panel,
+  .n2-shell-overflow,
+  .n2-shell-cursor {
     animation-duration: 0.01ms !important;
     transition-duration: 0.01ms !important;
+  }
+  .n2-shell-cursor {
+    animation: none;
   }
 }

--- a/yutori/navigator/macos/assets/navigator-overlay.html
+++ b/yutori/navigator/macos/assets/navigator-overlay.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <div id="n2-overlay-effects"></div>
-    <div id="n2-background-rail" aria-hidden="true"></div>
+    <div id="n2-shell-rail" aria-hidden="true"></div>
     <script src="navigator-overlay.iife.js"></script>
     <script src="macos-overlay.js"></script>
   </body>

--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -34,7 +34,12 @@ _PROCESS_EXIT_TIMEOUT_SECONDS = 1
 _OVERLAY_LEAD_SECONDS = 0.15
 _SHELL_MINIMUM_DWELL_SECONDS = 0.9
 _SHELL_TERMINAL_HOLD_SECONDS = 0.9
-_BACKGROUND_TERMINAL_HOLD_SECONDS = 1.5
+# The shell rail at the top-right keeps a finished command on screen long enough
+# to read: the capsule's 0.9s hold is tuned for a glance at the cursor, not for an
+# operator checking what just ran on their Mac.
+_SHELL_RAIL_TERMINAL_HOLD_SECONDS = 4.0
+_SHELL_RAIL_ROWS = 3
+_SHELL_TERMINAL_STATES = frozenset({"completed", "failed", "timed_out", "cancelled"})
 _NORMALIZED_SCALE = 1000
 
 _ACTION_STATUS = {
@@ -252,8 +257,8 @@ class MacOSPresentationController:
         self._batch_is_last = False
         self._capture_id = 0
         self._shell_started_at: dict[str, float] = {}
-        self._background: dict[str, ShellPresentationEvent] = {}
-        self._background_removals: set[asyncio.Task[None]] = set()
+        self._shell_rail: dict[str, ShellPresentationEvent] = {}
+        self._shell_rail_removals: set[asyncio.Task[None]] = set()
         self._telemetry: list[dict[str, Any]] = []
 
     @property
@@ -438,7 +443,7 @@ class MacOSPresentationController:
         if self._stopping:
             return
         self._stopping = True
-        await cancel_and_drain(*self._background_removals)
+        await cancel_and_drain(*self._shell_rail_removals)
         if self._process is not None and self._process.returncode is None and self._fatal_error is None:
             try:
                 await self._send_operation({"op": "destroy"}, allow_stopping=True)
@@ -647,13 +652,8 @@ class MacOSPresentationController:
                 **asdict(event),
             }
         )
+        await self._track_shell_rail(event)
         if event.run_in_background:
-            self._background[event.task_id] = event
-            await self._render_background_rail()
-            if event.state in {"completed", "failed", "timed_out", "cancelled"}:
-                task = asyncio.create_task(self._remove_background_after_hold(event.task_id, event))
-                self._background_removals.add(task)
-                task.add_done_callback(self._background_removals.discard)
             return
 
         if event.state in {"starting", "running"}:
@@ -690,21 +690,38 @@ class MacOSPresentationController:
         self._terminal_command = ""
         await self._render_capsule()
 
-    async def _render_background_rail(self) -> None:
-        events = list(self._background.values())
-        tasks = [asdict(event) for event in events[:3]]
-        signature = json.dumps([tasks, max(0, len(events) - 3)], separators=(",", ":"), sort_keys=True)
-        if self._last_render.get("backgroundTasks") == signature:
-            return
-        self._last_render["backgroundTasks"] = signature
-        await self._send_command({"op": "backgroundTasks", "tasks": tasks, "overflow": max(0, len(events) - 3)})
+    async def _track_shell_rail(self, event: ShellPresentationEvent) -> None:
+        """Mirror every shell lifecycle event, foreground or background, into the rail.
 
-    async def _remove_background_after_hold(self, task_id: str, terminal: ShellPresentationEvent) -> None:
-        if not await self._sleep(_BACKGROUND_TERMINAL_HOLD_SECONDS):
+        The capsule by the cursor only shows a foreground command for the ~1s it
+        takes to run, which is too brief for an operator to read; the rail under
+        the menu bar keeps each command visible while it runs and for a hold
+        after it finishes, so the operator can see what was sent to their Mac.
+        """
+        self._shell_rail[event.task_id] = event
+        await self._render_shell_rail()
+        if event.state in _SHELL_TERMINAL_STATES:
+            task = asyncio.create_task(self._remove_from_shell_rail_after_hold(event.task_id, event))
+            self._shell_rail_removals.add(task)
+            task.add_done_callback(self._shell_rail_removals.discard)
+
+    async def _render_shell_rail(self) -> None:
+        # Newest first: the most recent command lands at the top, just under the menu bar.
+        events = list(reversed(self._shell_rail.values()))
+        commands = [asdict(event) for event in events[:_SHELL_RAIL_ROWS]]
+        overflow = max(0, len(events) - _SHELL_RAIL_ROWS)
+        signature = json.dumps([commands, overflow], separators=(",", ":"), sort_keys=True)
+        if self._last_render.get("shellCommands") == signature:
             return
-        if self._background.get(task_id) == terminal:
-            self._background.pop(task_id, None)
-            await self._render_background_rail()
+        self._last_render["shellCommands"] = signature
+        await self._send_command({"op": "shellCommands", "commands": commands, "overflow": overflow})
+
+    async def _remove_from_shell_rail_after_hold(self, task_id: str, terminal: ShellPresentationEvent) -> None:
+        if not await self._sleep(_SHELL_RAIL_TERMINAL_HOLD_SECONDS):
+            return
+        if self._shell_rail.get(task_id) == terminal:
+            self._shell_rail.pop(task_id, None)
+            await self._render_shell_rail()
 
     async def _lead(self) -> bool:
         return await self._sleep(_OVERLAY_LEAD_SECONDS)
@@ -722,7 +739,10 @@ class MacOSPresentationController:
         stop_region = _valid_stop_region(reply.get("stop_region"))
         if not _positive_finite(width) or not _positive_finite(height) or not _positive_finite(scale):
             raise MacOSPresentationError("Overlay returned invalid viewport capabilities.")
-        if self._show_stop_button and stop_region is None:
+        # The Stop control is a menu bar status item. Its frame comes back as `stop_region` so
+        # model clicks on it are refused; a host whose menu bar sits on another display reports
+        # the control without a region, and then there is nothing on this screen to block.
+        if self._show_stop_button and stop_region is None and reply.get("stop_control") != "menu_bar":
             raise MacOSPresentationError("Overlay returned an invalid Stop region.")
         capabilities = MacOSPresentationCapabilities(
             protocol_version=OVERLAY_PROTOCOL_VERSION,


### PR DESCRIPTION
Foreground shell commands only flashed in the cursor capsule for under a second, so an operator could not see what n2 was running on their Mac. Every shell lifecycle event, foreground or background, now feeds a rail at the top-right styled after the playground's phosphor "run command" panel: newest first, three rows plus an overflow count, amber for failed or timed-out states, held 4s after a command finishes. The floating Stop panel is replaced by an `NSStatusItem` drawing the Yutori mark (from the dashboard's yutori-mark.svg, emitted as CGPath calls since AppKit has no SVG parser) whose menu carries "Yutori n2 is controlling this Mac" and "Stop ⇧⌘⎋"; its frame is still reported as `stop_region` so model clicks on it are refused, and a host whose menu bar sits on another display reports `stop_control: menu_bar` without a region. The host also injects `--n2-rail-top`/`--n2-rail-right` once the page loads, fixing the old rail sitting partly behind the Stop button on notch displays. Three new presentation tests cover rail rendering, ordering and overflow, hold-then-remove, render dedupe, and the region-less menu bar handshake; changed assets mean users re-run overlay preparation once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator stop UX and overlay click-blocking semantics during remote control; well-covered by tests but affects safety-critical “refuse clicks on Stop” behavior on multi-display setups.
> 
> **Overview**
> Operators can now see **what shell commands n2 runs on their Mac** in a top-right **shell rail** (phosphor-style panels), not only in the brief cursor capsule. **Every** foreground and background shell lifecycle event feeds the rail: **newest first**, up to **three rows** plus overflow, **4s hold** after finish, and deduped `shellCommands` host updates (replacing `backgroundTasks`).
> 
> The floating **Stop** WebKit panel becomes a **menu bar `NSStatusItem`** (Yutori mark) with a Stop menu and ⇧⌘Esc; the host still reports **`stop_region`** for click-blocking when the item is on-screen, or **`stop_control: menu_bar`** with no region when the menu bar is on another display. On load, the Swift host sets **`--n2-rail-top` / `--n2-rail-right`** so the rail clears the menu bar and notch layouts.
> 
> Presentation tests cover rail rendering, ordering/overflow, hold-then-remove, render dedupe, and the region-less menu bar handshake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baa6f9816404ae9e31b41d3dcf56fe5aa90796f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->