### PR TITLE
refactor(macos): return the capture scale from _validate_geometry

### DIFF
--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -747,10 +747,7 @@ class MacOSPresentationController:
             finally:
                 # Whatever the host answered, the probe panel must not outlive the check.
                 await self._send_command({"op": "captureProbe", "phase": "hide"})
-            self._validate_capture_geometry(width, height)
-            capabilities = self._status.capabilities
-            assert capabilities is not None
-            scale = (width / capabilities.viewport_width, height / capabilities.viewport_height)
+            scale = self._validate_capture_geometry(width, height)
             state, matches = _probe_verdict(png_bytes, probe, scale)
         except asyncio.CancelledError:
             raise
@@ -1160,14 +1157,16 @@ class MacOSPresentationController:
         self._validate_geometry(capabilities, self.native_width, self.native_height)
         return capabilities
 
-    def _validate_capture_geometry(self, width: int, height: int) -> None:
+    def _validate_capture_geometry(self, width: int, height: int) -> "tuple[float, float]":
         capabilities = self._status.capabilities
         if capabilities is None:
             raise MacOSPresentationError("Overlay capabilities are unavailable.")
-        self._validate_geometry(capabilities, width, height)
+        return self._validate_geometry(capabilities, width, height)
 
     @staticmethod
-    def _validate_geometry(capabilities: MacOSPresentationCapabilities, width: int, height: int) -> None:
+    def _validate_geometry(
+        capabilities: MacOSPresentationCapabilities, width: int, height: int
+    ) -> "tuple[float, float]":
         point_aspect = capabilities.viewport_width / capabilities.viewport_height
         pixel_aspect = width / height
         x_scale = width / capabilities.viewport_width
@@ -1181,6 +1180,7 @@ class MacOSPresentationController:
             raise MacOSPresentationError("Overlay display geometry does not match the captured desktop.")
         if abs(x_scale - capabilities.backing_scale) > 0.15:
             raise MacOSPresentationError("Overlay Retina scale does not match the captured desktop.")
+        return x_scale, y_scale
 
     async def _degrade(self, reason: str, error: "BaseException | None" = None) -> None:
         if self._fatal_error is not None or self._stopping:


### PR DESCRIPTION
## What

`MacOSPresentationController.verify_capture_exclusion()` (added in #406, the capture-exclusion probe) calls `_validate_capture_geometry(width, height)` to validate a captured frame's geometry against the overlay's viewport capabilities, then immediately recomputes the exact same `x_scale`/`y_scale` formula (`width / capabilities.viewport_width`, `height / capabilities.viewport_height`) that `_validate_geometry()` had just computed internally to perform that validation — re-fetching `self._status.capabilities` and asserting it non-`None` a second time in the process.

## Fix

`_validate_geometry()` (and its `_validate_capture_geometry()` wrapper) now returns the `(x_scale, y_scale)` tuple it already computes, instead of `None`. The one caller that needs the scale (`verify_capture_exclusion`) reuses it directly:

```python
scale = self._validate_capture_geometry(width, height)
state, matches = _probe_verdict(png_bytes, probe, scale)
```

The two other call sites (`_validate_ready`, `after_capture`) simply ignore the return value — unchanged.

## Safety

- No behavior change: same validation logic, same raised errors, same computed scale values.
- Both methods are private/module-internal (`MacOSPresentationController` is not part of the published SDK's public surface for these helpers) — no public API change.
- 1 file, +7/-7.

## Verification

- Full suite: `936 passed, 3 skipped, 1 deselected` (unchanged from baseline).
- Targeted: `tests/test_navigator_macos_capture_exclusion.py`, `tests/test_navigator_macos_computer.py`, `tests/test_navigator_macos_presentation.py`, `tests/test_navigator_macos_overlay_build.py` → `133 passed` (existing capture-exclusion tests already exercise `verify_capture_exclusion()`'s scale-dependent probe-matching end to end, so they pin the reused value transitively).
- `ruff check` / `ruff format --check` clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTrzJ1rP8rQmib3Rs9WfQS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTrzJ1rP8rQmib3Rs9WfQS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor only; same geometry checks and scale values, with duplicate logic removed in one caller.
> 
> **Overview**
> **`_validate_geometry`** and **`_validate_capture_geometry`** now return the **`(x_scale, y_scale)`** tuple they already compute during validation, instead of **`None`**.
> 
> **`verify_capture_exclusion`** uses that return value for **`_probe_verdict`** instead of re-reading capabilities and duplicating the width/height scale math. **`after_capture`** and **`_validate_ready`** still call the same helpers and ignore the return value — validation rules and errors are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3df2dfde07b3313a3bf6c9db17788320c99903e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->