### PR TITLE
ci: bump GitHub Actions to latest, cancel superseded runs, cache pip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
 
+# A new push to a PR makes the in-flight run for the previous commit
+# irrelevant, so stop paying for its 12 matrix jobs. Pushes to main are never
+# cancelled: every commit there keeps its own status.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -13,6 +20,8 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - run: pip install ruff
       - run: ruff check .
 
@@ -27,6 +36,8 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - run: pip install -e ".[dev]"
       - run: pytest -m "not slow"
 
@@ -44,6 +55,8 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - run: pip install -e ".[dev]" twine
       - name: Wheel content test
         run: pytest -m slow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,11 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: pyproject.toml
+      # No pip cache here on purpose. This job installs only ruff, but it
+      # would share the 3.12 cache key with test/package (setup-python keys on
+      # python version + pyproject.toml hash) and usually wins the race to
+      # write it, leaving those jobs to restore a cache with none of their
+      # dependencies in it.
       - run: pip install ruff
       - run: ruff check .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - run: pip install ruff
@@ -23,8 +23,8 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"
@@ -40,8 +40,8 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]" twine
@@ -55,7 +55,7 @@ jobs:
   install-sh:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Verify install.sh matches template + assets + version
         run: bash scripts/check_install_sh_fresh.sh
       - name: Syntax-check shell scripts

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -36,11 +36,11 @@ jobs:
       tag: ${{ steps.resolve.outputs.tag }}
       release: ${{ steps.resolve.outputs.release }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -88,12 +88,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -186,7 +186,7 @@ jobs:
           PY
 
       - name: Store release distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-distributions
           path: dist/
@@ -196,7 +196,7 @@ jobs:
         run: git archive --format=tar.gz --prefix=source/ HEAD > release-source.tar.gz
 
       - name: Store verified release source archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-source
           path: release-source.tar.gz
@@ -215,7 +215,7 @@ jobs:
       RELEASE_TAG: ${{ needs.build.outputs.release_tag }}
     steps:
       - name: Retrieve tested distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-distributions
           path: dist
@@ -265,7 +265,7 @@ jobs:
         if: steps.pypi-release.outputs.state == 'missing'
         # release/v1, pinned to an immutable commit. This action creates and
         # uploads PyPI attestations for the same distribution bytes by default.
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1 (v1.14.2)
         with:
           packages-dir: packages/
           attestations: true
@@ -283,7 +283,7 @@ jobs:
       RELEASE_TAG: ${{ needs.build.outputs.release_tag }}
     steps:
       - name: Retrieve tested distribution hashes
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-distributions
           path: dist
@@ -292,7 +292,7 @@ jobs:
         run: (cd dist && sha256sum --check SHA256SUMS)
 
       - name: Retrieve verified release source
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-source
           path: source-archive
@@ -330,7 +330,7 @@ jobs:
       - name: Upload release assets
         # Pinned to a commit SHA: this third-party action runs with
         # contents:write and uploads the curl|sh installer artifacts.
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           name: yutori ${{ env.RELEASE_TAG }}


### PR DESCRIPTION
Bumps every action used by CI and the release workflow to its latest version: `actions/checkout` v5 → v7, `actions/setup-python` v6 → v7, `actions/upload-artifact` v4 → v7, and `actions/download-artifact` v4 → v8. The two SHA-pinned third-party actions stay pinned, repointed at the current `release/v1` head of `pypa/gh-action-pypi-publish` (v1.14.2) and at `softprops/action-gh-release` v3.0.3. None of the intervening majors affect this repo: the artifact actions move to Node 24 and ESM (fine on `ubuntu-latest`), their new `archive` / `skip-decompress` inputs are opt-in and unused, and `setup-python` v7 drops the `pip-install` input these workflows never set. The one behavior change worth noting is that `download-artifact` v8 now fails on a digest mismatch instead of only warning, which lines up with the release workflow's existing `SHA256SUMS` verification.

The second commit is a CI cost fix. There was no `concurrency` group, so every push to a PR left the previous commit's 12 matrix jobs running to completion for a result nobody reads; runs are now grouped by workflow + ref and cancelled in progress for `pull_request` events only, leaving pushes to `main` to finish so each commit keeps its own status. It also enables `setup-python`'s pip cache keyed on `pyproject.toml` — the install step is ~12s of a ~45s job, mostly re-downloading the same wheels 12 times per run, and since pip still queries the index the unpinned dependency ranges keep resolving to current releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions configuration and dependency caching; no application, auth, or release logic beyond stricter artifact digest handling.
> 
> **Overview**
> **Updates CI and PyPI release workflows** by bumping first-party actions (`checkout` v7, `setup-python` v7, `upload-artifact` v7, `download-artifact` v8) and repinning `pypa/gh-action-pypi-publish` and `softprops/action-gh-release` to newer SHAs. `download-artifact` v8 now **fails on digest mismatch** instead of warning only, which matches the release workflow’s existing `SHA256SUMS` checks.
> 
> **Adds a workflow concurrency group** keyed on workflow + ref so new pushes on pull requests cancel in-flight runs (saving matrix job minutes); pushes to `main` are never cancelled.
> 
> **Enables `setup-python` pip caching** on the `test` and `package` matrix jobs (`cache-dependency-path: pyproject.toml`). The **lint** job deliberately omits pip cache so a ruff-only install doesn’t race and overwrite the shared 3.12 cache key, which would leave heavier jobs with an empty restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec026e17d719e3fa5123394418279347c4503256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->