### PR TITLE
chore(release): 0.9.23

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.22" \
+    "yutori==0.9.23" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.22'
+pip install 'yutori[macos]==0.9.23'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.22",
+    "yutori==0.9.23",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.22"]
+macos = ["yutori[macos]==0.9.23"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.22"
+YUTORI_INSTALLER_VERSION="0.9.23"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.22"
+version = "0.9.23"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps the SDK to 0.9.23, regenerates `install.sh`, and moves the pinned `yutori==` versions under `examples/navigator_n2/` (`pyproject.toml`, `README.md`, `Dockerfile.direct_x11`) to match.

This release ships the revert of #418 (#427): the shell run-command rail sits at the top-right under the menu bar again, the cursor capsule carries `$ <command>`, and the bundled navigator overlay runtime is back on renderer protocol 3.

Merging triggers the "Publish yutori to PyPI" workflow, which tags `v0.9.23` on the merge commit, publishes to PyPI, and creates the GitHub release. yutori-mcp 0.5.25 will pin `yutori==0.9.23` once this is on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation pin updates only; functional behavior ships in the tagged release already merged into this bump.
> 
> **Overview**
> **Release 0.9.23** — bumps the package version in root `pyproject.toml`, updates `YUTORI_INSTALLER_VERSION` in `install.sh`, and aligns pinned `yutori==0.9.23` references in the navigator n2 cookbooks (`pyproject.toml`, `README.md`, `Dockerfile.direct_x11`).
> 
> There are no SDK logic changes in this diff; it is the release cut that publishes **0.9.23** to PyPI (merge triggers the publish workflow and `v0.9.23` tag). That release carries the revert of #418 (#427): shell run-command rail back under the menu bar, cursor capsule shows `$ <command>`, and the bundled navigator overlay returns to **renderer protocol 3**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e2a1e2b5bfe5d8e9ad2d1fefceab877ec6742b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->