### PR TITLE
refactor(navigator): extract _require_action_method in execute_n2_computer_call

### DIFF
--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -509,6 +509,21 @@ def _custom_tool_not_supported_error(action: dict[str, Any]) -> str:
     return f"{name} was declared in tools= but this computer environment implements no run_custom_tool."
 
 
+def _require_action_method(
+    computer: Any, handlers: dict[str, str], action_type: Any, not_supported_error: Callable[[str], str]
+) -> Any:
+    """The bound handler for *action_type* in *handlers*, or raise if *computer* doesn't implement it.
+
+    A defense-in-depth check: ``execute_n2_computer_call``'s preflight loop already screens every
+    action for a missing handler before this dispatch runs, but each of the shell/file/browser
+    branches re-derived this same "getattr or raise" idiom independently.
+    """
+    method = getattr(computer, handlers[action_type], None)
+    if method is None:
+        raise RuntimeError(not_supported_error(str(action_type)))
+    return method
+
+
 @functools.lru_cache(maxsize=None)
 def _function_accepts_kwarg(func: Any, name: str) -> bool:
     try:
@@ -991,15 +1006,15 @@ async def execute_n2_computer_call(
                     if isinstance(batch_index, int):
                         member_outcomes[batch_index] = _BATCH_SCREENSHOT_MEMBER_TEXT
             elif action_type in SHELL_ACTION_HANDLERS:
-                shell_method = getattr(computer, SHELL_ACTION_HANDLERS[action_type], None)
-                if shell_method is None:
-                    raise RuntimeError(_shell_not_supported_error(str(action_type)))
+                shell_method = _require_action_method(
+                    computer, SHELL_ACTION_HANDLERS, action_type, _shell_not_supported_error
+                )
                 shell_result = await shell_method(**action_args)
                 shell_output_text = _backstop_result_text("" if shell_result is None else str(shell_result))
             elif action_type in FILE_ACTION_HANDLERS:
-                file_method = getattr(computer, FILE_ACTION_HANDLERS[action_type], None)
-                if file_method is None:
-                    raise RuntimeError(_file_not_supported_error(str(action_type)))
+                file_method = _require_action_method(
+                    computer, FILE_ACTION_HANDLERS, action_type, _file_not_supported_error
+                )
                 file_result = await file_method(**action_args)
                 # A file handler may return {"text", "image_url"} so `read` on an
                 # image file shows the model the image as well as the text.
@@ -1013,9 +1028,9 @@ async def execute_n2_computer_call(
                 )
                 custom_output_text = _backstop_result_text("" if custom_result is None else str(custom_result))
             elif action_type in BROWSER_ACTION_HANDLERS:
-                browser_method = getattr(computer, BROWSER_ACTION_HANDLERS[action_type], None)
-                if browser_method is None:
-                    raise RuntimeError(_browser_not_supported_error(str(action_type)))
+                browser_method = _require_action_method(
+                    computer, BROWSER_ACTION_HANDLERS, action_type, _browser_not_supported_error
+                )
                 action_result = await browser_method(**action_args)
                 if isinstance(action_result, dict) and action_result.get("success") is False:
                     raise RuntimeError(str(action_result.get("error") or action_result))


### PR DESCRIPTION
## What

`execute_n2_computer_call`'s shell/file/browser dispatch branches each independently did:

```python
xxx_method = getattr(computer, XXX_ACTION_HANDLERS[action_type], None)
if xxx_method is None:
    raise RuntimeError(_xxx_not_supported_error(str(action_type)))
```

— identical shape, three times, differing only in which handler map and which `_xxx_not_supported_error` formatter they used. (This is a defense-in-depth check: the preflight loop just above already screens every action for a missing handler before dispatch runs, so these three call sites were re-deriving the same guard independently rather than sharing it.)

Extracted a single `_require_action_method(computer, handlers, action_type, not_supported_error)` helper; all three call sites now delegate, passing only their own handler map and error formatter.

## Why it's safe

- No behavioral change: same `getattr` lookup, same `RuntimeError` type and message text, same call-site values in every branch.
- Internal-only helper (module-private, not exported, not in `api.md`) — no public API surface change on this published SDK.
- Verified by tests: full suite `925 passed / 3 skipped / 1 deselected` — identical to the pre-change baseline. Targeted n2 tests (`test_navigator_n2.py`, `test_navigator_n2_harness.py`, `test_navigator_n2_compaction.py`, `test_navigator_n2_cookbooks.py`, `test_navigator_n2_entrypoints.py`) `189 passed`. `ruff check .` and `ruff format --check` clean.

1 file changed, +24/-9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzENbZNZ2TuFwe2AmNMkwP

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzENbZNZ2TuFwe2AmNMkwP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no API or runtime behavior change beyond consolidating duplicate dispatch guards.
> 
> **Overview**
> Introduces a private **`_require_action_method`** helper in `n2.py` that resolves a computer handler from a handler map via `getattr`, and raises the same **`RuntimeError`** with the branch-specific “not supported” message when the method is missing.
> 
> The shell, file, and browser dispatch paths inside **`execute_n2_computer_call`** now call this helper instead of repeating the identical getattr-or-raise block three times. Behavior and error text are unchanged; this is a DRY refactor on top of the existing preflight handler checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b58af4568577a73fd0e5d0c675b1f1a44a094cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->