### PR TITLE
fix(macos): keep activity commands readable

### DIFF
--- a/tests/test_navigator_macos_overlay_build.py
+++ b/tests/test_navigator_macos_overlay_build.py
@@ -125,3 +125,14 @@ def test_stop_item_region_explicitly_converts_cgfloat_arithmetic_to_double():
     region = source.split("private func stopItemRegion", 1)[1].split("private func registerStopHotKey", 1)[0]
     for key in ("x", "y", "width", "height"):
         assert f'"{key}": Double(' in region
+
+
+def test_activity_shell_commands_do_not_inherit_the_phosphor_glow():
+    """Dense command text must stay legible instead of blurring into a green bar."""
+    css = overlay_build._asset_directory().joinpath("navigator-activity.css").read_text(encoding="utf-8")
+    shell_card = css.split(".n2-entry-shell {", 1)[1].split("}", 1)[0]
+    shell_body = css.split(".n2-shell-body {", 1)[1].split("}", 1)[0]
+    shell_command = css.split(".n2-shell-command {", 1)[1].split("}", 1)[0]
+    assert "text-shadow" not in shell_card
+    assert "text-shadow: none" in shell_body
+    assert "flex: 1 1 auto" in shell_command

--- a/yutori/navigator/macos/assets/navigator-activity.css
+++ b/yutori/navigator/macos/assets/navigator-activity.css
@@ -156,7 +156,6 @@ body {
   background: rgba(0, 0, 0, 0.55);
   color: #33ff33;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  text-shadow: 0 0 6px rgba(51, 255, 51, 0.45);
 }
 
 .n2-shell-header {
@@ -170,6 +169,7 @@ body {
   letter-spacing: 0.28em;
   text-transform: uppercase;
   opacity: 0.7;
+  text-shadow: 0 0 4px rgba(51, 255, 51, 0.35);
 }
 
 .n2-shell-caret,
@@ -206,8 +206,10 @@ body {
   display: flex;
   gap: 8px;
   padding: 8px 10px;
+  color: #b7f7b7;
   font-size: 12px;
   line-height: 18px;
+  text-shadow: none;
 }
 
 .n2-shell-prompt {
@@ -216,6 +218,7 @@ body {
 }
 
 .n2-shell-command {
+  flex: 1 1 auto;
   margin: 0;
   min-width: 0;
   font: inherit;


### PR DESCRIPTION
Remove the panel-wide phosphor glow that blurred dense terminal commands into a solid green line. Keep a subtler glow on the shell header while rendering command bodies in a lighter, crisp green with explicit flex sizing. Add a CSS regression test covering the activity shell card, body, and command styles.

Tested with uv run ruff check . and uv run pytest -q (878 passed, 9 skipped).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only CSS for the macOS activity overlay plus a static asset test; no auth, data, or runtime logic changes.
> 
> **Overview**
> **Activity shell command panels** no longer apply the phosphor `text-shadow` on the whole `.n2-entry-shell` card, which was making long command text look like a solid green blur.
> 
> The glow is limited to `.n2-shell-header` (slightly softer than before). Command rows in `.n2-shell-body` use a lighter green (`#b7f7b7`), explicit `text-shadow: none`, and `.n2-shell-command` gets `flex: 1 1 auto` so wrapped commands lay out cleanly in the flex row.
> 
> A regression test in `test_navigator_macos_overlay_build.py` asserts those three CSS blocks stay free of inherited glow and keep the flex rule on the command element.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0fb0ae6c9bf35e69bf0f352f4995664e5376769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->