### PR TITLE
chore(release): 0.9.25

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.24" \
+    "yutori==0.9.25" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.24'
+pip install 'yutori[macos]==0.9.25'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.24",
+    "yutori==0.9.25",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.24"]
+macos = ["yutori[macos]==0.9.25"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.24"
+YUTORI_INSTALLER_VERSION="0.9.25"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.24"
+version = "0.9.25"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps the SDK to 0.9.25, regenerates `install.sh`, and moves the pinned `yutori==` versions under `examples/navigator_n2/` to match.

Ships #432: a foreground shell command is now the renderer's cursor-attached `RUN COMMAND` card instead of the rail under the menu bar, which is what yutori-ai/yutori#13269 built `showTerminal` for. Verified on a real desktop run against this branch before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The diff is version and pin updates only; behavioral change is limited to desktop overlay presentation for confirmable shell commands.
> 
> **Overview**
> **Release 0.9.25** bumps the SDK package version and keeps install/docs/examples in sync.
> 
> `pyproject.toml` moves to **0.9.25**, `install.sh`’s `YUTORI_INSTALLER_VERSION` matches, and Navigator n2 cookbooks (README, `pyproject.toml`, `Dockerfile.direct_x11`) pin **`yutori==0.9.25`** / **`yutori[macos]==0.9.25`**.
> 
> This cut ships the foreground-shell UX from #432: pending shell commands show as the renderer’s **cursor-attached `RUN COMMAND` card** instead of the menu-bar rail (`showTerminal` path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 312b876d9f6caa2810a3c794672b9328eb494cbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->