### PR TITLE
refactor(macos): init run-command card state via _reset_terminal()

### DIFF
--- a/yutori/navigator/macos/presentation.py
+++ b/yutori/navigator/macos/presentation.py
@@ -500,11 +500,7 @@ class MacOSPresentationController:
         self._last_render: dict[str, str] = {}
         self._reasoning = ""
         self._action_status = ""
-        self._terminal_command = ""
-        self._terminal_running = False
-        self._terminal_failed = False
-        self._terminal_output = ""
-        self._terminal_task_id = ""
+        self._reset_terminal()
         self._active_keys: "list[str] | None" = None
         self._queue_active = False
         self._batch_is_last = False


### PR DESCRIPTION
## What

`MacOSPresentationController.__init__` hand-duplicated the exact five field resets (`_terminal_command`, `_terminal_running`, `_terminal_failed`, `_terminal_output`, `_terminal_task_id`) that `_reset_terminal()` already implements — both landed together in #435 (the run-command card feature). `__init__` now calls `self._reset_terminal()` instead of repeating the five assignments inline.

## Why it's an improvement

Two independent copies of the same five-field reset is exactly the kind of drift risk this repo has repeatedly extracted helpers to avoid (e.g. the same-file `_clear_action_labels()`/`_reset_terminal()` extractions in #424/#435 itself). If a sixth terminal-card field is added later, it's easy to update `_reset_terminal()` and forget `__init__` (or vice versa) since nothing ties them together today.

## Why it's safe

- Internal-only: `MacOSPresentationController` is not exported from `yutori/navigator/macos/__init__.py` and not part of the published SDK's public API (not in `api.md`).
- Zero behavior change: `__init__` ends with the same five fields set to the same initial values (`""`, `False`, `False`, `""`, `""`) as before, now via delegation instead of duplication.
- 1 file changed, +1/-5.
- Verified: `ruff check`/`ruff format --check` clean; full suite `pytest -q -m "not slow"` → 975 passed / 3 skipped / 1 deselected (baseline-identical); targeted `tests/test_navigator_macos_presentation.py` → 32 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyTFq6DbUvMn1wSy9Bgms8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyTFq6DbUvMn1wSy9Bgms8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no intended behavior change; only constructor wiring for presentation state.
> 
> **Overview**
> **`MacOSPresentationController.__init__`** no longer inlines five run-command card field resets; it delegates to the existing **`_reset_terminal()`** helper used elsewhere when clearing the terminal presentation.
> 
> This removes duplicate initialization of **`_terminal_command`**, **`_terminal_running`**, **`_terminal_failed`**, **`_terminal_output`**, and **`_terminal_task_id`**, so future terminal-card fields only need to be updated in one place. Initial values are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79df985d9c200bba34eaf122ea46b0157f200b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->