### PR TITLE
perf(n2): fold consecutive batch waits into one wait

### DIFF
--- a/tests/test_navigator_n2.py
+++ b/tests/test_navigator_n2.py
@@ -280,6 +280,52 @@ def test_batch_accepts_both_envelopes_and_is_all_or_nothing():
         )
 
 
+def test_batch_folds_consecutive_waits_into_one_summed_wait():
+    validated, translated = translate_n2_batch(
+        {
+            "actions": [
+                {"action": "left_click", "coordinates": [0, 0]},
+                {"action": "wait", "duration": 2},
+                {"action": "wait"},
+                {"action": "wait", "duration": 1.5},
+                {"action": "key_press", "key": "enter"},
+                {"action": "wait", "duration": 3},
+            ]
+        },
+        100,
+        100,
+    )
+    assert [member["action"] for member in validated] == ["left_click", "wait", "key_press", "wait"]
+    # 2 + the 5s default + 1.5 in one pause; the wait after the key press stays its own member.
+    assert [member.get("duration") for member in validated] == [None, 8.5, None, 3]
+    # `batch_index` is renumbered against the folded members, not the raw ones.
+    assert translated == [
+        {"type": "click", "x": 0, "y": 0, "button": "left", "batch_index": 0},
+        {"type": "wait", "ms": 8_500, "batch_index": 1},
+        {"type": "keypress", "keys": ["enter"], "batch_index": 2},
+        {"type": "wait", "ms": 3_000, "batch_index": 3},
+    ]
+
+
+def test_batch_caps_a_folded_wait_run_at_the_single_wait_ceiling():
+    validated, translated = translate_n2_batch(
+        {"actions": [{"action": "wait", "duration": 300}, {"action": "wait", "duration": 300}]},
+        100,
+        100,
+    )
+    assert validated == [{"action": "wait", "duration": 300}]
+    assert translated == [{"type": "wait", "ms": 300_000, "batch_index": 0}]
+
+
+def test_batch_still_rejects_an_overlong_wait_before_folding_it():
+    with pytest.raises(N2ActionValidationError, match="wait.duration must be between"):
+        translate_n2_batch(
+            {"actions": [{"action": "wait", "duration": 1}, {"action": "wait", "duration": 301}]},
+            100,
+            100,
+        )
+
+
 def test_historical_batches_reject_screenshot_and_all_batches_reject_shell_members():
     with pytest.raises(N2ActionValidationError, match="screenshot inside computer_batch"):
         translate_n2_batch(

--- a/yutori/navigator/n2_actions.py
+++ b/yutori/navigator/n2_actions.py
@@ -713,6 +713,37 @@ def internal_file_action(action_type: str, **kwargs: Any) -> dict[str, Any]:
     return {"type": action_type, **kwargs}
 
 
+def _member_wait_seconds(member: dict[str, Any]) -> "int | float":
+    """The seconds one already-validated `wait` member sleeps for."""
+    duration = member.get("duration", N2_DEFAULT_WAIT_SECONDS)
+    return duration if is_strict_number(duration) else N2_DEFAULT_WAIT_SECONDS
+
+
+def _coalesce_batch_waits(
+    members: "list[tuple[dict[str, Any], list[dict[str, Any]]]]",
+) -> "list[tuple[dict[str, Any], list[dict[str, Any]]]]":
+    """Fold every run of consecutive `wait` members into one wait of the summed duration.
+
+    A model that asks for three two-second waits in a row wants six seconds of settling,
+    not three separate pauses: each extra member costs a round of executor and frame-poll
+    overhead, an overlay queue slot, and a confirmation line, all for the same total sleep.
+    The fold keeps the ceiling a single wait may request, so a run summing past it sleeps
+    that maximum instead of failing the batch the model already committed to.
+    """
+    folded: "list[tuple[dict[str, Any], list[dict[str, Any]]]]" = []
+    for member, actions in members:
+        previous = folded[-1][0] if folded else None
+        if member.get("action") != "wait" or previous is None or previous.get("action") != "wait":
+            folded.append((member, actions))
+            continue
+        seconds = min(
+            _member_wait_seconds(previous) + _member_wait_seconds(member),
+            N2_MAX_WAIT_SECONDS,
+        )
+        folded[-1] = ({"action": "wait", "duration": seconds}, [{"type": "wait", "ms": round(float(seconds) * 1000)}])
+    return folded
+
+
 def translate_n2_batch(
     args: dict[str, Any],
     native_width: int,
@@ -729,8 +760,7 @@ def translate_n2_batch(
     if not isinstance(raw_actions, list) or not 1 <= len(raw_actions) <= N2_MAX_BATCH_ACTIONS:
         raise N2ActionValidationError(f"computer_batch.actions must contain 1-{N2_MAX_BATCH_ACTIONS} actions")
 
-    translated: list[dict[str, Any]] = []
-    validated: list[dict[str, Any]] = []
+    members: "list[tuple[dict[str, Any], list[dict[str, Any]]]]" = []
     for index, raw_action in enumerate(raw_actions):
         if not isinstance(raw_action, dict):
             raise N2ActionValidationError(f"computer_batch.actions[{index}] must be an object")
@@ -751,18 +781,23 @@ def translate_n2_batch(
             and tool_set not in TOOL_SETS_WITH_CLICK_MODIFIERS
         ):
             raise N2ActionValidationError(f"{tool_set} does not allow a held modifier inside computer_batch")
-        translated.extend(
-            translate_n2_action(
-                action,
-                member_args,
-                native_width,
-                native_height,
-                batch_index=index,
-                allow_click_modifiers=allow_click_modifiers,
-                allow_scroll_modifiers=allow_scroll_modifiers,
-            )
+        actions = translate_n2_action(
+            action,
+            member_args,
+            native_width,
+            native_height,
+            allow_click_modifiers=allow_click_modifiers,
+            allow_scroll_modifiers=allow_scroll_modifiers,
         )
         # The flattened member, not the raw one: confirmation prompts then render
         # one shape regardless of which envelope arrived.
-        validated.append(copy.deepcopy(member))
+        members.append((copy.deepcopy(member), actions))
+
+    translated: list[dict[str, Any]] = []
+    validated: list[dict[str, Any]] = []
+    # Numbered after the fold, not before: `batch_index` points the loop at the member
+    # it is executing, and folding a run of waits shifts every member that follows it.
+    for index, (member, actions) in enumerate(_coalesce_batch_waits(members)):
+        validated.append(member)
+        translated.extend({**action, "batch_index": index} for action in actions)
     return validated, translated


### PR DESCRIPTION
## What

`translate_n2_batch()` folds every run of consecutive `wait` members in a `computer_batch` into a single `wait` whose duration is the sum of the run.

A model that asks for three two-second waits in a row wants six seconds of settling, not three separate pauses. Each extra member costs a round of executor and frame-poll overhead, an overlay queue slot, and a line of confirmation UI — all for the same total sleep.

## How

- The per-member loop now collects `(flattened member, translated actions)` pairs instead of appending straight into the two output lists.
- `_coalesce_batch_waits()` folds adjacent `wait` pairs, summing `duration` (a member without one contributes the `N2_DEFAULT_WAIT_SECONDS` default) and capping the total at `N2_MAX_WAIT_SECONDS`, so a run summing past the ceiling sleeps that maximum rather than failing a batch the model already committed to.
- Folding runs *after* per-member validation, so an over-long `wait.duration` still fails the whole batch instead of being summed away.
- `batch_index` is stamped during final assembly rather than inside `translate_n2_action()`: the loop uses it to index `model_actions` and `batch_presentation["members"]`, and folding a run of waits shifts every member after it.

Non-wait members, single waits, and waits separated by another action are untouched.

## Testing

- `pytest tests/test_navigator_n2.py` → 79 passed, including three new cases: the fold with renumbered `batch_index`, the ceiling cap, and an over-long member still failing validation.
- Full `pytest` → 890 passed, 9 skipped. `tests/test_packaging.py::test_built_distributions_include_packaged_assets` fails in my local env (no `build` module in the ephemeral venv) and is unrelated to this change.
- `ruff check .` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to batch wait coalescing and batch_index renumbering after folds; validation rules for individual waits are unchanged.
> 
> **Overview**
> **`translate_n2_batch()`** now merges runs of adjacent **`wait`** members into a single wait whose duration is the sum (missing durations use the default 5s). That cuts executor round-trips, overlay slots, and confirmation lines while preserving total sleep time.
> 
> Folding runs **after** per-member validation, so an invalid **`wait.duration`** still fails the whole batch. If a folded run would exceed **`N2_MAX_WAIT_SECONDS` (300)**, the coalesced wait is capped at that ceiling instead of erroring. **`batch_index`** is applied only when assembling the final translated list, so indices align with the folded member list used by execution and UI.
> 
> Three tests cover summing with renumbered indices, the ceiling cap, and rejection of an overlong wait before folding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61bc87e173351bcce3ab3f0baa9e2ce01ee58fcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->