### PR TITLE
refactor(macos): merge the cancel/fail branches in _spawn_supervised_shell

### DIFF
--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -1700,13 +1700,11 @@ class MacOSComputer:
                 stderr=asyncio.subprocess.STDOUT,
                 start_new_session=True,
             )
-        except asyncio.CancelledError:
-            await self._present_shell(ShellPresentationEvent(task_id, preview, run_in_background, "cancelled"))
-            if on_start_failure is not None:
-                on_start_failure()
-            raise
-        except Exception:
-            await self._present_shell(ShellPresentationEvent(task_id, preview, run_in_background, "failed"))
+        except (asyncio.CancelledError, Exception) as error:
+            # Both branches present-then-reraise identically; only the reported
+            # lifecycle state differs by which of the two was actually raised.
+            state = "cancelled" if isinstance(error, asyncio.CancelledError) else "failed"
+            await self._present_shell(ShellPresentationEvent(task_id, preview, run_in_background, state))
             if on_start_failure is not None:
                 on_start_failure()
             raise


### PR DESCRIPTION
## Structural issue

`MacOSComputer._spawn_supervised_shell` (`yutori/navigator/macos/computer.py`) had two `except` clauses — `asyncio.CancelledError` and `Exception` — that did the exact same three-step sequence (present a `ShellPresentationEvent`, call `on_start_failure()` if given, re-raise), differing only in the literal lifecycle-state string passed to the event (`"cancelled"` vs `"failed"`).

## Fix

Merged both branches into a single `except (asyncio.CancelledError, Exception) as error:` clause that derives the state string from the caught exception's type via `isinstance`. This is the same class of dedup already applied repeatedly elsewhere in this file and in `macos/presentation.py` (see e.g. #392, #393, and the `_fail_soft_cancellable` decorator in `presentation.py`), just not previously applied to this call site.

## Why it's safe

- **No behavioral change.** Both branches still re-raise their original exception with its original traceback after presenting the identical event and invoking `on_start_failure`; only the code duplication is removed.
- **No public API surface touched.** This is a private method (`_spawn_supervised_shell`) with no external callers; nothing in `yutori/__init__.py` or any `__all__` changed.
- **Verified**: the full test suite passes (877 passed, 9 skipped — unrelated), including all 90 tests in `tests/test_navigator_macos_computer.py` which exercise foreground/background shell spawn, cancellation, and timeout paths. `ruff check` and `ruff format --check` both pass clean on the changed file.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154d5uWoUhU6dKPD8o2pgBp

---
_Generated by [Claude Code](https://claude.ai/code/session_0154d5uWoUhU6dKPD8o2pgBp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private helper refactor with no logic change beyond deduplicating identical error paths; shell presentation and re-raise semantics are preserved.
> 
> **Overview**
> **`_spawn_supervised_shell`** in `computer.py` previously had separate `except asyncio.CancelledError` and `except Exception` handlers that both presented a `ShellPresentationEvent`, optionally called `on_start_failure`, and re-raised—differing only in the lifecycle state string (`"cancelled"` vs `"failed"`).
> 
> Those handlers are **merged** into a single `except (asyncio.CancelledError, Exception)` block that picks the state with `isinstance(error, asyncio.CancelledError)`. Behavior on spawn failure or cancellation is unchanged; only duplicated control flow is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a966eae9842a1b38d8022ea0321d2b53d5e4f766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->