### PR TITLE
chore(release): 0.9.20

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.19" \
+    "yutori==0.9.20" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.19'
+pip install 'yutori[macos]==0.9.20'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.19",
+    "yutori==0.9.20",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.19"]
+macos = ["yutori[macos]==0.9.20"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.19"
+YUTORI_INSTALLER_VERSION="0.9.20"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.19"
+version = "0.9.20"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## What

- Releases the cursor-attached terminal command overlay from #418.
- Bundles `yutori-navigator-overlay-runtime==0.5.0`, built from `yutori/main` commit `e78194c988` containing yutori-ai/yutori#13269.
- Bumps the SDK and pinned examples to `0.9.20` and regenerates `install.sh`.

## Verified

- `uv run --extra dev pytest -q -m "not slow"`: 906 passed, 9 skipped.
- `uv run --extra dev ruff check .`
- `bash scripts/check_install_sh_fresh.sh`
- SDK #418 CI: all Python 3.9–3.14 test and package jobs passed.
- Runtime wheel asset SHA-256 is locked by the SDK provenance test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly version and documentation pin updates; functional overlay/runtime changes were validated in the preceding feature PR and release CI.
> 
> **Overview**
> **Releases the Python SDK as `0.9.20`**, aligning the package version in root `pyproject.toml`, the curl bootstrap `install.sh` installer banner, and the Navigator n2 cookbook pins (README, `pyproject.toml`, and `Dockerfile.direct_x11`).
> 
> Per the release notes, **0.9.20 ships the cursor-attached terminal command overlay** from the prior feature work, including **`yutori-navigator-overlay-runtime==0.5.0`** with provenance locked in tests. This PR’s diff is the version and install-script refresh so installs and examples pull the new release consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d259d496a3c7a2c043b00290b791af2d7b54af8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->