### PR TITLE
refactor(examples): dedupe the zero-timeout bash expiry check across 3 adapters

### DIFF
--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -1,4 +1,4 @@
-"""The Cua computer handler for Navigator n2 — the reference tool implementations.
+"""The Cua computer handler for Navigator n2 -- the reference tool implementations.
 
 Start from this file as a structural example when desktop operations cross an
 API boundary, whether to local sandbox software or a remote service. Adapt its
@@ -16,11 +16,11 @@ N more chars ...]`` caps, image reads returned as visible image content, the
 sha256-fingerprint read-before-edit gate, and every expected tool error as a plain
 ``ERROR: ...`` result rather than a raised failure envelope. Copy or adapt this module
 when building a handler for your own environment. The ``computer_batch`` tool itself
-lives in the SDK loop — this module implements what the loop delegates: the GUI
+lives in the SDK loop -- this module implements what the loop delegates: the GUI
 primitives it calls, and the full ``bash``/file-tool output contracts.
 
 Cua here is the sandbox vendor (https://cua.ai, github.com/trycua), whose
-``cua-sandbox`` package provides the disposable Docker desktop — not the generic
+``cua-sandbox`` package provides the disposable Docker desktop -- not the generic
 "computer-use agent" acronym used elsewhere in Yutori's own package names.
 """
 
@@ -46,7 +46,7 @@ from yutori.navigator.sandbox_tools import (
     build_cwd_tracking_bash_script as _build_cwd_tracking_bash_script,
 )
 from yutori.navigator.sandbox_tools import (
-    clamp_bash_timeout as _clamp_bash_timeout,
+    clamp_bash_timeout_or_expired as _clamp_bash_timeout_or_expired,
 )
 from yutori.navigator.sandbox_tools import (
     format_background_task_started as _format_background_task_started,
@@ -217,11 +217,9 @@ class CuaSandboxComputer(ShellFileToolsMixin, PointerKeyLifecycleMixin):
             process_id = str(session.get("pid") or "unknown")
             return _format_background_task_started(log_path, process_id)
 
-        # The n2 bash contract: the timeout is clamped to [0, 600] and an expiry is a
-        # NORMAL result the model can react to, never a raised failure envelope.
-        timeout_s = _clamp_bash_timeout(timeout)
-        if timeout_s == 0:
-            return "Command timed out after 0s"
+        timeout_s, expired = _clamp_bash_timeout_or_expired(timeout)
+        if expired is not None:
+            return expired
 
         # cua-computer-server runs /cmd subprocesses on uvloop. If a shell command
         # leaves any descendant alive (for example ``xcalc &``), uvloop reports that

--- a/examples/navigator_n2/direct_x11_adapter.py
+++ b/examples/navigator_n2/direct_x11_adapter.py
@@ -58,7 +58,7 @@ from yutori.navigator.sandbox_tools import (
     build_cwd_tracking_bash_script as _build_cwd_tracking_bash_script,
 )
 from yutori.navigator.sandbox_tools import (
-    clamp_bash_timeout as _clamp_bash_timeout,
+    clamp_bash_timeout_or_expired as _clamp_bash_timeout_or_expired,
 )
 from yutori.navigator.sandbox_tools import (
     format_background_task_started as _format_background_task_started,
@@ -325,11 +325,9 @@ class LocalX11Computer(ShellFileToolsMixin, PointerKeyLifecycleMixin):
                 )
             return _format_background_task_started(log_path, process.pid)
 
-        # The n2 bash contract: the timeout is clamped to [0, 600] and an expiry is a
-        # NORMAL result the model can react to, never a raised failure envelope.
-        timeout_s = _clamp_bash_timeout(timeout)
-        if timeout_s == 0:
-            return "Command timed out after 0s"
+        timeout_s, expired = _clamp_bash_timeout_or_expired(timeout)
+        if expired is not None:
+            return expired
 
         # Output goes to files rather than pipes: a command that leaves a
         # descendant alive (``xcalc &``) holds a pipe open past bash's own exit,

--- a/examples/navigator_n2_daytona.py
+++ b/examples/navigator_n2_daytona.py
@@ -9,7 +9,7 @@
 """
 A computer-use agent: Navigator n2 driving a disposable Daytona Linux desktop.
 
-Navigator n2 looks at a full-screen screenshot and answers with tool calls — a
+Navigator n2 looks at a full-screen screenshot and answers with tool calls -- a
 `computer_batch` of GUI actions, a `bash` command, or a file tool
 (`read`/`write`/`edit`). `N2ComputerAgent`, the SDK's n2 agent
 loop, executes each call through a small adapter, sends the result back (a
@@ -17,7 +17,7 @@ fresh screenshot for the batch, the tool's output otherwise), and asks again
 until the model answers with just text, which indicates stop.
 
 Daytona is third-party infrastructure; this Yutori-maintained example contains
-the whole integration — the `DaytonaComputer` adapter plus the sandbox
+the whole integration -- the `DaytonaComputer` adapter plus the sandbox
 lifecycle in `main`. Swap those pieces for your own environment to drive a
 different desktop.
 
@@ -72,7 +72,7 @@ from yutori.navigator import (
     format_stop_and_summarize,
 )
 from yutori.navigator.n2_compaction import response_message
-from yutori.navigator.sandbox_tools import clamp_bash_timeout
+from yutori.navigator.sandbox_tools import clamp_bash_timeout_or_expired
 
 # Any snapshot carrying Daytona's computer-use bundle. This one is a bare XFCE
 # desktop at 1024x768; build your own to give the model a browser or an editor.
@@ -177,7 +177,7 @@ class DaytonaComputer(ShellFileToolsMixin):
         # Daytona wants wheel notches and supports vertical scrolling only.
         # Declaring `model_action=` makes the loop pass the model's own call, whose
         # `direction`/`amount` are already notches (see api.md, "Navigator n2 loop"); the
-        # pixel arithmetic — one notch of `amount` is a tenth of the screen — is the
+        # pixel arithmetic -- one notch of `amount` is a tenth of the screen -- is the
         # fallback for callers that don't pass it.
         if model_action and model_action.get("direction"):
             direction, amount = str(model_action["direction"]), int(model_action.get("amount") or 3)
@@ -248,7 +248,7 @@ class DaytonaComputer(ShellFileToolsMixin):
             except Exception as exc:  # noqa: BLE001 - a failed start is a normal tool result
                 return f"ERROR: failed to start background command: {exc}"
             if launched.exit_code:
-                # The launch line itself failed — nothing started; don't claim it did.
+                # The launch line itself failed -- nothing started; don't claim it did.
                 # (The reference reports the same ERROR shape via its exception path.)
                 detail = (launched.result or "").strip()
                 return f"ERROR: failed to start background command: exit code {launched.exit_code}" + (
@@ -267,12 +267,10 @@ class DaytonaComputer(ShellFileToolsMixin):
                 lines.append(f"To cancel: run bash with `kill {pid}`")
             return "\n".join(lines)
 
-        # The n2 bash contract: the timeout is clamped to [0, 600] and an expiry is
-        # a normal result the model can react to, never a raised failure envelope.
         # (Daytona raises on expiry and discards the partial output.)
-        timeout_s = clamp_bash_timeout(timeout)
-        if timeout_s == 0:
-            return "Command timed out after 0s"
+        timeout_s, expired = clamp_bash_timeout_or_expired(timeout)
+        if expired is not None:
+            return expired
         # Run the command, then report the directory it finished in, keeping
         # the command's own exit code.
         wrapped = f'{command}\n__rc=$?\nprintf "\\n{CWD_SENTINEL}%s" "$PWD"\nexit $__rc'
@@ -280,7 +278,7 @@ class DaytonaComputer(ShellFileToolsMixin):
             result = await self._sandbox.process.exec(wrapped, cwd=self._cwd, timeout=max(1, int(timeout_s)))
         except Exception as error:  # noqa: BLE001 - classify sandbox timeouts below
             # Match the class name (DaytonaProcessExecutionTimeoutError) and the
-            # message ("command execution timeout" — which says "timeout", not
+            # message ("command execution timeout" -- which says "timeout", not
             # "timed out"), so a generically-named error is still classified.
             error_text = f"{type(error).__name__}: {error}".lower()
             if "timeout" in error_text or "timed out" in error_text:
@@ -347,7 +345,7 @@ async def main(task: str, max_steps: int = MAX_STEPS, record: bool = False) -> N
                     await sandbox.delete(wait=True)
 
         if agent.stopped_by == "max_steps":
-            # One summarize-only completion — sent by this harness itself via the
+            # One summarize-only completion -- sent by this harness itself via the
             # actor's exact next request, so a tool-call reply is never executed.
             # The sandbox is already deleted; only the Yutori client is needed.
             nudge = {"role": "user", "content": [{"type": "text", "text": format_stop_and_summarize(task)}]}

--- a/tests/test_navigator_sandbox_tools.py
+++ b/tests/test_navigator_sandbox_tools.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 
 from yutori.navigator import FILE_TOOL_SCRIPT, ShellFileToolsMixin, format_shell_output
 from yutori.navigator.sandbox_tools import (
+    clamp_bash_timeout_or_expired,
     format_shell_result,
     result_returncode,
     result_stderr,
@@ -64,6 +65,14 @@ def test_shared_helpers_render_the_bash_contract() -> None:
     assert format_shell_output("", 0) == "(Bash completed with no output)"
     assert format_shell_output("boom", 7) == "Exit code 7\nboom"
     assert "def done(text):" in FILE_TOOL_SCRIPT  # in-VM script is exported intact
+
+
+def test_clamp_bash_timeout_or_expired_flags_a_zero_clamp() -> None:
+    assert clamp_bash_timeout_or_expired(30) == (30.0, None)
+    assert clamp_bash_timeout_or_expired(None) == (120.0, None)  # missing -> the 120s default
+    assert clamp_bash_timeout_or_expired(9999) == (600.0, None)  # clamped to the 600s max
+    assert clamp_bash_timeout_or_expired(0) == (0.0, "Command timed out after 0s")
+    assert clamp_bash_timeout_or_expired(-5) == (0.0, "Command timed out after 0s")  # clamped to 0
 
 
 def test_result_accessors_tolerate_missing_and_none_fields() -> None:

--- a/yutori/navigator/sandbox_tools.py
+++ b/yutori/navigator/sandbox_tools.py
@@ -10,7 +10,7 @@ hooks the adapter supplies. The shell-result helpers render ``bash`` results
 the same way (``Exit code N`` headers, truncation caps).
 
 Ownership note: the n2 loop implements ``computer_batch`` itself but only
-routes shell/file handler text (a trim and a 256K backstop aside) — these
+routes shell/file handler text (a trim and a 256K backstop aside) -- these
 output contracts are the adapter's to honor. When building (or pointing a
 coding agent at) a custom adapter, the expected formats live in
 ``FILE_TOOL_SCRIPT`` below (``cat -n`` numbering, the sha256 read-before-edit
@@ -193,7 +193,7 @@ elif operation == "edit":
     if not path.is_file():
         done(f"ERROR: file does not exist: {display}")
     # NOTE: the decode/match/anchor semantics below deliberately reproduce the served
-    # n2 edit tool exactly — replace-mode decoding (invalid bytes become U+FFFD on
+    # n2 edit tool exactly -- replace-mode decoding (invalid bytes become U+FFFD on
     # write-back), matching against the raw text (read output is CRLF-normalized for
     # display, the edit match is not), and anchoring the snippet on the first
     # occurrence of new_string. Reproducing them byte-for-byte is the point of this
@@ -392,6 +392,21 @@ def clamp_bash_timeout(timeout: float | None) -> float:
     return max(0.0, min(float(BASH_TIMEOUT_DEFAULT_SECONDS if timeout is None else timeout), BASH_TIMEOUT_MAX_SECONDS))
 
 
+def clamp_bash_timeout_or_expired(timeout: float | None) -> tuple[float, str | None]:
+    """Clamp a `bash` timeout and flag an immediate expiry.
+
+    The n2 `bash` contract: the timeout is clamped to [0, 600], and a clamped value of 0 is
+    itself an expiry -- a NORMAL result the model can react to, never a raised failure
+    envelope. Returns ``(timeout_seconds, message)``: when ``message`` is not ``None`` the
+    caller should return it immediately without running the command; otherwise proceed using
+    ``timeout_seconds``.
+    """
+    timeout_s = clamp_bash_timeout(timeout)
+    if timeout_s == 0:
+        return timeout_s, "Command timed out after 0s"
+    return timeout_s, None
+
+
 def build_cwd_tracking_bash_script(command: str, *, cwd: str, cwd_path: str, status_path: str) -> str:
     """Build the n2 `bash` wrapper script: `cd` into ``cwd``, run ``command``, and record its
     resulting working directory and exit status for the caller to read back afterward.
@@ -400,7 +415,7 @@ def build_cwd_tracking_bash_script(command: str, *, cwd: str, cwd_path: str, sta
     cwd are written to a ``.tmp`` sibling and moved into place, never written in place: a status
     poller must never observe a partially written file. The cwd capture runs in an inner shell
     with its own ``trap ... 0`` so it fires even if ``command`` exits early, backgrounds a
-    descendant, or is killed by a signal — the outer ``if`` only backstops the case where the cd
+    descendant, or is killed by a signal -- the outer ``if`` only backstops the case where the cd
     itself failed and the inner shell never ran.
 
     Returns the script body only; the caller supplies its own output redirection, either embedded
@@ -514,7 +529,7 @@ IMAGE_VIEW_MAX_EDGE = 1568
 def render_image_result(file_path: str, data: bytes) -> "dict[str, str] | str":
     """Return an image read as visible image content: a note with the source
     dimensions plus the image itself, downscaled to a 1568-px max edge and
-    WEBP-encoded — the same bounds the loop applies to screenshots."""
+    WEBP-encoded -- the same bounds the loop applies to screenshots."""
     try:
         image = Image.open(io.BytesIO(data))
         image.load()
@@ -577,9 +592,9 @@ class ShellFileToolsMixin:
     Mix into a computer adapter and implement two hooks:
 
     - ``async def run_sandbox_shell(self, command: str, *, timeout_seconds: int)``
-      — run one shell command in the sandbox and return an object with
+      -- run one shell command in the sandbox and return an object with
       ``stdout``, ``stderr``, and ``returncode`` attributes.
-    - ``async def file_tool_cwd(self) -> str`` — the working directory that
+    - ``async def file_tool_cwd(self) -> str`` -- the working directory that
       relative paths resolve against (usually the bash tool's tracked cwd).
 
     The sandbox needs ``python3`` (stdlib only) on PATH.
@@ -687,6 +702,7 @@ __all__ = [
     "build_bash_result_paths",
     "build_cwd_tracking_bash_script",
     "clamp_bash_timeout",
+    "clamp_bash_timeout_or_expired",
     "format_background_task_started",
     "format_shell_output",
     "format_shell_result",


### PR DESCRIPTION
## What

`examples/navigator_n2/cua_adapter.py`, `examples/navigator_n2/direct_x11_adapter.py`, and `examples/navigator_n2_daytona.py` each independently hand-rolled the identical block right after calling `clamp_bash_timeout()`:

```python
# The n2 bash contract: the timeout is clamped to [0, 600] and an expiry is a
# NORMAL result the model can react to, never a raised failure envelope.
timeout_s = clamp_bash_timeout(timeout)
if timeout_s == 0:
    return "Command timed out after 0s"
```

(the Daytona variant had trivially reworded comment text, but the same code and message). This is the same repeated pattern the SDK's `sandbox_tools.py` module already exists to consolidate — `clamp_bash_timeout`, `wait_for_file`, `build_cwd_tracking_bash_script`, etc. all live there for exactly this reason (three independent reference/example adapters implementing the same n2 tool contract).

## Why this is an improvement

- Three copies of a comment describing a subtle contract ("a 0 timeout is a *normal* result, not a raised failure") is a drift risk: a future change to the contract only has to be remembered in one place instead of three.
- Matches the module's existing extraction pattern exactly (same file, same style as `clamp_bash_timeout`, `wait_for_file`, etc.), so this isn't introducing a new abstraction, just applying the established one to a leftover duplicate.

## What changed

- Added `clamp_bash_timeout_or_expired(timeout) -> tuple[float, str | None]` to `yutori/navigator/sandbox_tools.py`, next to `clamp_bash_timeout`. It returns the clamped timeout and, when the clamp lands on 0, the "Command timed out after 0s" message the caller should return immediately.
- All three call sites now delegate to it instead of duplicating the clamp + zero-check + message.
- Added to `sandbox_tools.__all__`.
- Added `test_clamp_bash_timeout_or_expired_flags_a_zero_clamp` to `tests/test_navigator_sandbox_tools.py`.

## Why this is safe

- Purely internal/example surface: `sandbox_tools.py` is already the SDK's dedicated home for this kind of shared reference-adapter helper (not customer-facing API behavior), and the three call sites are example scripts.
- No behavior change: verified with a standalone equivalence script comparing the old inline logic against the new helper across `[None, 0, -5, 0.001, 30, 120.0, 600, 601, 9999, 5.5]` — identical output for every input.
- Full test suite: `830 passed, 3 skipped, 1 deselected` (up from `829` on `main`, +1 for the new test), identical otherwise.
- `ruff check .` clean repo-wide; `ruff format --check` clean on all 5 touched files (the pre-existing 16-file formatting drift elsewhere in the repo is untouched and unrelated).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GG52f1KVmHAxBqWLUwzh5N

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GG52f1KVmHAxBqWLUwzh5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01GG52f1KVmHAxBqWLUwzh5N)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of shared example/SDK helper code with a dedicated unit test; no change to the bash timeout contract or message strings.
> 
> **Overview**
> Adds **`clamp_bash_timeout_or_expired`** in `yutori/navigator/sandbox_tools.py` next to `clamp_bash_timeout`. It returns the clamped timeout plus an optional immediate `"Command timed out after 0s"` message when the clamp lands on 0 (the n2 contract treats that as a normal tool result, not an exception).
> 
> The Cua, direct X11, and Daytona example adapters now call this helper instead of repeating the same clamp-and-zero-check block in `run_bash_command`. The helper is exported from `__all__`, and **`test_clamp_bash_timeout_or_expired_flags_a_zero_clamp`** locks in default, max clamp, and zero/negative behavior.
> 
> Several touched files also normalize docstring punctuation (em dashes to `--`); behavior is intended to be unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f267955269c89789bff86cd692da0b4982b8efea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->