### PR TITLE
chore(release): 0.9.16

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.15" \
+    "yutori==0.9.16" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.15'
+pip install 'yutori[macos]==0.9.16'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.15",
+    "yutori==0.9.16",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.15"]
+macos = ["yutori[macos]==0.9.16"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.15"
+YUTORI_INSTALLER_VERSION="0.9.16"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.15"
+version = "0.9.16"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts yutori 0.9.16.

## What's in it

- **#404** — the activity transcript no longer flattens shell panels. The transcript is a scrolling flex column and the shell panel is the one entry that clips its own overflow, which drops its automatic minimum size; once the transcript outgrew the window the flex algorithm squeezed the panel until only the `run command` header and the exit code survived, worse the shorter the window. `flex: none` on `.n2-entry` puts every entry back at its content height. The same PR stands the desktop shell rail down while the activity window is open, so a background run's commands are listed once, in the window the operator is reading, instead of also over the desktop behind it.

## Bump

`version` in pyproject.toml, `install.sh` regenerated via `scripts/build_install.sh`, and the `yutori==` pins under `examples/navigator_n2` (pyproject.toml x2, README.md, Dockerfile.direct_x11).

`880 passed, 9 skipped`; `ruff check .` clean; `check_install_sh_fresh.sh` clean.

**Full Changelog**: https://github.com/yutori-ai/yutori-sdk-python/compare/v0.9.15...v0.9.16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and dependency pin updates only; no application logic changes in this diff.
> 
> **Overview**
> **Cuts the `yutori` release to 0.9.16** by bumping the package `version` in root `pyproject.toml` from `0.9.15` to `0.9.16`.
> 
> The same release label is propagated to **`install.sh`** (`YUTORI_INSTALLER_VERSION`) and to **Navigator n2 cookbooks**: `examples/navigator_n2/pyproject.toml` (core and `macos` extra pins), `README.md` install example, and `Dockerfile.direct_x11` pip pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7b230fa1c270bb01a6217b87701fe41c8c3753e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->