### PR TITLE
Dedupe n2_payload's per-part byte-size helper

### DIFF
--- a/yutori/navigator/n2_payload.py
+++ b/yutori/navigator/n2_payload.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import base64
 import copy
 import io
-import json
 from typing import Any, Optional
 
 from PIL import Image
@@ -139,11 +138,10 @@ def _strip_images_from_message(message: dict[str, Any], omitted_text: Optional[s
 
 
 serialized_messages_bytes = estimate_messages_size_bytes
-
-
-def _serialized_bytes(value: Any) -> int:
-    """The JSON-serialized byte size of one content part, matching the messages estimate."""
-    return len(json.dumps(value, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+# estimate_messages_size_bytes only relies on its argument being
+# JSON-serializable, so the same function measures a single content part too —
+# no need for a second, identically-bodied helper.
+_serialized_bytes = estimate_messages_size_bytes
 
 
 def retain_n2_image_window(


### PR DESCRIPTION
## What

`yutori/navigator/n2_payload.py` defined a private helper, `_serialized_bytes(value)`, whose body was byte-for-byte identical to `estimate_messages_size_bytes()` in `yutori/navigator/payload.py`:

```python
return len(json.dumps(value, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
```

`n2_payload.py` already imports `estimate_messages_size_bytes` and aliases it as `serialized_messages_bytes` for measuring the whole messages list — but it kept a second, independently-defined copy of the exact same one-liner just for measuring a single content part (used once, in `prune_n2_screenshots_to_budget`).

## Why this is an improvement

`json.dumps` doesn't care whether its argument is a list of messages or a single dict — it only needs to be JSON-serializable. So there was no behavioral reason for two separately-maintained functions with the same body; it was a duplication that could silently drift (e.g. someone changes the separators/`ensure_ascii` in one copy and not the other, and the byte-budget math the pruning logic depends on becomes inconsistent between the two call sites).

The fix makes `_serialized_bytes` an alias for the already-imported `estimate_messages_size_bytes`, the same pattern already used two lines above it for `serialized_messages_bytes`. Also dropped the now-unused `import json` from this file (the only use was inside the removed function body).

## Why it's safe

- `_serialized_bytes` is a module-private helper (leading underscore), never exported from `yutori/navigator/__init__.py` and never imported anywhere else — purely an internal implementation detail.
- Zero public API or behavior change: the replacement function computes the exact same value for any input the original accepted.
- Verified: `ruff check .` and `ruff format --check` pass on the changed file; the full test suite (`pytest`, 877 passed / 9 skipped) passes unchanged, including `tests/test_navigator_n2.py` which exercises `prune_n2_screenshots_to_budget` (the sole caller of `_serialized_bytes`).
- Diff is a single file, 4 insertions / 6 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4X8gs69kSrP7HuoE9DBGU

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4X8gs69kSrP7HuoE9DBGU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor in navigator payload budgeting with no intended behavior change; only removes duplicate sizing logic.
> 
> **Overview**
> **`n2_payload.py`** no longer defines its own `_serialized_bytes` helper that duplicated `json.dumps` sizing logic from **`payload.estimate_messages_size_bytes`**. **`_serialized_bytes`** is now an alias of the already-imported estimator (matching **`serialized_messages_bytes`**), and the unused **`import json`** was removed.
> 
> This keeps screenshot budget math in **`prune_n2_screenshots_to_budget`** aligned with full-message size checks without maintaining two copies of the same serialization rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c4e80f42b2c0f25dca985d83c444672f698bc65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->