### PR TITLE
refactor(macos): extract _send_command_expecting in MacOSPresentationController

### DIFF
--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -593,18 +593,14 @@ class MacOSPresentationController:
                         },
                     }
                 )
-            armed = await self._send_command({"op": "arm"})
-            if armed.get("state") != "armed":
-                raise MacOSPresentationError("Overlay did not arm.")
+            await self._send_command_expecting({"op": "arm"}, "armed", "Overlay did not arm.")
             self._status = replace(self._status, state="armed")
         except BaseException:
             await self._terminate_process()
             raise
 
     async def reveal(self) -> None:
-        reply = await self._send_command({"op": "reveal"})
-        if reply.get("state") != "visible":
-            raise MacOSPresentationError("Overlay did not reveal.")
+        await self._send_command_expecting({"op": "reveal"}, "visible", "Overlay did not reveal.")
         cursor = "hidden" if self._mode == "status" else "yutori"
         self._status = replace(self._status, available=True, state="active", cursor=cursor)
 
@@ -616,9 +612,7 @@ class MacOSPresentationController:
         command: dict[str, Any] = {"op": "thumbnail", "data": base64.b64encode(image_bytes).decode("ascii")}
         if caption is not None:
             command["caption"] = caption
-        reply = await self._send_command(command)
-        if reply.get("state") != "shown":
-            raise MacOSPresentationError("Status item did not show the thumbnail.")
+        await self._send_command_expecting(command, "shown", "Status item did not show the thumbnail.")
         if caption is not None:
             self._last_render["status"] = caption
         return True
@@ -714,9 +708,9 @@ class MacOSPresentationController:
         text = _status_line(event)
         if text is not None and self._last_render.get("status") != text:
             self._last_render["status"] = text
-            reply = await self._send_command({"op": "status", "text": text})
-            if reply.get("state") != "shown":
-                raise MacOSPresentationError("Status item did not accept the caption.")
+            await self._send_command_expecting(
+                {"op": "status", "text": text}, "shown", "Status item did not accept the caption."
+            )
 
     async def _present_transcript(self, event: dict[str, Any]) -> None:
         """Append this event to the activity window's conversation, if it has a row to show."""
@@ -766,9 +760,13 @@ class MacOSPresentationController:
         if capture_id <= self._capture_id:
             raise MacOSPresentationError("Capture IDs must increase monotonically.")
         self._capture_id = capture_id
-        reply = await self._send_command({"op": "captureHide", "capture_id": capture_id})
-        if reply.get("capture_id") != capture_id or reply.get("state") != "hidden":
-            raise MacOSPresentationError("Overlay did not hide for capture.")
+        await self._send_command_expecting(
+            {"op": "captureHide", "capture_id": capture_id},
+            "hidden",
+            "Overlay did not hide for capture.",
+            echo_key="capture_id",
+            echo_value=capture_id,
+        )
         return True
 
     @_fail_soft("capture_reveal_failed", False)
@@ -776,9 +774,13 @@ class MacOSPresentationController:
         if not self._status.available or capture_id != self._capture_id:
             return False
         self._validate_capture_geometry(width, height)
-        reply = await self._send_command({"op": "captureReveal", "capture_id": capture_id})
-        if reply.get("capture_id") != capture_id or reply.get("state") != "visible":
-            raise MacOSPresentationError("Overlay did not reveal after capture.")
+        await self._send_command_expecting(
+            {"op": "captureReveal", "capture_id": capture_id},
+            "visible",
+            "Overlay did not reveal after capture.",
+            echo_key="capture_id",
+            echo_value=capture_id,
+        )
         return True
 
     @_fail_soft("encoder_failed", None)  # Pillow JPEG remains available
@@ -936,6 +938,27 @@ class MacOSPresentationController:
         allow_stopping: bool = False,
     ) -> dict[str, Any]:
         return await self._send_envelope({"command": command}, timeout=timeout, allow_stopping=allow_stopping)
+
+    async def _send_command_expecting(
+        self,
+        command: dict[str, Any],
+        expected_state: str,
+        error_message: str,
+        *,
+        echo_key: "str | None" = None,
+        echo_value: Any = None,
+        timeout: float = _OPERATION_TIMEOUT_SECONDS,
+        allow_stopping: bool = False,
+    ) -> dict[str, Any]:
+        """Send `command` and raise `error_message` unless the reply's `state` is `expected_state`.
+
+        If `echo_key` is given, the reply must also echo `echo_value` under that key (used by the
+        capture ops to confirm the reply matches the `capture_id` just sent, not a stale one).
+        """
+        reply = await self._send_command(command, timeout=timeout, allow_stopping=allow_stopping)
+        if reply.get("state") != expected_state or (echo_key is not None and reply.get(echo_key) != echo_value):
+            raise MacOSPresentationError(error_message)
+        return reply
 
     async def _render_capsule(self) -> None:
         if self._queue_active:


### PR DESCRIPTION
## What

`MacOSPresentationController` has six places that each independently:

```python
reply = await self._send_command({"op": "...", ...})
if reply.get("state") != "<expected>":
    raise MacOSPresentationError("<message>")
```

— `start()`'s arm step, `reveal()`, `show_thumbnail()`, `_present_status()`'s caption send, and (with an extra echoed-`capture_id` check) `before_capture()`/`after_capture()`'s `captureHide`/`captureReveal` — six call sites hand-rolling the identical "send a command, assert the reply's `state` matches, else raise" guard, only varying in the command, expected state, error message, and (for the two capture ops) an extra id-echo check.

Extracted `_send_command_expecting(command, expected_state, error_message, *, echo_key=None, echo_value=None, timeout=..., allow_stopping=...)` next to the existing `_send_command`; all six call sites now delegate, passing only what's specific to them.

## Why it's safe

- No behavioral change: same commands sent, same `_send_command` timeout/`allow_stopping` defaults, same state/echo conditions checked, same `MacOSPresentationError` messages raised at every site.
- Both methods are private (module-internal, not exported, not in `api.md`) — no public API surface change on this published SDK.
- Verified: full suite `936 passed / 3 skipped / 1 deselected` (unchanged baseline). Targeted macOS tests (`test_navigator_macos_presentation.py`, `test_navigator_macos_computer.py`, `test_navigator_macos_capture_exclusion.py`) `122 passed` — these exercise `start`/`arm`, `reveal`, `before_capture`/`after_capture`, and the status-mode caption/thumbnail paths directly. `ruff check .` and `ruff format --check` clean.

1 file changed, +41/-18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmGgsEmUcd3DZfwGNtzReu

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmGgsEmUcd3DZfwGNtzReu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with no intended behavior change; only private helper and call-site consolidation in macOS presentation control.
> 
> **Overview**
> **Deduplicates overlay RPC reply checks** in `MacOSPresentationController` by adding private `_send_command_expecting`, which sends a command via `_send_command` and raises `MacOSPresentationError` when the reply’s `state` (and optional echoed field) does not match.
> 
> Six paths now call it instead of inline `reply.get("state")` guards: **arm** on start, **reveal**, status **thumbnail** and **caption** updates, and **captureHide** / **captureReveal** (with `capture_id` echo validation). Timeout and `allow_stopping` behavior stay on `_send_command`; error strings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3e3eb2462a225b2e304e41d00119af79df859fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->