### PR TITLE
docs: remove stale manual-release section left by #357

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,16 +53,6 @@ Thank you for your interest in contributing to the Yutori Python SDK!
 4. Run tests and linting
 5. Submit a pull request
 
-## Releases
-
-Before the first release, register PyPI Trusted Publishing for GitHub Actions with owner `yutori-ai`, repository
-`yutori-sdk-python`, workflow `publish_to_pypi.yml`, and environment `pypi`. Then push an annotated `vX.Y.Z` tag and
-run **Publish yutori to PyPI** from the GitHub Actions UI with that tag (or the tag without its `v` prefix) as its input.
-The workflow builds and tests the exact tag, publishes it to PyPI, uploads every installer asset to a draft GitHub
-release, and only then publishes the release. Do not publish a GitHub release manually or dispatch the workflow for an
-already-published release:
-`yutori.com/install.sh` follows the latest published release.
-
 ## Releasing
 
 1. Open a PR titled `chore(release): X.Y.Z` that bumps `version` in `pyproject.toml`,
@@ -72,12 +62,15 @@ already-published release:
 2. Merge it. The "Publish yutori to PyPI" workflow runs on the version change: it creates
    the annotated `vX.Y.Z` tag on the merge commit, runs the tests, builds and verifies the
    exact distributions, publishes them with PyPI Trusted Publishing, and only then creates
-   the GitHub release with the checksums, provenance, and installer assets.
+   the GitHub release with the checksums, provenance, and installer assets. `yutori.com/install.sh`
+   follows the latest published release, so it updates automatically once that release goes live.
 
 Do not create the tag by hand. A `vX.Y.Z` tag that points at an older commit tells the
 workflow that version already shipped, so it skips. If a run fails after tagging, re-run it
 from the Actions tab: the tag job reuses a tag that points at the same commit, the PyPI step
-skips distributions PyPI already holds, and a published release is never overwritten.
+skips distributions PyPI already holds, and a published release is never overwritten. The
+workflow's `tag` input (workflow_dispatch) remains as a manual repair path for an existing
+annotated tag; it refuses to overwrite an already-published release.
 
 ## Reporting Issues
 


### PR DESCRIPTION
## Summary

Daily doc/test-drift review of the last ~24h of merged commits. Checked all the flagged leads (stale `0.9.9` version references after #358's bump to 0.9.10, the new direct-X11-Docker cookbook's discoverability from #352, and whether the internal refactors #366/#362/#354/#353/#350/#349 needed doc updates) and found them clean — no drift. One real drift found:

- #357 added an automated `## Releasing` section to `CONTRIBUTING.md` describing the new flow (merging a `chore(release): X.Y.Z` PR auto-creates the tag and cuts the release), but left the older `## Releases` section — describing the pre-automation flow of manually pushing an annotated tag and dispatching the "Publish yutori to PyPI" workflow by hand — still in place directly above it. The two sections contradicted each other (one says to push a tag by hand, the other says "Do not create the tag by hand").
- Verified against the current `.github/workflows/publish_to_pypi.yml`: it now triggers on `pyproject.toml` changes on `main`, and `workflow_dispatch` is only an optional manual repair path that refuses to overwrite an already-published release.
- Folded the still-accurate details (install.sh tracks the latest published release; the manual dispatch repair path) into the `## Releasing` section and removed the stale, contradictory `## Releases` section.

## Test plan

- [x] Grepped the repo for `0.9.9` (no stale hits — everything already reflects `0.9.10`)
- [x] Confirmed the new cookbook example is documented in-repo (`examples/navigator_n2/README.md`, added by the same commit #352)
- [x] Confirmed no CLAUDE.md/AGENTS.md or other doc itemizes the refactored helper functions
- [x] Verified the doc fix against the actual `publish_to_pypi.yml` workflow contents
- Docs-only change; no code behavior touched, no tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzoiTP1MpPaPP247C8QvKc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor release instructions; no runtime or CI behavior is modified.
> 
> **Overview**
> **Removes the outdated `## Releases` section** from `CONTRIBUTING.md` that still described manually pushing tags and dispatching **Publish yutori to PyPI**, which conflicted with the automated `## Releasing` flow added in #357.
> 
> **Expands `## Releasing`** with two clarifications: `yutori.com/install.sh` tracks the latest published GitHub release and updates when that release goes live, and the workflow’s optional `workflow_dispatch` `tag` input is only a repair path for an existing annotated tag (it will not overwrite an already-published release).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51701dc823b54f992e77e43a932d2467a90b0b2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->