### PR TITLE
refactor(navigator): dedupe not-supported error text in n2.py

### DIFF
--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -477,10 +477,6 @@ def _shell_tool_name(action_type: str) -> str:
     return "bash" if action_type == "run_bash_command" else "shell_command"
 
 
-def _shell_not_supported_error(action_type: str) -> str:
-    return f"{_shell_tool_name(action_type)} is not supported by this computer environment."
-
-
 def _file_tool_name(action_type: str) -> str:
     return {
         "read_file": "read",
@@ -491,8 +487,17 @@ def _file_tool_name(action_type: str) -> str:
     }.get(action_type, action_type)
 
 
+def _not_supported_by_computer_env(tool_name: str) -> str:
+    """Shared error text for a shell/file tool the current computer handler doesn't implement."""
+    return f"{tool_name} is not supported by this computer environment."
+
+
+def _shell_not_supported_error(action_type: str) -> str:
+    return _not_supported_by_computer_env(_shell_tool_name(action_type))
+
+
 def _file_not_supported_error(action_type: str) -> str:
-    return f"{_file_tool_name(action_type)} is not supported by this computer environment."
+    return _not_supported_by_computer_env(_file_tool_name(action_type))
 
 
 def _browser_not_supported_error(action_type: str) -> str:


### PR DESCRIPTION
## Summary
- `_shell_not_supported_error` and `_file_not_supported_error` in `yutori/navigator/n2.py` each independently formatted the same `"... is not supported by this computer environment."` suffix.
- Extracts a shared `_not_supported_by_computer_env(tool_name)` helper so the two error-message call sites can't drift apart.
- Internal-only change: no public API surface, method signature, or observable behavior changes — the produced error strings are byte-identical to before.

## Test plan
- [x] `pytest tests/test_navigator_n2.py tests/test_navigator_n2_cookbooks.py tests/test_navigator_n2_harness.py tests/test_navigator_n2_entrypoints.py` — 167 passed
- [x] Full suite: `pytest` — 876 passed, 9 skipped (unrelated)
- [x] `ruff check yutori/navigator/n2.py` and `ruff format --check yutori/navigator/n2.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDyPapdatFemwH7m4xsyzs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDyPapdatFemwH7m4xsyzs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private helper extraction with identical error strings; no runtime or public API changes.
> 
> **Overview**
> **Internal refactor** in `yutori/navigator/n2.py`: shell and file “not supported by this computer environment” messages no longer duplicate the same suffix string.
> 
> Adds `_not_supported_by_computer_env(tool_name)` and routes `_shell_not_supported_error` and `_file_not_supported_error` through it (still resolving display names via `_shell_tool_name` / `_file_tool_name`). Browser and custom-tool error helpers are unchanged.
> 
> No API or behavior change—the error strings stay the same; this only keeps the wording in one place so the two call sites can’t drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7364e0c602a75b4f665ed5993c720d8f95413320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->