### PR TITLE
chore(release): 0.9.17

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.16" \
+    "yutori==0.9.17" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.16'
+pip install 'yutori[macos]==0.9.17'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.16",
+    "yutori==0.9.17",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.16"]
+macos = ["yutori[macos]==0.9.17"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.16"
+YUTORI_INSTALLER_VERSION="0.9.17"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.16"
+version = "0.9.17"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts yutori 0.9.17.

## What's in it

- **#406** — the overlay stays on screen during captures. The session opens with a probe that sets `sharingType = .none` on the overlay windows, so the compositor excludes them from the capture instead of the driver hiding and re-showing them around every screenshot; hiding remains the fallback when the probe says exclusion did not take.
- **#407** — `_validate_geometry` returns the capture scale rather than having callers recompute it.
- **#408** — `_send_command_expecting` extracted in `MacOSPresentationController`, replacing the repeated send-then-await-reply-then-raise blocks.
- **#409** — an activity dot beside the menu bar icon, so a background run is visible without opening the activity window.
- **#410** — `computer_batch` folds each run of consecutive `wait` members into one wait of the summed duration. Three two-second waits in a row were three separate pauses, each paying executor and frame-poll overhead, an overlay queue slot, and a confirmation line for the same total sleep. Folding happens after per-member validation (an over-long duration still fails the batch) and is capped at `N2_MAX_WAIT_SECONDS`; `batch_index` is stamped after the fold, since the loop uses it to index the member list the fold shortens.

## Bump

`version` in pyproject.toml, `install.sh` regenerated via `scripts/build_install.sh`, and the `yutori==` pins under `examples/navigator_n2` (pyproject.toml x2, README.md, Dockerfile.direct_x11).

`892 passed, 9 skipped` (including `tests/test_packaging.py` with `build` available); `ruff check .` clean; `check_install_sh_fresh.sh` clean.

**Full Changelog**: https://github.com/yutori-ai/yutori-sdk-python/compare/v0.9.16...v0.9.17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and dependency pin updates only; no runtime logic changes in this diff.
> 
> **Overview**
> **Release 0.9.17** — bumps the published SDK version and keeps install/docs/examples on the same release.
> 
> Updates `version` in root `pyproject.toml` from **0.9.16** to **0.9.17**, syncs `YUTORI_INSTALLER_VERSION` in `install.sh`, and changes all `yutori==0.9.16` / `yutori[macos]==0.9.16` pins in `examples/navigator_n2` (`pyproject.toml`, `README.md`, `Dockerfile.direct_x11`) to **0.9.17**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b312a700553d280a2fff0f8e9875a446709ac47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->