### PR TITLE
refactor(macos): dedupe the cancellable fail-soft pattern in present/_present_status

### DIFF
--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -106,7 +106,7 @@ def _fail_soft(reason: str, default: _T) -> Callable[[Callable[..., Awaitable[_T
     presentation operation whose only failure handling is "degrade and report
     failure to the caller" -- unlike ``present``/``_present_status``, which
     interleave several branches and must re-raise ``asyncio.CancelledError``
-    before degrading, so those keep their own inline ``try``/``except``.
+    before degrading, so those use :func:`_fail_soft_cancellable` instead.
     """
 
     def decorator(func: Callable[..., Awaitable[_T]]) -> Callable[..., Awaitable[_T]]:
@@ -121,6 +121,28 @@ def _fail_soft(reason: str, default: _T) -> Callable[[Callable[..., Awaitable[_T
         return wrapper
 
     return decorator
+
+
+def _fail_soft_cancellable(func: Callable[..., Awaitable[None]]) -> Callable[..., Awaitable[None]]:
+    """Decorate a controller method: reraise ``asyncio.CancelledError``, else degrade and swallow.
+
+    Consolidates the identical ``except asyncio.CancelledError: raise`` / ``except
+    Exception as error: await self._degrade(f"presentation_failed:{type(error).__name__}",
+    error)`` shape shared by ``present`` and ``_present_status``. Unlike :func:`_fail_soft`,
+    these interleave several branches across a whole event dispatch and must let
+    cancellation propagate rather than being reported as a presentation failure.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(self: "MacOSPresentationController", *args: Any, **kwargs: Any) -> None:
+        try:
+            await func(self, *args, **kwargs)
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:  # noqa: BLE001 - presentation is fail-soft
+            await self._degrade(f"presentation_failed:{type(error).__name__}", error)
+
+    return wrapper
 
 
 class MacOSPresentationError(RuntimeError):
@@ -553,43 +575,39 @@ class MacOSPresentationController:
         self._terminal_command = ""
         self._active_keys = None
 
+    @_fail_soft_cancellable
     async def present(self, event: dict[str, Any]) -> None:
         if not self._status.available or self._stopping:
             return
         if self._mode == "status":
             await self._present_status(event)
             return
-        try:
-            # The transcript is the same conversation in either mode; only the desktop
-            # surfaces below differ.
-            await self._present_transcript(event)
-            event_type = event.get("type")
-            if event_type == "reasoning":
-                text = event.get("text")
-                if isinstance(text, str) and text.strip():
-                    self._reasoning = text.strip()
-                    self._clear_action_labels()
-                    await self._render_capsule()
-            elif event_type in {"action", "batch_member"}:
-                await self._present_action(event)
-            elif event_type == "action_done":
-                if self._batch_is_last:
-                    self._queue_active = False
-                    self._batch_is_last = False
+        # The transcript is the same conversation in either mode; only the desktop
+        # surfaces below differ.
+        await self._present_transcript(event)
+        event_type = event.get("type")
+        if event_type == "reasoning":
+            text = event.get("text")
+            if isinstance(text, str) and text.strip():
+                self._reasoning = text.strip()
                 self._clear_action_labels()
                 await self._render_capsule()
-            elif event_type == "final":
-                self._reasoning = ""
-                self._clear_action_labels()
-                await self._render_capsule()
-            elif event_type == "shell":
-                shell_event = event.get("event")
-                if isinstance(shell_event, ShellPresentationEvent):
-                    await self._present_shell(shell_event)
-        except asyncio.CancelledError:
-            raise
-        except Exception as error:  # noqa: BLE001 - presentation is fail-soft
-            await self._degrade(f"presentation_failed:{type(error).__name__}", error)
+        elif event_type in {"action", "batch_member"}:
+            await self._present_action(event)
+        elif event_type == "action_done":
+            if self._batch_is_last:
+                self._queue_active = False
+                self._batch_is_last = False
+            self._clear_action_labels()
+            await self._render_capsule()
+        elif event_type == "final":
+            self._reasoning = ""
+            self._clear_action_labels()
+            await self._render_capsule()
+        elif event_type == "shell":
+            shell_event = event.get("event")
+            if isinstance(shell_event, ShellPresentationEvent):
+                await self._present_shell(shell_event)
 
     async def show_preview_frame(self, image_bytes: bytes) -> bool:
         """Status mode: refresh the live frame (menu thumbnail and activity window) with a streamed frame.
@@ -607,6 +625,7 @@ class MacOSPresentationController:
             return False
         return reply.get("state") == "shown"
 
+    @_fail_soft_cancellable
     async def _present_status(self, event: dict[str, Any]) -> None:
         """Status mode: the menu's caption, the activity window's transcript, and the shell rail.
 
@@ -616,23 +635,18 @@ class MacOSPresentationController:
         rail under the menu bar a foreground run shows, because a command running on their
         Mac should not require opening a window to notice.
         """
-        try:
-            if event.get("type") == "shell":
-                shell_event = event.get("event")
-                if isinstance(shell_event, ShellPresentationEvent):
-                    self._record_shell(shell_event)
-                    await self._track_shell_rail(shell_event)
-            await self._present_transcript(event)
-            text = _status_line(event)
-            if text is not None and self._last_render.get("status") != text:
-                self._last_render["status"] = text
-                reply = await self._send_command({"op": "status", "text": text})
-                if reply.get("state") != "shown":
-                    raise MacOSPresentationError("Status item did not accept the caption.")
-        except asyncio.CancelledError:
-            raise
-        except Exception as error:  # noqa: BLE001 - presentation is fail-soft
-            await self._degrade(f"presentation_failed:{type(error).__name__}", error)
+        if event.get("type") == "shell":
+            shell_event = event.get("event")
+            if isinstance(shell_event, ShellPresentationEvent):
+                self._record_shell(shell_event)
+                await self._track_shell_rail(shell_event)
+        await self._present_transcript(event)
+        text = _status_line(event)
+        if text is not None and self._last_render.get("status") != text:
+            self._last_render["status"] = text
+            reply = await self._send_command({"op": "status", "text": text})
+            if reply.get("state") != "shown":
+                raise MacOSPresentationError("Status item did not accept the caption.")
 
     async def _present_transcript(self, event: dict[str, Any]) -> None:
         """Append this event to the activity window's conversation, if it has a row to show."""


### PR DESCRIPTION
## Issue

`MacOSPresentationController.present` and `_present_status` (`yutori/navigator/macos/presentation.py`) each wrapped their dispatch body in the identical

```python
except asyncio.CancelledError:
    raise
except Exception as error:  # noqa: BLE001 - presentation is fail-soft
    await self._degrade(f"presentation_failed:{type(error).__name__}", error)
```

block. This is the same duplication class the `_fail_soft` decorator (#373) already consolidated for `show_thumbnail`/`before_capture`/`after_capture`/`encode_observation` — those four methods explicitly couldn't reuse `_fail_soft` because they need to reraise `CancelledError` before degrading, so the pattern was left duplicated in these two methods instead.

## Improvement

Extracted a new `_fail_soft_cancellable` decorator — the cancellation-aware counterpart to `_fail_soft` — and applied it to both `present` and `_present_status`. Each method now keeps only its distinct dispatch body.

## Why it's safe

- **No behavior change.** The removed `try` previously wrapped only the code below each method's early-return guards (e.g. `if not self._status.available or self._stopping: return`); those guards are simple attribute checks that cannot raise, so moving them inside the decorated body is equivalent. The exception handling order (reraise `CancelledError`, else degrade with the same `f"presentation_failed:{type(error).__name__}"` reason) is byte-for-byte preserved.
- **Verified**: full suite passes unmodified — `914 passed, 3 skipped, 1 deselected` (same as baseline). `ruff check` and `ruff format --check` both clean on the touched file.
- **Scope**: 1 file changed, mechanical extraction only, no public API change (both are internal controller methods).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoGweAuMDdcoLXYHWgfY3j

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoGweAuMDdcoLXYHWgfY3j)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor in internal macOS presentation error handling with preserved cancellation and degrade semantics; no API or logic changes described.
> 
> **Overview**
> Introduces **`_fail_soft_cancellable`**, a decorator that **re-raises `asyncio.CancelledError`** and otherwise **degrades** with the same `presentation_failed:{exception}` reason used before, matching the cancellation-aware branch that was duplicated on **`present`** and **`_present_status`**.
> 
> Both methods **drop their inline `try`/`except` blocks** and are annotated with the new decorator so only event-dispatch logic remains. The **`_fail_soft` docstring** now points readers at **`_fail_soft_cancellable`** for methods that must not treat cancellation as a presentation failure.
> 
> **No intended behavior change**—exception order and degrade messaging are preserved; early-return guards now run inside the decorated wrapper (still safe for the existing guard checks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86b132d672c6978737527f618b82fdccbe19fc57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->