### PR TITLE
fix(macos): stop the activity transcript from flattening shell panels

### DIFF
--- a/tests/test_navigator_macos_overlay_build.py
+++ b/tests/test_navigator_macos_overlay_build.py
@@ -136,3 +136,29 @@ def test_activity_shell_commands_do_not_inherit_the_phosphor_glow():
     assert "text-shadow" not in shell_card
     assert "text-shadow: none" in shell_body
     assert "flex: 1 1 auto" in shell_command
+
+
+def test_activity_entries_are_not_shrunk_by_the_transcript_flex_column():
+    """A shell panel clips its overflow, so only `flex: none` keeps it at its text's height.
+
+    Without it the panel loses its automatic minimum size and the scrolling column
+    squeezes it flat -- worse the shorter the window -- until only the header shows.
+    """
+    css = overlay_build._asset_directory().joinpath("navigator-activity.css").read_text(encoding="utf-8")
+    entry = css.split(".n2-entry {", 1)[1].split("}", 1)[0]
+    assert "flex: none" in entry
+
+
+def test_the_shell_rail_stands_down_while_the_activity_window_is_open():
+    """One list of commands at a time: the window the operator opened, not the desktop."""
+    css = overlay_build._asset_directory().joinpath("navigator-overlay.css").read_text(encoding="utf-8")
+    hidden = css.split("html[data-n2-activity-open] #n2-shell-rail {", 1)[1].split("}", 1)[0]
+    assert "display: none" in hidden
+
+    source = overlay_build._asset_directory().joinpath("macos-overlay-host.swift").read_text(encoding="utf-8")
+    visibility = source.split("private func railVisibilityScript", 1)[1].split("}", 1)[0]
+    assert "toggleAttribute('data-n2-activity-open', \\(activityShown))" in visibility
+    # Both the show and the hide path, and the close button that bypasses them.
+    assert source.count("        syncRailVisibility()") == 3
+    # A rail page that loads while the window is already open must start hidden.
+    assert "railVisibilityScript()" in source.split("private func railStyleScript", 1)[1].split("}", 1)[0]

--- a/yutori/navigator/macos/assets/macos-overlay-host.swift
+++ b/yutori/navigator/macos/assets/macos-overlay-host.swift
@@ -401,6 +401,7 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
         panel.orderFrontRegardless()
         activityShown = true
         activityItem?.title = "Hide activity"
+        syncRailVisibility()
         emitPreviewDemand()
     }
 
@@ -408,6 +409,7 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
         activityPanel?.orderOut(nil)
         activityShown = false
         activityItem?.title = "Show activity"
+        syncRailVisibility()
         emitPreviewDemand()
     }
 
@@ -438,6 +440,7 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
         guard let closing = notification.object as? NSPanel, closing === activityPanel else { return }
         activityShown = false
         activityItem?.title = "Show activity"
+        syncRailVisibility()
         emitPreviewDemand()
     }
 
@@ -567,6 +570,22 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
     private func railStyleScript() -> String {
         "document.documentElement.style.setProperty('--n2-rail-top', '\(railTop)px');"
             + "document.documentElement.style.setProperty('--n2-rail-right', '\(railRight)px');"
+            + railVisibilityScript()
+    }
+
+    /// The rail repeats what the activity window already shows in full, so it stands
+    /// down while that window is open. Folded into `railStyleScript` as well, so a page
+    /// that finishes loading after the operator opened the window starts out hidden.
+    private func railVisibilityScript() -> String {
+        "document.documentElement.toggleAttribute('data-n2-activity-open', \(activityShown));"
+    }
+
+    /// Both rail hosts: its own panel in status mode, the desktop overlay page otherwise.
+    private func syncRailVisibility() {
+        let script = railVisibilityScript()
+        for host in [railWebView, webView].compactMap({ $0 }) {
+            host.evaluateJavaScript(script, completionHandler: nil)
+        }
     }
 
     /// Hand the shell rail its commands, holding them while the rail page loads.

