### PR TITLE
refactor(navigator): extract _resolved_batch_index helper in n2.py

### DIFF
--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -182,6 +182,11 @@ def _format_action_error(error: BaseException) -> str:
     return f"ERROR: {type(error).__name__}: {error}"
 
 
+def _resolved_batch_index(batch_index: Any) -> int:
+    """The action's batch member index, or 0 for a non-batch (or malformed) action."""
+    return batch_index if isinstance(batch_index, int) else 0
+
+
 def _format_batch_result(
     member_names: "list[str]",
     outcomes: "list[str | None]",
@@ -937,7 +942,7 @@ async def execute_n2_computer_call(
         deadline = item.get("_execution_deadline")
         if isinstance(deadline, (int, float)) and time.monotonic() >= deadline:
             stopped_reason = "deadline_reached"
-            failed_index = action.get("batch_index") if isinstance(action.get("batch_index"), int) else 0
+            failed_index = _resolved_batch_index(action.get("batch_index"))
             break
         cancellation = getattr(computer, "cancellation", None)
         if cancellation is not None and cancellation.cancelled:
@@ -950,7 +955,7 @@ async def execute_n2_computer_call(
         action_args = {key: value for key, value in action.items() if key not in {"type", "batch_index"}}
         # The model's own call ({"action": name, **arguments}) for handlers that want
         # the untranslated values (the key expression as spelled, scroll `amount`).
-        model_action = model_actions[batch_index if isinstance(batch_index, int) else 0]
+        model_action = model_actions[_resolved_batch_index(batch_index)]
         try:
             if isinstance(batch_index, int) and batch_index != presented_member and batch_presentation is not None:
                 member = batch_presentation["members"][batch_index]
@@ -1042,7 +1047,7 @@ async def execute_n2_computer_call(
                 if cleanup_error is not None:
                     raise RuntimeError(f"Failed to release held key: {cleanup_error}")
 
-            member_index = batch_index if isinstance(batch_index, int) else 0
+            member_index = _resolved_batch_index(batch_index)
             action_counts[member_index] = action_counts.get(member_index, 1) - 1
             if action_counts[member_index] == 0:
                 completed_members.add(member_index)
@@ -1076,7 +1081,7 @@ async def execute_n2_computer_call(
                     except Exception:
                         observation = None
                 return await finish_with_error(str(error), observation)
-            failed_index = batch_index if isinstance(batch_index, int) else 0
+            failed_index = _resolved_batch_index(batch_index)
             stopped_reason = _format_action_error(error)
             break
 


### PR DESCRIPTION
## What

The "coerce `batch_index` to a valid int, defaulting to 0" idiom (`batch_index if isinstance(batch_index, int) else 0`) was hand-repeated four times in `execute_n2_computer_call` (`yutori/navigator/n2.py`). Consolidated into one helper:

```python
def _resolved_batch_index(batch_index: Any) -> int:
    """The action's batch member index, or 0 for a non-batch (or malformed) action."""
    return batch_index if isinstance(batch_index, int) else 0
```

Also drops a redundant double `action.get("batch_index")` call at the deadline-reached branch (it was called twice inline; now once, passed into the helper).

## Why it's safe

Pure extraction — same coercion, same default, identical value at every call site. One call site (the deadline-reached branch, line ~940) intentionally calls `_resolved_batch_index(action.get("batch_index"))` rather than reusing the loop-local `batch_index` variable, since that local isn't assigned yet at that point in the loop iteration — preserved that distinction exactly.

- `ruff check` / `ruff format --check`: clean
- Full test suite (excluding `slow`): 924 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX8bJDAC5eesH2du4M6tBj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX8bJDAC5eesH2du4M6tBj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in the n2 action execution loop with no new logic paths.
> 
> **Overview**
> Introduces **`_resolved_batch_index`** in `n2.py` so batch member indexing is normalized in one place: use the action’s `batch_index` when it’s an `int`, otherwise **0** for non-batch or malformed actions.
> 
> **`execute_n2_computer_call`** now calls that helper instead of repeating the same `isinstance(batch_index, int)` coercion at four sites (deadline halt, `model_actions` lookup, per-member completion counting, and non-recoverable error halt). Behavior is unchanged; the deadline branch still resolves index from `action.get("batch_index")` before the loop-local `batch_index` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b5f5fe513d7554c3d9bb25f5d3d38383826c94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->