### PR TITLE
refactor(macos): dedupe the request/final capsule reset in MacOSPresentationController

### DIFF
--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -666,12 +666,23 @@ class MacOSPresentationController:
     def _clear_action_labels(self) -> None:
         """Reset the capsule's action-status and active-key labels.
 
-        Shared by the ``reasoning``, ``action_done``, and ``final`` branches of
+        Shared by the ``reasoning``, ``action_done``, ``request``, and ``final`` branches of
         :meth:`present`, each of which clears both fields immediately before
         re-rendering the capsule.
         """
         self._action_status = ""
         self._active_keys = None
+
+    async def _clear_reasoning_and_render(self) -> None:
+        """Drop any stale reasoning/action labels and re-render the capsule.
+
+        Shared by the ``request`` branch of :meth:`present` (clearing a completed step's
+        reasoning before the next model call) and the ``final`` branch (clearing it once the
+        run ends) -- both reset the capsule to the same idle state.
+        """
+        self._reasoning = ""
+        self._clear_action_labels()
+        await self._render_capsule()
 
     @_fail_soft_cancellable
     async def present(self, event: dict[str, Any]) -> None:
@@ -691,9 +702,7 @@ class MacOSPresentationController:
                 self._clear_action_labels()
                 await self._render_capsule()
         elif event_type == "request":
-            self._reasoning = ""
-            self._clear_action_labels()
-            await self._render_capsule()
+            await self._clear_reasoning_and_render()
         elif event_type in {"action", "batch_member"}:
             await self._present_action(event)
         elif event_type == "action_done":
@@ -703,9 +712,7 @@ class MacOSPresentationController:
             self._clear_action_labels()
             await self._render_capsule()
         elif event_type == "final":
-            self._reasoning = ""
-            self._clear_action_labels()
-            await self._render_capsule()
+            await self._clear_reasoning_and_render()
         elif event_type == "shell":
             shell_event = event.get("event")
             if isinstance(shell_event, ShellPresentationEvent):


### PR DESCRIPTION
## What

`MacOSPresentationController.present()`'s `request` branch (added in #424, "clear stale reasoning before model requests") and its `final` branch now perform the exact same three-step reset:

```python
self._reasoning = ""
self._clear_action_labels()
await self._render_capsule()
```

Extracted this into a new private method, `_clear_reasoning_and_render()`, right next to the existing `_clear_action_labels()` helper it calls. Both `present()` branches now delegate to it instead of repeating the sequence inline. Updated `_clear_action_labels()`'s docstring to also list the `request` branch among its callers (it previously only named `reasoning`/`action_done`/`final`).

## Why this is safe

- **Internal-only, no public API change**: `MacOSPresentationController` and this method are private implementation details of the macOS n2 presentation layer — not exported from `yutori/navigator/macos/__init__.py`, not documented in `api.md`. This is a published PyPI package and this change touches none of its public surface.
- **No behavioral change**: the extracted method executes the exact same three statements, in the exact same order, that both branches already ran. Confirmed via `git diff` that the resulting code is line-for-line equivalent to the pre-refactor bodies, just de-duplicated.
- **Follows established repo precedent**: this is the same pattern as the existing `_clear_action_labels()` extraction (originally done for the `reasoning`/`action_done`/`final` branches), just applied to the newest duplicate introduced by the latest merged commit.

## Verification

- `ruff check .` / `ruff format --check .` on the touched file: clean.
- Full test suite: `961 passed, 3 skipped, 1 deselected` (unchanged from baseline).
- Targeted tests: `tests/test_navigator_macos_presentation.py` + `tests/test_navigator_n2.py`: `107 passed`, including `test_model_request_clears_completed_step_reasoning`, which pins the exact `request` -> `clearThought` envelope sequence this refactor must preserve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrjM4EeELNvAohH1n1q6zi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrjM4EeELNvAohH1n1q6zi)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of macOS overlay presentation with no public API or logic changes; existing tests cover the request clearThought sequence.
> 
> **Overview**
> Extracts the duplicated **request** and **final** capsule reset in `MacOSPresentationController.present()` into a new private helper **`_clear_reasoning_and_render()`**, which clears stale reasoning, resets action/key labels via **`_clear_action_labels()`**, and re-renders the overlay capsule.
> 
> Both event branches now call that helper instead of repeating the same three-step sequence inline. **`_clear_action_labels()`**’s docstring is updated to note the **`request`** branch among its callers.
> 
> **No intended behavior change**—same statements in the same order, matching the pattern used when **`_clear_action_labels()`** was first extracted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9c3a5d48eeab58a510bb7a937dd6b234b6a173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->