### PR TITLE
docs(examples): add reference browser tool definitions for custom tools

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -91,3 +91,26 @@ uv run examples/navigator_n2_daytona.py \
 Pass `--record` to capture the desktop during the run; the video is downloaded to `n2-daytona-run.mp4` before the sandbox is deleted.
 
 To drive your own Mac instead, use [Yutori MCP](https://github.com/yutori-ai/yutori-mcp) (`uvx yutori-mcp computer-use setup`). Walkthrough: [Run n2 on Daytona](https://docs.yutori.com/reference/n2-daytona).
+
+## browser_tools.json
+
+Reference tool definitions for driving a browser from `N2ComputerAgent(tools=[...])`, in the
+shape the API expects. Eight tools: `goto_url`, `go_back`, `go_forward`, `refresh`,
+`extract_elements`, `find`, `set_element_value`, and `execute_js`. They are ordinary caller
+tools — nothing here is served by the model's built-in tool set — so your computer adapter
+implements `run_custom_tool(name, arguments)` to execute them, and the agent handles routing,
+results and frames. `navigator_n2_daytona.py` shows an adapter; [api.md](../api.md)'s
+"Custom tools" section documents the contract.
+
+```python
+import json
+from pathlib import Path
+
+tools = json.loads(Path("examples/browser_tools.json").read_text())
+agent = N2ComputerAgent(computer=computer, completions=..., model=..., tools=tools)
+```
+
+Serve the subset you actually implement. The four navigation tools are useful on their own;
+the DOM tools (`extract_elements`, `find`, `set_element_value`, `execute_js`) need a way to
+evaluate JavaScript in the page. Custom-tool results carry the post-action frame, so a tool
+that changes the page hands the model the new screenshot with its result.

--- a/examples/browser_tools.json
+++ b/examples/browser_tools.json
@@ -1,0 +1,136 @@
+[
+  {
+    "type": "function",
+    "function": {
+      "name": "goto_url",
+      "description": "Navigates directly to the specified URL.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Destination URL."
+          }
+        },
+        "required": [
+          "url"
+        ]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "go_back",
+      "description": "Navigates back to the previous page in browser history.",
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "go_forward",
+      "description": "Navigates forward to the next page in browser history.",
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "refresh",
+      "description": "Reloads the current page.",
+      "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "extract_elements",
+      "description": "Extracts page elements and references, optionally filtering by a query.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "string",
+            "description": "Optional filter query for page content."
+          }
+        },
+        "required": []
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "find",
+      "description": "Searches for text on the page.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "Text to search for."
+          }
+        },
+        "required": [
+          "text"
+        ]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "set_element_value",
+      "description": "Sets an input element's value by reference.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "ref": {
+            "type": "string",
+            "description": "Element reference for the form input field."
+          },
+          "value": {
+            "type": "string",
+            "description": "Value to set."
+          }
+        },
+        "required": [
+          "ref",
+          "value"
+        ]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "execute_js",
+      "description": "Executes JavaScript code on the page.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "JavaScript code to execute."
+          }
+        },
+        "required": [
+          "text"
+        ]
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Problem

[#364](https://github.com/yutori-ai/yutori-sdk-python/pull/364) lets a caller serve its own tools through `N2ComputerAgent(tools=[...])`, but left the reader to invent the definitions. The shape is easy to get subtly wrong — a schema the server rejects, or one the model reads as something other than what the adapter implements.

## Change

`examples/browser_tools.json`: the eight browser tools the feature was evaluated with, in the shape the API expects.

- **navigation** — `goto_url`, `go_back`, `go_forward`, `refresh`
- **DOM** — `extract_elements`, `find`, `set_element_value`, `execute_js`

```python
tools = json.loads(Path("examples/browser_tools.json").read_text())
agent = N2ComputerAgent(computer=computer, completions=..., model=..., tools=tools)
```

These are ordinary caller tools — nothing here is served by the built-in tool set. The adapter implements `run_custom_tool(name, arguments)`; the agent handles routing, results and frames.

Data and docs only. Nothing imports the file, and no runtime behaviour changes.

## Notes for the reviewer

Two things worth a look, since this is a public repo:

- **It documents a shape as supported.** The API does not implement these tools — the caller does — but shipping them as an official example may read as a support commitment. Happy to swap in a generic single-tool example if that is the wrong signal.
- **`set_element_value` is not independently useful.** Its `ref` argument only means something alongside `extract_elements`, which issues the references. The README says to serve the subset you implement; the DOM four travel together in practice.

Generated from the praxis navigator constants the evaluation actually served, so the file cannot drift from what was measured.

## Testing

`920 passed, 3 skipped` on the full suite; the JSON parses and carries all eight definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHkcDvvjaw6TNukT99af2o

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and static JSON only; no production code paths or behavioral changes.
> 
> **Overview**
> Adds **`examples/browser_tools.json`**, a copy-pasteable set of eight OpenAI-style function tool schemas for browser control via **`N2ComputerAgent(tools=[...])`**: navigation (`goto_url`, `go_back`, `go_forward`, `refresh`) and DOM helpers (`extract_elements`, `find`, `set_element_value`, `execute_js`).
> 
> **`examples/README.md`** gains a **`browser_tools.json`** section that explains these are caller-defined tools (adapter implements **`run_custom_tool`**, not built-in model tools), shows loading the JSON into the agent, and notes you can ship only the tools your adapter supports.
> 
> Documentation and example data only — nothing imports the file and runtime behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70417d1c6daf0eb3c8593e3965dffb6b996f8f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->