### PR TITLE
refactor(navigator): extract race_against_cancellation from computer.py and n2.py

### DIFF
--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -35,7 +35,7 @@ from .polling import (
 )
 from .presentation import MacOSPresentationController
 from .preview import WindowPreviewStreamer
-from .process_lifecycle import cancel_and_drain, race_sleep_against_cancellation
+from .process_lifecycle import cancel_and_drain, race_against_cancellation, race_sleep_against_cancellation
 from .sanitize import sanitize_command_preview
 from .transport import (
     CuaDriverConnectionError,
@@ -1303,15 +1303,7 @@ class MacOSComputer:
             raise
 
     async def _await_with_cancellation(self, awaitable: Awaitable[Any]) -> Any:
-        operation = asyncio.create_task(awaitable)
-        stopped = asyncio.create_task(self.cancellation.wait())
-        try:
-            done, _ = await asyncio.wait({operation, stopped}, return_when=asyncio.FIRST_COMPLETED)
-            if operation in done:
-                return operation.result()
-            raise asyncio.CancelledError(stopped.result())
-        finally:
-            await cancel_and_drain(operation, stopped)
+        return await race_against_cancellation(awaitable, self.cancellation)
 
     async def _capture_png(self) -> tuple[bytes, int, int]:
         if self.window_mode:

--- a/yutori/navigator/macos/process_lifecycle.py
+++ b/yutori/navigator/macos/process_lifecycle.py
@@ -14,6 +14,7 @@ cancellation before continuing.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -88,6 +89,24 @@ async def race_sleep_against_cancellation(
     done, pending = await asyncio.wait({sleeper, cancelled}, timeout=timeout, return_when=asyncio.FIRST_COMPLETED)
     await cancel_and_drain(*pending)
     return sleeper, cancelled, done
+
+
+async def race_against_cancellation(awaitable: Awaitable[Any], cancellation: "CancellationLatch") -> Any:
+    """Race *awaitable* against ``cancellation.wait()``, returning its result if it wins first.
+
+    Otherwise raises ``asyncio.CancelledError`` carrying the latch's cause, having cancelled
+    and drained the loser either way. Callers that need to special-case an already-cancelled
+    latch, or the absence of a cancellation source altogether, do so before calling this.
+    """
+    operation = asyncio.create_task(awaitable)
+    stopped = asyncio.create_task(cancellation.wait())
+    try:
+        done, _ = await asyncio.wait({operation, stopped}, return_when=asyncio.FIRST_COMPLETED)
+        if operation in done:
+            return operation.result()
+        raise asyncio.CancelledError(stopped.result())
+    finally:
+        await cancel_and_drain(operation, stopped)
 
 
 async def terminate_process_gracefully(

--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -52,7 +52,7 @@ import uuid
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import Any, Protocol, Union
 
-from .macos.process_lifecycle import cancel_and_drain
+from .macos.process_lifecycle import race_against_cancellation
 from .macos.sanitize import sanitize_command_preview
 from .macos.types import N2Observation, N2Presentation
 from .models import NAVIGATOR_N2_MODEL, TOOL_SET_COMPUTER_USE_LATEST
@@ -740,15 +740,7 @@ async def _await_model_response(computer: Any, awaitable: Awaitable[Any]) -> Any
         if inspect.iscoroutine(awaitable):
             awaitable.close()
         cancellation.raise_if_cancelled()
-    request = asyncio.create_task(awaitable)
-    stopped = asyncio.create_task(cancellation.wait())
-    try:
-        done, _ = await asyncio.wait({request, stopped}, return_when=asyncio.FIRST_COMPLETED)
-        if request in done:
-            return request.result()
-        raise asyncio.CancelledError(stopped.result())
-    finally:
-        await cancel_and_drain(request, stopped)
+    return await race_against_cancellation(awaitable, cancellation)
 
 
 def _parse_json_arguments(raw: Any) -> Any:


### PR DESCRIPTION
## What

`MacOSComputer._await_with_cancellation` (`yutori/navigator/macos/computer.py`) and the module-level `_await_model_response` (`yutori/navigator/n2.py`) each independently implemented the identical "race an awaitable against `cancellation.wait()`" idiom:

```python
operation = asyncio.create_task(awaitable)
stopped = asyncio.create_task(cancellation.wait())
try:
    done, _ = await asyncio.wait({operation, stopped}, return_when=asyncio.FIRST_COMPLETED)
    if operation in done:
        return operation.result()
    raise asyncio.CancelledError(stopped.result())
finally:
    await cancel_and_drain(operation, stopped)
```

This is the same race-against-a-`CancellationLatch` shape `process_lifecycle.py` already extracted once for `asyncio.sleep` (`race_sleep_against_cancellation`) — the sleep helper's docstring was itself born from consolidating three near-identical sleep/cancellation races. This PR does the analogous consolidation for the "race an arbitrary awaitable" variant.

## Why it's an improvement

Two independent, byte-identical implementations of the same cancellation race meant any future fix to this logic (e.g. an edge case in how the loser is drained) would need to be applied twice, with no compiler/test enforcement that both stay in sync.

## Why it's safe

- **No public API change.** Both call sites are private/internal: `_await_with_cancellation` is a private method on `MacOSComputer`, and `_await_model_response` is a module-private function in `n2.py`. The new `race_against_cancellation` helper lives in `process_lifecycle.py` next to its sibling `race_sleep_against_cancellation`, itself not exported from any `__init__.py` or documented in `api.md`.
- **No behavioral change.** Same task race, same `CancelledError` cause value, same `cancel_and_drain` cleanup on the loser — verified by direct code comparison; `n2.py`'s pre-existing "already cancelled" fast path and `computer.py`'s call sites are untouched, only the shared race body moved.
- **Verified:** full suite `925 passed / 3 skipped / 1 deselected` (unchanged from the pre-change baseline), targeted n2 tests (152 passed) and macOS computer/transport/presentation/preview tests (123 passed) all pass, `ruff check` / `ruff format --check` clean on all three touched files.
- **Small, scoped diff:** 3 files, +23/-20.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSzyUXZwDpB7jwaPqCJqKo

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSzyUXZwDpB7jwaPqCJqKo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of private cancellation-race logic with identical semantics; no auth, data, or API surface changes.
> 
> **Overview**
> Duplicates the same **race an awaitable against `CancellationLatch.wait()`** pattern that lived inline in `MacOSComputer._await_with_cancellation` and `n2._await_model_response` into a shared **`race_against_cancellation`** in `process_lifecycle.py`, alongside the existing `race_sleep_against_cancellation` helper.
> 
> Both call sites now delegate to that helper; **`n2.py` drops its direct `cancel_and_drain` import** in favor of the shared implementation. **No public API or call-site behavior change**—same `asyncio.wait` race, `CancelledError` cause, and loser cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fba8e926fe1f3f97e492d922fb70883fbe709513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->