### PR TITLE
docs: sync api.md and n2.py docstring with #364 custom tools

### DIFF
--- a/api.md
+++ b/api.md
@@ -551,14 +551,15 @@ from yutori.navigator import N2Computer, N2ComputerAgent, N2InlineCompactor, TOO
 from yutori.navigator.macos import MacOSComputer  # macOS only; needs the `macos` extra
 ```
 
-`N2ComputerAgent(*, computer, tool_set=TOOL_SET_COMPUTER_USE_LATEST, completions=None, api_key=None, base_url=None, model="n2", instructions=None, callbacks=None, action_confirmation_callback=None, presentation=None, screenshot_delay=0.5, execution_deadline=None, temperature=None, supports_click_modifiers=False, supports_scroll_modifiers=None, **loop_policies)` drives one n2 conversation against any computer adapter. The loop is async: pass `completions=AsyncYutoriClient().chat.completions` (the sync client's completions will not work), or an `api_key` — the agent then owns its own `AsyncYutoriClient`; close it with `aclose()` or the async context manager. The defaults are already pinned: stable model `n2` and the current dated tool set.
+`N2ComputerAgent(*, computer, tool_set=TOOL_SET_COMPUTER_USE_LATEST, tools=None, completions=None, api_key=None, base_url=None, model="n2", instructions=None, callbacks=None, action_confirmation_callback=None, presentation=None, screenshot_delay=0.5, execution_deadline=None, temperature=None, supports_click_modifiers=False, supports_scroll_modifiers=None, **loop_policies)` drives one n2 conversation against any computer adapter. The loop is async: pass `completions=AsyncYutoriClient().chat.completions` (the sync client's completions will not work), or an `api_key` — the agent then owns its own `AsyncYutoriClient`; close it with `aclose()` or the async context manager. The defaults are already pinned: stable model `n2` and the current dated tool set.
 
 Constructor parameters (the `**loop_policies` keywords have [their own table](#loop-policies)):
 
 | Parameter | What it does |
 |---|---|
 | `computer` | Your adapter — see [the adapter contract](#the-adapter-contract-n2computer). |
-| `tool_set` | A dated set from `SUPPORTED_N2_TOOL_SETS`. The loop serves exactly the set's tools — it has no `disable_tools`/`tools` passthrough, a custom tool call gets a recoverable does-not-expose error, and the adapter must serve every tool in the set (see [Changing the n2 tool set](#changing-the-n2-tool-set)). |
+| `tool_set` | A dated set from `SUPPORTED_N2_TOOL_SETS`. The loop serves exactly the set's tools, and the adapter must serve every tool in the set (see [Changing the n2 tool set](#changing-the-n2-tool-set)). |
+| `tools` | Optional list of caller-owned tool definitions (standard OpenAI shape), served alongside the tool set. Calls to these are dispatched to the adapter's `run_custom_tool(name, arguments)` and their results carry the post-action frame. An adapter without the hook gets a recoverable "not supported" error. |
 | `instructions` | Optional text inserted as the first user message of the run's history. |
 | `callbacks` | List of duck-typed observer objects — see [Callbacks and confirmation](#callbacks-and-confirmation). |
 | `action_confirmation_callback` | Opt-in approval gate for model actions — same section. |

--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -1256,9 +1256,9 @@ class N2ComputerAgent:
     - ``tools``: caller-owned tool definitions, in the standard OpenAI shape,
       served alongside the tool set. The loop dispatches a call to one of them
       to the computer's ``run_custom_tool(name, arguments)``, whose returned
-      text becomes the tool result — no frame rides with it, as for ``bash``.
-      A computer that does not implement the hook answers with a recoverable
-      "not supported" result instead of failing the run.
+      text becomes the tool result, carried with the post-action frame like
+      ``computer_batch``. A computer that does not implement the hook answers
+      with a recoverable "not supported" result instead of failing the run.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary

- **api.md constructor signature**: add missing `tools=None` parameter (was omitted when #364 landed)
- **api.md constructor table**: replace stale "no `disable_tools`/`tools` passthrough" text in the `tool_set` row; add new `tools` row documenting the parameter, its dispatch to `run_custom_tool`, and that results carry the post-action frame
- **n2.py class docstring**: fix incorrect "no frame rides with it, as for `bash`" — custom tool results DO carry the post-action frame (like `computer_batch`), matching the N2Computer protocol docstring at line 252 and the actual code flow (custom_output_text falls through to the screenshot path at line 1143, unlike shell_output_text which early-returns at line 1137)

## Test plan

- [ ] Documentation and docstring-only change — no behavior change
- [ ] Verify api.md constructor signature matches the actual `__init__` parameter order
- [ ] Verify the n2.py docstring now agrees with the N2Computer protocol docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtJXDwG67CQBRqrhQEFUD2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtJXDwG67CQBRqrhQEFUD2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring and reference edits only; no runtime behavior changes.
> 
> **Overview**
> Documentation-only follow-up to custom `tools=` support: **`api.md`** now lists `tools=None` on `N2ComputerAgent`, trims outdated `tool_set` wording about no tools passthrough, and adds a **`tools`** table row (`run_custom_tool`, post-action frame). **`N2ComputerAgent`**’s class docstring is corrected so custom tool results are described as carrying the **post-action screenshot** (like `computer_batch`), not text-only like `bash`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d7902842c0faeb9b25d24c91d5508aae1033b60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->