### PR TITLE
refactor(navigator): use functools.cache over lru_cache(maxsize=None)

### DIFF
--- a/yutori/navigator/_assets.py
+++ b/yutori/navigator/_assets.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from functools import lru_cache
+from functools import cache
 from importlib.resources import files
 
 
-@lru_cache(maxsize=None)
+@cache
 def _load_js_resource(package: str, name: str) -> str:
     """Read a bundled ``<package>/js/<name>`` file, stripped of surrounding whitespace."""
     return files(package).joinpath("js", name).read_text(encoding="utf-8").strip()

--- a/yutori/navigator/n2.py
+++ b/yutori/navigator/n2.py
@@ -524,7 +524,7 @@ def _require_action_method(
     return method
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _function_accepts_kwarg(func: Any, name: str) -> bool:
     try:
         params = inspect.signature(func).parameters


### PR DESCRIPTION
## What

Replaces the two remaining `lru_cache(maxsize=None)` usages in the Navigator package with `functools.cache`:

- `yutori/navigator/_assets.py` — `@lru_cache(maxsize=None)` → `@cache` (import narrowed to `from functools import cache`)
- `yutori/navigator/n2.py` — `@functools.lru_cache(maxsize=None)` → `@functools.cache`

## Why

`functools.cache` is defined in CPython as exactly `lru_cache(maxsize=None)`, so this is a byte-for-byte behavior-preserving readability cleanup. `functools.cache` requires Python 3.9+, and the package already pins `requires-python = ">=3.10"`.

This resolves the `UP033` (`lru-cache-with-maxsize-none`) pyupgrade lint in the `yutori/` package.

## Verification

- `ruff check yutori/` → All checks passed
- `ruff check yutori/ --select UP033` → clean (was 2)
- `ruff format --check` → unchanged
- `python -m py_compile` → OK on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KF8xgn8nMCUD6EHKKWsE58)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical decorator swap with no semantic change to caching or call sites.
> 
> **Overview**
> Replaces the last two **`lru_cache(maxsize=None)`** decorators in Navigator with **`functools.cache`**, which is the idiomatic equivalent on Python 3.9+.
> 
> **`_assets.py`** narrows the import to `cache` and applies it to **`_load_js_resource`** (bundled JS loading). **`n2.py`** switches **`_function_accepts_kwarg`** to **`@functools.cache`**. Runtime behavior is unchanged; this is a lint-driven readability cleanup (pyupgrade **UP033**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78402b233709a7832b7ec07ae2d4461addfeed49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->