### PR TITLE
refactor(macos): dedupe optional-coordinate resolution in left_mouse_down/up

### DIFF
--- a/tests/test_navigator_macos_computer.py
+++ b/tests/test_navigator_macos_computer.py
@@ -353,6 +353,32 @@ async def test_manual_drag_and_timed_held_modifier_use_public_driver_primitives(
     assert not [call for call in transport.calls if call[0] in {"mouse_down", "mouse_up", "hold_key"}]
 
 
+@pytest.mark.parametrize("method_name", ["left_mouse_down", "left_mouse_up"])
+async def test_mouse_down_and_up_reject_partial_coordinates(method_name: str):
+    transport = FakeTransport()
+    async with MacOSComputer(transport, owns_transport=False, presentation=False) as computer:
+        method = getattr(computer, method_name)
+        with pytest.raises(ValueError, match=f"{method_name.split('_', 1)[1]} coordinates must include both x and y"):
+            await method(x=10)
+        with pytest.raises(ValueError, match=f"{method_name.split('_', 1)[1]} coordinates must include both x and y"):
+            await method(y=10)
+
+
+async def test_left_mouse_down_without_a_prior_pointer_position_is_recoverable():
+    transport = FakeTransport()
+    async with MacOSComputer(transport, owns_transport=False, presentation=False) as computer:
+        with pytest.raises(MacOSRecoverableActionError, match="requires coordinates after the pointer has moved"):
+            await computer.left_mouse_down()
+
+
+async def test_left_mouse_up_without_a_preceding_mouse_down_is_recoverable():
+    transport = FakeTransport()
+    async with MacOSComputer(transport, owns_transport=False, presentation=False) as computer:
+        await computer.move(10, 20)
+        with pytest.raises(MacOSRecoverableActionError, match="requires a preceding mouse_down"):
+            await computer.left_mouse_up()
+
+
 async def test_uncertain_mutation_captures_a_fresh_observation():
     class UncertainTransport(FakeTransport):
         async def call_tool(self, name, arguments, **kwargs):

--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -772,10 +772,15 @@ class MacOSComputer:
         )
         self._pointer = (end["x"], end["y"])
 
-    async def left_mouse_down(self, x: "int | None" = None, y: "int | None" = None) -> None:
+    def _point_from_optional_coordinates(
+        self, action_name: str, x: "int | None", y: "int | None"
+    ) -> "tuple[int, int] | None":
         if (x is None) != (y is None):
-            raise ValueError("mouse_down coordinates must include both x and y")
-        point = (x, y) if x is not None and y is not None else self._pointer
+            raise ValueError(f"{action_name} coordinates must include both x and y")
+        return (x, y) if x is not None and y is not None else self._pointer
+
+    async def left_mouse_down(self, x: "int | None" = None, y: "int | None" = None) -> None:
+        point = self._point_from_optional_coordinates("mouse_down", x, y)
         if point is None:
             raise MacOSRecoverableActionError("mouse_down requires coordinates after the pointer has moved.")
         self._refuse_stop_point(*point)
@@ -784,9 +789,7 @@ class MacOSComputer:
         self._left_mouse_down = True
 
     async def left_mouse_up(self, x: "int | None" = None, y: "int | None" = None) -> None:
-        if (x is None) != (y is None):
-            raise ValueError("mouse_up coordinates must include both x and y")
-        point = (x, y) if x is not None and y is not None else self._pointer
+        point = self._point_from_optional_coordinates("mouse_up", x, y)
         if self._held_mouse_start is None or point is None:
             raise MacOSRecoverableActionError("mouse_up requires a preceding mouse_down with known coordinates.")
         self._refuse_stop_point(*point)


### PR DESCRIPTION
## The issue

`MacOSComputer.left_mouse_down` and `left_mouse_up` (`yutori/navigator/macos/computer.py`) each hand-duplicated the identical 3-line "resolve an optional `(x, y)` pair" idiom:

```python
if (x is None) != (y is None):
    raise ValueError("mouse_down coordinates must include both x and y")
point = (x, y) if x is not None and y is not None else self._pointer
```

(with `mouse_up` in the string literal on the other call site). Both then feed `point` into their own, genuinely different follow-up checks (`left_mouse_down` requires a non-`None` point; `left_mouse_up` additionally requires a preceding `left_mouse_down`) and error messages.

## The fix

Extracted a private `_point_from_optional_coordinates(action_name, x, y)` helper that does the shared validate-and-resolve step, parameterized by the action name so each call site keeps its own exact error message (`"mouse_down coordinates must include both x and y"` / `"mouse_up coordinates must include both x and y"`). Each call site keeps its own post-validation branch untouched.

## Why it's safe

- **No public API change.** `left_mouse_down`/`left_mouse_up` keep the exact same signatures, behavior, and error messages/types — verified line-for-line against the pre-refactor code. The new helper is a private method (`_`-prefixed), not exported.
- These two error branches (mismatched x/y, and the two "missing prior state" `MacOSRecoverableActionError`s) had no direct test coverage before this PR — added `test_mouse_down_and_up_reject_partial_coordinates`, `test_left_mouse_down_without_a_prior_pointer_position_is_recoverable`, and `test_left_mouse_up_without_a_preceding_mouse_down_is_recoverable` to pin the exact messages/behavior first.
- Verified: full suite with `pip install -e ".[dev]"` (CI's exact install path) → 874 passed / 9 skipped / 1 deselected (up from 870 baseline, +4 for the new tests); with `dev`+`examples` extras → 923 passed / 3 skipped / 1 deselected. `ruff check`/`ruff format --check` clean on both touched files.
- 2 files touched, +35/-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEHBV5oknBGzMA31U25sUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEHBV5oknBGzMA31U25sUE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private refactor with preserved public API and behavior, plus new tests for input validation edge cases only.
> 
> **Overview**
> **MacOSComputer** now resolves optional `(x, y)` for `left_mouse_down` and `left_mouse_up` through a private `_point_from_optional_coordinates` helper instead of duplicating the same validate-and-fallback logic at both call sites. Action-specific `ValueError` messages (`mouse_down` vs `mouse_up`) are unchanged; the existing recoverable errors for missing pointer state and missing prior `mouse_down` are still enforced in each method.
> 
> Adds navigator macOS computer tests that lock in partial-coordinate rejection, `left_mouse_down` without a prior move, and `left_mouse_up` without a held button—paths that previously had no direct coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2b7042a323d571251d25022551a59bc5b96373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->