### PR TITLE
ci: cut the PyPI release automatically when a version bump lands

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,304 +1,130 @@
 name: Publish yutori to PyPI
 
+# A release is cut by merging a version bump: a PR that raises `version` in
+# pyproject.toml and regenerates install.sh (scripts/build_install.sh). When that
+# lands on main this workflow tags the merge commit vX.Y.Z, publishes the package
+# to PyPI, and creates the GitHub release with the installer assets. Do not create
+# the tag or the release by hand: an existing vX.Y.Z tag is the signal that the
+# version already shipped, and the run skips.
 on:
+  push:
+    branches: [main]
+    paths:
+      - pyproject.toml
+  # Re-run for the current main by hand if a publish attempt failed midway.
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Annotated release tag to publish (vX.Y.Z or X.Y.Z)"
-        required: true
-        type: string
 
-# A GitHub Release becomes "latest" as soon as it is published. Build, test,
-# publish to PyPI, and attach every release asset before publishing the release
-# so yutori.com/install.sh can never point at an incomplete release.
+# One publish at a time, and never cancel one that is already uploading.
 concurrency:
-  group: yutori-release
+  group: publish-to-pypi
   cancel-in-progress: false
 
 jobs:
-  normalize_tag:
-    name: Normalize release tag
+  version:
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.normalize.outputs.tag }}
-    steps:
-      - id: normalize
-        env:
-          INPUT_TAG: ${{ inputs.tag }}
-        run: |
-          version="${INPUT_TAG#v}"
-          test -n "$version"
-          printf 'tag=v%s\n' "$version" >> "$GITHUB_OUTPUT"
-
-  build:
-    name: Build release artifacts
-    needs: normalize_tag
-    runs-on: ubuntu-latest
-    outputs:
-      release_tag: ${{ needs.normalize_tag.outputs.tag }}
-    env:
-      RELEASE_TAG: ${{ needs.normalize_tag.outputs.tag }}
-    permissions:
-      contents: read
+      version: ${{ steps.read.outputs.version }}
+      unreleased: ${{ steps.check.outputs.unreleased }}
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - name: Verify annotated release tag and package version
+      - name: Read the version from pyproject.toml
+        id: read
         run: |
-          test "$(git cat-file -t "refs/tags/$RELEASE_TAG")" = tag
-          test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$(git rev-parse HEAD)"
-          test "${RELEASE_TAG#v}" != "$RELEASE_TAG"
-          test "$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")" = "${RELEASE_TAG#v}"
+          version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-      - name: Refuse to overwrite a published release
+      - name: Check whether this version is already tagged
+        id: check
         env:
-          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.read.outputs.version }}
         run: |
-          python - <<'PY'
-          import json
-          import os
-          from urllib.error import HTTPError
-          from urllib.parse import quote
-          from urllib.request import Request, urlopen
+          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null; then
+            echo "v${VERSION} is already released; nothing to publish."
+            echo "unreleased=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "v${VERSION} is not tagged yet; publishing."
+            echo "unreleased=true" >> "$GITHUB_OUTPUT"
+          fi
 
-          repository = os.environ["GITHUB_REPOSITORY"]
-          tag = quote(os.environ["RELEASE_TAG"], safe="")
-          request = Request(
-              f"https://api.github.com/repos/{repository}/releases/tags/{tag}",
-              headers={"Authorization": f"Bearer {os.environ['GH_TOKEN']}"},
-          )
-          try:
-              with urlopen(request, timeout=30) as response:
-                  release = json.load(response)
-          except HTTPError as error:
-              if error.code == 404:
-                  raise SystemExit(0)
-              raise
+  publish:
+    needs: version
+    if: needs.version.outputs.unreleased == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
 
-          if not release["draft"]:
-              raise SystemExit(
-                  "Refusing to overwrite a published release; repair it separately or create a new release tag."
-              )
-          PY
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
 
       - name: Install build tools
         run: pip install build twine
 
+      # Gate publishing on the test suite — a broken version bump must not ship.
       - name: Run tests
         run: |
           pip install -e ".[dev]"
           pytest -m "not slow"
 
