### PR TITLE
refactor(macos): dedupe cancel-and-drain in WindowPreviewStreamer.aclose

### DIFF
--- a/yutori/navigator/macos/preview.py
+++ b/yutori/navigator/macos/preview.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from PIL import Image
 
+from .process_lifecycle import cancel_and_drain
 from .transport import CuaDriverConnectionError, CuaDriverToolError, CuaDriverTransport, inline_image_data
 from .types import CancellationLatch, MacOSWindowTarget
 
@@ -102,10 +103,8 @@ class WindowPreviewStreamer:
         self._closed = True
         self._active = False
         task, self._task = self._task, None
-        if task is not None and not task.done():
-            task.cancel()
-            with suppress(asyncio.CancelledError):
-                await task
+        if task is not None:
+            await cancel_and_drain(task)
 
     def _cancelled(self) -> bool:
         return self._cancellation is not None and self._cancellation.cancelled


### PR DESCRIPTION
## What

`WindowPreviewStreamer.aclose()` in `yutori/navigator/macos/preview.py` hand-rolled the same
cancel-then-await-suppressing-`CancelledError` idiom that
`yutori.navigator.macos.process_lifecycle.cancel_and_drain()` already implements:

```python
if task is not None and not task.done():
    task.cancel()
    with suppress(asyncio.CancelledError):
        await task
```

`cancel_and_drain()` already exists precisely for this cross-cutting need (its own module
docstring calls out "the frame-polling ... helpers" — `preview.py` is that frame-polling helper)
and is already used by `transport.py`, `presentation.py`, `n2.py`, and — as of the immediately
prior PR (#390) — `computer.py`'s `_deadline_task` cleanup. `preview.py` was the one remaining
sibling call site still inlining the pattern instead of delegating to the shared helper.

## Why this is safe

No behavior change. `WindowPreviewStreamer._run()` only ever propagates `asyncio.CancelledError`
— every other exception is caught internally (`except Exception: self._failures += 1`) — so
suppressing just `CancelledError` around `await task` and `cancel_and_drain`'s broader
`asyncio.gather(*tasks, return_exceptions=True)` are equivalent outcomes for this specific task.
`cancel_and_drain` also folds in the redundant `not task.done()` guard (it already checks this
internally before cancelling).

Verified:
- Full suite: **925 passed / 3 skipped** — identical to the baseline on `main` (unchanged).
- Dedicated `tests/test_navigator_macos_preview.py` (5 tests, covering `aclose()` both mid-stream
  and after natural completion): all pass.
- `ruff check .` and `ruff format --check` on the changed file: clean.

1 file changed, +3/-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uc9sFGD15yB9buMAsGZZ8

---
_Generated by [Claude Code](https://claude.ai/code/session_012uc9sFGD15yB9buMAsGZZ8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor with no intended behavior change; only affects advisory live-preview task shutdown.
> 
> **Overview**
> **`WindowPreviewStreamer.aclose()`** no longer inlines cancel-then-await with `CancelledError` suppression; it delegates to the shared **`cancel_and_drain`** helper from `process_lifecycle`, matching other macOS navigator teardown paths (`transport`, `presentation`, etc.).
> 
> Behavior for the preview background task should be unchanged: `_run()` only re-raises cancellation, so draining via `cancel_and_drain` is equivalent to the previous hand-rolled cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ba79a3fb5a7193521ae10738aac87fce211e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->