### PR TITLE
feat(macos): drive the renderer's run-command card from the cursor

### DIFF
--- a/tests/test_navigator_macos_presentation.py
+++ b/tests/test_navigator_macos_presentation.py
@@ -374,58 +374,109 @@ def _rail_renders(commands: list[dict]) -> list[dict]:
     return [command for command in commands if command.get("op") == "shellCommands"]
 
 
-async def test_foreground_shell_command_is_shown_in_the_rail_and_the_capsule(monkeypatch):
+def _terminal_renders(operations: list[dict]) -> list[dict]:
+    return [operation for operation in operations if operation.get("op") == "showTerminal"]
+
+
+async def test_foreground_shell_command_is_a_run_command_card_at_the_cursor(monkeypatch):
+    """A foreground command rides the renderer's cursor-attached card, not the rail."""
     controller, operations, commands, sleeps = _rail_controller(monkeypatch)
 
     await controller.present(_shell("shell-1", "ls -la ~/Documents", "starting"))
     await controller.present(_shell("shell-1", "ls -la ~/Documents", "running"))
 
-    rail = _rail_renders(commands)
-    assert [entry["state"] for render in rail for entry in render["commands"]] == ["starting", "running"]
-    assert rail[-1]["commands"][0]["command"] == "ls -la ~/Documents"
-    assert rail[-1]["commands"][0]["run_in_background"] is False
-    assert rail[-1]["overflow"] == 0
-    assert any(
-        operation.get("op") == "showThought" and "Run command · $ ls -la ~/Documents" in operation["markdown"]
+    assert _terminal_renders(operations)[-1] == {
+        "op": "showTerminal",
+        "presentation": {"command": "ls -la ~/Documents", "running": True, "failed": False},
+    }
+    # One command on screen once: the rail is for commands with no cursor to hang off.
+    assert _rail_renders(commands) == []
+    # The card's header carries "RUN COMMAND", so the capsule does not repeat the command.
+    assert not any(
+        operation.get("op") == "showThought" and "ls -la ~/Documents" in operation["markdown"]
         for operation in operations
     )
 
     await controller.present(_shell("shell-1", "ls -la ~/Documents", "completed", exit_code=0))
-    finished = _rail_renders(commands)[-1]["commands"][0]
-    assert (finished["state"], finished["exit_code"]) == ("completed", 0)
-    assert controller._shell_rail_removals
-    await asyncio.gather(*controller._shell_rail_removals)
-    assert _rail_renders(commands)[-1] == {"op": "shellCommands", "commands": [], "overflow": 0}
-    assert 4.0 in sleeps
+
+    assert _terminal_renders(operations)[-1]["presentation"] == {
+        "command": "ls -la ~/Documents",
+        "running": False,
+        "failed": False,
+    }
+    # The card holds long enough to read, then hands the box back to the exit code.
+    assert sleeps.count(4.0) == 1
+    thoughts = [operation for operation in operations if operation.get("op") == "showThought"]
+    assert thoughts[-1]["markdown"] == "Command completed · exit 0"
+    assert operations[-1] == {"op": "clearThought"}
 
 
-async def test_shell_rail_lists_newest_first_with_overflow_and_keeps_background_commands(monkeypatch):
+async def test_a_failed_foreground_command_tints_the_card_before_reporting_its_exit(monkeypatch):
+    controller, operations, _commands, _sleeps = _rail_controller(monkeypatch)
+
+    await controller.present(_shell("shell-1", "false", "running"))
+    await controller.present(_shell("shell-1", "false", "failed", exit_code=1))
+
+    assert _terminal_renders(operations)[-1]["presentation"] == {
+        "command": "false",
+        "running": False,
+        "failed": True,
+    }
+    thoughts = [operation for operation in operations if operation.get("op") == "showThought"]
+    assert thoughts[-1]["markdown"] == "Command failed · exit 1"
+
+
+async def test_the_next_step_takes_a_staged_card_down(monkeypatch):
+    """`clearThought` shares the card's dedupe slot, so it is never suppressed as a repeat."""
+    controller = _active_controller()
+    sent: list[dict] = []
+
+    async def send_envelope(payload, **_kwargs):
+        if "operation" in payload:
+            sent.append(payload["operation"])
+        return {"ok": True}
+
+    monkeypatch.setattr(controller, "_send_envelope", send_envelope)
+
+    await controller.present({"type": "request"})
+    await controller.present(_shell("shell-1", "pwd", "running"))
+    await controller.present({"type": "request"})
+
+    assert [operation["op"] for operation in sent if operation["op"] != "previewAction"] == [
+        "clearThought",
+        "showTerminal",
+        "clearThought",
+    ]
+    assert controller._terminal_command == ""
+
+
+async def test_shell_rail_lists_newest_first_with_overflow_and_keeps_running_commands(monkeypatch):
     controller, _operations, commands, _sleeps = _rail_controller(monkeypatch)
 
     await controller.present(_shell("bash-1", "sleep 30", "running", background=True))
-    await controller.present(_shell("shell-2", "pwd", "running"))
-    await controller.present(_shell("shell-3", "whoami", "running"))
-    await controller.present(_shell("shell-4", "date", "running"))
+    await controller.present(_shell("bash-2", "pwd", "running", background=True))
+    await controller.present(_shell("bash-3", "whoami", "running", background=True))
+    await controller.present(_shell("bash-4", "date", "running", background=True))
 
     render = _rail_renders(commands)[-1]
-    assert [entry["task_id"] for entry in render["commands"]] == ["shell-4", "shell-3", "shell-2"]
+    assert [entry["task_id"] for entry in render["commands"]] == ["bash-4", "bash-3", "bash-2"]
     assert render["overflow"] == 1
     assert not controller._shell_rail_removals
 
-    await controller.present(_shell("shell-4", "date", "failed", exit_code=1))
+    await controller.present(_shell("bash-4", "date", "failed", exit_code=1, background=True))
     await asyncio.gather(*controller._shell_rail_removals)
     render = _rail_renders(commands)[-1]
-    assert [entry["task_id"] for entry in render["commands"]] == ["shell-3", "shell-2", "bash-1"]
+    assert [entry["task_id"] for entry in render["commands"]] == ["bash-3", "bash-2", "bash-1"]
     assert render["commands"][-1]["run_in_background"] is True
     assert render["overflow"] == 0
-    assert controller.background_counts == {"started": 1, "completed": 0, "failed": 0, "cancelled": 0}
+    assert controller.background_counts == {"started": 4, "completed": 0, "failed": 1, "cancelled": 0}
 
 
 async def test_shell_rail_does_not_resend_an_unchanged_render(monkeypatch):
     controller, _operations, commands, _sleeps = _rail_controller(monkeypatch)
 
-    await controller.present(_shell("shell-1", "pwd", "running"))
-    await controller.present(_shell("shell-1", "pwd", "running"))
+    await controller.present(_shell("bash-1", "pwd", "running", background=True))
+    await controller.present(_shell("bash-1", "pwd", "running", background=True))
 
     assert len(_rail_renders(commands)) == 1
 

--- a/yutori/navigator/macos/assets/macos-overlay-host.swift
+++ b/yutori/navigator/macos/assets/macos-overlay-host.swift
@@ -459,10 +459,11 @@ private final class OverlayApp: NSObject, NSApplicationDelegate, WKNavigationDel
     /// The click-through shell rail a background run gets, in its own borderless panel.
     ///
     /// A window-scope run drives one window and paints nothing on the desktop, but it still
-    /// runs commands on this Mac -- and those should be visible without opening a window, the
-    /// same way a foreground run shows them under the menu bar. The panel ignores mouse events
-    /// and never takes focus, and window-scope capture sees only the target window, so neither
-    /// the operator's work nor the model's view is disturbed.
+    /// runs commands on this Mac -- and those should be visible without opening a window. It
+    /// has no cursor to hang a run-command card off, which is where a foreground run shows
+    /// the command it is waiting on, so the rail is the surface. The panel ignores mouse
+    /// events and never takes focus, and window-scope capture sees only the target window,
+    /// so neither the operator's work nor the model's view is disturbed.
     private func createRailPanel(on screen: NSScreen) {
         let panel = NSPanel(
             contentRect: screen.frame,

--- a/yutori/navigator/macos/assets/macos-overlay.js
+++ b/yutori/navigator/macos/assets/macos-overlay.js
@@ -91,8 +91,9 @@ const shellSpan = (className, text) => {
 };
 
 // One phosphor "run command" panel per shell the model is running, newest on
-// top, stacked under the menu bar so the operator can read what is being
-// sent to this Mac without following the cursor capsule.
+// top, stacked under the menu bar. This rail carries the commands with no
+// cursor of their own to hang a run-command card off -- a foreground run's
+// background commands -- so nothing sent to this Mac runs unseen.
 window.__n2ShellCommands = ({ commands, overflow }) => {
   const rail = document.getElementById("n2-shell-rail");
   rail.replaceChildren();

--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -40,10 +40,11 @@ _PROCESS_EXIT_TIMEOUT_SECONDS = 1
 _OVERLAY_LEAD_SECONDS = 0.15
 _SHELL_MINIMUM_DWELL_SECONDS = 0.9
 _SHELL_TERMINAL_HOLD_SECONDS = 0.9
-# The shell rail at the top-right keeps a finished command on screen long enough
-# to read: the capsule's 0.9s hold is tuned for a glance at the cursor, not for an
-# operator checking what just ran on their Mac.
-_SHELL_RAIL_TERMINAL_HOLD_SECONDS = 4.0
+# A finished command stays on screen long enough to read on whichever surface carried
+# it -- the run-command card by the cursor in a foreground run, the rail under the menu
+# bar otherwise. The capsule's 0.9s hold is tuned for a glance at a status word, not for
+# an operator checking what just ran on their Mac.
+_SHELL_COMMAND_TERMINAL_HOLD_SECONDS = 4.0
 _SHELL_RAIL_ROWS = 3
 _SHELL_TERMINAL_STATES = frozenset({"completed", "failed", "timed_out", "cancelled"})
 _NORMALIZED_SCALE = 1000
@@ -500,6 +501,8 @@ class MacOSPresentationController:
         self._reasoning = ""
         self._action_status = ""
         self._terminal_command = ""
+        self._terminal_running = False
+        self._terminal_failed = False
         self._active_keys: "list[str] | None" = None
         self._queue_active = False
         self._batch_is_last = False
@@ -665,15 +668,21 @@ class MacOSPresentationController:
         return self.blocking_surface(point) is not None
 
     def _clear_action_labels(self) -> None:
-        """Reset the capsule's action-status, terminal-command, and active-key labels.
+        """Reset the capsule's action-status and active-key labels and the run-command card.
 
         Shared by the ``reasoning``, ``action_done``, ``request``, and ``final`` branches of
-        :meth:`present`, each of which clears these three fields immediately
-        before re-rendering the capsule.
+        :meth:`present`, each of which clears all three immediately before re-rendering the
+        capsule -- and that re-render is what takes a finished card off the screen.
         """
         self._action_status = ""
-        self._terminal_command = ""
         self._active_keys = None
+        self._reset_terminal()
+
+    def _reset_terminal(self) -> None:
+        """Unstage the run-command card so the next render falls back to the capsule."""
+        self._terminal_command = ""
+        self._terminal_running = False
+        self._terminal_failed = False
 
     async def _clear_reasoning_and_render(self) -> None:
         """Drop any stale reasoning/action labels and re-render the capsule.
@@ -1013,7 +1022,11 @@ class MacOSPresentationController:
 
     async def _send_operation(self, operation: dict[str, Any], *, allow_stopping: bool = False) -> dict[str, Any]:
         operation_name = str(operation.get("op"))
-        dedupe_key = "thought" if operation_name in {"showThought", "clearThought"} else operation_name
+        # showTerminal replaces the capsule in the renderer, so it shares the capsule's
+        # dedupe slot -- otherwise the clearThought that takes a finished card down would
+        # be suppressed as a repeat of the clearThought that preceded the card.
+        capsule_ops = {"showThought", "clearThought", "showTerminal"}
+        dedupe_key = "thought" if operation_name in capsule_ops else operation_name
         if dedupe_key in {"thought", "previewAction", "moveCursor"} and not self._render_changed(dedupe_key, operation):
             return {"ok": True}
         return await self._send_envelope({"operation": operation}, allow_stopping=allow_stopping)
@@ -1064,15 +1077,7 @@ class MacOSPresentationController:
     async def _render_capsule(self) -> None:
         if self._queue_active:
             return
-        text = " · ".join(
-            part
-            for part in (
-                self._action_status,
-                f"$ {self._terminal_command}" if self._terminal_command else "",
-                self._reasoning,
-            )
-            if part
-        )
+        text = " · ".join(part for part in (self._action_status, self._reasoning) if part)
         if not text and not self._active_keys:
             await self._send_operation({"op": "clearThought"})
             return
@@ -1080,6 +1085,31 @@ class MacOSPresentationController:
         if self._active_keys:
             operation["keys"] = self._active_keys
         await self._send_operation(operation)
+
+    async def _render_terminal(self) -> None:
+        """Morph the cursor badge into the renderer's run-command card.
+
+        Placement belongs to the renderer: the card hangs off the cursor with the same
+        edge-aware flipping the thought capsule gets, so the command reads where the
+        operator is already looking rather than under the menu bar. With no command
+        staged this falls back to the capsule, whose ``showThought``/``clearThought``
+        is what takes a finished card down.
+        """
+        if not self._terminal_command:
+            await self._render_capsule()
+            return
+        if self._queue_active:
+            return
+        await self._send_operation(
+            {
+                "op": "showTerminal",
+                "presentation": {
+                    "command": self._terminal_command,
+                    "running": self._terminal_running,
+                    "failed": self._terminal_failed,
+                },
+            }
+        )
 
     async def _present_action(self, event: dict[str, Any]) -> None:
         name = str(event.get("name") or "")
@@ -1113,8 +1143,8 @@ class MacOSPresentationController:
         if batch:
             status = f"{int(batch.get('index') or 0) + 1} of {len(batch.get('members') or [])} · {status}"
         self._action_status = status
-        self._terminal_command = ""
         self._active_keys = visual.get("keys")
+        self._reset_terminal()
 
         viewport = self._viewport
         if viewport is None:
@@ -1163,28 +1193,50 @@ class MacOSPresentationController:
         )
 
     async def _present_shell(self, event: ShellPresentationEvent) -> None:
+        """Foreground: the run-command card by the cursor. Background: the rail.
+
+        A foreground command has a cursor to hang off, so the renderer's card carries it
+        and the rail stays out of the way -- one command on screen once, where the
+        operator is already looking. A background command has no cursor moment of its
+        own, so the rail under the menu bar remains its only surface.
+        """
         self._record_shell(event)
-        await self._track_shell_rail(event)
         if event.run_in_background:
+            await self._track_shell_rail(event)
             return
 
         if event.state in {"starting", "running"}:
             self._shell_started_at.setdefault(event.task_id, time.monotonic())
-            self._action_status = "Run command"
-            self._terminal_command = event.command
+            # The card's own header says "RUN COMMAND", so the capsule keeps only the
+            # reasoning; the badge under the card is reset before the card covers it.
+            self._action_status = ""
             self._active_keys = None
-            await self._render_capsule()
             await self._send_operation(
                 {
                     "op": "previewAction",
                     "presentation": {"badge": {"type": "loop"}, "queue": None, "transientEffects": []},
                 }
             )
+            self._terminal_command = event.command
+            self._terminal_running = True
+            self._terminal_failed = False
+            await self._render_terminal()
             return
 
         started_at = self._shell_started_at.pop(event.task_id, time.monotonic())
         remaining = _SHELL_MINIMUM_DWELL_SECONDS - (time.monotonic() - started_at)
         if remaining > 0 and not await self._sleep(remaining):
+            return
+        # The finished command reads in two beats, because the card and the capsule are
+        # the same box in the renderer and cannot share it: the card holds with its caret
+        # stopped (tinted, if the command did not exit clean) long enough to read the
+        # command, then it gives the box back to a one-line verdict carrying the exit
+        # code -- which reads better as a number beside the cursor than inside a card
+        # whose body is the command itself.
+        self._terminal_running = False
+        self._terminal_failed = event.state != "completed"
+        await self._render_terminal()
+        if not await self._sleep(_SHELL_COMMAND_TERMINAL_HOLD_SECONDS):
             return
         labels = {
             "completed": "Command completed",
@@ -1195,19 +1247,19 @@ class MacOSPresentationController:
         self._action_status = labels.get(event.state, "Command finished")
         if event.exit_code is not None:
             self._action_status = f"{self._action_status} · exit {event.exit_code}"
-        self._terminal_command = ""
+        self._reset_terminal()
         await self._render_capsule()
         await self._sleep(_SHELL_TERMINAL_HOLD_SECONDS)
         self._clear_action_labels()
         await self._render_capsule()
 
     async def _track_shell_rail(self, event: ShellPresentationEvent) -> None:
-        """Mirror every shell lifecycle event, foreground or background, into the rail.
+        """Mirror a shell lifecycle event into the rail under the menu bar.
 
-        The capsule by the cursor only shows a foreground command for the ~1s it
-        takes to run, which is too brief for an operator to read; the rail under
-        the menu bar keeps each command visible while it runs and for a hold
-        after it finishes, so the operator can see what was sent to their Mac.
+        The rail carries the commands with no cursor of their own to hang a card off:
+        every command in a status-mode run, and a foreground run's background commands.
+        It keeps each one visible while it runs and for a hold after it finishes, so a
+        command sent to the operator's Mac is never invisible.
         """
         self._shell_rail[event.task_id] = event
         await self._render_shell_rail()
@@ -1226,7 +1278,7 @@ class MacOSPresentationController:
         await self._send_command({"op": "shellCommands", "commands": commands, "overflow": overflow})
 
     async def _remove_from_shell_rail_after_hold(self, task_id: str, terminal: ShellPresentationEvent) -> None:
-        if not await self._sleep(_SHELL_RAIL_TERMINAL_HOLD_SECONDS):
+        if not await self._sleep(_SHELL_COMMAND_TERMINAL_HOLD_SECONDS):
             return
         if self._shell_rail.get(task_id) == terminal:
             self._shell_rail.pop(task_id, None)


### PR DESCRIPTION
**Why the released 0.9.24 still shows the old UI, and it isn't a cache.** The bundled overlay runtime has carried a cursor-attached run-command card since 0.5.0 (yutori-ai/yutori#13269), but nothing in this runtime ever sent the `showTerminal` op that mounts it — I checked, there was no caller anywhere in `yutori/`. Restoring the 0.5.0 bundle in #430 put the card in the wheel without putting it on screen, so a foreground command still rendered as the top-right rail under the menu bar with the command repeated in the capsule.

(For the record on caching: the overlay cache can't serve a stale runtime. `_pointer_name()` keys each cache entry on the packaged assets' SHA-256 plus both protocol versions, so a new bundle lands under a new pointer.)

**What this does.** A foreground shell step now renders the card: the command goes over the wire as `showTerminal` with `running`/`failed` state, and the renderer owns placement — it hangs off the cursor with the same edge-aware flipping the thought capsule gets. `sanitize_command_preview` already produces the bounded, redacted one-line copy the wire contract asks hosts for, so the card and the telemetry identity stay the same string. The capsule stops repeating the command, since the card's header says `RUN COMMAND`.

**Two calls I made that are worth a look, since they're presentation choices rather than mechanics:**
1. The card and the capsule are the same box in the renderer (`showTerminal` sets `state.thought = null` and removes the capsule element), so they can't share the screen. A finished command therefore reads in two beats: the card holds with its caret stopped — tinted, if it didn't exit clean — for the 4s an operator needs, then hands the box back to a one-line verdict carrying the exit code. Keeping the exit code visible seemed worth the extra beat; the alternative was dropping it, since `ShellPresentationEvent` deliberately excludes output and the card has no other slot for it.
2. A foreground command no longer goes into the rail as well — that duplication is what put the same command on screen twice. The rail keeps the commands with no cursor to hang a card off: every command in a status-mode run, and a foreground run's background commands. It also inherits the 4s hold, now shared by both surfaces.

863 passed, ruff clean. Test coverage for the card: the running/finished payloads, the failed tint plus its exit line, that `clearThought` isn't deduped away behind a card, and that a foreground command stays out of the rail.

Worth driving on a real Mac before release, since the payoff is visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator-visible macOS overlay presentation and shell lifecycle timing/deduping; behavior is well-tested but worth validating on a real Mac before release.
> 
> **Overview**
> **Foreground shell commands** now drive the overlay renderer’s cursor-attached run-command card via **`showTerminal`** (`command`, `running`, `failed`) instead of duplicating the command in the menu-bar **shell rail** and the thought **capsule**.
> 
> The **capsule** no longer embeds `$ <command>`; the card header carries “RUN COMMAND”. On finish, the card holds for **4s** (shared hold constant with the rail), optionally **tints on failure**, then clears to a one-line capsule verdict with the **exit code**. **`showTerminal`** shares the capsule **dedupe** slot with `showThought`/`clearThought` so a later `clearThought` (e.g. on the next model step) is not suppressed.
> 
> The **rail** is limited to commands without a cursor anchor: **background** shells in a foreground run and all shells in **status** mode. Overlay **comments** in JS/Swift were updated to match. **Tests** cover terminal payloads, failure tint, dedupe/clear behavior, and rail-only background commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67d23c3d628d3b9b9c3a127d8af3deedc47e83b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->