### PR TITLE
chore(release): 0.9.19

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.18" \
+    "yutori==0.9.19" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.18'
+pip install 'yutori[macos]==0.9.19'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.18",
+    "yutori==0.9.19",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.18"]
+macos = ["yutori[macos]==0.9.19"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.18"
+YUTORI_INSTALLER_VERSION="0.9.19"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.18"
+version = "0.9.19"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bumps the package to 0.9.19, regenerates install.sh, and moves the examples/navigator_n2 pins.

Included since 0.9.18: #416 (recordable overlay via a capturer-side filter: `exclude_overlay_from_capture=False` keeps the overlay in screen recordings and screen shares while the model's frames come from the overlay host with its own windows filtered out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and dependency pin updates only; no application logic changes in the diff.
> 
> **Overview**
> **Releases the SDK as `0.9.19`** by updating the root `pyproject.toml` version and the `YUTORI_INSTALLER_VERSION` string in `install.sh` so curl-based installs report the new release.
> 
> **Aligns the Navigator n2 cookbooks** with the same release: `examples/navigator_n2/pyproject.toml` (including the `macos` extra), `Dockerfile.direct_x11`, and the macOS install line in `README.md` now pin `yutori==0.9.19` / `yutori[macos]==0.9.19` instead of `0.9.18`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 784600cd014d0be860c675dcd6ec5d7040a97560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->