### PR TITLE
chore(release): 0.9.18

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.17" \
+    "yutori==0.9.18" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.17'
+pip install 'yutori[macos]==0.9.18'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.17",
+    "yutori==0.9.18",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.17"]
+macos = ["yutori[macos]==0.9.18"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.17"
+YUTORI_INSTALLER_VERSION="0.9.18"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.17"
+version = "0.9.18"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Release 0.9.18. Since 0.9.17:

- #413 feat(macos): let clicks through the activity window except on its grip — the activity window's body ignores the mouse, so clicks reach the app behind it (fixes foreground runs where a model click landed on the window); only the grip strip (drag, close) takes the mouse, and model input on it is refused like input on the Stop item.

Bumps `version` in pyproject.toml, regenerates install.sh, and moves the `yutori==` pins under examples/navigator_n2.

## Test plan

- [ ] CI green
- [ ] Merge tags v0.9.18, publishes to PyPI, and creates the release automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is version and dependency pin updates only; no runtime logic changes in this PR.
> 
> **Overview**
> **Release 0.9.18** — bumps the SDK from `0.9.17` to `0.9.18` in root `pyproject.toml`, updates `YUTORI_INSTALLER_VERSION` in `install.sh`, and aligns Navigator n2 cookbook pins (`examples/navigator_n2` `pyproject.toml`, `Dockerfile.direct_x11`, and README install examples).
> 
> This PR is packaging/version alignment only; the functional delta since 0.9.17 (per release notes) is the macOS Navigator change that lets clicks pass through the activity window except on the grip strip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c79cfa459cb7701c8f50ba104450f05b987b0995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->