### PR TITLE
fix(macos): paint the loop mark with flat colour, not a gradient reference

### DIFF
--- a/tests/test_navigator_macos_overlay_build.py
+++ b/tests/test_navigator_macos_overlay_build.py
@@ -160,6 +160,20 @@ def test_activity_entries_are_not_shrunk_by_the_transcript_flex_column():
     assert "flex: none" in entry
 
 
+def test_the_loop_mark_is_painted_with_flat_colour_not_a_gradient_reference():
+    """The badge's loop is stroked through `url(#yutoriNavigatorLoopGradient)` in the bundle.
+
+    In the WKWebView host that paint server has dropped out mid-run, leaving the solid crossover
+    mask as a faint dark diamond where the loop should be. The host stylesheet paints the loop's
+    stroke and travelling dot directly so the mark never depends on the gradient resolving.
+    """
+    css = overlay_build._asset_directory().joinpath("navigator-overlay.css").read_text(encoding="utf-8")
+    stroke = css.split(".yutori-loop-path,\n.yutori-loop-mask-top {", 1)[1].split("}", 1)[0]
+    assert "stroke: #a8fbfc !important" in stroke
+    dot = css.split(".yutori-loop-dot {", 1)[1].split("}", 1)[0]
+    assert "fill: #a8fbfc !important" in dot
+
+
 def test_the_shell_rail_stands_down_while_the_activity_window_is_open():
     """One list of commands at a time: the window the operator opened, not the desktop."""
     css = overlay_build._asset_directory().joinpath("navigator-overlay.css").read_text(encoding="utf-8")

--- a/yutori/navigator/macos/assets/navigator-overlay.css
+++ b/yutori/navigator/macos/assets/navigator-overlay.css
@@ -192,6 +192,25 @@ html[data-n2-activity-open] #n2-shell-rail {
   pointer-events: none;
 }
 
+/*
+ * The loop mark's stroke and travelling dot are painted through an SVG gradient
+ * (`url(#yutoriNavigatorLoopGradient)`), and the path toggles `display` every
+ * cycle as the loop retracts into a dot and redraws. In the WKWebView host that
+ * paint server has been seen to drop out mid-run: the solid crossover mask kept
+ * painting (a faint dark diamond in the badge slot) while the gradient-stroked
+ * loop around it vanished. The gradient only runs #C6FAFB to #9DFBFC, so at
+ * badge size a flat colour is indistinguishable; paint the loop directly and
+ * skip the reference.
+ */
+.yutori-loop-path,
+.yutori-loop-mask-top {
+  stroke: #a8fbfc !important;
+}
+
+.yutori-loop-dot {
+  fill: #a8fbfc !important;
+}
+
 .yutori-overlay-rim {
   background: linear-gradient(
     145deg,


### PR DESCRIPTION
## Summary
- The reasoning capsule's badge slot showed only a faint dark rotated square instead of the Yutori loop. That square is the loop's solid crossover mask (`.yutori-loop-mask`); the loop stroke and travelling dot are painted through `url(#yutoriNavigatorLoopGradient)`, and in the WKWebView host that paint server stopped painting mid-run while solid fills kept drawing. The DOM can never legitimately show the mask without the path, so this was a paint failure, not the animation stalling.
- The host stylesheet (`navigator-overlay.css`, injected into the overlay's shadow root) now strokes `.yutori-loop-path` / `.yutori-loop-mask-top` and fills `.yutori-loop-dot` with a flat `#a8fbfc`. The bundle's gradient only spans #C6FAFB to #9DFBFC, so nothing visible changes at badge size.
- Adds a test pinning the rules.

## Verification
- `uv run pytest tests/test_navigator_macos_overlay_build.py` passes (13 tests).
- Compiled the host with the new CSS, mounted the badge with a thought, and confirmed the loop draws in the capsule both via `WKWebView.takeSnapshot` and in an on-screen `screencapture`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS override for overlay badge visuals in WKWebView; no auth, data, or API changes.
> 
> **Overview**
> Fixes a **WKWebView rendering bug** where the reasoning capsule badge sometimes showed only a faint dark diamond (the loop’s solid mask) because the SVG gradient used for the loop stroke and travelling dot stopped painting mid-animation.
> 
> The macOS host overlay stylesheet now **overrides** `.yutori-loop-path` / `.yutori-loop-mask-top` and `.yutori-loop-dot` with a flat `#a8fbfc` stroke/fill (`!important`), avoiding `url(#yutoriNavigatorLoopGradient)` while staying visually the same at badge size.
> 
> A build test asserts those rules stay in `navigator-overlay.css`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a55508d52bfe96ea52cda092c5d5a6bd814bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->