### PR TITLE
chore(release): 0.9.12

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.11" \
+    "yutori==0.9.12" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.11'
+pip install 'yutori[macos]==0.9.12'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.11",
+    "yutori==0.9.12",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.11"]
+macos = ["yutori[macos]==0.9.12"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.11"
+YUTORI_INSTALLER_VERSION="0.9.12"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.11"
+version = "0.9.12"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bumps `version` to 0.9.12, regenerates `install.sh`, and updates the pinned `yutori==` versions under `examples/navigator_n2/`.

## What ships in 0.9.12

- **The activity window** (#370): a floating, non-activating panel carrying the conversation with the model — the task, its thinking, every action, and every shell command — opened from *Show activity* in the menu bar item's menu. Window-scope runs put the driven window's live frame above it; foreground runs show no frame pane and hide the window for every capture, so the model never sees it.
- **The shell rail for background runs** (#370): the click-through "run command" panels a foreground run already paints under the menu bar, so a command running on this Mac is visible without opening anything.
- `run()` and `resume()` present a `task` event, so a presentation shows the conversation from its first message; background runs now record shell telemetry the way foreground runs do.

Merging this triggers the publish workflow: annotated `v0.9.12` tag on the merge commit, tests, build, PyPI Trusted Publishing, then the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and pin updates only; no runtime or API logic modified in the diff.
> 
> **Overview**
> **Release 0.9.12** — version metadata and consumer pins only; no SDK source changes in this diff.
> 
> Bumps the root `yutori` version in `pyproject.toml` from **0.9.11** to **0.9.12**, updates `YUTORI_INSTALLER_VERSION` in `install.sh` to match, and aligns Navigator n2 cookbook pins (`examples/navigator_n2/pyproject.toml`, `Dockerfile.direct_x11`, and the macOS `pip install` line in the README) to `yutori==0.9.12` / `yutori[macos]==0.9.12`.
> 
> Per the PR description, merging is intended to drive the publish workflow (tag, tests, PyPI, GitHub release); behavioral changes for this release live in other commits, not in this changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18c1b54b613835901ec42030f560880ec6717c32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->