### PR TITLE
refactor(macos): dedupe the lsappinfo ASN-resolve-then-query idiom

### DIFF
--- a/yutori/navigator/macos/frontmost.py
+++ b/yutori/navigator/macos/frontmost.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass
 
@@ -69,6 +70,27 @@ async def _reap(process: asyncio.subprocess.Process) -> None:
         await asyncio.wait_for(asyncio.shield(process.wait()), timeout=_LSAPPINFO_TIMEOUT_SECONDS)
 
 
+async def _lsappinfo_info(
+    run: Callable[..., Awaitable["str | None"]], *find_args: str, only: tuple[str, ...]
+) -> "str | None":
+    """Resolve an app's ASN via ``lsappinfo <find_args>``, then query its ``only`` info fields.
+
+    Shared by :func:`frontmost_app` (``front``, pid/name) and
+    ``visibility.application_hidden`` (``find pid=<pid>``, hidden). ``run`` is the caller's
+    own module-level probe function, so each caller keeps its own patchable entry point for
+    tests. Returns the raw ``lsappinfo info`` output, or None when the ASN cannot be
+    resolved or either call times out.
+    """
+    try:
+        asn = await run("lsappinfo", *find_args)
+        if not asn or not asn.strip().startswith("ASN:"):
+            return None
+        only_flags = [flag for field in only for flag in ("-only", field)]
+        return await run("lsappinfo", "info", *only_flags, asn.strip())
+    except asyncio.TimeoutError:
+        return None
+
+
 async def frontmost_app() -> FrontmostApp | None:
     """Return the frontmost regular application, or None when it cannot be determined.
 
@@ -76,13 +98,7 @@ async def frontmost_app() -> FrontmostApp | None:
     the probe is a safety net, and LaunchServices being unavailable (headless session,
     login window) is not evidence that focus moved.
     """
-    try:
-        asn = await _run("lsappinfo", "front")
-        if not asn or not asn.strip().startswith("ASN:"):
-            return None
-        info = await _run("lsappinfo", "info", "-only", "pid", "-only", "name", asn.strip())
-    except asyncio.TimeoutError:
-        return None
+    info = await _lsappinfo_info(_run, "front", only=("pid", "name"))
     if info is None:
         return None
     return parse_lsappinfo_info(info)

--- a/yutori/navigator/macos/visibility.py
+++ b/yutori/navigator/macos/visibility.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import re
 
-from .frontmost import _run
+from .frontmost import _lsappinfo_info, _run
 
 _VISIBILITY_SETTLE_SECONDS = 0.2
 _VISIBILITY_POLLS = 5
@@ -43,13 +43,7 @@ def parse_lsappinfo_hidden(output: str) -> bool | None:
 
 async def application_hidden(pid: int) -> bool | None:
     """Report whether LaunchServices lists ``pid`` as hidden, or None when it cannot say."""
-    try:
-        asn = await _run("lsappinfo", "find", f"pid={pid}")
-        if not asn or not asn.strip().startswith("ASN:"):
-            return None
-        info = await _run("lsappinfo", "info", "-only", "hidden", asn.strip())
-    except asyncio.TimeoutError:
-        return None
+    info = await _lsappinfo_info(_run, "find", f"pid={pid}", only=("hidden",))
     if info is None:
         return None
     return parse_lsappinfo_hidden(info)


### PR DESCRIPTION
## What

`frontmost.py::frontmost_app` and `visibility.py::application_hidden` each hand-rolled the identical "resolve an app's ASN via `lsappinfo`, bail if it doesn't look like one, then run `lsappinfo info` with `-only` flags" idiom, wrapped in the same `try/except asyncio.TimeoutError: return None`. They differ only in the find command (`front` vs `find pid=<pid>`) and which info fields they ask for (`pid`/`name` vs `hidden`).

Extracted `_lsappinfo_info(run, *find_args, only=...)` into `frontmost.py` — already the home of the shared `_run` subprocess helper that `visibility.py` imports from it. Both callers now delegate and keep only their own response parsing (`parse_lsappinfo_info` / `parse_lsappinfo_hidden`).

`run` is passed in as a parameter rather than imported and called directly, so each module keeps its own patchable `_run` entry point — the existing tests independently monkeypatch `frontmost_module._run` and `visibility._run` and assert the exact `lsappinfo` argv sequences; those assertions are unchanged and still pass.

## Why it's safe

- No behavior change: same commands, same argument order (`-only pid -only name` and `-only hidden` build byte-identical argv to before), same None/timeout handling.
- Both `frontmost_app`/`application_hidden` and the new `_lsappinfo_info` helper are module-private — no public SDK surface touched.
- 2 files changed, +25/-15.

## Verified

- Targeted macOS test files: `tests/test_navigator_macos_frontmost.py`, `tests/test_navigator_macos_visibility.py`, `tests/test_navigator_macos_computer.py`, `tests/test_navigator_macos_presentation.py`, `tests/test_navigator_macos_windows.py` — 139 passed.
- Full suite `pytest -m "not slow"` — 914 passed / 3 skipped / 1 deselected (identical to `main`).
- `ruff check .` and `ruff format --check` on both touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K71RXveRiGk9TegiU6sCBw

---
_Generated by [Claude Code](https://claude.ai/code/session_01K71RXveRiGk9TegiU6sCBw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor only: same `lsappinfo` argv sequences and None/timeout behavior; private helpers with existing test coverage unchanged in intent.
> 
> **Overview**
> Extracts shared **`_lsappinfo_info`** in `frontmost.py` so **`frontmost_app`** and **`visibility.application_hidden`** no longer duplicate the same two-step `lsappinfo` pattern (resolve ASN, then `info` with `-only` fields).
> 
> Callers pass their module’s **`_run`** and the find args / field list they need; each keeps its own parsers and test patch points. **`application_hidden`** drops its local try/except in favor of the helper’s timeout handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 217af4aed94bd87829d49ee0baff3f1d4d64904b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->