### PR TITLE
chore(release): 0.9.22

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.21" \
+    "yutori==0.9.22" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.21'
+pip install 'yutori[macos]==0.9.22'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.21",
+    "yutori==0.9.22",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.21"]
+macos = ["yutori[macos]==0.9.22"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.21"
+YUTORI_INSTALLER_VERSION="0.9.22"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.21"
+version = "0.9.22"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps the SDK and bundled installer to 0.9.22, carrying the macOS overlay request-boundary fix from #424. Updates the pinned Navigator N2 examples to the same version. Validated with 912 fast tests, Ruff on the changed runtime, installer freshness, exact distribution builds, and Twine checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only release metadata and example pins; no runtime logic changes in the diff.
> 
> **Overview**
> **Release 0.9.22** — bumps the published SDK version in root `pyproject.toml` and the bootstrap **`YUTORI_INSTALLER_VERSION`** in `install.sh` so installs and bug reports match the new wheel.
> 
> Navigator n2 cookbooks stay aligned: **`yutori==0.9.22`** (and **`yutori[macos]==0.9.22`**) in `examples/navigator_n2/pyproject.toml`, the direct X11 Docker image pip pin, and the macOS install line in the README. No functional code changes appear in this diff—only version pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75caa930efbe6eb5edad43c78ad4fc43e4b1f94a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->