### PR TITLE
fix(macos): send n2 key names in cua-driver's vocabulary

### DIFF
--- a/tests/test_navigator_macos_computer.py
+++ b/tests/test_navigator_macos_computer.py
@@ -1855,3 +1855,32 @@ async def test_window_scope_without_a_status_item_has_no_streamer(monkeypatch):
     async with _bound_window_computer(WindowFakeTransport()) as computer:
         assert computer.preview_frames_sent == 0
     assert not _FakeStreamer.instances
+
+
+async def test_keypress_speaks_the_driver_key_vocabulary():
+    """n2's canonical key names cross the RPC boundary as names cua-driver's macOS keycode table knows.
+
+    The table spells the page keys `pageup`/`pagedown`, and it reads `delete` as kVK_Delete (erase LEFT),
+    so the forward delete the model means has to travel as `forward_delete`. `backspace`, modifiers, and
+    names the table already knows pass through untouched.
+    """
+    transport = FakeTransport()
+    async with MacOSComputer(transport, owns_transport=False, presentation=False, verify_focus=False) as computer:
+        await computer.keypress("page_up")
+        await computer.keypress("page_down")
+        await computer.keypress("delete")
+        await computer.keypress("backspace")
+        await computer.keypress("Return")
+        await computer.keypress(["cmd", "delete"])
+        await computer.keypress(["shift", "page_down"])
+    assert [call["key"] for call in _arguments(transport, "press_key")] == [
+        "pageup",
+        "pagedown",
+        "forward_delete",
+        "backspace",
+        "Return",
+    ]
+    assert [call["keys"] for call in _arguments(transport, "hotkey")] == [
+        ["cmd", "forward_delete"],
+        ["shift", "pagedown"],
+    ]

--- a/yutori/navigator/macos/computer.py
+++ b/yutori/navigator/macos/computer.py
@@ -74,6 +74,13 @@ _VCS_DIRECTORIES = {".git", ".hg", ".svn"}
 _GLOB_RESULT_LIMIT = 100
 _DELIVERY_BACKGROUND = "background"
 _DELIVERY_FOREGROUND = "foreground"
+# n2 emits the Linux key vocabulary its training desktop used, and `n2_actions` canonicalizes
+# it to `page_up`/`page_down`/`delete`. cua-driver's macOS keycode table
+# (platform-macos/src/input/keyboard.rs) only knows the page keys as `pageup`/`pagedown`, and it
+# reads `delete` as kVK_Delete, which erases LEFT; the forward delete the model means is
+# `forward_delete`. Rewritten here, at the RPC boundary, because this is the only handler that
+# speaks cua-driver: the X11 adapters consume the canonical names unchanged.
+_DRIVER_KEY_NAMES = {"page_up": "pageup", "page_down": "pagedown", "delete": "forward_delete"}
 # Driver refusal codes that mean the driven window is gone (or never belonged to the
 # target process) versus ones that only invalidate the frame the coordinates came from.
 _WINDOW_LOSS_CODES = frozenset({"window_id_not_found", "window_owner_pid_mismatch"})
@@ -917,6 +924,7 @@ class MacOSComputer:
         sequence = [keys] if isinstance(keys, str) else list(keys)
         if self._emulated_held_keys:
             sequence = self._merged_modifiers(sequence)
+        sequence = [_DRIVER_KEY_NAMES.get(key.lower(), key) for key in sequence]
         await self._guard_frontmost("press_key" if len(sequence) == 1 else "hotkey")
         if len(sequence) == 1:
             await self._mutate("press_key", self._action_args(key=sequence[0]))


### PR DESCRIPTION
## What this fixes

One executor-side gap between the n2 macOS lane (`N2ComputerAgent` + `MacOSComputer` + cua-driver 0.23.2) and the contract the model was trained and is evaluated under. Nothing the model is served changes.

### `MacOSComputer.keypress` now speaks cua-driver's key vocabulary

n2 emits the Linux key vocabulary of its training desktop, and `n2_actions` canonicalizes it to `page_up` / `page_down` / `delete`. cua-driver's macOS keycode table (`platform-macos/src/input/keyboard.rs` at the pinned 0.23.2) disagrees on exactly three names:

| n2 canonical | what cua-driver did | now sent |
| --- | --- | --- |
| `page_up` / `page_down` | `Unknown key name` → the batch halted at that member | `pageup` / `pagedown` (kVK_PageUp 116 / kVK_PageDown 121) |
| `delete` | keycode 51 = kVK_Delete, which erases **left** | `forward_delete` (kVK_ForwardDelete 117) |

`pageup`/`pagedown` are the spellings the served schema teaches the model, so this was a deterministic failure whenever it used them; the iPhone Mirroring skill even recommends Page Up / Page Down as swipe substitutes. `delete` on the training desktop and in the praxis MacAgentBench driver (pyautogui's macOS backend, `'delete': 0x75`) is a forward delete; on cua-driver it only behaved when a selection made the direction moot.

The rewrite lives at the RPC boundary because `MacOSComputer` is the only handler that speaks cua-driver; the X11 adapters keep the canonical names. `backspace`, modifiers, and names the table already knows pass through untouched. Both Mac modes are covered — foreground desktop and background window scope share `keypress`.

### Not in this PR

An earlier revision also made the `computer_batch` member cap tool-set-aware (100 on the nested sets). Dropped after review: the 20 the SDK enforces today stays.

## Test plan

- New: `test_keypress_speaks_the_driver_key_vocabulary` asserts the exact `press_key`/`hotkey` wire arguments through the fake transport, including `backspace` and `Return` passing through unchanged.
- `uv run --extra dev pytest -m "not slow"`: 976 passed, 3 skipped.
- `ruff check .` clean; `ruff format --check` clean on both touched files.
- Not exercised live against a Mac in this PR; the mapping is asserted against the 0.23.2 source table, so a `computer-use smoke` on the next MCP bump is the end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized input translation at the driver RPC boundary with test coverage; no auth, data, or broad behavioral changes beyond three key aliases.
> 
> **Overview**
> Fixes macOS keyboard actions failing or sending the wrong key when the model uses n2’s canonical names **`page_up`**, **`page_down`**, and **`delete`**.
> 
> **`MacOSComputer.keypress`** now rewrites those three names (case-insensitive) to **`pageup`**, **`pagedown`**, and **`forward_delete`** immediately before **`press_key`** / **`hotkey`** RPCs, matching cua-driver’s macOS key table. Everything else—including **`backspace`**, modifiers, and **`Return`**—is unchanged. The mapping is scoped to this adapter only; X11 paths keep canonical names.
> 
> A new test asserts the exact wire arguments through the fake transport for singles and chords.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9019b85bde066a416591d82a9b0e65430c1979bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->