### PR TITLE
chore(release): 0.9.13

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.12" \
+    "yutori==0.9.13" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.12'
+pip install 'yutori[macos]==0.9.13'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.12",
+    "yutori==0.9.13",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.12"]
+macos = ["yutori[macos]==0.9.13"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.12"
+YUTORI_INSTALLER_VERSION="0.9.13"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.12"
+version = "0.9.13"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts 0.9.13, whose one change is #374.

## What ships

**`fix(n2): send the whole screenshot history, pruning only to fit the wire cap` (#374)**

The n2 loop no longer windows each request down to the two newest image-bearing messages. It sends every frame the run has taken and drops oldest-first only when the serialized request would exceed the 10 MB cap.

The window bought the model nothing — the API's n2 handler applies exactly that window itself before serving the model — while it emptied the request log a run's replay is built from, which is why a macOS run's story stopped after its last two frames.

- `prune_n2_screenshots_to_budget` replaces `retain_n2_image_window` + `fit_n2_request_images_to_budget` in the loop, matching the reference harness's `pruneScreenshotsToBudget`, including its 64 KB headroom and its silence (a dropped frame leaves no marker).
- `retain_n2_image_window` stays exported; `fit_n2_request_images_to_budget` is removed (never exported from `yutori.navigator`, never in api.md).
- `prepare_n2_image_data_url` reads the media type off the data-URL header instead of decoding the payload, keeping the now-per-frame conversion pass cheap.

**Callers should expect larger requests.** A run past roughly 50 steps now sends several MB per request instead of two frames' worth. That is the trade the change exists to make.

## Release mechanics

Version bumped in `pyproject.toml`, `install.sh` regenerated via `scripts/build_install.sh`, and the `navigator_n2` cookbook pins moved to 0.9.13 — the same five-file shape as #371.

Merging this tags `v0.9.13` on the merge commit and publishes to PyPI.

## Test plan

- `pytest -m "not slow"` — 865 passed, 9 skipped
- `scripts/check_install_sh_fresh.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is version and pin updates only; behavioral risk lives in the already-merged #374 n2 request sizing change users get when they upgrade to 0.9.13.
> 
> **Overview**
> **Release cut** that bumps the SDK from **0.9.12** to **0.9.13** and keeps install/cookbook pins in sync.
> 
> `pyproject.toml` sets the package version; `install.sh` updates `YUTORI_INSTALLER_VERSION` (regenerated via `scripts/build_install.sh`). The **navigator_n2** cookbook pins move to `yutori==0.9.13` in `pyproject.toml`, the macOS install line in `README.md`, and the direct X11 `Dockerfile`.
> 
> Merging is intended to tag **v0.9.13** and publish **0.9.13** to PyPI. That release includes the n2 screenshot-history fix from #374 (full frame history with budget pruning); this diff is only the version/release mechanics, not that loop change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df8f875d1d2bd20627e1f5894b3f290112c0d959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->