### PR TITLE
refactor(macos): dedupe deadline-task cancel-and-drain in MacOSComputer.aclose

### DIFF
--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -642,8 +642,7 @@ class MacOSComputer:
             return
         self._closed = True
         if self._deadline_task is not None:
-            self._deadline_task.cancel()
-            await asyncio.gather(self._deadline_task, return_exceptions=True)
+            await cancel_and_drain(self._deadline_task)
             self._deadline_task = None
         await self._cancel_shell_processes()
         if self._preview is not None:


### PR DESCRIPTION
## What
`MacOSComputer.aclose()` hand-rolled the exact "cancel, then gather with `return_exceptions=True`" idiom that `yutori.navigator.macos.process_lifecycle.cancel_and_drain` already implements:

```python
if self._deadline_task is not None:
    self._deadline_task.cancel()
    await asyncio.gather(self._deadline_task, return_exceptions=True)
    self._deadline_task = None
```

replaced with:

```python
if self._deadline_task is not None:
    await cancel_and_drain(self._deadline_task)
    self._deadline_task = None
```

## Why
This same file (`yutori/navigator/macos/computer.py`) already imports `cancel_and_drain` and uses it twice elsewhere (`_await_with_cancellation`'s operation/stopped race at line ~1315, and the shell communication/cancellation race at line ~1832). The deadline-task cleanup in `aclose()` predates those call sites and was the one sibling left inline — a same-pattern miss one file over from the recently-landed `#388` (`_await_model_response`'s cancel-and-drain dedupe in `n2.py`).

## Why safe
No behavior change: `cancel_and_drain` cancels the task only if it isn't already done — calling `.cancel()` on an already-done task is a no-op either way — then awaits it with `return_exceptions=True`, exactly matching the two-line `asyncio.gather(...)` block it replaces. Single call site, single file.

**Verified:**
- Full suite: 925 passed / 3 skipped (unchanged baseline)
- Targeted: `pytest -k "computer or deadline"` — 98 passed
- `ruff check .` — all checks passed
- `ruff format --check` on the changed file — clean (13 pre-existing unrelated formatting diffs elsewhere in the repo are untouched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjArcQUjY3e6Xut6dscxiP

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjArcQUjY3e6Xut6dscxiP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication of existing cancel-and-await logic with no intended behavior change during session teardown.
> 
> **Overview**
> **`MacOSComputer.aclose()`** now tears down the execution-deadline watcher via the shared **`cancel_and_drain`** helper instead of inlining `task.cancel()` plus `asyncio.gather(..., return_exceptions=True)`.
> 
> This aligns deadline cleanup with other cancellation paths in **`computer.py`** that already use **`cancel_and_drain`**; shutdown behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b16c3e424090b60bf66b911f2849e182f5ecdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->