### PR TITLE
chore(release): 0.9.27

### DIFF
--- a/examples/navigator_n2/Dockerfile.direct_x11
+++ b/examples/navigator_n2/Dockerfile.direct_x11
@@ -30,7 +30,7 @@ RUN apt-get update \
 # released package here supplies its third-party dependencies; PYTHONPATH then
 # makes the mounted checkout itself win at import time.
 RUN python -m pip install --no-cache-dir \
-    "yutori==0.9.26" \
+    "yutori==0.9.27" \
     "pyautogui>=0.9.54" \
     "mss>=9.0.1"
 

--- a/examples/navigator_n2/README.md
+++ b/examples/navigator_n2/README.md
@@ -36,7 +36,7 @@ No Cua cloud credential is used. The Yutori key remains on the host and is never
 The local entrypoint uses yutori.navigator.macos.MacOSComputer, the public SDK runtime that yutori-mcp uses. Install the SDK macOS extra, grant Accessibility and Screen Recording to CuaDriver.app in an unlocked GUI session, and then run it:
 
 ~~~bash
-pip install 'yutori[macos]==0.9.26'
+pip install 'yutori[macos]==0.9.27'
 uv run --extra macos python local_macos.py "Open Calculator and compute 17 * 23"
 ~~~
 

--- a/examples/navigator_n2/pyproject.toml
+++ b/examples/navigator_n2/pyproject.toml
@@ -8,11 +8,11 @@ dependencies = [
     # drops the image); 0.1.17 keeps the local Docker runtime working. The
     # sandbox package alone is all the cookbook needs — no cua meta-package.
     "cua-sandbox==0.1.17",
-    "yutori==0.9.26",
+    "yutori==0.9.27",
 ]
 
 [project.optional-dependencies]
-macos = ["yutori[macos]==0.9.26"]
+macos = ["yutori[macos]==0.9.27"]
 linux = [
     # pyautogui executes n2's GUI actions in their native X11 units (wheel
     # notches, key events); mss captures X11 screenshots without scrot.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ YUTORI_RESET=$'\033[0m'
 # Installer version, injected at build time from pyproject.toml by
 # scripts/build_install.sh. Surfaced in the header so users can tell at a
 # glance which release they fetched (useful for bug reports).
-YUTORI_INSTALLER_VERSION="0.9.26"
+YUTORI_INSTALLER_VERSION="0.9.27"
 
 # Read the banner into a variable via `read -d ''` rather than `$(cat <<EOF)`.
 # Bash 3.2 (macOS /bin/bash) has a known parser bug where a heredoc nested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yutori"
-version = "0.9.26"
+version = "0.9.27"
 description = "Official Python SDK for the Yutori API"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Ships #440: `key_press` now sends cua-driver's macOS key names, so `pageup`/`pagedown` no longer halt a batch with "Unknown key name" and `delete` deletes forward instead of erasing left. Also #438 and #439 (internal refactors).

Bumps `version` in pyproject.toml, regenerates install.sh, and moves the `yutori==` pins under examples/navigator_n2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation/pin updates only in the visible diff; no runtime logic changes in this PR.
> 
> **Overview**
> **Release 0.9.27** bumps the SDK from `0.9.26` to `0.9.27` in the root `pyproject.toml` and syncs downstream references: `YUTORI_INSTALLER_VERSION` in `install.sh`, and all `yutori==` / `yutori[macos]==` pins in `examples/navigator_n2` (`pyproject.toml`, `README.md`, `Dockerfile.direct_x11`).
> 
> Per the release notes, this tag ships macOS `key_press` alignment with cua-driver key names (fixes `pageup`/`pagedown` batch failures and forward `delete` behavior) plus related internal refactors (#438–#440); those code changes are not part of this diff—only the version and pin updates are.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3ee59d0e95d97d520d03eff6627c3cc5fee89f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->