### PR TITLE
Speed up PR checks with uv and a consolidated matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,72 +6,97 @@ on:
   pull_request:
 
 # A new push to a PR makes the in-flight run for the previous commit
-# irrelevant, so stop paying for its 12 matrix jobs. Pushes to main are never
+# irrelevant, so stop paying for its matrix jobs. Pushes to main are never
 # cancelled: every commit there keeps its own status.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# No job here writes anything back to the repository, so drop the default
+# token down to a read-only one.
+permissions:
+  contents: read
+
+env:
+  # setup-python owns the interpreter; this stops uv from quietly building
+  # against a different one it downloaded for itself.
+  UV_PYTHON_DOWNLOADS: only-system
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
-      # No pip cache here on purpose. This job installs only ruff, but it
-      # would share the 3.12 cache key with test/package (setup-python keys on
-      # python version + pyproject.toml hash) and usually wins the race to
-      # write it, leaving those jobs to restore a cache with none of their
-      # dependencies in it.
-      - run: pip install ruff
-      - run: ruff check .
+          persist-credentials: false
+      # ruff-action fetches the standalone binary, so this job needs neither a
+      # Python interpreter nor the project's dependencies. The version is
+      # pinned: an unpinned linter turns an upstream release into a red main.
+      - uses: astral-sh/ruff-action@v4
+        with:
+          version: "0.16.6"
+          args: check
 
+  # One job per interpreter runs the source tests, builds the distributions,
+  # and tests those exact distributions. Splitting this into separate `test`
+  # and `package` jobs doubled the matrix and made every packaging job repeat
+  # the checkout, the interpreter setup, and the dependency install for the
+  # sake of one extra pytest marker.
   test:
