### PR TITLE
refactor(examples): drop redundant "r" mode from open() in navigator_n1_5_memo

### DIFF
--- a/examples/navigator_n1_5_memo.py
+++ b/examples/navigator_n1_5_memo.py
@@ -108,7 +108,7 @@ class MemoToolSuite:
     @staticmethod
     async def read_jsonl(file_path: str) -> list[dict]:
         try:
-            with open(file_path, "r") as f:
+            with open(file_path) as f:
                 content = f.read()
             return [json.loads(line) for line in content.splitlines()]
         except FileNotFoundError:
@@ -149,7 +149,7 @@ class MemoToolSuite:
         return f"Successfully added options to question {question_index}"
 
     async def list_records(self) -> str:
-        with open(self.file_path, "r") as f:
+        with open(self.file_path) as f:
             content = f.read()
         return f"Memo file path: {self.file_path}\nRecords:\n{content}"
 


### PR DESCRIPTION
## What

Removes the explicit `"r"` mode argument from two `open()` calls in `examples/navigator_n1_5_memo.py` (`MemoToolSuite.read_jsonl` and `MemoToolSuite.list_records`).

## Why

`"r"` is `open()`'s default mode, so dropping it is byte-for-byte identical behavior — a pure readability simplification (ruff `UP015`, redundant-open-modes). The `"w"` write path in `write_jsonl` is intentionally left untouched.

## Verification

- `python -m py_compile` passes.
- `ruff check` (repo config: E/F/I/W) and `ruff format --check` both clean.
- Change is confined to an `examples/` file that pytest does not collect; no test behavior is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tuj38CbztC3vWsBkD6MYKW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only cosmetic change with identical runtime behavior; no tests or production paths affected.
> 
> **Overview**
> Removes the explicit `"r"` argument from **`open()`** in **`MemoToolSuite.read_jsonl`** and **`MemoToolSuite.list_records`** in `examples/navigator_n1_5_memo.py`. Read mode is already the default, so behavior is unchanged—this is a style/lint cleanup (e.g. ruff **UP015**). **`write_jsonl`** still uses **`open(..., "w")`** and is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecb7c0a71dbd8f13f74af78694f9fe86224e5f4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->