### PR TITLE
Reuse _clear_action_labels() for the shell terminal-state reset

### DIFF
--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -1117,8 +1117,7 @@ class MacOSPresentationController:
         self._terminal_command = ""
         await self._render_capsule()
         await self._sleep(_SHELL_TERMINAL_HOLD_SECONDS)
-        self._action_status = ""
-        self._terminal_command = ""
+        self._clear_action_labels()
         await self._render_capsule()
 
     async def _track_shell_rail(self, event: ShellPresentationEvent) -> None:


### PR DESCRIPTION
## What

`MacOSPresentationController._present_shell`'s post-hold terminal-state reset hand-inlined the same three-field reset (`_action_status`, `_terminal_command`, `_active_keys`) that `_clear_action_labels()` already centralizes and is reused by the `reasoning`, `action_done`, and `final` branches of `present()`.

## Why it's an improvement

The inlined reset duplicated a pattern that's already extracted elsewhere in the same class, for the exact same purpose (resetting the capsule's action-status/terminal-command/active-keys before re-rendering). Routing this call site through the shared helper removes the duplication and keeps future changes to that reset logic in one place.

## Why it's safe — no behavioral change

- `_active_keys` is already `None` at this point in the shell-terminal-state flow (it was last set to `None` a few lines earlier in the `starting`/`running` branch, and nothing between there and here sets it), so `_clear_action_labels()`'s `self._active_keys = None` is a no-op — the reset is textually and behaviorally identical.
- Verified: `ruff check` / `ruff format --check` clean, and the full test suite passes (897 passed, 9 skipped; the one pre-existing failure, `test_packaging.py::test_built_distributions_include_packaged_assets`, reproduces identically on `main` before this change — it's a sandbox-only `No module named build` issue, unrelated).
- 1 file changed, 1 insertion / 2 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HATzRpKhaEX6E3p3U2ScEz

---
_Generated by [Claude Code](https://claude.ai/code/session_01HATzRpKhaEX6E3p3U2ScEz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single call-site refactor in presentation UI state with no intended behavior change.
> 
> **Overview**
> **Refactor:** After a foreground shell command finishes its terminal hold in `_present_shell`, the capsule reset now goes through `_clear_action_labels()` instead of manually clearing `_action_status` and `_terminal_command`.
> 
> This matches how `present()` already clears the same capsule fields for reasoning, `action_done`, and `final`, so any future tweak to that reset stays in one helper. Behavior is unchanged: `_active_keys` is already `None` at that point in the shell flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea7f1f02e255cc9042032d1dab2d40031a24874f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->