### PR TITLE
Clear stale macOS overlay reasoning before model requests

### DIFF
--- a/tests/test_navigator_macos_presentation.py
+++ b/tests/test_navigator_macos_presentation.py
@@ -142,6 +142,29 @@ async def test_reasoning_action_and_batch_map_to_renderer_operations(monkeypatch
     )
 
 
+async def test_model_request_clears_completed_step_reasoning(monkeypatch):
+    controller = _active_controller()
+    envelopes: list[dict] = []
+
+    async def send_envelope(envelope, **_kwargs):
+        envelopes.append(envelope)
+        return {"ok": True}
+
+    monkeypatch.setattr(controller, "_send_envelope", send_envelope)
+
+    await controller.present({"type": "request"})
+    await controller.present({"type": "reasoning", "text": "Apply the form changes"})
+    await controller.present({"type": "action_done", "call_id": "c1"})
+    await controller.present({"type": "request"})
+
+    operations = [envelope["operation"] for envelope in envelopes if "operation" in envelope]
+    assert operations == [
+        {"op": "clearThought"},
+        {"op": "showThought", "markdown": "Apply the form changes"},
+        {"op": "clearThought"},
+    ]
+
+
 async def test_capture_ids_are_monotonic_and_a_stale_transition_degrades(monkeypatch):
     restored = False
 
@@ -598,6 +621,9 @@ async def test_send_operation_skips_unchanged_dedupe_eligible_renders_but_not_ot
     first = await controller._send_operation({"op": "showThought", "markdown": "a"})
     repeat = await controller._send_operation({"op": "showThought", "markdown": "a"})
     changed = await controller._send_operation({"op": "showThought", "markdown": "b"})
+    await controller._send_operation({"op": "clearThought"})
+    await controller._send_operation({"op": "clearThought"})
+    await controller._send_operation({"op": "showThought", "markdown": "b"})
     # "mount" is not in the dedupe-eligible op set, so it is always sent even when unchanged.
     await controller._send_operation({"op": "mount", "snapshot": {}})
     await controller._send_operation({"op": "mount", "snapshot": {}})
@@ -607,6 +633,8 @@ async def test_send_operation_skips_unchanged_dedupe_eligible_renders_but_not_ot
     assert changed == {"ok": True}
     assert envelopes == [
         {"operation": {"op": "showThought", "markdown": "a"}},
+        {"operation": {"op": "showThought", "markdown": "b"}},
+        {"operation": {"op": "clearThought"}},
         {"operation": {"op": "showThought", "markdown": "b"}},
         {"operation": {"op": "mount", "snapshot": {}}},
         {"operation": {"op": "mount", "snapshot": {}}},

--- a/tests/test_navigator_n2.py
+++ b/tests/test_navigator_n2.py
@@ -1169,9 +1169,11 @@ async def test_agent_defaults_to_latest_tool_set_and_preserves_native_observatio
     # The task opens the transcript, so a presentation shows the conversation from its first message.
     assert [event["type"] for event in presentation.events] == [
         "task",
+        "request",
         "reasoning",
         "batch_member",
         "action_done",
+        "request",
         "final",
     ]
     assert presentation.events[0]["text"] == "task"

--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -690,6 +690,10 @@ class MacOSPresentationController:
                 self._reasoning = text.strip()
                 self._clear_action_labels()
                 await self._render_capsule()
+        elif event_type == "request":
+            self._reasoning = ""
+            self._clear_action_labels()
+            await self._render_capsule()
         elif event_type in {"action", "batch_member"}:
             await self._present_action(event)
         elif event_type == "action_done":
@@ -999,17 +1003,16 @@ class MacOSPresentationController:
                 future.cancel()
 
     async def _send_operation(self, operation: dict[str, Any], *, allow_stopping: bool = False) -> dict[str, Any]:
-        dedupe_key = str(operation.get("op"))
-        if dedupe_key in {"showThought", "clearThought", "previewAction", "moveCursor"} and not self._render_changed(
-            dedupe_key, operation
-        ):
+        operation_name = str(operation.get("op"))
+        dedupe_key = "thought" if operation_name in {"showThought", "clearThought"} else operation_name
+        if dedupe_key in {"thought", "previewAction", "moveCursor"} and not self._render_changed(dedupe_key, operation):
             return {"ok": True}
         return await self._send_envelope({"operation": operation}, allow_stopping=allow_stopping)
 
     def _render_changed(self, key: str, payload: Any) -> bool:
         """Return whether `payload` differs from the last render cached under `key`, updating the cache.
 
-        Shared by `_send_operation` (deduping showThought/clearThought/previewAction/moveCursor) and
+        Shared by `_send_operation` (deduping thought/previewAction/moveCursor state) and
         `_render_shell_rail` (deduping the shell rail's commands/overflow payload) -- both compare a
         canonical JSON signature against `self._last_render` before sending.
         """

--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -1469,6 +1469,7 @@ class N2ComputerAgent:
         return await _await_model_response(self.computer, awaitable)
 
     async def _predict_step(self, items: list[dict[str, Any]]) -> dict[str, Any]:
+        await _present(self.presentation, {"type": "request"})
         api_kwargs = self.completion_request(items=items)
         completion_messages = api_kwargs["messages"]
 


### PR DESCRIPTION
Ports the stale-thought lifecycle fix from yutori#13292 to the Python SDK path used by yutori-mcp. Emits a presentation request event at the exact boundary before each model call, then clears completed reasoning so the overlay shows only its loop mark while waiting. Keeping the clear at the request boundary avoids hiding narration early between multiple actions in one model turn. Validated with 912 fast tests, focused presentation/agent tests, and Ruff on the touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer UX and overlay dedupe only; behavior is covered by focused navigator/presentation tests with no auth or data-path changes.
> 
> **Overview**
> Emits a **`request`** presentation event immediately before each N2 model completion so the macOS overlay can drop **stale reasoning** at the wait boundary instead of leaving the last step’s narration visible while the model thinks.
> 
> **`MacOSPresentationController`** handles **`request`** by clearing internal reasoning/action labels and re-rendering the capsule. Overlay operation dedupe now treats **`showThought`** and **`clearThought`** as one **`thought`** channel so clears and re-shows behave correctly (including after a completed step). Tests cover the request→reasoning→action_done→request sequence and the updated dedupe envelopes; the agent integration test expects **`request`** bookending each model turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd92fcf6e4e1c36ba1f7c05d9c98bac0afef892c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->