### PR TITLE
chore(release): 0.9.26

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.25" \
+    "yutori==0.9.26" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.25'
+pip install 'yutori[macos]==0.9.26'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.25",
+    "yutori==0.9.26",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.25"]
+macos = ["yutori[macos]==0.9.26"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.25"
+YUTORI_INSTALLER_VERSION="0.9.26"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.25"
+version = "0.9.26"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Cuts 0.9.26. Merging this publishes to PyPI — `publish_to_pypi.yml` triggers on a `pyproject.toml` change landing on `main`, tags the merge commit, and releases.

## Ships

**#435** — a running shell command's output now streams into the macOS run-command card. `_run_foreground_shell` ended at `process.communicate()`, which returns once at exit, so a command that ran for a minute showed a spinner for a minute. It now reads stdout incrementally (stdin written concurrently, so a script larger than the pipe buffer can't deadlock against a child that prints immediately) and feeds a throttled, redacted tail to the card.

That commit also vendors `yutori-navigator-overlay-runtime==0.5.1` (yutori#13319), which grows the card's output block from two rendered rows to four. The bundle and `OUTPUT_PREVIEW_MAX_LINES` move together on purpose: the block clips from the bottom, so a host sending more lines than the renderer shows drops the *newest* ones.

## Version bump

The usual five files, six lines — `pyproject.toml`, a regenerated `install.sh` (via `scripts/build_install.sh`), and the three `examples/navigator_n2` references. Same shape as #433.

## Checks

- `scripts/check_install_sh_fresh.sh` passes.
- `930 passed, 6 skipped`; ruff clean; 3.10–3.14 green on #435's head.
- Repo-wide scan confirms no `0.9.25` references remain outside the changelog.
- Live-verified on a real Mac against the published 0.5.1 bundle: `computer-use doctor` 14/14, and a 20-second `ping` streamed into the four-row card.

## Downstream

`yutori-mcp` pins this SDK by version plus three digests computed from the published wheel, so its bump can only be written once 0.9.26 is on PyPI. One of the four is already known — `SDK_PROVENANCE_SHA256` will be `04ccce6bc1c85552…`, since it hashes the vendored `provenance.json` rather than the wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version string and dependency pin updates; no runtime or security logic changes in the diff.
> 
> **Overview**
> **Release 0.9.26** — bumps the published SDK version from **0.9.25** to **0.9.26** in root `pyproject.toml` and keeps installer and example pins in sync.
> 
> `install.sh`’s `YUTORI_INSTALLER_VERSION` is updated to **0.9.26** (regenerated from `scripts/build_install.sh`). The Navigator n2 cookbook pins the same version in `examples/navigator_n2/pyproject.toml`, `README.md`, and `Dockerfile.direct_x11`.
> 
> No application logic changes appear in this diff; it is the standard version alignment ahead of a PyPI publish when `pyproject.toml` lands on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 751a42ecdd8e94d341f5d4493f38452883b26298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->