-      - name: Build and validate exact distributions
-        run: |
-          python -m build
-          twine check dist/*
-          (cd dist && sha256sum *.tar.gz *.whl > SHA256SUMS)
+      - name: Build package
+        run: python -m build
 
-      - name: Test exact distributions
-        env:
-          YUTORI_TEST_DISTRIBUTIONS_DIR: ${{ github.workspace }}/dist
-        run: pytest -m slow tests/test_packaging.py
+      - name: Validate package metadata
+        run: twine check dist/*
 
-      - name: Record public source provenance
-        run: |
-          python - <<'PY'
-          import hashlib
-          import json
-          import os
-          import subprocess
-          import tomllib
-          from pathlib import Path
-
-          dist = Path("dist")
-          tag = os.environ["RELEASE_TAG"]
-          artifacts = {
-              path.name: f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
-              for path in sorted([*dist.glob("*.tar.gz"), *dist.glob("*.whl")])
-          }
-          provenance = {
-              "repository": "${{ github.repository }}",
-              "tag": tag,
-              "tag_object": subprocess.check_output(
-                  ["git", "rev-parse", f"refs/tags/{tag}"], text=True
-              ).strip(),
-              "commit": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
-              "version": tomllib.load(open("pyproject.toml", "rb"))["project"]["version"],
-              "artifacts": artifacts,
-          }
-          (dist / "RELEASE-PROVENANCE.json").write_text(
-              json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-          )
-          PY
-
-      - name: Store release distributions
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-distributions
-          path: dist/
-          if-no-files-found: error
-
-      - name: Store verified release source
-        run: git archive --format=tar.gz --prefix=source/ HEAD > release-source.tar.gz
-
-      - name: Store verified release source archive
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-source
-          path: release-source.tar.gz
-          if-no-files-found: error
-
-  publish:
-    name: Publish exact distributions to PyPI
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/yutori
-    permissions:
-      id-token: write
-    env:
-      RELEASE_TAG: ${{ needs.build.outputs.release_tag }}
-    steps:
-      - name: Retrieve tested distributions
-        uses: actions/download-artifact@v4
-        with:
-          name: python-distributions
-          path: dist
-
-      - name: Verify distribution hashes
-        run: (cd dist && sha256sum --check SHA256SUMS)
-
-      - name: Prepare exact distributions for publishing
-        run: |
-          mkdir packages
-          cp dist/*.tar.gz dist/*.whl packages/
-
-      - name: Check whether PyPI already has these distributions
-        id: pypi-release
-        run: |
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-          from urllib.error import HTTPError
-          from urllib.request import urlopen
-
-          expected = {}
-          for line in Path("dist/SHA256SUMS").read_text(encoding="utf-8").splitlines():
-              digest, filename = line.split(maxsplit=1)
-              expected[filename.removeprefix("*")] = digest
-
-          version = os.environ["RELEASE_TAG"].removeprefix("v")
-          try:
-              with urlopen(f"https://pypi.org/pypi/yutori/{version}/json", timeout=30) as response:
-                  release = json.load(response)
-          except HTTPError as error:
-              if error.code != 404:
-                  raise
-              state = "missing"
-          else:
-              actual = {file["filename"]: file["digests"]["sha256"] for file in release["urls"]}
-              if actual != expected:
-                  raise SystemExit(f"PyPI yutori {version} does not match the verified distributions")
-              state = "matching"
-
-          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
-              print(f"state={state}", file=output)
-          PY
-
-      - name: Publish with PyPI Trusted Publishing
-        if: steps.pypi-release.outputs.state == 'missing'
-        # release/v1, pinned to an immutable commit. This action creates and
-        # uploads PyPI attestations for the same distribution bytes by default.
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
-        with:
-          packages-dir: packages/
-          attestations: true
-
-  release-assets:
-    name: Upload release checksums and installers
-    # Do not let a release become latest until its PyPI distributions exist.
-    # This job still creates a draft first, then publishes it only after all
-    # installer assets have been verified and uploaded.
-    needs: [build, publish]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      RELEASE_TAG: ${{ needs.build.outputs.release_tag }}
-    steps:
-      - name: Retrieve tested distribution hashes
-        uses: actions/download-artifact@v4
-        with:
-          name: python-distributions
-          path: dist
-
-      - name: Verify distribution hashes
-        run: (cd dist && sha256sum --check SHA256SUMS)
-
-      - name: Retrieve verified release source
-        uses: actions/download-artifact@v4
-        with:
-          name: release-source
-          path: source-archive
-
-      - name: Extract verified release source
-        run: |
-          mkdir source
-          tar -xzf source-archive/release-source.tar.gz -C source --strip-components=1
+      - name: Verify the build carries the bumped version
+        run: ls "dist/yutori-${VERSION}.tar.gz" "dist/yutori-${VERSION}-py3-none-any.whl"
 
       # install.sh is regenerated from the committed template + banner +
       # frames so the uploaded release asset matches the tagged commit
       # deterministically. The pre-commit hook at
       # scripts/check_install_sh_fresh.sh catches drift at PR time.
       - name: Regenerate install.sh
-        run: bash source/scripts/build_install.sh
+        run: bash scripts/build_install.sh
 
       - name: Generate installer checksums
         run: |
-          chmod +x source/install.sh source/uninstall.sh
-          sha256sum source/install.sh > source/install.sh.sha256
-          sha256sum source/uninstall.sh > source/uninstall.sh.sha256
+          chmod +x install.sh uninstall.sh
+          sha256sum install.sh > install.sh.sha256
+          sha256sum uninstall.sh > uninstall.sh.sha256
 
-      - name: Verify release assets
+      - name: Publish to PyPI
+        # --skip-existing lets a re-run after a failed tag or release step pass the
+        # files PyPI already accepted instead of failing on them.
+        run: twine upload --skip-existing dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Tag the release commit
         run: |
-          for file in \
-            dist/SHA256SUMS \
-            dist/RELEASE-PROVENANCE.json \
-            source/install.sh \
-            source/install.sh.sha256 \
-            source/uninstall.sh \
-            source/uninstall.sh.sha256; do
-            test -s "$file"
-          done
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "yutori ${VERSION}" "${GITHUB_SHA}"
+          git push origin "v${VERSION}"
 
-      - name: Upload release assets
+      - name: Create the GitHub release with installer assets
         # Pinned to a commit SHA: this third-party action runs with
-        # contents:write and uploads the curl|sh installer artifacts.
+        # contents:write and uploads the curl|sh installer artifact, so a
+        # mutable tag would be a supply-chain risk.
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          name: yutori ${{ env.RELEASE_TAG }}
+          tag_name: v${{ needs.version.outputs.version }}
+          name: yutori v${{ needs.version.outputs.version }}
+          target_commitish: ${{ github.sha }}
           generate_release_notes: true
-          draft: true
           fail_on_unmatched_files: true
           files: |
-            dist/SHA256SUMS
-            dist/RELEASE-PROVENANCE.json
-            source/install.sh
-            source/install.sh.sha256
-            source/uninstall.sh
-            source/uninstall.sh.sha256
-
-      - name: Publish release after verified assets upload
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+            install.sh
+            install.sh.sha256
+            uninstall.sh
+            uninstall.sh.sha256

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,130 +1,351 @@
 name: Publish yutori to PyPI
 
 # A release is cut by merging a version bump: a PR that raises `version` in
-# pyproject.toml and regenerates install.sh (scripts/build_install.sh). When that
-# lands on main this workflow tags the merge commit vX.Y.Z, publishes the package
-# to PyPI, and creates the GitHub release with the installer assets. Do not create
-# the tag or the release by hand: an existing vX.Y.Z tag is the signal that the
-# version already shipped, and the run skips.
+# pyproject.toml and regenerates install.sh. When that lands on main, the tag
+# job creates the annotated vX.Y.Z tag on the merge commit and the rest of this
+# workflow publishes it. Do not create the tag by hand; a tag that already
+# points at an older commit is the signal that the version has shipped.
 on:
   push:
     branches: [main]
     paths:
       - pyproject.toml
-  # Re-run for the current main by hand if a publish attempt failed midway.
   workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Existing annotated release tag to publish (vX.Y.Z or X.Y.Z). Leave
+          empty to release the version pyproject.toml declares on this ref.
+        required: false
+        type: string
 
-# One publish at a time, and never cancel one that is already uploading.
+# A GitHub Release becomes "latest" as soon as it is published. Build, test,
+# publish to PyPI, and attach every release asset before publishing the release
+# so yutori.com/install.sh can never point at an incomplete release.
 concurrency:
-  group: publish-to-pypi
+  group: yutori-release
   cancel-in-progress: false
 
 jobs:
-  version:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.read.outputs.version }}
-      unreleased: ${{ steps.check.outputs.unreleased }}
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Read the version from pyproject.toml
-        id: read
-        run: |
-          version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
-      - name: Check whether this version is already tagged
-        id: check
-        env:
-          VERSION: ${{ steps.read.outputs.version }}
-        run: |
-          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null; then
-            echo "v${VERSION} is already released; nothing to publish."
-            echo "unreleased=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "v${VERSION} is not tagged yet; publishing."
-            echo "unreleased=true" >> "$GITHUB_OUTPUT"
-          fi
-
-  publish:
-    needs: version
-    if: needs.version.outputs.unreleased == 'true'
+  tag:
+    name: Resolve or create the release tag
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    env:
-      VERSION: ${{ needs.version.outputs.version }}
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      release: ${{ steps.resolve.outputs.release }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+
+      - id: resolve
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        # An explicit tag input publishes that tag as before. Otherwise the tag
+        # is derived from pyproject.toml: create it when it does not exist yet,
+        # reuse it when it already points at this commit (a retry of a run that
+        # failed after tagging), and skip when it points anywhere else because
+        # that version has already shipped.
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            printf 'tag=v%s\nrelease=true\n' "${INPUT_TAG#v}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          version="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
+          tag="v${version}"
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            if [ "$(git rev-parse "${tag}^{commit}")" = "$GITHUB_SHA" ]; then
+              echo "${tag} already points at this commit; resuming its release."
+              printf 'tag=%s\nrelease=true\n' "$tag" >> "$GITHUB_OUTPUT"
+            else
+              echo "${tag} already points at another commit; yutori ${version} has shipped."
+              printf 'tag=%s\nrelease=false\n' "$tag" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$tag" -m "yutori ${version}" "$GITHUB_SHA"
+          git push origin "refs/tags/${tag}"
+          echo "Created ${tag} on ${GITHUB_SHA}."
+          printf 'tag=%s\nrelease=true\n' "$tag" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build release artifacts
+    needs: tag
+    if: needs.tag.outputs.release == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ needs.tag.outputs.tag }}
+    env:
+      RELEASE_TAG: ${{ needs.tag.outputs.tag }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Verify annotated release tag and package version
+        run: |
+          test "$(git cat-file -t "refs/tags/$RELEASE_TAG")" = tag
+          test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$(git rev-parse HEAD)"
+          test "${RELEASE_TAG#v}" != "$RELEASE_TAG"
+          test "$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")" = "${RELEASE_TAG#v}"
+
+      - name: Refuse to overwrite a published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from urllib.error import HTTPError
+          from urllib.parse import quote
+          from urllib.request import Request, urlopen
+
+          repository = os.environ["GITHUB_REPOSITORY"]
+          tag = quote(os.environ["RELEASE_TAG"], safe="")
+          request = Request(
+              f"https://api.github.com/repos/{repository}/releases/tags/{tag}",
+              headers={"Authorization": f"Bearer {os.environ['GH_TOKEN']}"},
+          )
+          try:
+              with urlopen(request, timeout=30) as response:
+                  release = json.load(response)
+          except HTTPError as error:
+              if error.code == 404:
+                  raise SystemExit(0)
+              raise
+
+          if not release["draft"]:
+              raise SystemExit(
+                  "Refusing to overwrite a published release; repair it separately or create a new release tag."
+              )
+          PY
 
       - name: Install build tools
         run: pip install build twine
 
-      # Gate publishing on the test suite — a broken version bump must not ship.
       - name: Run tests
         run: |
           pip install -e ".[dev]"
           pytest -m "not slow"
 
-      - name: Build package
-        run: python -m build
+      - name: Build and validate exact distributions
+        run: |
+          python -m build
+          twine check dist/*
+          (cd dist && sha256sum *.tar.gz *.whl > SHA256SUMS)
 
-      - name: Validate package metadata
-        run: twine check dist/*
+      - name: Test exact distributions
+        env:
+          YUTORI_TEST_DISTRIBUTIONS_DIR: ${{ github.workspace }}/dist
+        run: pytest -m slow tests/test_packaging.py
 
-      - name: Verify the build carries the bumped version
-        run: ls "dist/yutori-${VERSION}.tar.gz" "dist/yutori-${VERSION}-py3-none-any.whl"
+      - name: Record public source provenance
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import subprocess
+          import tomllib
+          from pathlib import Path
+
+          dist = Path("dist")
+          tag = os.environ["RELEASE_TAG"]
+          artifacts = {
+              path.name: f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
+              for path in sorted([*dist.glob("*.tar.gz"), *dist.glob("*.whl")])
+          }
+          provenance = {
+              "repository": "${{ github.repository }}",
+              "tag": tag,
+              "tag_object": subprocess.check_output(
+                  ["git", "rev-parse", f"refs/tags/{tag}"], text=True
+              ).strip(),
+              "commit": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+              "version": tomllib.load(open("pyproject.toml", "rb"))["project"]["version"],
+              "artifacts": artifacts,
+          }
+          (dist / "RELEASE-PROVENANCE.json").write_text(
+              json.dumps(provenance, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          PY
+
+      - name: Store release distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-distributions
+          path: dist/
+          if-no-files-found: error
+
+      - name: Store verified release source
+        run: git archive --format=tar.gz --prefix=source/ HEAD > release-source.tar.gz
+
+      - name: Store verified release source archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-source
+          path: release-source.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: Publish exact distributions to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/yutori
+    permissions:
+      id-token: write
+    env:
+      RELEASE_TAG: ${{ needs.build.outputs.release_tag }}
+    steps:
+      - name: Retrieve tested distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-distributions
+          path: dist
+
+      - name: Verify distribution hashes
+        run: (cd dist && sha256sum --check SHA256SUMS)
+
+      - name: Prepare exact distributions for publishing
+        run: |
+          mkdir packages
+          cp dist/*.tar.gz dist/*.whl packages/
+
+      - name: Check whether PyPI already has these distributions
+        id: pypi-release
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          from urllib.error import HTTPError
+          from urllib.request import urlopen
+
+          expected = {}
+          for line in Path("dist/SHA256SUMS").read_text(encoding="utf-8").splitlines():
+              digest, filename = line.split(maxsplit=1)
+              expected[filename.removeprefix("*")] = digest
+
+          version = os.environ["RELEASE_TAG"].removeprefix("v")
+          try:
+              with urlopen(f"https://pypi.org/pypi/yutori/{version}/json", timeout=30) as response:
+                  release = json.load(response)
+          except HTTPError as error:
+              if error.code != 404:
+                  raise
+              state = "missing"
+          else:
+              actual = {file["filename"]: file["digests"]["sha256"] for file in release["urls"]}
+              if actual != expected:
+                  raise SystemExit(f"PyPI yutori {version} does not match the verified distributions")
+              state = "matching"
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              print(f"state={state}", file=output)
+          PY
+
+      - name: Publish with PyPI Trusted Publishing
+        if: steps.pypi-release.outputs.state == 'missing'
+        # release/v1, pinned to an immutable commit. This action creates and
+        # uploads PyPI attestations for the same distribution bytes by default.
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
+        with:
+          packages-dir: packages/
+          attestations: true
+
+  release-assets:
+    name: Upload release checksums and installers
+    # Do not let a release become latest until its PyPI distributions exist.
+    # This job still creates a draft first, then publishes it only after all
+    # installer assets have been verified and uploaded.
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ needs.build.outputs.release_tag }}
+    steps:
+      - name: Retrieve tested distribution hashes
+        uses: actions/download-artifact@v4
+        with:
+          name: python-distributions
+          path: dist
+
+      - name: Verify distribution hashes
+        run: (cd dist && sha256sum --check SHA256SUMS)
+
+      - name: Retrieve verified release source
+        uses: actions/download-artifact@v4
+        with:
+          name: release-source
+          path: source-archive
+
+      - name: Extract verified release source
+        run: |
+          mkdir source
+          tar -xzf source-archive/release-source.tar.gz -C source --strip-components=1
 
       # install.sh is regenerated from the committed template + banner +
       # frames so the uploaded release asset matches the tagged commit
       # deterministically. The pre-commit hook at
       # scripts/check_install_sh_fresh.sh catches drift at PR time.
       - name: Regenerate install.sh
-        run: bash scripts/build_install.sh
+        run: bash source/scripts/build_install.sh
 
       - name: Generate installer checksums
         run: |
-          chmod +x install.sh uninstall.sh
-          sha256sum install.sh > install.sh.sha256
-          sha256sum uninstall.sh > uninstall.sh.sha256
+          chmod +x source/install.sh source/uninstall.sh
+          sha256sum source/install.sh > source/install.sh.sha256
+          sha256sum source/uninstall.sh > source/uninstall.sh.sha256
 
-      - name: Publish to PyPI
-        # --skip-existing lets a re-run after a failed tag or release step pass the
-        # files PyPI already accepted instead of failing on them.
-        run: twine upload --skip-existing dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-
-      - name: Tag the release commit
+      - name: Verify release assets
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${VERSION}" -m "yutori ${VERSION}" "${GITHUB_SHA}"
-          git push origin "v${VERSION}"
+          for file in \
+            dist/SHA256SUMS \
+            dist/RELEASE-PROVENANCE.json \
+            source/install.sh \
+            source/install.sh.sha256 \
+            source/uninstall.sh \
+            source/uninstall.sh.sha256; do
+            test -s "$file"
+          done
 
-      - name: Create the GitHub release with installer assets
+      - name: Upload release assets
         # Pinned to a commit SHA: this third-party action runs with
-        # contents:write and uploads the curl|sh installer artifact, so a
-        # mutable tag would be a supply-chain risk.
+        # contents:write and uploads the curl|sh installer artifacts.
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          tag_name: v${{ needs.version.outputs.version }}
-          name: yutori v${{ needs.version.outputs.version }}
-          target_commitish: ${{ github.sha }}
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: yutori ${{ env.RELEASE_TAG }}
           generate_release_notes: true
+          draft: true
           fail_on_unmatched_files: true
           files: |
-            install.sh
-            install.sh.sha256
-            uninstall.sh
-            uninstall.sh.sha256
+            dist/SHA256SUMS
+            dist/RELEASE-PROVENANCE.json
+            source/install.sh
+            source/install.sh.sha256
+            source/uninstall.sh
+            source/uninstall.sh.sha256
+
+      - name: Publish release after verified assets upload
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,14 +69,15 @@ already-published release:
    runs `bash scripts/build_install.sh` to regenerate `install.sh`, and updates the pinned
    `yutori==` versions under `examples/navigator_n2/` (`pyproject.toml`, `README.md`,
    `Dockerfile.direct_x11`).
-2. Merge it. The "Publish yutori to PyPI" workflow runs on the version change: it runs the
-   tests, builds and uploads the package, tags the merge commit `vX.Y.Z`, and creates the
-   GitHub release with generated notes and the installer assets.
+2. Merge it. The "Publish yutori to PyPI" workflow runs on the version change: it creates
+   the annotated `vX.Y.Z` tag on the merge commit, runs the tests, builds and verifies the
+   exact distributions, publishes them with PyPI Trusted Publishing, and only then creates
+   the GitHub release with the checksums, provenance, and installer assets.
 
-Do not create the tag or the release by hand. An existing `vX.Y.Z` tag tells the workflow
-that version already shipped, so it skips. If a run fails after PyPI accepted the upload,
-fix the cause and re-run it from the Actions tab; the upload step skips files PyPI already
-has, and the tag and release steps pick up where it stopped.
+Do not create the tag by hand. A `vX.Y.Z` tag that points at an older commit tells the
+workflow that version already shipped, so it skips. If a run fails after tagging, re-run it
+from the Actions tab: the tag job reuses a tag that points at the same commit, the PyPI step
+skips distributions PyPI already holds, and a published release is never overwritten.
 
 ## Reporting Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,21 @@ release, and only then publishes the release. Do not publish a GitHub release ma
 already-published release:
 `yutori.com/install.sh` follows the latest published release.
 
+## Releasing
+
+1. Open a PR titled `chore(release): X.Y.Z` that bumps `version` in `pyproject.toml`,
+   runs `bash scripts/build_install.sh` to regenerate `install.sh`, and updates the pinned
+   `yutori==` versions under `examples/navigator_n2/` (`pyproject.toml`, `README.md`,
+   `Dockerfile.direct_x11`).
+2. Merge it. The "Publish yutori to PyPI" workflow runs on the version change: it runs the
+   tests, builds and uploads the package, tags the merge commit `vX.Y.Z`, and creates the
+   GitHub release with generated notes and the installer assets.
+
+Do not create the tag or the release by hand. An existing `vX.Y.Z` tag tells the workflow
+that version already shipped, so it skips. If a run fails after PyPI accepted the upload,
+fix the cause and re-run it from the Actions tab; the upload step skips files PyPI already
+has, and the tag and release steps pick up where it stopped.
+
 ## Reporting Issues
 
 Please report issues at https://github.com/yutori-ai/yutori-sdk-python/issues


### PR DESCRIPTION
Releasing needed two manual steps after the `chore(release): X.Y.Z` PR merged: create the annotated `vX.Y.Z` tag, then dispatch the publish workflow with it. The workflow now also runs on pushes to main that touch `pyproject.toml`. A new `tag` job derives `vX.Y.Z` from the declared version and creates the annotated tag on the merge commit; it reuses a tag that already points at this commit so a run that failed after tagging can simply be re-run, and skips when the tag points at an older commit because that version already shipped. Everything downstream is unchanged: tag and version verification, the refusal to overwrite a published release, exact-distribution tests, provenance, PyPI Trusted Publishing on the `pypi` environment with attestations, and the draft-first release with checksums and installer assets. The `workflow_dispatch` tag input stays as the manual repair path, now optional. CONTRIBUTING.md gains a Releasing section that says to bump and merge, and never to tag by hand. Validated by parsing the workflow, diffing it against main to confirm only the trigger and tag job changed, and exercising the three tag-resolution branches against origin's real tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation (auto-tagging with `contents: write` and new skip/resume logic); mistakes could affect when PyPI/GitHub releases run, though existing guards against overwriting published releases remain.
> 
> **Overview**
> **Merging a version bump on `main` now triggers PyPI publishing** without manually creating `vX.Y.Z` or dispatching the workflow. Pushes to `main` that change `pyproject.toml` run **Publish yutori to PyPI**; the first job reads the declared version, creates and pushes an annotated tag on the merge commit when needed, reuses the tag if it already points at that commit (failed-run retry), or sets `release=false` so later jobs skip when the tag points at another commit (version already shipped). **`workflow_dispatch`** keeps an optional tag input for repair publishes. **`build`** and downstream jobs only run when `needs.tag.outputs.release == 'true'**.
> 
> **CONTRIBUTING.md** adds a **Releasing** section: open `chore(release): X.Y.Z`, merge, let CI tag and publish; do not tag by hand; re-run Actions after a post-tag failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abb3924ea157510d0b2119b306e9a7c8e203d54b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->