### PR TITLE
refactor(navigator): dedupe custom-tool call-item construction in parse_n2_tool_calls

### DIFF
--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -591,25 +591,19 @@ def parse_n2_tool_calls(
             if not isinstance(args, dict):
                 raise N2ActionValidationError(f"{name} arguments must be an object")
 
-            if name in custom_tool_names:
-                # The name travels with the action: one action type serves every custom
-                # tool, and the adapter dispatches on the name it is handed.
-                call_item = _function_call_with_execution(
-                    name,
-                    args,
-                    call_id,
-                    [{"type": CUSTOM_TOOL_ACTION, "tool_name": name, "tool_arguments": args}],
-                    execution_deadline=execution_deadline,
-                )
-                output.append(call_item)
-                continue
-
             def finish(
                 translated: list[dict[str, Any]], *, batch_actions: "list[dict[str, Any]] | None" = None
             ) -> dict[str, Any]:
                 return _function_call_with_execution(
                     name, args, call_id, translated, batch_actions=batch_actions, execution_deadline=execution_deadline
                 )
+
+            if name in custom_tool_names:
+                # The name travels with the action: one action type serves every custom
+                # tool, and the adapter dispatches on the name it is handed.
+                call_item = finish([{"type": CUSTOM_TOOL_ACTION, "tool_name": name, "tool_arguments": args}])
+                output.append(call_item)
+                continue
 
             if name == "computer_batch":
                 if tool_set not in TOOL_SETS_WITH_BATCH:


### PR DESCRIPTION
## What

`parse_n2_tool_calls` in `yutori/navigator/n2.py` had two separate call sites building the trajectory's `function_call` item via `_function_call_with_execution(...)`:

1. The custom-tool branch (`if name in custom_tool_names:`) called `_function_call_with_execution(name, args, call_id, [...], execution_deadline=execution_deadline)` directly.
2. Every other branch (`computer_batch`, `shell_command`, `bash`, the file-tool group, `goto_url`, and the fallback `translate_n2_action` path) already goes through a local `finish(translated, *, batch_actions=None)` closure defined right after the custom-tool branch, which wraps the exact same `_function_call_with_execution(name, args, call_id, translated, batch_actions=batch_actions, execution_deadline=execution_deadline)` call.

The custom-tool branch's call is byte-for-byte what `finish(translated)` produces (with `batch_actions` left at its default `None` in both), so it was hand-duplicating a helper defined two lines below it purely because of ordering.

## Why this is an improvement

This is the same kind of internal duplication this repo's own refactor history has repeatedly consolidated in this exact function (e.g. #279 extracted `finish()` for the non-custom-tool branches). Moving `finish()`'s definition above the custom-tool check and having that branch call `finish([...])` removes the last of the six branches still constructing the call item by hand, so every branch of the tool-dispatch chain now goes through one call site for building a `function_call` item.

## Why this is safe — no public API change

- `parse_n2_tool_calls` keeps its exact signature and is called identically by `N2ComputerAgent._predict_step`.
- The change is purely internal reordering within one function body: `finish`'s closure captures `name`, `args`, `call_id`, `execution_deadline` — all already in scope at its new location — and is only reordered to before its first use, not modified.
- `finish(translated)` with `batch_actions` omitted defaults to `None`, which is exactly what the custom-tool branch passed implicitly before (it never passed `batch_actions` at all) — so the resulting `call_item` dict is byte-identical to what the old direct call produced.
- Verified: full test suite (`pytest -q -m "not slow"`, with `dev`+`examples` extras installed) — 924 passed / 3 skipped / 1 deselected, unchanged from `main`. The targeted n2 suite (`test_navigator_n2.py`, `test_navigator_n2_harness.py`, `test_navigator_n2_compaction.py`, `test_navigator_n2_cookbooks.py`) — 152 passed. `ruff check` and `ruff format --check` clean on the touched file.
- 1 file changed, +7/-13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdWPUCUyhG9H4ZBda5bKZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdWPUCUyhG9H4ZBda5bKZx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-function internal reorder with no signature or wire-format changes; behavior is intended to be byte-identical for custom tools.
> 
> **Overview**
> In **`parse_n2_tool_calls`**, the custom-tool branch no longer calls **`_function_call_with_execution`** directly. The local **`finish`** helper is defined **before** the **`name in custom_tool_names`** check, and that branch now builds the trajectory item with **`finish([{... CUSTOM_TOOL_ACTION ...}])`**, matching every other tool-dispatch path.
> 
> Behavior and public API are unchanged: **`finish`** with default **`batch_actions=None`** is the same call the old inline code made, so custom-tool **`function_call`** items should be identical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a001044dc80a4f2a075a2ceca8f44f14c5de89d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->