### PR TITLE
refactor(examples): dedupe the docker-missing guard in local_x11_docker.py

### DIFF
--- a/examples/navigator_n2/local_x11_docker.py
+++ b/examples/navigator_n2/local_x11_docker.py
@@ -38,11 +38,16 @@ def _authentication_args() -> list[str]:
     raise RuntimeError(f"unsupported Yutori authentication source: {status.source!r}")
 
 
-def _run_checked(command: list[str], description: str, **kwargs: object) -> None:
+def _run_docker(command: list[str], **kwargs: object) -> "subprocess.CompletedProcess[bytes]":
+    """Run a docker subprocess, translating a missing binary into a clear error."""
     try:
-        result = subprocess.run(command, **kwargs)
+        return subprocess.run(command, **kwargs)
     except FileNotFoundError as error:
         raise SystemExit("docker is not installed") from error
+
+
+def _run_checked(command: list[str], description: str, **kwargs: object) -> None:
+    result = _run_docker(command, **kwargs)
     if result.returncode != 0:
         raise SystemExit(f"{description} failed with exit code {result.returncode}")
 
@@ -125,10 +130,7 @@ def main(args: argparse.Namespace) -> None:
     )
 
     print(f"Watch the desktop live: http://localhost:{novnc_port}/vnc.html", flush=True)
-    try:
-        result = subprocess.run(docker_command)
-    except FileNotFoundError as error:
-        raise SystemExit("docker is not installed") from error
+    result = _run_docker(docker_command)
     if result.returncode != 0:
         raise SystemExit(result.returncode)
 

--- a/tests/test_navigator_n2_entrypoints.py
+++ b/tests/test_navigator_n2_entrypoints.py
@@ -269,6 +269,49 @@ def test_local_x11_docker_builds_image_and_delegates_to_local_x11(
     assert "view-only noVNC session" in documentation
 
 
+def test_run_docker_translates_missing_binary_into_clear_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*_args: object, **_kwargs: object) -> None:
+        raise FileNotFoundError("docker")
+
+    monkeypatch.setattr(local_x11_docker.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit, match="docker is not installed"):
+        local_x11_docker._run_docker(["docker", "info"])
+
+
+def test_local_x11_docker_reports_missing_binary_when_the_final_docker_run_vanishes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # shutil.which and the earlier `docker info`/`docker build` checks can only prove
+    # docker existed at that moment -- this pins that a docker binary removed in between
+    # (e.g. a race, or another process uninstalling it) still surfaces the SDK's one clear
+    # "docker is not installed" message, not a raw traceback, from the *final* `docker run`.
+    call_count = 0
+
+    def fake_run(command: list[str], **_kwargs: object) -> SimpleNamespace:
+        nonlocal call_count
+        call_count += 1
+        if command[0:2] == ["docker", "run"]:
+            raise FileNotFoundError("docker")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setenv("YUTORI_API_KEY", "test-yutori-key")
+    monkeypatch.setattr(
+        local_x11_docker,
+        "get_auth_status",
+        lambda: SimpleNamespace(authenticated=True, source="env_var", config_path=None),
+    )
+    monkeypatch.setattr(local_x11_docker.shutil, "which", lambda _command: "/usr/local/bin/docker")
+    monkeypatch.setattr(local_x11_docker, "_available_local_port", lambda: 54321)
+    monkeypatch.setattr(local_x11_docker.subprocess, "run", fake_run)
+    args = argparse.Namespace(max_steps=7, task="Open Calculator", tool_set="latest", auto_approve=False)
+
+    with pytest.raises(SystemExit, match="docker is not installed"):
+        local_x11_docker.main(args)
+
+    assert call_count == 3  # docker info, docker build, docker run
+
+
 def test_local_x11_docker_uses_sdk_config_path_for_authentication(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         local_x11_docker,


### PR DESCRIPTION
`local_x11_docker.py`'s `main()` had two independent implementations of the same "docker binary missing" guard:

- `_run_checked()` (used for the `docker info` and `docker build` calls) wraps `subprocess.run` in `try/except FileNotFoundError` and raises `SystemExit("docker is not installed")`.
- The final `docker run` invocation hand-rolled the identical `try/except FileNotFoundError as error: raise SystemExit("docker is not installed") from error` block inline, because it needs the raw `CompletedProcess` (to propagate the container's exact exit code) rather than `_run_checked()`'s formatted "`{description} failed with exit code N`" behavior.

**Fix:** extracted the FileNotFoundError-translating subprocess call into a small `_run_docker()` helper. `_run_checked()` now delegates to it, and the final `docker run` call site uses `_run_docker()` directly instead of duplicating the try/except.

**Why it's safe:**
- No behavior change — same command, same kwargs, same error message, same exit-code handling as before at every call site.
- Internal-only: `local_x11_docker.py` is a local example entrypoint script, not part of the published `yutori` package's public API surface.
- This exact path (docker vanishing between the earlier `shutil.which`/`docker info` checks and the final `docker run`) had **zero test coverage** before this PR. Added two tests first to pin the behavior:
  - `test_run_docker_translates_missing_binary_into_clear_error` — direct unit test of the new helper.
  - `test_local_x11_docker_reports_missing_binary_when_the_final_docker_run_vanishes` — drives `main()` through a `docker run` that raises `FileNotFoundError`, confirming the SDK's one clear message surfaces (not a raw traceback) from the exact code path this refactor touches.

**Verified:**
- Full suite: 829 passed / 3 skipped / 1 deselected (up from 823 at baseline — +2 for the new tests here, +4 from unrelated same-day merges already on `main`).
- `ruff check` and `ruff format --check` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01831vuPYnk394AKggzZEdsu

---
_Generated by [Claude Code](https://claude.ai/code/session_01831vuPYnk394AKggzZEdsu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only script refactor with no intended behavior change; risk is limited to Docker subprocess error/exit handling in that entrypoint.
> 
> **Overview**
> **Refactors** `local_x11_docker.py` so the duplicated “docker binary missing” handling lives in one place. A new **`_run_docker()`** helper runs `subprocess.run` and turns `FileNotFoundError` into `SystemExit("docker is not installed")`; **`_run_checked()`** and the final **`docker run`** both call it instead of repeating the same try/except.
> 
> **Adds tests** that pin that behavior: a direct unit test on `_run_docker`, and an integration-style test where `docker run` fails with `FileNotFoundError` after earlier checks succeed, so users still get the clear message instead of a traceback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f283660ae1802b6da9d7facf0ff8c389a3bb664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->