+    name: test (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
-      - run: pip install -e ".[dev]"
-      - run: pytest -m "not slow"
+          persist-credentials: false
 
-  # Every supported interpreter must build the source, wheel, and an extracted
-  # sdist-derived wheel. This catches packaging regressions that source tests
-  # alone cannot see.
-  package:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-    steps:
-      - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
-      - run: pip install -e ".[dev]" twine
-      - name: Wheel content test
-        run: pytest -m slow
+
+      - uses: astral-sh/setup-uv@v10
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+          # Every matrix leg resolves a different set of wheels. Without a
+          # per-interpreter suffix they all share one cache key, and whichever
+          # job wins the race to save it leaves the rest restoring a cache
+          # built for someone else's Python.
+          cache-suffix: py${{ matrix.python-version }}
+
+      - name: Install the project
+        run: uv pip install --system -e ".[dev]" twine
+
+      - name: Test the source tree
+        run: pytest -m "not slow"
+
+      # `--installer uv` keeps `python -m build`'s PEP 517 isolation while
+      # provisioning the build environment from the uv cache instead of a cold
+      # pip install of setuptools.
       - name: Build and validate metadata
         run: |
-          python -m build
+          python -m build --installer uv
           twine check dist/*
+
+      # The slow packaging tests build their own distributions when pointed at
+      # no directory. Handing them the ones just built covers the same sdist,
+      # wheel, and sdist-derived-wheel assertions with one build instead of two,
+      # and checks the artifacts this job actually produced.
+      - name: Test the built distributions
+        env:
+          YUTORI_TEST_DISTRIBUTIONS_DIR: ${{ github.workspace }}/dist
+        run: pytest -m slow
 
   install-sh:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Verify install.sh matches template + assets + version
         run: bash scripts/check_install_sh_fresh.sh
       - name: Syntax-check shell scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ permissions:
 env:
   # setup-python owns the interpreter; this stops uv from quietly building
   # against a different one it downloaded for itself.
-  UV_PYTHON_DOWNLOADS: only-system
+  UV_PYTHON_PREFERENCE: only-system
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       # ruff-action fetches the standalone binary, so this job needs neither a
       # Python interpreter nor the project's dependencies. The version is
       # pinned: an unpinned linter turns an upstream release into a red main.
-      - uses: astral-sh/ruff-action@v4
+      - uses: astral-sh/ruff-action@v4.1.0
         with:
           version: "0.16.6"
           args: check
@@ -58,7 +58,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: pyproject.toml

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: pyproject.toml

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -87,7 +87,7 @@ jobs:
       RELEASE_TAG: ${{ needs.tag.outputs.tag }}
       # Build against the interpreter setup-python pinned, never one uv
       # decides to download.
-      UV_PYTHON_DOWNLOADS: only-system
+      UV_PYTHON_PREFERENCE: only-system
     permissions:
       contents: read
     steps:

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -85,6 +85,9 @@ jobs:
       release_tag: ${{ needs.tag.outputs.tag }}
     env:
       RELEASE_TAG: ${{ needs.tag.outputs.tag }}
+      # Build against the interpreter setup-python pinned, never one uv
+      # decides to download.
+      UV_PYTHON_DOWNLOADS: only-system
     permissions:
       contents: read
     steps:
@@ -92,10 +95,16 @@ jobs:
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v10
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
 
       - name: Verify annotated release tag and package version
         run: |
@@ -135,17 +144,17 @@ jobs:
               )
           PY
 
-      - name: Install build tools
-        run: pip install build twine
+      - name: Install the project and build tools
+        run: uv pip install --system -e ".[dev]" build twine
 
       - name: Run tests
-        run: |
-          pip install -e ".[dev]"
-          pytest -m "not slow"
+        run: pytest -m "not slow"
 
+      # `--installer uv` is the same command CI runs on every PR, so the build
+      # path that produces the published artifacts is the one already tested.
       - name: Build and validate exact distributions
         run: |
-          python -m build
+          python -m build --installer uv
           twine check dist/*
           (cd dist && sha256sum *.tar.gz *.whl > SHA256SUMS)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Yutori Python SDK & CLI
 
 [![PyPI version](https://img.shields.io/pypi/v/yutori.svg)](https://pypi.org/project/yutori/)
-[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 
 The official Python SDK and CLI for the [Yutori API](https://docs.yutori.com) — build agents that monitor, research, and browse the web, and operate computers with [Yutori](https://yutori.com/api).
 
@@ -25,7 +25,7 @@ curl -fsSL https://yutori.com/install.sh | bash
 
 Installs the global `yutori` CLI via `uv tool install` and prompts to add the SDK to your project, run `yutori auth login`, register the MCP server, install workflow skills, and verify with a browsing task.
 
-Python 3.9+ is required for the SDK.
+Python 3.10+ is required for the SDK.
 
 <details>
 <summary>Non-interactive install (CI, pipe, AI coding agent)</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ name = "yutori"
 version = "0.9.20"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 authors = [{ name = "Yutori", email = "support@yutori.com" }]
 
@@ -20,7 +20,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -48,7 +47,7 @@ yutori = "yutori.cli.main:app"
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "ruff>=0.1", "build>=1.2.0"]
 examples = ["loguru>=0.7.0", "playwright>=1.40.0", "pydantic>=2.0.0", "tenacity>=9.0.0"]
-macos = ["cua-driver==0.23.2; python_version >= '3.10' and platform_system == 'Darwin'"]
+macos = ["cua-driver==0.23.2; platform_system == 'Darwin'"]
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -62,7 +61,7 @@ include = ["yutori*"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]

--- a/tests/test_install_flow.py
+++ b/tests/test_install_flow.py
@@ -201,19 +201,19 @@ def test_detect_sdk_install_plan_uses_uv_for_pep621_project(tmp_path: Path, monk
 
 def test_detect_sdk_install_plan_uses_poetry_for_poetry_project(tmp_path: Path, monkeypatch):
     # No Python range anywhere in the project: Poetry would reject `yutori`
-    # (Requires-Python >=3.9) against its implicit "any Python", so the SDK's
+    # (Requires-Python >=3.10) against its implicit "any Python", so the SDK's
     # range is stated on the dependency.
     (tmp_path / "pyproject.toml").write_text("[tool.poetry]\nname='demo'\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 
     with (
         patch("yutori.cli.commands.install_flow._which", return_value="/usr/bin/poetry"),
-        patch("yutori.cli.commands.install_flow._yutori_requires_python", return_value=">=3.9"),
+        patch("yutori.cli.commands.install_flow._yutori_requires_python", return_value=">=3.10"),
     ):
         plan = detect_sdk_install_plan()
 
     assert plan.reason == "Detected a Poetry project in the current directory."
-    assert plan.command == ("/usr/bin/poetry", "add", "--python", ">=3.9", "yutori")
+    assert plan.command == ("/usr/bin/poetry", "add", "--python", ">=3.10", "yutori")
     assert plan.default is True
     assert plan.availability_error is None
 
@@ -227,7 +227,7 @@ def test_detect_sdk_install_plan_poetry_project_with_python_range_omits_python_f
 
     with (
         patch("yutori.cli.commands.install_flow._which", return_value="/usr/bin/poetry"),
-        patch("yutori.cli.commands.install_flow._yutori_requires_python", return_value=">=3.9"),
+        patch("yutori.cli.commands.install_flow._yutori_requires_python", return_value=">=3.10"),
     ):
         plan = detect_sdk_install_plan()
 
@@ -246,7 +246,7 @@ def test_detect_sdk_install_plan_prefers_poetry_for_pep621_project_managed_by_po
 
     with (
         patch("yutori.cli.commands.install_flow._which", return_value="/usr/bin/poetry"),
-        patch("yutori.cli.commands.install_flow._yutori_requires_python", return_value=">=3.9"),
+        patch("yutori.cli.commands.install_flow._yutori_requires_python", return_value=">=3.10"),
     ):
         plan = detect_sdk_install_plan()
 
@@ -260,11 +260,11 @@ def test_detect_sdk_install_plan_flags_missing_poetry(tmp_path: Path, monkeypatc
 
     with (
         patch("yutori.cli.commands.install_flow._which", return_value=None),
-        patch("yutori.cli.commands.install_flow._yutori_requires_python", return_value=">=3.9"),
+        patch("yutori.cli.commands.install_flow._yutori_requires_python", return_value=">=3.10"),
     ):
         plan = detect_sdk_install_plan()
 
-    assert plan.command == ("poetry", "add", "--python", ">=3.9", "yutori")
+    assert plan.command == ("poetry", "add", "--python", ">=3.10", "yutori")
     assert plan.availability_error == "`poetry` is required for Poetry project installs."
 
 

--- a/yutori/cli/commands/install_flow.py
+++ b/yutori/cli/commands/install_flow.py
@@ -553,7 +553,7 @@ def _pyproject_declared_keys(path: Path) -> set[str]:
 
     Table headers appear as-is (``"tool.poetry"``); ``key = value`` lines
     appear prefixed by their table (``"project.requires-python"``,
-    ``"tool.poetry.dependencies.python"``). The installer supports Python 3.9+,
+    ``"tool.poetry.dependencies.python"``). The installer supports Python 3.10+,
     so it cannot rely on stdlib ``tomllib``; this is enough to recognize the
     canonical project formats and whether they pin a Python range, without
     parsing arbitrary TOML values.

--- a/yutori/navigator/_assets.py
+++ b/yutori/navigator/_assets.py
@@ -9,9 +9,7 @@ from importlib.resources import files
 @lru_cache(maxsize=None)
 def _load_js_resource(package: str, name: str) -> str:
     """Read a bundled ``<package>/js/<name>`` file, stripped of surrounding whitespace."""
-    # Chained single-segment joins: on Python 3.9, zipfile.Path.joinpath
-    # accepts only one argument, so a two-argument join breaks zip imports.
-    return (files(package) / "js" / name).read_text(encoding="utf-8").strip()
+    return files(package).joinpath("js", name).read_text(encoding="utf-8").strip()
 
 
 def load_js_asset(name: str) -> str:


### PR DESCRIPTION
## Summary
- cut the CI test/package matrix from 12 jobs to 5 consolidated Python 3.10-3.14 jobs
- use uv caching, reuse built artifacts for packaging validation, and align the release workflow with the tested build path
- raise the minimum supported Python version to 3.10 and update compatibility metadata and code

## Testing
- `.context/pr-venv/bin/python -m pytest -m 'not slow'` (906 passed, 9 skipped)
- `python -m build --installer uv`, `twine check`, and the slow packaging test
- `ruff check .`
- install.sh freshness and shell syntax checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dropping Python 3.9 is a breaking change for downstream users; CI/release behavior changes are substantial but mostly tooling, with publish still gated by the same test and dist validation steps.
> 
> **Overview**
> **CI and release workflows are reworked around uv** to cut matrix cost and align builds with what ships. The separate `test` and `package` jobs are merged into one per-interpreter job (Python **3.10–3.14**; **3.9 dropped**), with `setup-uv` caching keyed per Python version, `uv pip install` for deps, and `python -m build --installer uv`. Slow packaging tests reuse artifacts from that same build via `YUTORI_TEST_DISTRIBUTIONS_DIR` instead of building twice. Lint no longer installs Python or project deps—it uses a **pinned** `astral-sh/ruff-action`. Workflows also set **read-only** `contents` where appropriate, `persist-credentials: false` on checkout, and `UV_PYTHON_PREFERENCE: only-system`.
> 
> **Minimum supported Python is raised to 3.10** in `pyproject.toml`, README, Ruff target, Poetry install-plan tests/comments, and the macOS optional extra (drops the old `python_version >= '3.10'` marker). Navigator JS loading drops the Python 3.9 `zipfile.Path` join workaround and uses `joinpath("js", name)` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b87b13fd5a7c9a7d1def5a52d5047e8e75865e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->