### PR TITLE
refactor(macos): dedupe the try-enable-cursor fallback in MacOSComputer

### DIFF
--- a/tests/test_navigator_macos_computer.py
+++ b/tests/test_navigator_macos_computer.py
@@ -261,6 +261,18 @@ async def test_native_cursor_fallback_order_uses_current_then_cursorless():
     assert await computer._select_native_cursor() == "cursorless"
 
 
+async def test_restore_native_cursor_falls_back_to_cursorless_like_select_does():
+    class CursorlessTransport(FakeTransport):
+        async def call_tool(self, name, arguments, **kwargs):
+            if name == "set_agent_cursor_enabled":
+                raise RuntimeError("cursor unavailable")
+            return await super().call_tool(name, arguments, **kwargs)
+
+    computer = MacOSComputer(CursorlessTransport(), owns_transport=False, presentation=False)
+    computer._native_cursor = "yutori.default"
+    assert await computer._restore_native_cursor() == "cursorless"
+
+
 async def test_stop_region_refuses_click_drag_and_anchored_scroll_before_driver_input():
     transport = FakeTransport()
     computer = MacOSComputer(transport, owns_transport=False, presentation=False)

--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -1631,10 +1631,20 @@ class MacOSComputer:
         if self.presentation.blocks_point(normalized):
             raise MacOSActionRefusedError("Action refused because it intersects the Stop control.")
 
-    async def _select_native_cursor(self) -> str:
+    async def _try_enable_native_cursor(self) -> bool:
+        """Enable the native cursor, reporting failure instead of raising.
+
+        Shared by _select_native_cursor and _restore_native_cursor, which both
+        fall back to "cursorless" the same way when the driver can't enable it.
+        """
         try:
             await self._configure_cursor(True)
+            return True
         except Exception:
+            return False
+
+    async def _select_native_cursor(self) -> str:
+        if not await self._try_enable_native_cursor():
             return "cursorless"
         for theme in ("yutori.default", "cua.default"):
             try:
@@ -1659,9 +1669,7 @@ class MacOSComputer:
             )
 
     async def _restore_native_cursor(self) -> str:
-        try:
-            await self._configure_cursor(True)
-        except Exception:
+        if not await self._try_enable_native_cursor():
             return "cursorless"
         return self._native_cursor
 


### PR DESCRIPTION
## What

`MacOSComputer._select_native_cursor` and `_restore_native_cursor` in `yutori/navigator/macos/computer.py` each independently wrapped the same call in the same broad fallback:

```python
try:
    await self._configure_cursor(True)
except Exception:
    return "cursorless"
```

Extracted `_try_enable_native_cursor() -> bool`; both methods now call it and branch on the result, keeping their own distinct continuation logic afterward (`_select_native_cursor` probes cursor themes, `_restore_native_cursor` returns `self._native_cursor`).

## Why this is safe

No behavior change — same broad `except Exception`, same `"cursorless"` fallback string, same continuation in each caller. Purely internal to this class; no signature or public API change.

`_restore_native_cursor`'s cursorless-fallback path had no direct unit test before this change (only `_select_native_cursor`'s was covered, via `test_native_cursor_fallback_order_uses_current_then_cursorless`). Added `test_restore_native_cursor_falls_back_to_cursorless_like_select_does` first, reusing the same `CursorlessTransport` fixture pattern, to pin the behavior before refactoring it.

## Verification

- Full suite: **925 passed / 3 skipped / 1 deselected** (up from 924/3/1 baseline, +1 for the new test).
- Targeted `tests/test_navigator_macos_computer.py`: 90 passed.
- `ruff check` and `ruff format --check` on both touched files: clean.

2 files changed, +24/-4.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqDELzAc96hrHZvwmfSWkU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqDELzAc96hrHZvwmfSWkU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no public API or intentional behavior change; only macOS presentation cursor enable/restore paths are touched.
> 
> **Overview**
> **MacOSComputer** now routes “try to turn the agent cursor back on” through a single **`_try_enable_native_cursor()`** helper instead of duplicating the same `try` / broad `except` / `"cursorless"` branch in **`_select_native_cursor`** and **`_restore_native_cursor`**.
> 
> Each caller still does its own follow-up: theme probing vs returning **`self._native_cursor`**. A new unit test asserts **`_restore_native_cursor`** returns **`"cursorless"`** when **`set_agent_cursor_enabled`** fails, matching the existing select-path coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c499b65300b0f62cc725b7c2db8d1a2346acb96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->