### PR TITLE
refactor(macos): dedupe cancel/timeout branches in foreground shell

### DIFF
--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -1840,14 +1840,13 @@ class MacOSComputer:
         # frame AFTER the card had already been marked timed out or cancelled --
         # putting it back into its running state for the whole finished-card dwell.
         # `close` is idempotent, so the `finally` below is the backstop for the paths
-        # that do not raise.
-        except TimeoutError:
+        # that do not raise. Both branches close-present-then-reraise identically;
+        # only the reported lifecycle state differs by which was actually raised --
+        # the same shape `_spawn_supervised_shell` above uses for its own split.
+        except (TimeoutError, asyncio.CancelledError) as error:
             await stream.close()
-            await self._present_shell(ShellPresentationEvent(task_id, preview, False, "timed_out"))
-            raise
-        except asyncio.CancelledError:
-            await stream.close()
-            await self._present_shell(ShellPresentationEvent(task_id, preview, False, "cancelled"))
+            state = "cancelled" if isinstance(error, asyncio.CancelledError) else "timed_out"
+            await self._present_shell(ShellPresentationEvent(task_id, preview, False, state))
             raise
         finally:
             self._foreground_processes.discard(process)


### PR DESCRIPTION
## Structural issue

`_run_foreground_shell` (in `yutori/navigator/macos/computer.py`, added by #435 a few hours before this run) had two `except` branches — `TimeoutError` and `asyncio.CancelledError` — that each did the exact same three things: `await stream.close()`, present the identical `ShellPresentationEvent` shape, and `raise`. The only difference between them was the literal state string (`"timed_out"` vs `"cancelled"`).

## The fix

Merged the two branches into one `except (TimeoutError, asyncio.CancelledError) as error:` clause that derives the state string from the caught exception type via `isinstance`. This is the same shape `_spawn_supervised_shell`, defined a few dozen lines above in the same file, already uses for its own cancel/fail split (`state = "cancelled" if isinstance(error, asyncio.CancelledError) else "failed"`) — so this brings a brand-new duplicate in line with an existing, established pattern in the same module rather than inventing a new one.

## Why it's safe

- **No public API change.** `_run_foreground_shell` is a private method, not exported from any `__init__.py` and not listed in `api.md`.
- **No behavior change.** Both paths still close the output stream first (preserving the ordering the surrounding comment calls out — an `except` runs before `finally`), present the same event shape with the same state string as before, and re-raise the original exception unchanged.
- **Verified:**
  - Full suite: `975 passed, 3 skipped, 1 deselected` (unchanged from baseline on `main`).
  - Targeted: `tests/test_navigator_macos_computer.py` — 95 passed, including the dedicated timeout and cancellation regression tests for this exact code path.
  - `ruff check .` and `ruff format --check` on the touched file: clean.

1 file changed, 6 insertions(+), 7 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLtds38ZnZSb8agGShyYhb


---
_Generated by [Claude Code](https://claude.ai/code/session_01RLtds38ZnZSb8agGShyYhb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private refactor with identical control flow and presentation semantics; no API or shell lifecycle behavior change.
> 
> **Overview**
> Refactors `_run_foreground_shell` so **timeout** and **cancellation** share one `except (TimeoutError, asyncio.CancelledError)` handler instead of two copy-pasted blocks.
> 
> Behavior is unchanged: the stream still closes before the terminal shell card event, the lifecycle state is still `"timed_out"` or `"cancelled"` depending on the exception, and the original error is re-raised. The state is now chosen with the same `isinstance` pattern already used in `_spawn_supervised_shell` nearby in `computer.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1487b442b6f5f6b73ae2bd84e902dfd3d62251d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->