### PR TITLE
refactor(navigator): delegate native_point to denormalize_coordinates

### DIFF
--- a/yutori/navigator/n2_actions.py
+++ b/yutori/navigator/n2_actions.py
@@ -12,6 +12,7 @@ import copy
 from typing import Any
 
 from ._key_symbols import PUNCTUATION_KEY_NAMES
+from .coordinates import denormalize_coordinates
 from .models import (
     TOOL_SET_COMPUTER_USE,
     TOOL_SET_COMPUTER_USE_20260825,
@@ -368,10 +369,7 @@ def native_point(value: Any, path: str, width: int, height: int) -> "tuple[int, 
     if width <= 0 or height <= 0:
         raise N2ActionValidationError("native screenshot dimensions must be positive")
     x, y = _coordinate(value, path)
-    return (
-        min(width - 1, round((x / N2_COORDINATE_SCALE) * width)),
-        min(height - 1, round((y / N2_COORDINATE_SCALE) * height)),
-    )
+    return denormalize_coordinates((x, y), width, height, scale=N2_COORDINATE_SCALE)
 
 
 def _validate_wait_seconds(duration: Any, field: str) -> "int | float":


### PR DESCRIPTION
## What

`native_point()` in `yutori/navigator/n2_actions.py` reimplemented the exact "scale a 0-1000 normalized coordinate to native pixel space" formula that `denormalize_coordinates()` in `yutori/navigator/coordinates.py` already provides and already exports publicly from `yutori/navigator/__init__.py` — same `round(x / scale * dimension)` math, clamped to `[0, dimension - 1]`.

This delegates `native_point()` to the shared helper instead of re-deriving the formula inline, so Navigator's normalized→pixel coordinate mapping has exactly one implementation SDK-wide (avoids the two silently drifting if the rounding/clamping logic is ever tweaked in one place and not the other).

## Why this is safe

- `native_point()` already validates `width > 0`/`height > 0` and rejects out-of-range coordinates via `_coordinate()` *before* this call, so `denormalize_coordinates`'s own internal validation is a no-op here.
- `denormalize_coordinates`'s default `clamp=True` clamps to `[0, dimension - 1]` on both ends; the lower bound is a no-op here too since `_coordinate()` already guarantees `x, y >= 0` and `width, height > 0`, so `round(x/scale*width) >= 0` always. Output is byte-for-byte identical for every call site (`left_click`, `drag`, `scroll`, etc. all route through `native_point`).
- Single file touched (plus one new import), signature and return type unchanged.
- Full test suite passes locally (925 passed, 3 skipped), `ruff check`/`ruff format --check` clean. Pre-existing mypy errors in this file (line 474/480/482, unrelated `Any | None` operand issues) are unchanged before/after this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELGR8HoGxvNYtnFaWd7LSy

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELGR8HoGxvNYtnFaWd7LSy)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-function refactor with unchanged API and equivalent math; no auth, data, or security surface.
> 
> **Overview**
> **`native_point()`** in `n2_actions.py` no longer inlines the 0–1000 → native pixel mapping; it calls the shared **`denormalize_coordinates()`** helper with `scale=N2_COORDINATE_SCALE`.
> 
> Behavior for click, drag, scroll, and other paths that use `native_point` should stay the same (same rounding and upper-bound clamping). The change centralizes coordinate denormalization so Navigator has one implementation instead of duplicated formulas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d013e8c10ae2426687b76644248e93c5f5176f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->