### PR TITLE
refactor(examples): route CuaSandboxComputer.run_shell_command through run_sandbox_shell

### DIFF
--- a/examples/navigator_n2/cua_adapter.py
+++ b/examples/navigator_n2/cua_adapter.py
@@ -199,7 +199,7 @@ class CuaSandboxComputer(ShellFileToolsMixin, PointerKeyLifecycleMixin):
         timeout_seconds: int = 10,
     ) -> str:
         prefix = f"cd {shlex.quote(cwd)} && " if cwd else ""
-        return _shell_result(await self.sandbox.shell.run(f"{prefix}{command}", timeout=timeout_seconds))
+        return _shell_result(await self.run_sandbox_shell(f"{prefix}{command}", timeout_seconds=timeout_seconds))
 
     async def run_bash_command(
         self,

--- a/tests/test_navigator_n2_cookbooks.py
+++ b/tests/test_navigator_n2_cookbooks.py
@@ -304,6 +304,23 @@ async def test_public_cua_adapter_labels_jpeg_screenshots_correctly() -> None:
         assert image.format == "JPEG"
 
 
+async def test_public_cua_adapter_run_shell_command_goes_through_run_sandbox_shell() -> None:
+    """`run_shell_command` must reuse the `run_sandbox_shell` hook the file tools rely on
+    instead of calling ``sandbox.shell.run`` a second, independent way."""
+    calls: list[tuple[str, int]] = []
+
+    class Shell:
+        async def run(self, command: str, timeout: int = 30) -> SimpleNamespace:
+            calls.append((command, timeout))
+            return SimpleNamespace(stdout="ok\n", stderr="", returncode=0)
+
+    computer = CuaSandboxComputer(SimpleNamespace(shell=Shell()))
+    output = await computer.run_shell_command("pwd", cwd="/tmp", timeout_seconds=5)
+
+    assert calls == [("cd /tmp && pwd", 5)]
+    assert output == "ok\n"
+
+
 async def test_public_cua_adapter_executes_all_current_batch_actions() -> None:
     sandbox = FakeSandbox()
     computer = CuaSandboxComputer(sandbox)


### PR DESCRIPTION
## What

`CuaSandboxComputer.run_shell_command` (the `run_shell_command` tool handler, `examples/navigator_n2/cua_adapter.py`) called `self.sandbox.shell.run(...)` directly. The same class already implements `run_sandbox_shell`, the exact hook `ShellFileToolsMixin`'s file tools (`read`/`write`/`edit`/`grep`/`glob`) call to reach the sandbox shell — and it does the identical `self.sandbox.shell.run(command, timeout=timeout_seconds)` call. So the class had two independent call sites hitting the same underlying API, one of which bypassed the class's own designated hook.

The sibling reference adapter, `direct_x11_adapter.py`, already gets this right: its `run_shell_command` delegates to `self.run_sandbox_shell(...)`. This PR makes `cua_adapter.py` consistent with it.

## Why this is safe — no behavior change

Both the old and new code paths resolve to the exact same call with the exact same arguments:

```python
self.sandbox.shell.run(f"{prefix}{command}", timeout=timeout_seconds)
```

- Verified with an old-vs-new equivalence check (ran both implementations against an identical fake `shell.run`, confirmed identical calls recorded and identical output returned).
- Added `tests/test_navigator_n2_cookbooks.py::test_public_cua_adapter_run_shell_command_goes_through_run_sandbox_shell`, asserting `run_shell_command` still prefixes `cwd` and forwards the exact command/timeout to the sandbox's shell.
- Full existing test suite passes (`977 passed, 3 skipped`; the one pre-existing failure, `test_packaging.py::test_built_distributions_include_packaged_assets`, is an environment issue — missing the `build` module — reproducible on `main` before this change, unrelated to this diff).
- `ruff check` and `ruff format --check` both pass on the changed files.
- This is example/reference code, not part of the published `yutori` package's importable API surface, so there's no PyPI-facing signature/behavior risk either way.

## Why this matters

One call site instead of two for the same low-level sandbox primitive means any future change to how this class talks to the sandbox's shell (retries, logging, argument shape) only needs to happen in one place, and can't silently miss `run_shell_command`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSa3sTt1qVDczr21MEzzj3


---
_Generated by [Claude Code](https://claude.ai/code/session_01PSa3sTt1qVDczr21MEzzj3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only refactor with no intended behavior change; a new test pins the delegation path.
> 
> **Overview**
> **`CuaSandboxComputer.run_shell_command`** now delegates to **`run_sandbox_shell`** instead of calling **`sandbox.shell.run`** directly, matching **`direct_x11_adapter.py`** and the same hook **`ShellFileToolsMixin`** uses for read/write/edit/grep/glob.
> 
> Behavior should be unchanged (still `cd`-prefixes `cwd`, same timeout, same formatted shell output); the goal is a single place to adjust sandbox shell access later.
> 
> Adds **`test_public_cua_adapter_run_shell_command_goes_through_run_sandbox_shell`** to assert the prefixed command and timeout reach the shell layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9839d2fecbc25aabbcfa5c32ca62c41eed188956. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->