### PR TITLE
fix(macos): disambiguate overlay coordinate arithmetic

### DIFF
--- a/tests/test_navigator_macos_overlay_build.py
+++ b/tests/test_navigator_macos_overlay_build.py
@@ -117,3 +117,11 @@ def test_non_macos_check_is_read_only_and_unavailable(tmp_path, monkeypatch):
     checked = check_macos_overlay(tmp_path / "missing")
     assert checked.available is False
     assert set(os.listdir(tmp_path)) == before
+
+
+def test_stop_item_region_explicitly_converts_cgfloat_arithmetic_to_double():
+    """Older Swift/CoreFoundation combinations cannot infer the numeric-literal overload."""
+    source = overlay_build._asset_directory().joinpath("macos-overlay-host.swift").read_text(encoding="utf-8")
+    region = source.split("private func stopItemRegion", 1)[1].split("private func registerStopHotKey", 1)[0]
+    for key in ("x", "y", "width", "height"):
+        assert f'"{key}": Double(' in region

--- a/yutori/navigator/macos/assets/macos-overlay-host.swift
+++ b/yutori/navigator/macos/assets/macos-overlay-host.swift
@@ -479,11 +479,14 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
         guard let itemFrame = stopItem?.button?.window?.frame else { return nil }
         let frame = itemFrame.intersection(screen.frame)
         guard !frame.isEmpty else { return nil }
+        // Some Swift/CoreFoundation combinations expose both CGFloat and Double arithmetic
+        // candidates here. Convert before scaling so the dictionary's Double value type does
+        // not have to disambiguate the numeric-literal overload.
         return [
-            "x": (frame.minX - screen.frame.minX) / screen.frame.width * 1000,
-            "y": (screen.frame.maxY - frame.maxY) / screen.frame.height * 1000,
-            "width": frame.width / screen.frame.width * 1000,
-            "height": frame.height / screen.frame.height * 1000,
+            "x": Double((frame.minX - screen.frame.minX) / screen.frame.width) * 1000.0,
+            "y": Double((screen.frame.maxY - frame.maxY) / screen.frame.height) * 1000.0,
+            "width": Double(frame.width / screen.frame.width) * 1000.0,
+            "height": Double(frame.height / screen.frame.height) * 1000.0,
         ]
     }
 


### PR DESCRIPTION
## Summary
- explicitly convert normalized `CGFloat` coordinate ratios to `Double`
- avoid ambiguous numeric-literal overloads in older Swift/CoreFoundation combinations
- add a source-contract regression test for all four Stop-region coordinates

## Verification
- `uv run pytest -m "not slow"` (871 passed, 9 skipped)
- `uv run ruff check .`
- compiled and self-tested the overlay with Swift 6.3.3 / macOS SDK 26.5
- compiled and self-tested the overlay with Swift 6.4 / macOS SDK 27.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time type disambiguation only; normalized Stop-region math is unchanged and is covered by a lightweight source assertion test.
> 
> **Overview**
> Fixes **macOS overlay host** compile failures on some Swift/CoreFoundation toolchains where normalized Stop menu-bar coordinates in `stopItemRegion` could not pick an overload for `1000` against mixed `CGFloat`/`Double` math.
> 
> **`stopItemRegion`** now wraps each ratio in `Double(...)` and scales with `1000.0` so the `[String: Double]` payload stays unambiguous; behavior for `stop_region` click-blocking should be unchanged.
> 
> Adds a **source-contract test** that parses `macos-overlay-host.swift` and requires explicit `Double(` for all four keys (`x`, `y`, `width`, `height`) so the fix cannot regress silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66ad2fd705c888849d4aa4c7b3538d4a7b23ab1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->