### PR TITLE
chore(release): 0.9.10

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.9" \
+    "yutori==0.9.10" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.9'
+pip install 'yutori[macos]==0.9.10'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.9",
+    "yutori==0.9.10",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.9"]
+macos = ["yutori[macos]==0.9.10"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.9"
+YUTORI_INSTALLER_VERSION="0.9.10"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.9"
+version = "0.9.10"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bumps `version` to 0.9.10, regenerates `install.sh`, and moves the `yutori==` pins under `examples/navigator_n2/` to 0.9.10. Ships the macOS overlay shell-command rail and the menu bar Stop item drawn with the Yutori mark (#356). Merge after #356 and #357: with #357 in, landing this bump on main tags `v0.9.10` and runs the publish workflow automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and dependency pin updates only; no SDK logic changes in this PR.
> 
> **Overview**
> **Release 0.9.10** — bumps the SDK `version` in `pyproject.toml` and the installer banner string in `install.sh` so `curl | bash` installs report the new release.
> 
> Navigator n2 cookbooks stay aligned: `examples/navigator_n2/pyproject.toml`, `README.md` macOS install line, and `Dockerfile.direct_x11` all pin **`yutori==0.9.10`** (and the macOS extra where applicable). No runtime or API code changes in this diff.
> 
> Landing on `main` after the feature PRs is intended to tag **`v0.9.10`** and trigger the publish workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 612affdc8a46928a332255c22dee83ac4d952729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->