### PR TITLE
refactor(macos): share the render-dedup cache check between showThought and the shell rail

### DIFF
--- a/tests/test_navigator_macos_presentation.py
+++ b/tests/test_navigator_macos_presentation.py
@@ -352,3 +352,31 @@ async def test_shell_rail_does_not_resend_an_unchanged_render(monkeypatch):
     await controller.present(_shell("shell-1", "pwd", "running"))
 
     assert len(_rail_renders(commands)) == 1
+
+
+async def test_send_operation_skips_unchanged_dedupe_eligible_renders_but_not_others(monkeypatch):
+    controller = _active_controller()
+    envelopes: list[dict] = []
+
+    async def send_envelope(envelope, **_kwargs):
+        envelopes.append(envelope)
+        return {"ok": True}
+
+    monkeypatch.setattr(controller, "_send_envelope", send_envelope)
+
+    first = await controller._send_operation({"op": "showThought", "markdown": "a"})
+    repeat = await controller._send_operation({"op": "showThought", "markdown": "a"})
+    changed = await controller._send_operation({"op": "showThought", "markdown": "b"})
+    # "mount" is not in the dedupe-eligible op set, so it is always sent even when unchanged.
+    await controller._send_operation({"op": "mount", "snapshot": {}})
+    await controller._send_operation({"op": "mount", "snapshot": {}})
+
+    assert first == {"ok": True}
+    assert repeat == {"ok": True}
+    assert changed == {"ok": True}
+    assert envelopes == [
+        {"operation": {"op": "showThought", "markdown": "a"}},
+        {"operation": {"op": "showThought", "markdown": "b"}},
+        {"operation": {"op": "mount", "snapshot": {}}},
+        {"operation": {"op": "mount", "snapshot": {}}},
+    ]

--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -536,13 +536,25 @@ class MacOSPresentationController:
                 future.cancel()
 
     async def _send_operation(self, operation: dict[str, Any], *, allow_stopping: bool = False) -> dict[str, Any]:
-        signature = json.dumps(operation, separators=(",", ":"), sort_keys=True)
         dedupe_key = str(operation.get("op"))
-        if dedupe_key in {"showThought", "clearThought", "previewAction", "moveCursor"}:
-            if self._last_render.get(dedupe_key) == signature:
-                return {"ok": True}
-            self._last_render[dedupe_key] = signature
+        if dedupe_key in {"showThought", "clearThought", "previewAction", "moveCursor"} and not self._render_changed(
+            dedupe_key, operation
+        ):
+            return {"ok": True}
         return await self._send_envelope({"operation": operation}, allow_stopping=allow_stopping)
+
+    def _render_changed(self, key: str, payload: Any) -> bool:
+        """Return whether `payload` differs from the last render cached under `key`, updating the cache.
+
+        Shared by `_send_operation` (deduping showThought/clearThought/previewAction/moveCursor) and
+        `_render_shell_rail` (deduping the shell rail's commands/overflow payload) -- both compare a
+        canonical JSON signature against `self._last_render` before sending.
+        """
+        signature = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        if self._last_render.get(key) == signature:
+            return False
+        self._last_render[key] = signature
+        return True
 
     async def _send_command(
         self,
@@ -710,10 +722,8 @@ class MacOSPresentationController:
         events = list(reversed(self._shell_rail.values()))
         commands = [asdict(event) for event in events[:_SHELL_RAIL_ROWS]]
         overflow = max(0, len(events) - _SHELL_RAIL_ROWS)
-        signature = json.dumps([commands, overflow], separators=(",", ":"), sort_keys=True)
-        if self._last_render.get("shellCommands") == signature:
+        if not self._render_changed("shellCommands", [commands, overflow]):
             return
-        self._last_render["shellCommands"] = signature
         await self._send_command({"op": "shellCommands", "commands": commands, "overflow": overflow})
 
     async def _remove_from_shell_rail_after_hold(self, task_id: str, terminal: ShellPresentationEvent) -> None:


### PR DESCRIPTION
## What

`MacOSPresentationController._send_operation` (deduping `showThought`/`clearThought`/`previewAction`/`moveCursor`) and `_render_shell_rail` (deduping the shell rail's `commands`/`overflow` payload, added in #356) each independently computed a canonical JSON signature (`json.dumps(payload, separators=(",", ":"), sort_keys=True)`) and compared it against `self._last_render[key]` before sending — the same "has this render changed" idiom, freshly duplicated by #356 rather than reused from the copy `_send_operation` already had.

Extracted `_render_changed(key, payload) -> bool` — the signature-compute-compare-and-cache-update check — so both call sites now delegate to it.

## Why it's safe

- **No behavior change.** Same signature computation, same `self._last_render` cache semantics, same return values at both call sites. `_render_changed` is a private method on `MacOSPresentationController`, not exported from `yutori/navigator/macos/__init__.py` and not documented in `api.md` — zero public-API surface change on this published PyPI package.
- **New coverage for a previously-untested path.** `_send_operation`'s internal dedup cache had zero direct test coverage before this PR — every existing test that reaches `present()` monkeypatches `_send_operation` itself, bypassing its internal logic. Added `test_send_operation_skips_unchanged_dedupe_eligible_renders_but_not_others`, which calls the real `_send_operation` (mocking only `_send_envelope`) and asserts: a repeated `showThought` payload is deduped, a changed one is sent, and an op outside the dedupe-eligible set (`mount`) is always sent even when unchanged — pinning the exact behavior before any future change to this path.
- **Verified:**
  - Targeted: `pytest tests/test_navigator_macos_presentation.py` → 13 passed (12 existing + 1 new), including the pre-existing `test_shell_rail_does_not_resend_an_unchanged_render` which exercises the `_render_shell_rail` half of this refactor unchanged.
  - Full suite (with `dev`+`examples` extras installed): `pytest -m "not slow"` → 831 passed / 3 skipped / 1 deselected (830 baseline + 1 new test).
  - `ruff check` and `ruff format --check` on both touched files: clean.

2 files changed, 1 private helper extracted, no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3qNPsG4eourVXgFWUScyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3qNPsG4eourVXgFWUScyf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private refactor with equivalent dedupe semantics; new tests reduce regression risk on overlay traffic.
> 
> **Overview**
> **Refactors macOS overlay render deduplication** so `_send_operation` and `_render_shell_rail` no longer duplicate the same canonical JSON signature + `_last_render` cache check.
> 
> Adds private **`_render_changed(key, payload)`**, which compares `json.dumps(..., sort_keys=True)` to the cached signature, updates the cache when the payload changes, and returns whether a send is needed. **`_send_operation`** still short-circuits unchanged `showThought` / `clearThought` / `previewAction` / `moveCursor` with `{"ok": True}`; **`_render_shell_rail`** still skips redundant `shellCommands` commands the same way as before.
> 
> Adds **`test_send_operation_skips_unchanged_dedupe_eligible_renders_but_not_others`**, exercising real `_send_operation` (mocking only `_send_envelope`) to lock in dedupe for repeated `showThought`, sends on change, and no dedupe for ops like `mount`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45dbf5b0b5faa2d675884e0d299d424758414405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->