--- a/yutori/navigator/macos/assets/navigator-activity.css
+++ b/yutori/navigator/macos/assets/navigator-activity.css
@@ -95,7 +95,13 @@ body {
   background-clip: content-box;
 }
 
+/* `flex: none` because the transcript is a scrolling flex column: an entry that
+ * clips its own overflow (the shell panel) loses the automatic minimum size that
+ * keeps the others intact, so the flex algorithm squeezes it -- the taller the
+ * transcript and the shorter the window, the flatter it gets, until only the
+ * header survives. Entries size to their text and the column scrolls instead. */
 .n2-entry {
+  flex: none;
   min-width: 0;
   animation: n2EntryIn 160ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }

--- a/yutori/navigator/macos/assets/navigator-overlay.css
+++ b/yutori/navigator/macos/assets/navigator-overlay.css
@@ -48,6 +48,14 @@ body {
   text-shadow: 0 0 6px rgba(51, 255, 51, 0.55);
 }
 
+/* The activity window lists every command, with its full text and exit code, so
+ * the rail stands down while that window is open rather than saying the same
+ * thing twice -- once in the window the operator is reading, once over the
+ * desktop behind it. The host sets the attribute when the window is shown. */
+html[data-n2-activity-open] #n2-shell-rail {
+  display: none;
+}
+
 .n2-shell-panel,
 .n2-shell-overflow {
   overflow: hidden;


### PR DESCRIPTION
## The bug


The activity transcript is a scrolling flex column (`#n2-activity-transcript`). Every entry sizes to its text — except the shell panel, which sets `overflow: hidden` to clip its rounded corners. That drops the entry's automatic minimum size (`min-height: auto` only applies when `overflow` is `visible`), so the flex algorithm is free to shrink it.

Once the transcript is taller than the window it does exactly that. Measured on the shipping asset at a 387pt-wide window: a shell panel whose content is 59px tall renders at **2px** — border only. Partially-squeezed states are what the operator actually sees: the `run command` header and `exit 0`, with the command itself clipped away. Resizing the window changes how much survives, which is why it reads as "it resizes depending on the size of the window."

`flex: none` on `.n2-entry` puts every entry back at its content height and lets the column scroll, which is what the `overflow-y: auto` was already there for.

## The rail

While the activity window is open, the desktop shell rail now stands down. The rail exists so a background run's commands are visible without opening a window; the activity window lists the same commands in full, with their exit codes. Leaving both up says the same thing twice — once in the window the operator is reading, once over the desktop behind it.

The host toggles `data-n2-activity-open` on both rail hosts (its own borderless panel in status mode, the desktop overlay page otherwise) from `showActivity`, `hideActivity`, and the window's close button, and folds the same call into `railStyleScript()` so a rail page that finishes loading after the window was opened starts out hidden.

## Verification

- Reproduced and confirmed the fix by driving the shipped `navigator-activity.{html,css,js}` in a browser: 2px → 61px at 387pt, and 79px at 300pt where the command wraps to two lines — the panel grows with the text instead of shrinking with the window.
- `swiftc -O -target arm64-apple-macos14.0` on `macos-overlay-host.swift` compiles clean.
- `880 passed, 9 skipped`; `ruff check .` clean.
- Two new asset tests pin both behaviours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only macOS overlay CSS and visibility sync; no auth, data, or Python runtime behavior changes beyond presentation.
> 
> **Overview**
> Fixes the macOS activity window where **shell command panels collapsed** in the scrolling transcript when the window was short or the list was long—often down to a few pixels so only the header showed.
> 
> **`.n2-entry` now uses `flex: none`** so each transcript row keeps its content height and the column scrolls instead of shrinking overflow-clipped shell panels.
> 
> While the activity window is open, the **desktop shell rail is hidden** so command lists aren’t duplicated. The overlay host toggles `data-n2-activity-open` on both rail WebViews from show/hide/close paths, and includes the same script in `railStyleScript()` so rails that load late start hidden.
> 
> **Asset tests** lock in `flex: none` and the rail visibility CSS/Swift wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91dc88f4653d540555a4161595f83c0e1a509043. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->