### PR TITLE
refactor(navigator): dedupe best-effort JSON-arguments parsing in n2.py

### DIFF
--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -726,6 +726,24 @@ async def _await_model_response(computer: Any, awaitable: Awaitable[Any]) -> Any
         await cancel_and_drain(request, stopped)
 
 
+def _parse_json_arguments(raw: Any) -> Any:
+    """Best-effort JSON-decode a possibly-string "arguments" value.
+
+    Returns ``raw`` unchanged when it is not a string (already a dict, a
+    list, ``None``, etc.). Returns ``{}`` when it is a string that fails to
+    parse as JSON. Does not itself validate that the result is a dict --
+    callers that need that check it themselves, since some care whether a
+    valid-but-non-object payload (e.g. ``"[1, 2]"``) should be treated the
+    same as unparseable input.
+    """
+    if not isinstance(raw, str):
+        return raw
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
 def _presentation_text(item: dict[str, Any], field: str) -> str:
     return "\n".join(
         str(part.get("text") or "") for part in item.get(field) or [] if isinstance(part, dict) and part.get("text")
@@ -843,12 +861,7 @@ async def execute_n2_computer_call(
 
     record_action = getattr(computer, "record_model_action", None)
     if callable(record_action):
-        arguments = item.get("arguments")
-        if isinstance(arguments, str):
-            try:
-                arguments = json.loads(arguments)
-            except json.JSONDecodeError:
-                arguments = {}
+        arguments = _parse_json_arguments(item.get("arguments"))
         record_action(str(item.get("name") or ""), arguments if isinstance(arguments, dict) else {})
 
     action_counts: dict[int, int] = {}
@@ -901,11 +914,7 @@ async def execute_n2_computer_call(
         ]
         batch_presentation = {"id": str(call_id), "members": members}
     elif item.get("name") not in SHELL_COMMAND_TOOL_NAMES and item.get("name") != BASH_TOOL_NAME:
-        arguments = item.get("arguments")
-        try:
-            parsed_arguments = json.loads(arguments) if isinstance(arguments, str) else arguments
-        except json.JSONDecodeError:
-            parsed_arguments = {}
+        parsed_arguments = _parse_json_arguments(item.get("arguments"))
         if isinstance(parsed_arguments, dict):
             await _present(
                 presentation,


### PR DESCRIPTION
## Structural issue

`execute_n2_computer_call()` in `yutori/navigator/n2.py` had two nearly identical inline blocks, ~15 lines apart, that both best-effort JSON-decode `item["arguments"]` (a field that arrives as either a JSON string or an already-decoded value):

- One feeds `computer.record_model_action(...)`.
- One feeds the non-batch `_present(...)` presentation event.

Both parse a string with `json.loads`, swallow `json.JSONDecodeError` by falling back to `{}`, and leave non-string values untouched — the exact same hand-rolled idiom duplicated verbatim, just with cosmetically different local variable names.

## Fix

Extracted the shared logic into a small helper, `_parse_json_arguments(raw) -> Any`, placed alongside the file's other small presentation/parsing helpers (`_presentation_text`, `_safe_presentation_arguments`). Both call sites now call the helper and keep their own post-parse `isinstance(..., dict)` check exactly as before (the two sites intentionally differ on how they treat a non-dict parse result, so that check stays local rather than being folded into the helper).

## Why this is safe

- **No behavior change.** The helper's logic is a direct, line-for-line transcription of both original blocks — string input goes through `json.loads`, `JSONDecodeError` maps to `{}`, and non-string input passes through unchanged. Each call site's downstream `isinstance` check is untouched.
- **Single file, single function touched** (`yutori/navigator/n2.py`, `execute_n2_computer_call`).
- Full suite: `876 passed, 9 skipped` before and after (matches the stated baseline as of `3492ee8`), including the two dedicated n2 test files (`tests/test_navigator_n2.py`, `tests/test_navigator_n2_harness.py`, 106 passed).
- `ruff check` and `ruff format --check` both pass on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnH9AjgN7uNSGg5ZLznUBs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnH9AjgN7uNSGg5ZLznUBs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file refactor with line-for-line equivalent logic; no change to confirmation, execution, or presentation semantics.
> 
> **Overview**
> **Refactors** duplicated best-effort parsing of tool `arguments` in `execute_n2_computer_call` by introducing `_parse_json_arguments`.
> 
> The helper decodes JSON strings via `json.loads`, returns `{}` on decode failure, and leaves non-string values unchanged. **`record_model_action`** and the non-batch **`_present`** action path now call it instead of inline copies; each site still applies its own `isinstance(..., dict)` handling afterward, so behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6a332dfad68639aa1ea1d341de47a76eafe4c78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->