### PR TITLE
refactor(macos): drop the now-dead window_mode branch in _capture_png

### DIFF
--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -462,7 +462,7 @@ class MacOSComputer:
                 {"session": self.session, "capture_scope": "desktop"},
             )
             self._session_started = True
-            self._initial_png, width, height = await self._capture_png()
+            self._initial_png, width, height = await self._capture_desktop_png()
             self._native_size = (width, height)
             self._native_cursor = await self._select_native_cursor()
             if self.presentation_requested:
@@ -1300,11 +1300,6 @@ class MacOSComputer:
 
     async def _await_with_cancellation(self, awaitable: Awaitable[Any]) -> Any:
         return await race_against_cancellation(awaitable, self.cancellation)
-
-    async def _capture_png(self) -> tuple[bytes, int, int]:
-        if self.window_mode:
-            return await self._capture_window_png()
-        return await self._capture_desktop_png()
 
     async def _capture_observation_png(self, capture_id: int) -> tuple[bytes, int, int]:
         """The model's frame: the driven window; else the overlay host's own desktop capture with its


### PR DESCRIPTION
@juanpin — automated cleanup found while sweeping today's macOS presentation-controller commits (#413, #416, #418) for the reintroduced-duplication pattern the last couple of `refactor(macos)` PRs (#407, #408) fixed in this same subsystem. This one is smaller and different in shape: not duplication between two commits, but a helper left partly dead by one commit's own refactor.

**What happened:** #416 replaced `screenshot()`'s call to `_capture_png()` with the new `_capture_observation_png()`, which inlines its own `window_mode` check plus the overlay-capture path. That left `_capture_png()` with exactly one remaining caller — in `__aenter__()` — reached only through the non-`window_mode` branch (the `window_mode` branch returns early a few lines above). So `_capture_png()`'s own `if self.window_mode: return await self._capture_window_png()` line was already unreachable at that call site.

**Fix:** inline the remaining call as `_capture_desktop_png()` directly and remove `_capture_png()`. No behavior change — the call site's `window_mode` is always `False`, so the branch it evaluated was never taken. Confirmed no other call sites or test references.

**Verification:**
- `ruff check` / `ruff format --check` clean on the touched file
- `pytest tests/test_navigator_macos_computer.py tests/test_navigator_macos_presentation.py tests/test_navigator_macos_capture_exclusion.py` — 132 passed
- Full suite: 907 passed, 9 skipped

Diff is a single 7-line change (1 insertion, 6 deletions) in `yutori/navigator/macos/computer.py`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DVBN51EQUugFhBPpMfAVvq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no behavioral change at the sole call site; macOS navigator tests reportedly pass.
> 
> **Overview**
> Removes the dead **`_capture_png`** indirection in macOS desktop session startup after observation capture moved to **`_capture_observation_png`**.
> 
> **`__aenter__`** now calls **`_capture_desktop_png()`** directly for the initial desktop frame (the only path that reached the old helper, since window scope returns earlier). The removed helper’s **`window_mode`** branch was unreachable at that call site, so capture behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97eaf64fe803ce99a1352a5c4d00727c80c44745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->