### PR TITLE
docs(README): lift the n2 reference implementations out of the ownership table

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,11 @@ Your `MyComputer` environment is responsible for tool implementations (they are 
 
 | Tool | You implement | The SDK provides |
 |---|---|---|
-| `computer_batch` | the single-action GUI primitives (`click`, `type`, etc)<br>[reference implementations: [direct_x11_adapter.py](examples/navigator_n2/direct_x11_adapter.py) (direct X11), [cua_adapter.py](examples/navigator_n2/cua_adapter.py) (API-backed sandbox)] | the batching: validation, coordinate mapping, sequencing, the screenshot result |
-| `bash` | `run_bash_command`<br>[reference implementations: [direct_x11_adapter.py](examples/navigator_n2/direct_x11_adapter.py) (direct X11), [cua_adapter.py](examples/navigator_n2/cua_adapter.py) (API-backed sandbox)] | [`format_shell_output`](yutori/navigator/sandbox_tools.py) for the result format |
-| `read`/`write`/`edit` | `read_file`/`write_file`/`edit_file`<br>[reference implementations: [direct_x11_adapter.py](examples/navigator_n2/direct_x11_adapter.py) (direct X11) and [cua_adapter.py](examples/navigator_n2/cua_adapter.py) (API-backed sandbox) via the mixin, [MacOSComputer](yutori/navigator/macos/computer.py) (native)] | [`ShellFileToolsMixin`](yutori/navigator/sandbox_tools.py): a complete implementation over a POSIX shell — inherit it and supply its two small hooks |
+| `computer_batch` | the single-action GUI primitives (`click`, `type`, etc) | the batching: validation, coordinate mapping, sequencing, the screenshot result. [`PointerKeyLifecycleMixin`](yutori/navigator/sandbox_tools.py) derives `hold_key`/`wait`/`release_held_mouse_button` from the primitives |
+| `bash` | `run_bash_command` | [`format_shell_output`](yutori/navigator/sandbox_tools.py) for the result format |
+| `read`/`write`/`edit` | `read_file`/`write_file`/`edit_file` | [`ShellFileToolsMixin`](yutori/navigator/sandbox_tools.py): a complete implementation over a POSIX shell — inherit it and supply its two small hooks |
+
+Three complete `MyComputer` implementations to copy from: [direct_x11_adapter.py](examples/navigator_n2/direct_x11_adapter.py) (direct X11), [cua_adapter.py](examples/navigator_n2/cua_adapter.py) (API-backed sandbox), and [MacOSComputer](yutori/navigator/macos/computer.py) (native macOS). The first two inherit both mixins, so the only things they implement themselves are the GUI primitives and `run_bash_command`.
 
 The full contract is documented in [Navigator n2 loop](api.md#navigator-n2-loop).
 


### PR DESCRIPTION
The reference-implementation citations added in #325/#326 grew to dominate the "You implement" column: the same two adapter links repeated in all three rows, wrapped in a `<br>[reference implementations: ...]` block that buried the actual hook names the column exists to name.

The repetition was the tell. `direct_x11_adapter.py`, `cua_adapter.py` and `MacOSComputer` are each a complete `MyComputer`, not a per-tool reference — they don't vary along the table's axis, so they never belonged in its cells. Citing them row-by-row also implied "here's how to do `bash`" / "here's how to do `read`" when it's really "here's one class that does all of it."

A third column was the other option considered, but it keeps every bit of the duplication (still two adapter links per row, just in a narrower cell) and spends the table's clean `you` / `SDK` symmetry to do it. Lifting them out fixes the clutter and the scoping at once.

They now appear once, as a sentence under the table:

> Three complete `MyComputer` implementations to copy from: direct_x11_adapter.py (direct X11), cua_adapter.py (API-backed sandbox), and MacOSComputer (native macOS). The first two inherit both mixins, so the only things they implement themselves are the GUI primitives and `run_bash_command`.

One correctness fix while rewriting the `computer_batch` row: since #350 both adapters also inherit `PointerKeyLifecycleMixin`, so the SDK column's "the batching" no longer described everything the SDK hands you. It now names the mixin that derives `hold_key`/`wait`/`release_held_mouse_button` from the primitives.

Not changed here: `FILE_TOOL_NAMES` is five tools, not three (`read`/`write`/`edit`/`grep`/`glob`), so the file-tool row label is arguably incomplete. But `grep`/`glob` are gated as `LEGACY_FILE_SEARCH_TOOL_NAMES` and reach only some tool sets, so documenting them is a separate call about which tool sets the README speaks for.

Docs-only. Verified every relative link in the README resolves on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime or API behavior changes.
> 
> **Overview**
> **Restructures the Navigator n2 `MyComputer` tool table** so the “You implement” column stays focused on hook names instead of repeating adapter links in every row.
> 
> The three full reference implementations (`direct_x11_adapter.py`, `cua_adapter.py`, `MacOSComputer`) are cited **once** in a new paragraph under the table, including that the X11/Cua adapters inherit both SDK mixins and only implement GUI primitives plus `run_bash_command`.
> 
> The **`computer_batch` SDK column** is updated to mention **`PointerKeyLifecycleMixin`**, which derives `hold_key` / `wait` / `release_held_mouse_button` from the primitives—not just batching and screenshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf00f165ae733a5fdaf9d6d968cf5f4ad026918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->