### PR TITLE
feat(macos): let the cua-driver transport attach to a host-embedded daemon

### DIFF
--- a/tests/test_navigator_macos_transport.py
+++ b/tests/test_navigator_macos_transport.py
@@ -89,3 +89,65 @@ async def test_tool_refusal_is_not_reclassified_as_a_connection_loss(monkeypatch
     monkeypatch.setattr(transport, "_call_tool_once", call_once)
     with pytest.raises(CuaDriverToolError, match="permission denied"):
         await transport.call_tool("click", {})
+
+
+def test_driver_resolution_prefers_the_host_binary_override(tmp_path, monkeypatch):
+    host_binary = tmp_path / "host-cua-driver"
+    package_binary = tmp_path / "package-cua-driver"
+    host_binary.touch()
+    package_binary.touch()
+    monkeypatch.setitem(sys.modules, "cua_driver", SimpleNamespace(get_binary_path=lambda: package_binary))
+    monkeypatch.setenv(transport_module.ENV_DRIVER_BINARY, str(host_binary))
+
+    assert find_cua_driver_binary() == host_binary
+
+
+def test_driver_resolution_rejects_a_missing_host_binary(tmp_path, monkeypatch):
+    monkeypatch.setenv(transport_module.ENV_DRIVER_BINARY, str(tmp_path / "absent"))
+    with pytest.raises(transport_module.CuaDriverError, match="missing cua-driver binary"):
+        find_cua_driver_binary()
+
+
+async def _spawn_recording_start(monkeypatch, transport: CuaDriverTransport) -> list[str]:
+    """Run ``transport.start()`` against a stubbed subprocess and return the argv it spawned."""
+    spawned: list[str] = []
+
+    async def spawn(*argv: str):
+        spawned.extend(argv)
+        return SimpleNamespace(returncode=None, stderr=None)
+
+    async def no_rpc(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setattr(transport_module, "spawn_rpc_subprocess", spawn)
+    monkeypatch.setattr(transport, "_request", no_rpc)
+    monkeypatch.setattr(transport, "_notify", no_rpc)
+    await transport.start()
+    return spawned
+
+
+async def test_transport_attaches_to_the_embedded_daemon_named_by_the_environment(tmp_path, monkeypatch):
+    binary = tmp_path / "cua-driver"
+    binary.touch()
+    monkeypatch.setenv(transport_module.ENV_DRIVER_BINARY, str(binary))
+    monkeypatch.setenv(transport_module.ENV_DRIVER_SOCKET, "/tmp/host.sock")
+
+    spawned = await _spawn_recording_start(monkeypatch, CuaDriverTransport())
+
+    assert spawned == [str(binary), "mcp", "--embedded", "--socket", "/tmp/host.sock"]
+
+
+async def test_transport_explicit_arguments_override_the_environment(tmp_path, monkeypatch):
+    binary = tmp_path / "cua-driver"
+    binary.touch()
+    monkeypatch.setenv(transport_module.ENV_DRIVER_SOCKET, "/tmp/host.sock")
+
+    spawned = await _spawn_recording_start(monkeypatch, CuaDriverTransport(binary=binary, arguments=()))
+
+    assert spawned == [str(binary), "mcp"]
+
+
+def test_transport_spawns_a_plain_proxy_without_an_embedded_socket(monkeypatch):
+    monkeypatch.delenv(transport_module.ENV_DRIVER_SOCKET, raising=False)
+    assert CuaDriverTransport().arguments == []
+    assert transport_module.embedded_daemon_arguments("/tmp/x.sock") == ["--embedded", "--socket", "/tmp/x.sock"]

--- a/yutori/navigator/macos/transport.py
+++ b/yutori/navigator/macos/transport.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import shutil
+from collections.abc import Sequence
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
@@ -13,6 +15,12 @@ from .process_lifecycle import cancel_and_drain, drain_stream, spawn_rpc_subproc
 
 _RPC_TIMEOUT_SECONDS = 30.0
 _PROCESS_EXIT_TIMEOUT_SECONDS = 3.0
+# A host application that embeds cua-driver (see the driver's EMBEDDING contract) names its
+# own binary and the private socket of the daemon it spawned. The binary override wins over
+# package and PATH discovery; the socket turns every ``cua-driver mcp`` spawn into a proxy to
+# that daemon, so the host's TCC grants apply instead of the standalone CuaDriver.app's.
+ENV_DRIVER_BINARY = "YUTORI_CUA_DRIVER_BINARY"
+ENV_DRIVER_SOCKET = "YUTORI_CUA_DRIVER_SOCKET"
 
 
 class CuaDriverError(RuntimeError):
@@ -62,6 +70,12 @@ def inline_image_data(result: dict[str, Any]) -> "str | None":
 
 
 def find_cua_driver_binary() -> Path:
+    override = os.environ.get(ENV_DRIVER_BINARY)
+    if override:
+        candidate = Path(override)
+        if not candidate.is_file():
+            raise CuaDriverError(f"{ENV_DRIVER_BINARY} names a missing cua-driver binary: {candidate}")
+        return candidate
     try:
         from cua_driver import get_binary_path
 
@@ -79,6 +93,18 @@ def find_cua_driver_binary() -> Path:
     raise CuaDriverError("cua-driver is not installed; install `yutori[macos]` or run `yutori-mcp computer-use setup`.")
 
 
+def embedded_daemon_arguments(socket_path: "str | None" = None) -> list[str]:
+    """``cua-driver mcp`` arguments that attach the proxy to a host-owned embedded daemon.
+
+    Empty when no socket is configured: the proxy then auto-launches or joins the standalone
+    CuaDriver.app daemon exactly as before.
+    """
+    path = socket_path if socket_path is not None else os.environ.get(ENV_DRIVER_SOCKET)
+    if not path:
+        return []
+    return ["--embedded", "--socket", path]
+
+
 class CuaDriverTransport:
     """One serialized, restartable MCP session over a persistent subprocess."""
 
@@ -86,9 +112,14 @@ class CuaDriverTransport:
         self,
         binary: "str | Path | None" = None,
         *,
+        arguments: "Sequence[str] | None" = None,
         request_timeout_seconds: float = _RPC_TIMEOUT_SECONDS,
     ) -> None:
         self.binary = Path(binary) if binary is not None else None
+        # Extra ``cua-driver mcp`` arguments. None defers to the environment so an embedding
+        # host configures every transport the SDK creates without threading a parameter
+        # through MacOSComputer; an explicit sequence (even empty) is used verbatim.
+        self.arguments = list(arguments) if arguments is not None else embedded_daemon_arguments()
         self.request_timeout_seconds = request_timeout_seconds
         self._process: "asyncio.subprocess.Process | None" = None
         self._stderr_task: "asyncio.Task[None] | None" = None
@@ -106,7 +137,7 @@ class CuaDriverTransport:
         self._closing = False
         binary = self.binary or find_cua_driver_binary()
         try:
-            self._process = await spawn_rpc_subprocess(str(binary), "mcp")
+            self._process = await spawn_rpc_subprocess(str(binary), "mcp", *self.arguments)
         except OSError as error:
             raise CuaDriverConnectionError(f"Failed to start cua-driver: {error}") from error
         self._stderr_task = asyncio.create_task(self._drain_stderr())


### PR DESCRIPTION
## Summary

Lets an application that embeds cua-driver (the driver's [EMBEDDING contract](https://github.com/trycua/cua/blob/main/libs/cua-driver/rust/Skills/cua-driver/EMBEDDING.md)) point the SDK at its own daemon, so the driver runs inside the host's TCC responsibility chain and never needs the standalone `CuaDriver.app` identity.

- `CuaDriverTransport(arguments=...)`: extra arguments appended to `cua-driver mcp`.
- Environment defaults: `YUTORI_CUA_DRIVER_SOCKET` → `--embedded --socket <path>`; `YUTORI_CUA_DRIVER_BINARY` wins over the `cua_driver` package and `PATH` in `find_cua_driver_binary()`.
- No change when neither variable is set.

First consumer: Yutori Local's tray computer-use (yutori-mcp gains an embedded-host mode that forwards these variables to the runner).

## Test plan

- [x] `pytest tests/test_navigator_macos_transport.py tests/test_navigator_macos_computer.py` (101 passed)
- [x] `ruff check` / `ruff format --check` on the touched files
- [x] Live: `cua-driver serve --embedded --socket …` spawned by a host process, SDK transport attached through the proxy, `check_permissions` reported `source.attribution: host`; a background n2 run on Calculator completed through this transport from the bundled Yutori Local runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS driver discovery and subprocess launch for computer-use; backward compatible by default but misconfigured env vars could break MCP attachment or permissions attribution.
> 
> **Overview**
> Adds **host-embedded cua-driver** support on macOS so embedders can run computer-use under their own binary and TCC identity instead of standalone `CuaDriver.app`.
> 
> `find_cua_driver_binary()` now honors **`YUTORI_CUA_DRIVER_BINARY`** ahead of the `cua_driver` package and `PATH`, and fails fast if that path is missing. **`embedded_daemon_arguments()`** (driven by **`YUTORI_CUA_DRIVER_SOCKET`**) appends `--embedded --socket <path>` to `cua-driver mcp` spawns; **`CuaDriverTransport`** accepts an optional **`arguments`** sequence (default from env; an explicit value—including empty—overrides env). **`start()`** forwards those args when spawning the MCP subprocess. Behavior is unchanged when neither env var is set.
> 
> Tests cover binary override precedence, missing override errors, spawn argv with/without embedded socket, and explicit `arguments=()` overriding the socket env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd980a4d2b73239a1d2e04d34692fa654525e1fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->