### PR TITLE
chore(release): 0.9.11

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.10" \
+    "yutori==0.9.11" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.10'
+pip install 'yutori[macos]==0.9.11'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.10",
+    "yutori==0.9.11",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.10"]
+macos = ["yutori[macos]==0.9.11"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.10"
+YUTORI_INSTALLER_VERSION="0.9.11"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.10"
+version = "0.9.11"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Release commit for 0.9.11, same shape as #358 (0.9.10): `pyproject.toml` version, the pins in `examples/navigator_n2/pyproject.toml`, `Dockerfile.direct_x11`, and `README.md`, and `YUTORI_INSTALLER_VERSION` in the regenerated `install.sh` (`scripts/check_install_sh_fresh.sh` passes).

Since 0.9.10: window scope for background computer use in `MacOSComputer` (#359) and the menu bar status item with the latest frame for window-scope runs (#365).

Stacked on #359 and #365: merge those first (in that order), then this one (the diff collapses to the version bump once #359 lands). With #357 in, merging this cuts the tag and PyPI release automatically; yutori-ai/yutori-mcp#242 then bumps its pin to 0.9.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-string and dependency pin updates only; no runtime or API logic changes in this diff.
> 
> **Overview**
> **Release 0.9.11** — bumps the SDK from `0.9.10` to `0.9.11` in the root `pyproject.toml` and keeps every consumer-facing pin in sync.
> 
> The navigator n2 cookbook (`examples/navigator_n2/pyproject.toml`, `Dockerfile.direct_x11`, and the macOS `pip install` line in `README.md`) now depend on `yutori==0.9.11` (and `yutori[macos]==0.9.11` where applicable). Regenerated `install.sh` sets `YUTORI_INSTALLER_VERSION` to **0.9.11** so the curl installer banner matches the package release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571a7f433b30c0d1d00b8d8343827add36847cd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->