### PR TITLE
refactor(navigator): dedupe cancel-and-drain cleanup in _await_model_response

### DIFF
--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -52,6 +52,7 @@ import uuid
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import Any, Protocol, Union
 
+from .macos.process_lifecycle import cancel_and_drain
 from .macos.sanitize import sanitize_command_preview
 from .macos.types import N2Observation, N2Presentation
 from .models import NAVIGATOR_N2_MODEL, TOOL_SET_COMPUTER_USE_LATEST
@@ -722,10 +723,7 @@ async def _await_model_response(computer: Any, awaitable: Awaitable[Any]) -> Any
             return request.result()
         raise asyncio.CancelledError(stopped.result())
     finally:
-        for task in (request, stopped):
-            if not task.done():
-                task.cancel()
-        await asyncio.gather(request, stopped, return_exceptions=True)
+        await cancel_and_drain(request, stopped)
 
 
 def _presentation_text(item: dict[str, Any], field: str) -> str:


### PR DESCRIPTION
## What

`_await_model_response` in `yutori/navigator/n2.py` (the helper that races an in-flight model call against the computer session's `cancellation` latch) hand-rolled its own task cleanup in the `finally` block:

```python
finally:
    for task in (request, stopped):
        if not task.done():
            task.cancel()
    await asyncio.gather(request, stopped, return_exceptions=True)
```

This is byte-for-byte the same "cancel whichever of the raced tasks is still running, then await both with exceptions absorbed" idiom that `yutori.navigator.macos.process_lifecycle.cancel_and_drain` already implements — and that `MacOSComputer._await_with_cancellation` (in `macos/computer.py`) already delegates to for the structurally identical model-request-vs-cancellation race on that side.

## Why this is safe

- **No behavior change.** `cancel_and_drain(request, stopped)` cancels the same two tasks and awaits them with `return_exceptions=True`, exactly like the inlined loop it replaces.
- **No new coupling.** `n2.py` already imports from `.macos.sanitize` and `.macos.types`, so importing `cancel_and_drain` from `.macos.process_lifecycle` adds no new dependency-graph edge — it's already coupled to the `macos` subpackage.
- **No public API change.** `_await_model_response` is a private module-level helper, not exported or documented in `api.md`.
- **Minimal diff.** One file, +2/-4 lines.

## Verification

- Targeted cancellation tests pass: `test_operator_stop_cancels_an_in_flight_model_request`, `test_outer_task_cancellation_cancels_an_in_flight_model_request` (both directly exercise this code path).
- Full suite: `pytest -q -m "not slow"` → 924 passed / 3 skipped / 1 deselected (unchanged from baseline).
- `ruff check .` and `ruff format --check` clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKHJHVi9Rcsaj3Z9rFPwym

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKHJHVi9Rcsaj3Z9rFPwym)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with identical asyncio cleanup semantics; private helper only, covered by existing cancellation tests.
> 
> **Overview**
> **`_await_model_response`** in `n2.py` now uses the shared **`cancel_and_drain`** helper from `macos.process_lifecycle` in its `finally` block instead of inlining cancel-then-`gather(..., return_exceptions=True)` on the raced `request` and `stopped` tasks.
> 
> This matches the cleanup pattern already used by **`MacOSComputer._await_with_cancellation`** for the same model-request-vs-session-cancellation race. Behavior is unchanged: both tasks are cancelled if still running, then awaited with exceptions absorbed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99c83531637ebd73905e62be80dd6ae322405a6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->