### PR TITLE
refactor(macos): dedupe background-monitor cancel-and-drain in _cancel_shell_processes

### DIFF
--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -1856,13 +1856,7 @@ class MacOSComputer:
                 self._kill_process_group(process)
         await asyncio.gather(*(process.wait() for process in foreground), return_exceptions=True)
         backgrounds = tuple(self._background.values())
-        for background in backgrounds:
-            if background.monitor is not None:
-                background.monitor.cancel()
-        await asyncio.gather(
-            *(background.monitor for background in backgrounds if background.monitor is not None),
-            return_exceptions=True,
-        )
+        await cancel_and_drain(*(background.monitor for background in backgrounds if background.monitor is not None))
         for background in backgrounds:
             was_running = background.terminal_state is None
             if background.process.returncode is None and self._identity_matches(background.identity):


### PR DESCRIPTION
## Issue

`MacOSComputer._cancel_shell_processes()` hand-rolled the same cancel-then-gather idiom that `yutori.navigator.macos.process_lifecycle.cancel_and_drain` already implements, and that this same file already imports and uses (the deadline-task cleanup just deduped in #390, the operation/stopped race in `_await_with_cancellation`, and the shell communication/cancellation race). This was the one remaining inline cancel-and-gather, over the background-process monitor tasks:

```python
for background in backgrounds:
    if background.monitor is not None:
        background.monitor.cancel()
await asyncio.gather(
    *(background.monitor for background in backgrounds if background.monitor is not None),
    return_exceptions=True,
)
```

## Improvement

Replaced both statements with a single call to the existing helper:

```python
await cancel_and_drain(*(background.monitor for background in backgrounds if background.monitor is not None))
```

## Safety / equivalence

No behavior change:
- `cancel_and_drain(*tasks)` cancels each task that is not already done, then awaits all of them with `return_exceptions=True` — the exact same net effect as the two statements it replaces. Calling `asyncio.Task.cancel()` on an already-done task (as the old unconditional loop did) is already a documented no-op, so the `if not task.done()` guard inside `cancel_and_drain` changes nothing observable.
- `cancel_and_drain`'s `*tasks: asyncio.Task[Any]` signature already matches `background.monitor: asyncio.Task[None] | None`, so no wrapping/casting is needed at the call site.
- Purely internal method (`_cancel_shell_processes`, leading underscore) — no public API surface touched.

Verified:
- Full suite: `924 passed / 3 skipped / 1 deselected` — identical to the pre-change baseline.
- Targeted macOS computer tests: `89 passed`, including the two tests that already exercise this exact code path with a still-running monitor task (cancelled via `aclose()` mid-command) and an already-completed one (`test_background_supervisor_retains_group_ownership_until_teardown`, `test_background_command_text_is_absent_from_long_lived_process_arguments`).
- `ruff check` and `ruff format --check` clean on the changed file.

1 file changed, +1/-7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114eTAcLsD6GBj7QvHeQmFH

---
_Generated by [Claude Code](https://claude.ai/code/session_0114eTAcLsD6GBj7QvHeQmFH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with equivalent cancel-and-await semantics; no public API or observable behavior change.
> 
> **Overview**
> **`_cancel_shell_processes`** no longer hand-rolls cancel-then-`gather` for background shell **monitor** tasks during session teardown.
> 
> The inline loop that called **`monitor.cancel()`** on each background process and then **`asyncio.gather`** on those monitors is replaced with a single **`await cancel_and_drain(...)`**, matching how **`aclose`**, **`_await_with_cancellation`**, and **`_communicate`** already shut down asyncio tasks in this module. Foreground shell kill/wait and the subsequent background process termination logic are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2188c7885599a7c46399432dca8c966a8c79ffd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->