### PR TITLE
refactor(macos): dedupe cancel-and-drain in WindowPreviewStreamer.aclose

### DIFF
--- a/yutori/navigator/macos/preview.py
+++ b/yutori/navigator/macos/preview.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from PIL import Image
 
+from .process_lifecycle import cancel_and_drain
 from .transport import CuaDriverConnectionError, CuaDriverToolError, CuaDriverTransport, inline_image_data
 from .types import CancellationLatch, MacOSWindowTarget
 
@@ -102,10 +103,8 @@ class WindowPreviewStreamer:
         self._closed = True
         self._active = False
         task, self._task = self._task, None
-        if task is not None and not task.done():
-            task.cancel()
-            with suppress(asyncio.CancelledError):
-                await task
+        if task is not None:
+            await cancel_and_drain(task)
 
     def _cancelled(self) -> bool:
         return self._cancellation is not None and self._cancellation.cancelled


### PR DESCRIPTION
## What

`WindowPreviewStreamer.aclose()` (in `yutori/navigator/macos/preview.py`) hand-rolled the exact cancel-then-await idiom that `yutori.navigator.macos.process_lifecycle.cancel_and_drain` already implements:

```python
if task is not None and not task.done():
    task.cancel()
    with suppress(asyncio.CancelledError):
        await task
```

replaced with:

```python
if task is not None:
    await cancel_and_drain(task)
```

## Why this is the right fix

This is the same structural issue #390 and #392 recently fixed at two sibling call sites in this same package (`MacOSComputer.aclose`'s deadline task, and `_cancel_shell_processes`'s background monitor) — this was the one remaining hand-rolled sibling using the identical shape.

## Why it's safe (no behavior change)

- `WindowPreviewStreamer._run()` already re-raises `asyncio.CancelledError` but catches every other exception internally (`except Exception: self._failures += 1`), so the only thing that can ever propagate out of `await task` is `CancelledError` — exactly what the old `with suppress(asyncio.CancelledError): await task` handled, and exactly what `cancel_and_drain`'s `asyncio.gather(..., return_exceptions=True)` absorbs.
- Cancelling an already-done task is a no-op inside `cancel_and_drain` (`if not task.done(): task.cancel()`), so dropping the outer `not task.done()` guard changes nothing observable — awaiting an already-completed task just returns immediately.

## Verification

- Full suite: 876 passed, 9 skipped (baseline unchanged from `origin/main`)
- Targeted: `tests/test_navigator_macos_preview.py` — 5 passed
- `ruff check .` — clean
- `ruff format --check yutori/navigator/macos/preview.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGMvHrjTNXksNzvc2HbVXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGMvHrjTNXksNzvc2HbVXU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor of asyncio task teardown in the advisory preview streamer; no auth, data, or API surface changes.
> 
> **Overview**
> **`WindowPreviewStreamer.aclose()`** now shuts down its background preview task through the shared **`cancel_and_drain`** helper instead of inline `task.cancel()` plus `suppress(CancelledError)` around `await task`.
> 
> The import from **`process_lifecycle`** aligns this call site with other macOS navigator shutdown paths. Observable behavior should be unchanged: completed tasks are still awaited safely, and cancellation errors are absorbed the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 173bce17679d73b65fdd7628beae3327d11d946b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->